### PR TITLE
feat(groups): define strict contracts and durable persistence

### DIFF
--- a/apps/cli/src/commands/configDiagnostics.ts
+++ b/apps/cli/src/commands/configDiagnostics.ts
@@ -165,6 +165,7 @@ function emptySnapshot(now: string): StationSnapshot {
     projects: [],
     rows: [],
     sessions: [],
+    sessionGroups: [],
     counts: {
       projects: 0,
       sessions: 0,

--- a/apps/cli/test/integration/command-command.test.ts
+++ b/apps/cli/test/integration/command-command.test.ts
@@ -229,9 +229,9 @@ describe("CLI command dispatch/get", () => {
             ({
               health: async () =>
                 spawned
-                  ? { schemaVersion: "0.9.0", status: "healthy" }
+                  ? { schemaVersion: "0.10.0", status: "healthy" }
                   : {
-                      schemaVersion: "0.9.0",
+                      schemaVersion: "0.10.0",
                       status: "healthy",
                       pid: 1234,
                       startedAt: now,
@@ -263,7 +263,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.9.0",
+          schemaVersion: "0.10.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,

--- a/apps/cli/test/integration/diagnostic-commands.test.ts
+++ b/apps/cli/test/integration/diagnostic-commands.test.ts
@@ -27,7 +27,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.9.0",
+            schemaVersion: "0.10.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -49,7 +49,7 @@ describe("CLI diagnostic commands", () => {
     ).resolves.toMatchObject({
       code: 0,
       output: {
-        schemaVersion: "0.9.0",
+        schemaVersion: "0.10.0",
         status: "healthy",
         debugBundle: {
           available: true,
@@ -166,7 +166,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.9.0",
+            schemaVersion: "0.10.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -201,7 +201,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.9.0",
+            schemaVersion: "0.10.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -238,7 +238,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.9.0",
+            schemaVersion: "0.10.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -301,7 +301,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.9.0",
+            schemaVersion: "0.10.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -342,7 +342,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.9.0",
+            schemaVersion: "0.10.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -756,12 +756,12 @@ describe("CLI diagnostic commands", () => {
 
 function doctorReport(stateDir: string): DoctorReport {
   return {
-    schemaVersion: "0.9.0",
+    schemaVersion: "0.10.0",
     generatedAt: now,
     status: "healthy",
     checks: [{ name: "observer", status: "ok", message: "Observer is healthy." }],
     observer: {
-      schemaVersion: "0.9.0",
+      schemaVersion: "0.10.0",
       status: "healthy",
       pid: 1234,
       startedAt: now,
@@ -789,23 +789,24 @@ function doctorReport(stateDir: string): DoctorReport {
 
 function diagnosticSnapshot(): DiagnosticSnapshot {
   return {
-    schemaVersion: "0.9.0",
+    schemaVersion: "0.10.0",
     collectedAt: now,
     observerHealth: {
-      schemaVersion: "0.9.0",
+      schemaVersion: "0.10.0",
       status: "healthy",
       pid: 1234,
       startedAt: now,
       version: observerBuildVersion,
     },
     snapshot: {
-      schemaVersion: "0.9.0",
+      schemaVersion: "0.10.0",
       generatedAt: now,
       observer: { pid: 1234, startedAt: now, version: "0.7.0", healthy: true },
       providerHealth: {},
       projects: [],
       rows: [],
       sessions: [],
+      sessionGroups: [],
       counts: {
         projects: 0,
         sessions: 0,

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -57,7 +57,7 @@ describe("CLI manual-smoke commands", () => {
     const configPath = await writeConfigToml(fixture.root, fixture.config);
     const reconciles: Array<string | undefined> = [];
     const receipt: ReconcileReceipt = {
-      schemaVersion: "0.9.0",
+      schemaVersion: "0.10.0",
       reason: "manual-smoke",
       reconciledAt: now,
       snapshot: snapshotFixture(),
@@ -311,7 +311,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.9.0",
+          schemaVersion: "0.10.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,
@@ -322,7 +322,7 @@ function runningObserverDeps(options: {
         reconcile:
           options.reconcile ??
           (async (reason?: string) => ({
-            schemaVersion: "0.9.0",
+            schemaVersion: "0.10.0",
             reason: reason ?? "manual",
             reconciledAt: now,
             snapshot: options.snapshot ?? snapshotFixture(),
@@ -334,13 +334,14 @@ function runningObserverDeps(options: {
 
 function snapshotFixture(): StationSnapshot {
   return {
-    schemaVersion: "0.9.0",
+    schemaVersion: "0.10.0",
     generatedAt: now,
     observer: { pid: 1234, startedAt: now, version: "0.7.0", healthy: true },
     providerHealth: {},
     projects: [],
     rows: [],
     sessions: [],
+    sessionGroups: [],
     counts: {
       projects: 0,
       sessions: 0,

--- a/apps/cli/test/integration/observe-command.test.ts
+++ b/apps/cli/test/integration/observe-command.test.ts
@@ -265,7 +265,7 @@ describe("CLI observe command", () => {
                       tag: "ProtocolError",
                       code: "PROTOCOL_SCHEMA_MISMATCH",
                       message:
-                        "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.9.0.",
+                        "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.10.0.",
                       hint: "A different STATION checkout may own the observer socket.",
                     };
                   },
@@ -280,7 +280,7 @@ describe("CLI observe command", () => {
         ),
       ).rejects.toThrow(
         [
-          "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.9.0.",
+          "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.10.0.",
           "Hint: A different STATION checkout may own the observer socket.",
           "Code: PROTOCOL_SCHEMA_MISMATCH",
         ].join("\n"),
@@ -304,7 +304,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.9.0",
+          schemaVersion: "0.10.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,
@@ -317,7 +317,7 @@ function runningObserverDeps(options: {
           return options.events;
         },
         reconcile: async (reason?: string): Promise<ReconcileReceipt> => ({
-          schemaVersion: "0.9.0",
+          schemaVersion: "0.10.0",
           reason: reason ?? "manual",
           reconciledAt: now,
           snapshot: options.snapshot ?? snapshotFixture(),
@@ -391,13 +391,14 @@ async function sleep(ms: number): Promise<void> {
 
 function snapshotFixture(): StationSnapshot {
   return {
-    schemaVersion: "0.9.0",
+    schemaVersion: "0.10.0",
     generatedAt: now,
     observer: { pid: 1234, startedAt: now, version: "0.7.0", healthy: true },
     providerHealth: {},
     projects: [],
     rows: [],
     sessions: [],
+    sessionGroups: [],
     counts: {
       projects: 0,
       sessions: 0,

--- a/apps/cli/test/integration/observer-commands.test.ts
+++ b/apps/cli/test/integration/observer-commands.test.ts
@@ -27,7 +27,7 @@ describe("CLI observer commands", () => {
               throw new Error("stopped");
             }
             return {
-              schemaVersion: "0.9.0",
+              schemaVersion: "0.10.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -37,7 +37,7 @@ describe("CLI observer commands", () => {
           },
           stop: async () => {
             running = false;
-            return { schemaVersion: "0.9.0", stopped: true, at: now };
+            return { schemaVersion: "0.10.0", stopped: true, at: now };
           },
         }) as never,
       sleep: async () => undefined,
@@ -74,7 +74,7 @@ describe("CLI observer commands", () => {
               throw new Error("stopped");
             }
             return {
-              schemaVersion: "0.9.0",
+              schemaVersion: "0.10.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -84,7 +84,7 @@ describe("CLI observer commands", () => {
           },
           stop: async () => {
             running = false;
-            return { schemaVersion: "0.9.0", stopped: true, at: now };
+            return { schemaVersion: "0.10.0", stopped: true, at: now };
           },
         }) as never,
       sleep: async () => undefined,
@@ -143,7 +143,7 @@ describe("CLI observer commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.9.0",
+            schemaVersion: "0.10.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,

--- a/apps/cli/test/integration/popup-command.test.ts
+++ b/apps/cli/test/integration/popup-command.test.ts
@@ -46,7 +46,7 @@ describe("CLI popup command", () => {
           health: async () => {
             if (!running) throw new Error("stopped");
             return {
-              schemaVersion: "0.9.0",
+              schemaVersion: "0.10.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -119,7 +119,7 @@ describe("CLI popup command", () => {
                   if (!spawned) throw new Error("stopped");
                   await healthReady;
                   return {
-                    schemaVersion: "0.9.0",
+                    schemaVersion: "0.10.0",
                     status: "healthy",
                     pid: 1234,
                     startedAt: now,
@@ -189,7 +189,7 @@ describe("CLI popup command", () => {
               clientFactory: () =>
                 ({
                   health: async () => ({
-                    schemaVersion: "0.9.0",
+                    schemaVersion: "0.10.0",
                     status: "healthy",
                     pid: 1234,
                     startedAt: now,
@@ -218,7 +218,7 @@ describe("CLI popup command", () => {
       () =>
         ({
           health: async () => ({
-            schemaVersion: "0.9.0",
+            schemaVersion: "0.10.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -702,7 +702,7 @@ function runningObserverDeps(reconciles: string[]): ObserverProcessDeps {
     clientFactory: () =>
       ({
         health: async () => ({
-          schemaVersion: "0.9.0",
+          schemaVersion: "0.10.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,
@@ -719,17 +719,18 @@ function runningObserverDeps(reconciles: string[]): ObserverProcessDeps {
 
 function emptySnapshot(reason: string) {
   return {
-    schemaVersion: "0.9.0",
+    schemaVersion: "0.10.0",
     reason,
     reconciledAt: now,
     snapshot: {
-      schemaVersion: "0.9.0",
+      schemaVersion: "0.10.0",
       generatedAt: now,
       observer: { pid: 1234, startedAt: now, version: "0.7.0", healthy: true },
       providerHealth: {},
       projects: [],
       rows: [],
       sessions: [],
+      sessionGroups: [],
       counts: {
         projects: 0,
         sessions: 0,
@@ -766,7 +767,7 @@ function nonCompletingReconcileObserverDeps(reconciles: string[]): ObserverProce
     clientFactory: () =>
       ({
         health: async () => ({
-          schemaVersion: "0.9.0",
+          schemaVersion: "0.10.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,

--- a/apps/cli/test/integration/project-command.test.ts
+++ b/apps/cli/test/integration/project-command.test.ts
@@ -144,7 +144,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.9.0",
+          schemaVersion: "0.10.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,

--- a/apps/cli/test/integration/tui-command.test.ts
+++ b/apps/cli/test/integration/tui-command.test.ts
@@ -51,17 +51,18 @@ const tuiConfig: TuiConfig = {
 
 function emptySnapshot(reason: string) {
   return {
-    schemaVersion: "0.9.0",
+    schemaVersion: "0.10.0",
     reason,
     reconciledAt: now,
     snapshot: {
-      schemaVersion: "0.9.0",
+      schemaVersion: "0.10.0",
       generatedAt: now,
       observer: { pid: 1234, startedAt: now, version: "0.7.0", healthy: true },
       providerHealth: {},
       projects: [],
       rows: [],
       sessions: [],
+      sessionGroups: [],
       counts: {
         projects: 0,
         sessions: 0,
@@ -103,7 +104,7 @@ function runningObserverDeps(
         health: async () => {
           if (!running) throw new Error("stopped");
           return {
-            schemaVersion: "0.9.0",
+            schemaVersion: "0.10.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -129,7 +130,7 @@ function warmObserverDeps(version: string): ObserverProcessDeps {
     clientFactory: () =>
       ({
         health: async () => ({
-          schemaVersion: "0.9.0",
+          schemaVersion: "0.10.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,
@@ -323,7 +324,7 @@ describe("CLI tui command", () => {
                   if (!spawned) throw new Error("stopped");
                   await healthReady;
                   return {
-                    schemaVersion: "0.9.0",
+                    schemaVersion: "0.10.0",
                     status: "healthy",
                     pid: 1234,
                     startedAt: now,
@@ -389,7 +390,7 @@ describe("CLI tui command", () => {
               clientFactory: () =>
                 ({
                   health: async () => ({
-                    schemaVersion: "0.9.0",
+                    schemaVersion: "0.10.0",
                     status: "healthy",
                     pid: 1234,
                     startedAt: now,
@@ -420,7 +421,7 @@ describe("CLI tui command", () => {
       () =>
         ({
           health: async () => ({
-            schemaVersion: "0.9.0",
+            schemaVersion: "0.10.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,

--- a/apps/cli/test/unit/ingress-command.test.ts
+++ b/apps/cli/test/unit/ingress-command.test.ts
@@ -51,7 +51,7 @@ describe("provider hook ingress command", () => {
             ingestProviderHookEvent: async (event: ProviderHookEvent) => {
               if (!running) throw new Error("offline");
               return {
-                schemaVersion: "0.9.0",
+                schemaVersion: "0.10.0",
                 hookId: event.hookId ?? "hook_final_command",
                 provider: event.provider,
                 event: event.event,
@@ -121,7 +121,7 @@ describe("provider hook ingress command", () => {
             ingestProviderHookEvent: async (event: ProviderHookEvent) => {
               if (!(await fileExists(argvPath))) throw new Error("offline");
               return {
-                schemaVersion: "0.9.0",
+                schemaVersion: "0.10.0",
                 hookId: event.hookId ?? "hook_child_timeout",
                 provider: event.provider,
                 event: event.event,
@@ -172,7 +172,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedPayload = event.payload;
             return {
-              schemaVersion: "0.9.0",
+              schemaVersion: "0.10.0",
               hookId: event.hookId ?? "hook_worktrunk_1",
               provider: event.provider,
               event: event.event,
@@ -227,7 +227,7 @@ describe("provider hook ingress command", () => {
         writeSpool: async ({ spoolDir, event, error, clock }) => {
           observedSpoolDir = spoolDir;
           return {
-            schemaVersion: "0.9.0",
+            schemaVersion: "0.10.0",
             hookId: event.hookId ?? "hook_worktrunk_config_only",
             provider: event.provider,
             event: event.event,
@@ -291,7 +291,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedEvent = event;
             return {
-              schemaVersion: "0.9.0",
+              schemaVersion: "0.10.0",
               hookId: event.hookId ?? "hook_1",
               provider: event.provider,
               event: event.event,
@@ -355,7 +355,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedEvent = event;
             return {
-              schemaVersion: "0.9.0",
+              schemaVersion: "0.10.0",
               hookId: event.hookId ?? "hook_1",
               provider: event.provider,
               event: event.event,
@@ -415,7 +415,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedEvent = event;
             return {
-              schemaVersion: "0.9.0",
+              schemaVersion: "0.10.0",
               hookId: event.hookId ?? "hook_1",
               provider: event.provider,
               event: event.event,
@@ -481,7 +481,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedEvent = event;
             return {
-              schemaVersion: "0.9.0",
+              schemaVersion: "0.10.0",
               hookId: event.hookId ?? "hook_opencode_1",
               provider: event.provider,
               event: event.event,
@@ -493,7 +493,7 @@ describe("provider hook ingress command", () => {
           };
           return {
             health: async () => ({
-              schemaVersion: "0.9.0",
+              schemaVersion: "0.10.0",
               status: "healthy",
               pid: 12345,
               startedAt: now,
@@ -549,7 +549,7 @@ describe("provider hook ingress command", () => {
             health: async () => {
               healthCalls += 1;
               return {
-                schemaVersion: "0.9.0",
+                schemaVersion: "0.10.0",
                 status: "healthy",
                 pid: 12345,
                 startedAt: now,
@@ -563,7 +563,7 @@ describe("provider hook ingress command", () => {
             ): Promise<ProviderHookReceipt> => {
               deliveryCalls += 1;
               return {
-                schemaVersion: "0.9.0",
+                schemaVersion: "0.10.0",
                 hookId: event.hookId ?? "hook_pi_invalid",
                 provider: event.provider,
                 event: event.event,
@@ -632,7 +632,7 @@ describe("provider hook ingress command", () => {
             observedBuildVersion = options.expectedBuildVersion;
           }
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => ({
-            schemaVersion: "0.9.0",
+            schemaVersion: "0.10.0",
             hookId: event.hookId ?? "hook_timeout_1",
             provider: event.provider,
             event: event.event,
@@ -800,7 +800,7 @@ function stationEnv(): Record<string, string> {
 
 function healthyObserver(paths: { socketPath: string; stateDir: string }): ObserverHealth {
   return {
-    schemaVersion: "0.9.0",
+    schemaVersion: "0.10.0",
     status: "healthy",
     pid: 12345,
     startedAt: now,

--- a/apps/cli/test/unit/ingress-correlation.test.ts
+++ b/apps/cli/test/unit/ingress-correlation.test.ts
@@ -238,7 +238,7 @@ describe("provider hook ingress correlation", () => {
     );
 
     expect(receipt).toEqual({
-      schemaVersion: "0.9.0",
+      schemaVersion: "0.10.0",
       hookId,
       provider,
       event: expectedEvent,
@@ -352,7 +352,7 @@ describe("provider hook ingress correlation", () => {
     );
 
     expect(receipt).toEqual({
-      schemaVersion: "0.9.0",
+      schemaVersion: "0.10.0",
       hookId: "hook_logging_failure",
       provider: "cursor",
       event: "beforeShellExecution",

--- a/apps/cli/test/unit/observe-formatters.test.ts
+++ b/apps/cli/test/unit/observe-formatters.test.ts
@@ -108,7 +108,7 @@ describe("observe snapshot context", () => {
 
 function snapshotFixture(): StationSnapshot {
   return {
-    schemaVersion: "0.9.0",
+    schemaVersion: "0.10.0",
     generatedAt: now,
     observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
     providerHealth: {},

--- a/apps/cli/test/unit/observer-process/activation-surfacing.test.ts
+++ b/apps/cli/test/unit/observer-process/activation-surfacing.test.ts
@@ -143,14 +143,14 @@ describe("a failed cross-build restart retains the incumbent build context", () 
         clientFactory: () =>
           ({
             health: async () => ({
-              schemaVersion: "0.9.0",
+              schemaVersion: "0.10.0",
               status: "healthy",
               pid: 4321,
               startedAt: now,
               version: sourceBuildVersion,
               socketPath: fixture.socketPath,
             }),
-            stop: async () => ({ schemaVersion: "0.9.0", stopped: true, at: now }),
+            stop: async () => ({ schemaVersion: "0.10.0", stopped: true, at: now }),
           }) as never,
       },
     );
@@ -181,14 +181,14 @@ describe("a failed cross-build restart retains the incumbent build context", () 
         clientFactory: () =>
           ({
             health: async () => ({
-              schemaVersion: "0.9.0",
+              schemaVersion: "0.10.0",
               status: "healthy",
               pid: 4321,
               startedAt: now,
               version: compiledBuildVersion,
               socketPath: fixture.socketPath,
             }),
-            stop: async () => ({ schemaVersion: "0.9.0", stopped: true, at: now }),
+            stop: async () => ({ schemaVersion: "0.10.0", stopped: true, at: now }),
           }) as never,
       },
     );

--- a/apps/cli/test/unit/observer-process/lifecycle.test.ts
+++ b/apps/cli/test/unit/observer-process/lifecycle.test.ts
@@ -59,7 +59,7 @@ describe("CLI observer process lifecycle", () => {
                 throw new Error("not yet");
               }
               return {
-                schemaVersion: "0.9.0",
+                schemaVersion: "0.10.0",
                 status: "healthy",
                 pid: 1234,
                 startedAt: now,
@@ -109,7 +109,7 @@ describe("CLI observer process lifecycle", () => {
                 throw new Error("not running");
               }
               return {
-                schemaVersion: "0.9.0",
+                schemaVersion: "0.10.0",
                 status: "healthy",
                 pid: 1234,
                 startedAt: now,
@@ -224,7 +224,7 @@ describe("CLI observer process lifecycle", () => {
                   tag: "ProtocolError",
                   code: "PROTOCOL_SCHEMA_MISMATCH",
                   message:
-                    "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.9.0.",
+                    "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.10.0.",
                   hint: "A different STATION checkout may own the observer socket.",
                 };
               },
@@ -304,7 +304,7 @@ describe("CLI observer process lifecycle", () => {
           clientFactory: () =>
             ({
               health: async () => ({
-                schemaVersion: "0.9.0",
+                schemaVersion: "0.10.0",
                 status: "healthy",
                 pid: 1234,
                 startedAt: now,
@@ -335,7 +335,7 @@ describe("CLI observer process lifecycle", () => {
         clientFactory: () =>
           ({
             health: async () => ({
-              schemaVersion: "0.9.0",
+              schemaVersion: "0.10.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -373,7 +373,7 @@ describe("CLI observer process lifecycle", () => {
         clientFactory: () =>
           ({
             health: async () => ({
-              schemaVersion: "0.9.0",
+              schemaVersion: "0.10.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -382,7 +382,7 @@ describe("CLI observer process lifecycle", () => {
             }),
             stop: async () => {
               stops += 1;
-              return { schemaVersion: "0.9.0", stopped: true, at: now };
+              return { schemaVersion: "0.10.0", stopped: true, at: now };
             },
           }) as never,
       },
@@ -422,7 +422,7 @@ describe("CLI observer process lifecycle", () => {
             health: async () => {
               if (!running) throw new Error("stopped");
               return {
-                schemaVersion: "0.9.0",
+                schemaVersion: "0.10.0",
                 status: "healthy",
                 pid: 1234,
                 startedAt: now,
@@ -433,7 +433,7 @@ describe("CLI observer process lifecycle", () => {
             stop: async () => {
               stops += 1;
               running = false;
-              return { schemaVersion: "0.9.0", stopped: true, at: now };
+              return { schemaVersion: "0.10.0", stopped: true, at: now };
             },
           } as never;
         },
@@ -476,7 +476,7 @@ describe("CLI observer process lifecycle", () => {
             health: async () => {
               if (!stopping) {
                 return {
-                  schemaVersion: "0.9.0",
+                  schemaVersion: "0.10.0",
                   status: "healthy",
                   pid: 1234,
                   startedAt: now,
@@ -494,7 +494,7 @@ describe("CLI observer process lifecycle", () => {
             },
             stop: async () => {
               stopping = true;
-              return { schemaVersion: "0.9.0", stopped: true, at: now };
+              return { schemaVersion: "0.10.0", stopped: true, at: now };
             },
           }) as never,
       },
@@ -533,7 +533,7 @@ describe("CLI observer process lifecycle", () => {
               health: async () => {
                 if (!running) throw new Error("stopped");
                 return {
-                  schemaVersion: "0.9.0",
+                  schemaVersion: "0.10.0",
                   status: "healthy",
                   pid: 1234,
                   startedAt: now,
@@ -544,7 +544,7 @@ describe("CLI observer process lifecycle", () => {
               stop: async () => {
                 await new Promise((resolve) => setTimeout(resolve, 700));
                 running = false;
-                return { schemaVersion: "0.9.0", stopped: true, at: now };
+                return { schemaVersion: "0.10.0", stopped: true, at: now };
               },
             } as never;
           },
@@ -573,7 +573,7 @@ describe("CLI observer process lifecycle", () => {
               health: async () => {
                 if (!running) throw new Error("stopped");
                 return {
-                  schemaVersion: "0.9.0",
+                  schemaVersion: "0.10.0",
                   status: "healthy",
                   pid: 1234,
                   startedAt: now,
@@ -581,7 +581,7 @@ describe("CLI observer process lifecycle", () => {
               },
               stop: async () => {
                 running = false;
-                return { schemaVersion: "0.9.0", stopped: true, at: now };
+                return { schemaVersion: "0.10.0", stopped: true, at: now };
               },
             } as never;
           },
@@ -617,7 +617,7 @@ describe("CLI observer process lifecycle", () => {
             health: async () => {
               if (!running) throw new Error("stopped");
               return {
-                schemaVersion: "0.9.0",
+                schemaVersion: "0.10.0",
                 status: "healthy",
                 pid: version === exactOneBuildVersion ? 5678 : 1234,
                 startedAt: now,
@@ -627,7 +627,7 @@ describe("CLI observer process lifecycle", () => {
             stop: async () => {
               stops += 1;
               running = false;
-              return { schemaVersion: "0.9.0", stopped: true, at: now };
+              return { schemaVersion: "0.10.0", stopped: true, at: now };
             },
           }) as never,
       },
@@ -652,14 +652,14 @@ describe("CLI observer process lifecycle", () => {
           clientFactory: () =>
             ({
               health: async () => ({
-                schemaVersion: "0.9.0",
+                schemaVersion: "0.10.0",
                 status: "healthy",
                 startedAt: now,
                 version: "1.0.0",
               }),
               stop: async () => {
                 stops += 1;
-                return { schemaVersion: "0.9.0", stopped: true, at: now };
+                return { schemaVersion: "0.10.0", stopped: true, at: now };
               },
             }) as never,
         },
@@ -690,7 +690,7 @@ describe("CLI observer process lifecycle", () => {
         clientFactory: () =>
           ({
             health: async () => ({
-              schemaVersion: "0.9.0",
+              schemaVersion: "0.10.0",
               status: "healthy",
               pid,
               startedAt: now,
@@ -699,7 +699,7 @@ describe("CLI observer process lifecycle", () => {
             }),
             stop: async () => {
               stops += 1;
-              return { schemaVersion: "0.9.0", stopped: true, at: now };
+              return { schemaVersion: "0.10.0", stopped: true, at: now };
             },
           }) as never,
       },
@@ -729,7 +729,7 @@ describe("CLI observer process lifecycle", () => {
         clientFactory: () =>
           ({
             health: async () => ({
-              schemaVersion: "0.9.0",
+              schemaVersion: "0.10.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -738,7 +738,7 @@ describe("CLI observer process lifecycle", () => {
             }),
             stop: async () => {
               stops += 1;
-              return { schemaVersion: "0.9.0", stopped: true, at: now };
+              return { schemaVersion: "0.10.0", stopped: true, at: now };
             },
           }) as never,
       },
@@ -778,7 +778,7 @@ describe("CLI observer process lifecycle", () => {
               healthAttempts += 1;
               if (!spawned || healthAttempts < 3) {
                 return {
-                  schemaVersion: "0.9.0",
+                  schemaVersion: "0.10.0",
                   status: "healthy",
                   pid: 1234,
                   startedAt: now,
@@ -787,7 +787,7 @@ describe("CLI observer process lifecycle", () => {
                 };
               }
               return {
-                schemaVersion: "0.9.0",
+                schemaVersion: "0.10.0",
                 status: "healthy",
                 pid: 5678,
                 startedAt: now,
@@ -829,7 +829,7 @@ describe("CLI observer process lifecycle", () => {
         clientFactory: () =>
           ({
             health: async () => ({
-              schemaVersion: "0.9.0",
+              schemaVersion: "0.10.0",
               status: "healthy",
               ...identity,
             }),

--- a/apps/cli/test/unit/observer-process/setup-observer-activation.test.ts
+++ b/apps/cli/test/unit/observer-process/setup-observer-activation.test.ts
@@ -24,7 +24,7 @@ restartObserverSpy.mockImplementation(async () => ({
     stateDir: "unused",
   },
   health: {
-    schemaVersion: "0.9.0",
+    schemaVersion: "0.10.0",
     status: "healthy",
     pid: 1234,
     startedAt: now,

--- a/apps/cli/test/unit/observer-process/startup.test.ts
+++ b/apps/cli/test/unit/observer-process/startup.test.ts
@@ -13,7 +13,7 @@ const lowerBuildVersion = `1.0.0+station.${"b".repeat(64)}`;
 
 const healthyObserver = (pid = 1234, version = stationObserverBuildVersion()) =>
   ({
-    schemaVersion: "0.9.0",
+    schemaVersion: "0.10.0",
     status: "healthy",
     pid,
     startedAt: now,

--- a/apps/observer/src/migrations/017_session_groups.ts
+++ b/apps/observer/src/migrations/017_session_groups.ts
@@ -1,0 +1,33 @@
+import type { ObserverSqliteMigration } from "./migration.js";
+
+export const sessionGroupsMigration: ObserverSqliteMigration = {
+  version: 17,
+  name: "session_groups",
+  sql: `
+    CREATE TABLE session_groups (
+      id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      parent_group_id TEXT,
+      version INTEGER NOT NULL CHECK (version > 0),
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE INDEX session_groups_project_idx
+      ON session_groups (project_id, id);
+    CREATE INDEX session_groups_parent_idx
+      ON session_groups (project_id, parent_group_id);
+
+    CREATE TABLE session_group_memberships (
+      session_id TEXT PRIMARY KEY,
+      group_id TEXT NOT NULL,
+      project_id TEXT NOT NULL
+    );
+
+    CREATE INDEX session_group_memberships_group_idx
+      ON session_group_memberships (group_id, session_id);
+    CREATE INDEX session_group_memberships_project_idx
+      ON session_group_memberships (project_id, group_id, session_id);
+  `,
+};

--- a/apps/observer/src/migrations/index.ts
+++ b/apps/observer/src/migrations/index.ts
@@ -14,6 +14,7 @@ import { sessionHarnessExecutionsMigration } from "./013_session_harness_executi
 import { nativeBindingIngressClaimsMigration } from "./014_native_binding_ingress_claims.js";
 import { dropRecoveryBreadcrumbsMigration } from "./015_drop_recovery_breadcrumbs.js";
 import { worktreeDisplayTitlesMigration } from "./016_worktree_display_titles.js";
+import { sessionGroupsMigration } from "./017_session_groups.js";
 
 /** @knipignore Retains the historical migration type import surface. */
 export type { ObserverSqliteMigration } from "./migration.js";
@@ -35,6 +36,7 @@ export const migrations = [
   nativeBindingIngressClaimsMigration,
   dropRecoveryBreadcrumbsMigration,
   worktreeDisplayTitlesMigration,
+  sessionGroupsMigration,
 ] as const;
 
 export const latestSchemaVersion = migrations[migrations.length - 1]?.version ?? 0;

--- a/apps/observer/src/persistence/ports.ts
+++ b/apps/observer/src/persistence/ports.ts
@@ -4,6 +4,8 @@ import type {
   ObserverHealth,
   ProviderId,
   SafeError,
+  SessionGroupId,
+  SessionGroupView,
   SessionRecoveryHandle,
   StationCommand,
   StationEvent,
@@ -29,6 +31,8 @@ import type {
   ProviderObservationKind,
   ProviderObservationsIngressDedupeResult,
   RecordProviderObservationInput,
+  SessionGroupMemberExpectation,
+  SessionGroupStoreResult,
   SessionHarnessDerivedStateRepair,
   SessionTurnReadinessMutation,
   WorktreeMetadataCurrentKind,
@@ -214,6 +218,51 @@ export interface SessionStore {
 /**
  * DRIVEN PORT
  *
+ * Maintains durable project-local Group definitions, exclusive membership, and parentage through atomic stale-write-safe conversations.
+ */
+export interface SessionGroupStore {
+  listSessionGroups(): Promise<SessionGroupView[]>;
+  createSessionGroup(input: {
+    id: SessionGroupId;
+    projectId: string;
+    name: string;
+    initialMembers?: SessionGroupMemberExpectation[];
+    parentGroupId?: SessionGroupId;
+    createdAt?: string;
+  }): Promise<SessionGroupStoreResult>;
+  renameSessionGroup(input: {
+    id: SessionGroupId;
+    expectedVersion: number;
+    name: string;
+    updatedAt?: string;
+  }): Promise<SessionGroupStoreResult>;
+  updateSessionGroupMembership(input: {
+    id: SessionGroupId;
+    expectedVersion: number;
+    add?: SessionGroupMemberExpectation[];
+    remove?: SessionGroupMemberExpectation[];
+    updatedAt?: string;
+  }): Promise<SessionGroupStoreResult>;
+  reparentSessionGroup(input: {
+    id: SessionGroupId;
+    expectedVersion: number;
+    parentGroupId?: SessionGroupId;
+    updatedAt?: string;
+  }): Promise<SessionGroupStoreResult>;
+  deleteSessionGroup(input: {
+    id: SessionGroupId;
+    expectedVersion: number;
+    updatedAt?: string;
+  }): Promise<SessionGroupStoreResult>;
+  pruneSessionGroupMemberships(input: {
+    sessions: Array<{ id: string; projectId: string }>;
+    updatedAt?: string;
+  }): Promise<SessionGroupStoreResult>;
+}
+
+/**
+ * DRIVEN PORT
+ *
  * Maintains the current worktree metadata cache independently of repository adapters.
  */
 export interface WorktreeMetadataStore {
@@ -244,6 +293,7 @@ export type ObserverPersistenceBundle = CommandJournal &
   ObservationStore &
   ReconcileStore &
   SessionStore &
+  SessionGroupStore &
   WorktreeMetadataStore;
 
 /**

--- a/apps/observer/src/persistence/rows.ts
+++ b/apps/observer/src/persistence/rows.ts
@@ -1,7 +1,8 @@
-import type { StationCommand } from "@station/contracts";
+import type { SessionGroupView, StationCommand } from "@station/contracts";
 import {
   ErrorEnvelopeSchema,
   SafeErrorSchema,
+  SessionGroupViewSchema,
   StationCommandSchema,
   StationEventSchema,
 } from "@station/contracts";
@@ -81,6 +82,30 @@ export type SqliteSessionRow = {
   lifecycle: "open" | "ended" | null;
   last_seen_at: string;
 };
+
+export type SqliteSessionGroupRow = {
+  id: string;
+  project_id: string;
+  name: string;
+  parent_group_id: string | null;
+  version: number;
+  created_at: string;
+  updated_at: string;
+  session_ids_json: string;
+};
+
+export function sessionGroupFromRow(row: SqliteSessionGroupRow): SessionGroupView {
+  return SessionGroupViewSchema.parse({
+    id: row.id,
+    projectId: row.project_id,
+    name: row.name,
+    sessionIds: parseJson(row.session_ids_json),
+    ...(row.parent_group_id === null ? {} : { parentGroupId: row.parent_group_id }),
+    version: row.version,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  });
+}
 
 export function commandFromRow(row: SqliteCommandRow): PersistedCommand {
   const command = StationCommandSchema.parse(parseJson(row.payload_json));

--- a/apps/observer/src/persistence/sessionGroupSqlite.ts
+++ b/apps/observer/src/persistence/sessionGroupSqlite.ts
@@ -1,0 +1,87 @@
+import type { SessionGroupId, SessionGroupView } from "@station/contracts";
+import type { SqlDatabase } from "../sqlite/driver.js";
+import { type SqliteSessionGroupRow, sessionGroupFromRow } from "./rows.js";
+import type { SessionGroupPersistenceState } from "./sessionGroups.js";
+
+export function readSessionGroupState(database: SqlDatabase): SessionGroupPersistenceState {
+  const membershipRows = database
+    .prepare(
+      "SELECT session_id, group_id, project_id FROM session_group_memberships ORDER BY session_id",
+    )
+    .all() as Array<{ session_id: string; group_id: string; project_id: string }>;
+  const membershipsByGroup = new Map<string, string[]>();
+  const assignments = new Map<string, { groupId: SessionGroupId; projectId: string }>();
+  for (const row of membershipRows) {
+    assignments.set(row.session_id, { groupId: row.group_id, projectId: row.project_id });
+    const members = membershipsByGroup.get(row.group_id) ?? [];
+    members.push(row.session_id);
+    membershipsByGroup.set(row.group_id, members);
+  }
+  const rows = database
+    .prepare(
+      `SELECT id, project_id, name, parent_group_id, version, created_at, updated_at
+       FROM session_groups ORDER BY project_id, id`,
+    )
+    .all() as Array<Omit<SqliteSessionGroupRow, "session_ids_json">>;
+  const groups = new Map<SessionGroupId, SessionGroupView>();
+  for (const row of rows) {
+    const group = sessionGroupFromRow({
+      ...row,
+      session_ids_json: JSON.stringify(membershipsByGroup.get(row.id) ?? []),
+    });
+    groups.set(group.id, group);
+  }
+  if ([...assignments.values()].some((assignment) => !groups.has(assignment.groupId))) {
+    throw new Error("Session Group membership references a missing Group.");
+  }
+  return { groups, assignments };
+}
+
+export function writeSessionGroupState(
+  database: SqlDatabase,
+  before: SessionGroupPersistenceState,
+  after: SessionGroupPersistenceState,
+): void {
+  const deleteMembership = database.prepare(
+    "DELETE FROM session_group_memberships WHERE session_id = ?",
+  );
+  const insertMembership = database.prepare(
+    "INSERT INTO session_group_memberships (session_id, group_id, project_id) VALUES (?, ?, ?)",
+  );
+  for (const sessionId of new Set([...before.assignments.keys(), ...after.assignments.keys()])) {
+    const previous = before.assignments.get(sessionId);
+    const next = after.assignments.get(sessionId);
+    if (previous?.groupId === next?.groupId && previous?.projectId === next?.projectId) continue;
+    if (previous !== undefined) deleteMembership.run(sessionId);
+    if (next !== undefined) insertMembership.run(sessionId, next.groupId, next.projectId);
+  }
+
+  const deleteGroup = database.prepare("DELETE FROM session_groups WHERE id = ?");
+  for (const id of before.groups.keys()) {
+    if (!after.groups.has(id)) deleteGroup.run(id);
+  }
+  const upsertGroup = database.prepare(`
+    INSERT INTO session_groups
+      (id, project_id, name, parent_group_id, version, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET
+      project_id = excluded.project_id,
+      name = excluded.name,
+      parent_group_id = excluded.parent_group_id,
+      version = excluded.version,
+      created_at = excluded.created_at,
+      updated_at = excluded.updated_at
+  `);
+  for (const [id, group] of after.groups) {
+    if (JSON.stringify(before.groups.get(id)) === JSON.stringify(group)) continue;
+    upsertGroup.run(
+      group.id,
+      group.projectId,
+      group.name,
+      group.parentGroupId ?? null,
+      group.version,
+      group.createdAt,
+      group.updatedAt,
+    );
+  }
+}

--- a/apps/observer/src/persistence/sessionGroups.ts
+++ b/apps/observer/src/persistence/sessionGroups.ts
@@ -1,0 +1,312 @@
+import {
+  type SessionGroupId,
+  type SessionGroupView,
+  SessionGroupViewSchema,
+} from "@station/contracts";
+import type { SessionGroupMemberExpectation, SessionGroupStoreResult } from "./types.js";
+
+type Assignment = { groupId: SessionGroupId; projectId: string };
+
+export type SessionGroupPersistenceState = {
+  groups: Map<SessionGroupId, SessionGroupView>;
+  assignments: Map<string, Assignment>;
+};
+
+export type SessionGroupMutation = {
+  state: SessionGroupPersistenceState;
+  result: SessionGroupStoreResult;
+  changed: boolean;
+};
+
+type VersionedInput = { id: SessionGroupId; expectedVersion: number };
+
+export function emptySessionGroupState(): SessionGroupPersistenceState {
+  return { groups: new Map(), assignments: new Map() };
+}
+
+export function cloneSessionGroupState(
+  state: SessionGroupPersistenceState,
+): SessionGroupPersistenceState {
+  return {
+    groups: new Map([...state.groups].map(([id, group]) => [id, structuredClone(group)])),
+    assignments: new Map(
+      [...state.assignments].map(([sessionId, assignment]) => [sessionId, { ...assignment }]),
+    ),
+  };
+}
+
+export function listSessionGroups(state: SessionGroupPersistenceState): SessionGroupView[] {
+  const byProject = new Map<string, SessionGroupView[]>();
+  for (const group of state.groups.values()) {
+    const sessionIds = [...state.assignments]
+      .filter(([, assignment]) => assignment.groupId === group.id)
+      .map(([sessionId]) => sessionId)
+      .sort();
+    const canonical = SessionGroupViewSchema.parse({ ...group, sessionIds });
+    const projectGroups = byProject.get(group.projectId) ?? [];
+    projectGroups.push(canonical);
+    byProject.set(group.projectId, projectGroups);
+  }
+
+  const ordered: SessionGroupView[] = [];
+  for (const projectId of [...byProject.keys()].sort()) {
+    const projectGroups = byProject.get(projectId) ?? [];
+    const groupsById = new Map(projectGroups.map((group) => [group.id, group]));
+    const emitted = new Set<string>();
+    const emit = (group: SessionGroupView): void => {
+      if (emitted.has(group.id)) return;
+      const parent =
+        group.parentGroupId === undefined ? undefined : groupsById.get(group.parentGroupId);
+      if (parent !== undefined) emit(parent);
+      emitted.add(group.id);
+      ordered.push(structuredClone(group));
+    };
+    for (const group of projectGroups.sort((left, right) => left.id.localeCompare(right.id))) {
+      emit(group);
+    }
+  }
+  return ordered;
+}
+
+export function createSessionGroup(
+  state: SessionGroupPersistenceState,
+  input: {
+    id: SessionGroupId;
+    projectId: string;
+    name: string;
+    initialMembers?: SessionGroupMemberExpectation[];
+    parentGroupId?: SessionGroupId;
+    createdAt: string;
+  },
+): SessionGroupMutation {
+  if (state.groups.has(input.id)) return conflict(state, "already_exists");
+  const draft = cloneSessionGroupState(state);
+  validateUniqueExpectations(input.initialMembers ?? []);
+  if (input.parentGroupId !== undefined) {
+    const parent = draft.groups.get(input.parentGroupId);
+    if (parent === undefined) return conflict(state, "not_found");
+    if (parent.projectId !== input.projectId)
+      throw new Error("Group parent must share its project.");
+  }
+  for (const member of input.initialMembers ?? []) {
+    if (member.projectId !== input.projectId)
+      throw new Error("Group members must share its project.");
+    if (member.expectedGroupId !== null || draft.assignments.has(member.sessionId)) {
+      return conflict(state, "unexpected_assignment");
+    }
+  }
+  const group = SessionGroupViewSchema.parse({
+    id: input.id,
+    projectId: input.projectId,
+    name: input.name,
+    sessionIds: [],
+    ...(input.parentGroupId === undefined ? {} : { parentGroupId: input.parentGroupId }),
+    version: 1,
+    createdAt: input.createdAt,
+    updatedAt: input.createdAt,
+  });
+  draft.groups.set(group.id, group);
+  for (const member of input.initialMembers ?? []) {
+    draft.assignments.set(member.sessionId, { groupId: group.id, projectId: member.projectId });
+  }
+  return success(draft, [group.id], true);
+}
+
+export function renameSessionGroup(
+  state: SessionGroupPersistenceState,
+  input: VersionedInput & { name: string; updatedAt: string },
+): SessionGroupMutation {
+  const group = expectedGroup(state, input);
+  if (!group.ok) return group.mutation;
+  const name = input.name.trim();
+  SessionGroupViewSchema.parse({ ...group.value, name });
+  if (group.value.name === name) return success(state, [group.value.id], false);
+  const draft = cloneSessionGroupState(state);
+  draft.groups.set(
+    group.value.id,
+    SessionGroupViewSchema.parse({
+      ...group.value,
+      name,
+      version: group.value.version + 1,
+      updatedAt: input.updatedAt,
+    }),
+  );
+  return success(draft, [group.value.id], true);
+}
+
+export function updateSessionGroupMembership(
+  state: SessionGroupPersistenceState,
+  input: VersionedInput & {
+    add?: SessionGroupMemberExpectation[];
+    remove?: SessionGroupMemberExpectation[];
+    updatedAt: string;
+  },
+): SessionGroupMutation {
+  const target = expectedGroup(state, input);
+  if (!target.ok) return target.mutation;
+  const add = input.add ?? [];
+  const remove = input.remove ?? [];
+  validateUniqueExpectations([...add, ...remove]);
+  const draft = cloneSessionGroupState(state);
+  const touched = new Set<SessionGroupId>();
+
+  for (const member of [...add, ...remove]) {
+    const current = draft.assignments.get(member.sessionId)?.groupId ?? null;
+    if (current !== member.expectedGroupId) return conflict(state, "unexpected_assignment");
+    if (member.projectId !== target.value.projectId) {
+      throw new Error("Group members must share its project.");
+    }
+  }
+  for (const member of add) {
+    const current = draft.assignments.get(member.sessionId);
+    if (current?.groupId === target.value.id) continue;
+    if (current !== undefined) touched.add(current.groupId);
+    draft.assignments.set(member.sessionId, {
+      groupId: target.value.id,
+      projectId: member.projectId,
+    });
+    touched.add(target.value.id);
+  }
+  for (const member of remove) {
+    if (member.expectedGroupId !== target.value.id) {
+      throw new Error("Removed members must be expected in the target Group.");
+    }
+    draft.assignments.delete(member.sessionId);
+    touched.add(target.value.id);
+  }
+  touchGroups(draft, touched, input.updatedAt);
+  return success(draft, touched.size === 0 ? [target.value.id] : [...touched], touched.size > 0);
+}
+
+export function reparentSessionGroup(
+  state: SessionGroupPersistenceState,
+  input: VersionedInput & { parentGroupId?: SessionGroupId; updatedAt: string },
+): SessionGroupMutation {
+  const child = expectedGroup(state, input);
+  if (!child.ok) return child.mutation;
+  if (input.parentGroupId === child.value.parentGroupId) {
+    return success(state, [child.value.id], false);
+  }
+  if (input.parentGroupId === child.value.id) throw new Error("A Group cannot parent itself.");
+  if (input.parentGroupId !== undefined) {
+    const parent = state.groups.get(input.parentGroupId);
+    if (parent === undefined) return conflict(state, "not_found");
+    if (parent.projectId !== child.value.projectId) {
+      throw new Error("Group parent must share its project.");
+    }
+    let ancestor: SessionGroupView | undefined = parent;
+    while (ancestor !== undefined) {
+      if (ancestor.id === child.value.id) throw new Error("Group parents must not form a cycle.");
+      ancestor =
+        ancestor.parentGroupId === undefined ? undefined : state.groups.get(ancestor.parentGroupId);
+    }
+  }
+  const draft = cloneSessionGroupState(state);
+  const next = { ...child.value, version: child.value.version + 1, updatedAt: input.updatedAt };
+  if (input.parentGroupId === undefined) delete next.parentGroupId;
+  else next.parentGroupId = input.parentGroupId;
+  draft.groups.set(next.id, SessionGroupViewSchema.parse(next));
+  return success(draft, [next.id], true);
+}
+
+export function deleteSessionGroup(
+  state: SessionGroupPersistenceState,
+  input: VersionedInput & { updatedAt: string },
+): SessionGroupMutation {
+  const deleted = expectedGroup(state, input);
+  if (!deleted.ok) return deleted.mutation;
+  const draft = cloneSessionGroupState(state);
+  draft.groups.delete(deleted.value.id);
+  for (const [sessionId, assignment] of draft.assignments) {
+    if (assignment.groupId === deleted.value.id) draft.assignments.delete(sessionId);
+  }
+  const touched = new Set<SessionGroupId>();
+  for (const group of draft.groups.values()) {
+    if (group.parentGroupId !== deleted.value.id) continue;
+    const next = { ...group, version: group.version + 1, updatedAt: input.updatedAt };
+    if (deleted.value.parentGroupId === undefined) delete next.parentGroupId;
+    else next.parentGroupId = deleted.value.parentGroupId;
+    draft.groups.set(group.id, SessionGroupViewSchema.parse(next));
+    touched.add(group.id);
+  }
+  return success(draft, [...touched], true);
+}
+
+export function pruneSessionGroupMemberships(
+  state: SessionGroupPersistenceState,
+  input: { sessions: Array<{ id: string; projectId: string }>; updatedAt: string },
+): SessionGroupMutation {
+  const validSessions = new Map(input.sessions.map((session) => [session.id, session.projectId]));
+  const draft = cloneSessionGroupState(state);
+  const touched = new Set<SessionGroupId>();
+  for (const [sessionId, assignment] of draft.assignments) {
+    const group = draft.groups.get(assignment.groupId);
+    if (
+      group === undefined ||
+      validSessions.get(sessionId) !== group.projectId ||
+      assignment.projectId !== group.projectId
+    ) {
+      draft.assignments.delete(sessionId);
+      if (group !== undefined) touched.add(group.id);
+    }
+  }
+  touchGroups(draft, touched, input.updatedAt);
+  return success(draft, [...touched], touched.size > 0);
+}
+
+function expectedGroup(
+  state: SessionGroupPersistenceState,
+  input: VersionedInput,
+): { ok: true; value: SessionGroupView } | { ok: false; mutation: SessionGroupMutation } {
+  const group = state.groups.get(input.id);
+  if (group === undefined) return { ok: false, mutation: conflict(state, "not_found") };
+  if (group.version !== input.expectedVersion) {
+    return { ok: false, mutation: conflict(state, "stale_version") };
+  }
+  return { ok: true, value: group };
+}
+
+function touchGroups(
+  state: SessionGroupPersistenceState,
+  ids: ReadonlySet<SessionGroupId>,
+  updatedAt: string,
+): void {
+  for (const id of ids) {
+    const group = state.groups.get(id);
+    if (group === undefined)
+      throw new Error("Session Group assignment references a missing Group.");
+    state.groups.set(
+      id,
+      SessionGroupViewSchema.parse({ ...group, version: group.version + 1, updatedAt }),
+    );
+  }
+}
+
+function validateUniqueExpectations(expectations: SessionGroupMemberExpectation[]): void {
+  if (new Set(expectations.map((member) => member.sessionId)).size !== expectations.length) {
+    throw new Error("A membership update may mention each session only once.");
+  }
+}
+
+function success(
+  state: SessionGroupPersistenceState,
+  affectedIds: SessionGroupId[],
+  changed: boolean,
+): SessionGroupMutation {
+  const affected = new Set(affectedIds);
+  return {
+    state,
+    changed,
+    result: {
+      ok: true,
+      groups: listSessionGroups(state).filter((group) => affected.has(group.id)),
+    },
+  };
+}
+
+function conflict(
+  state: SessionGroupPersistenceState,
+  reason: Exclude<SessionGroupStoreResult, { ok: true }>["reason"],
+): SessionGroupMutation {
+  return { state, changed: false, result: { ok: false, reason } };
+}

--- a/apps/observer/src/persistence/sqliteAdapter.ts
+++ b/apps/observer/src/persistence/sqliteAdapter.ts
@@ -15,6 +15,8 @@ import {
 } from "./observations.js";
 import type { ObserverPersistenceBundle, PersistenceHealthSource } from "./ports.js";
 import { providerObservationRetentionDays } from "./retention.js";
+import * as sessionGroupSqlite from "./sessionGroupSqlite.js";
+import * as sessionGroupStore from "./sessionGroups.js";
 import * as sessionHarnessDerivedState from "./sessionHarnessDerivedState.js";
 import * as sessionHarnessExecutionStore from "./sessionHarnessExecutions.js";
 import * as sessionRecoveryHandleStore from "./sessionRecoveryHandles.js";
@@ -46,6 +48,19 @@ export function createSqliteObserverPersistence(
   const now = () => toIsoTimestamp(clock.now());
   const transaction = <T>(task: (database: SqlDatabase) => T): Promise<T> =>
     Effect.runPromise(runSqliteTransactionEffect(options.sqlite, task));
+  const sessionGroupMutation = (
+    mutate: (
+      state: sessionGroupStore.SessionGroupPersistenceState,
+    ) => sessionGroupStore.SessionGroupMutation,
+  ) =>
+    transaction((database) => {
+      const before = sessionGroupSqlite.readSessionGroupState(database);
+      const mutation = mutate(before);
+      if (mutation.changed) {
+        sessionGroupSqlite.writeSessionGroupState(database, before, mutation.state);
+      }
+      return mutation.result;
+    });
 
   return {
     health: () => options.sqlite.health(),
@@ -271,6 +286,59 @@ export function createSqliteObserverPersistence(
       }),
 
     listSessions: () => transaction(correlationStore.listSessions),
+
+    listSessionGroups: () =>
+      transaction((database) =>
+        sessionGroupStore.listSessionGroups(sessionGroupSqlite.readSessionGroupState(database)),
+      ),
+
+    createSessionGroup: (input) =>
+      sessionGroupMutation((state) =>
+        sessionGroupStore.createSessionGroup(state, {
+          ...input,
+          createdAt: input.createdAt ?? now(),
+        }),
+      ),
+
+    renameSessionGroup: (input) =>
+      sessionGroupMutation((state) =>
+        sessionGroupStore.renameSessionGroup(state, {
+          ...input,
+          updatedAt: input.updatedAt ?? now(),
+        }),
+      ),
+
+    updateSessionGroupMembership: (input) =>
+      sessionGroupMutation((state) =>
+        sessionGroupStore.updateSessionGroupMembership(state, {
+          ...input,
+          updatedAt: input.updatedAt ?? now(),
+        }),
+      ),
+
+    reparentSessionGroup: (input) =>
+      sessionGroupMutation((state) =>
+        sessionGroupStore.reparentSessionGroup(state, {
+          ...input,
+          updatedAt: input.updatedAt ?? now(),
+        }),
+      ),
+
+    deleteSessionGroup: (input) =>
+      sessionGroupMutation((state) =>
+        sessionGroupStore.deleteSessionGroup(state, {
+          ...input,
+          updatedAt: input.updatedAt ?? now(),
+        }),
+      ),
+
+    pruneSessionGroupMemberships: (input) =>
+      sessionGroupMutation((state) =>
+        sessionGroupStore.pruneSessionGroupMemberships(state, {
+          ...input,
+          updatedAt: input.updatedAt ?? now(),
+        }),
+      ),
 
     listWorktreeDisplayTitles: () =>
       transaction(worktreeDisplayTitleStore.listWorktreeDisplayTitles),

--- a/apps/observer/src/persistence/types.ts
+++ b/apps/observer/src/persistence/types.ts
@@ -10,6 +10,9 @@ import type {
   ProviderId,
   ProviderProjectConfig,
   SafeError,
+  SessionGroupId,
+  SessionGroupView,
+  SessionId,
   SessionRecoveryHandle,
   StationCommand,
   StationEvent,
@@ -19,6 +22,22 @@ import type {
   WorktreeObservation,
   WorktreePullRequest,
 } from "@station/contracts";
+
+export type SessionGroupMemberExpectation = {
+  sessionId: SessionId;
+  projectId: string;
+  expectedGroupId: SessionGroupId | null;
+};
+
+export type SessionGroupStoreConflictReason =
+  | "already_exists"
+  | "not_found"
+  | "stale_version"
+  | "unexpected_assignment";
+
+export type SessionGroupStoreResult =
+  | { ok: true; groups: SessionGroupView[] }
+  | { ok: false; reason: SessionGroupStoreConflictReason };
 
 export type PersistedCommandStatus = "accepted" | "started" | "succeeded" | "failed";
 

--- a/apps/observer/src/reconcile/graph.ts
+++ b/apps/observer/src/reconcile/graph.ts
@@ -228,6 +228,7 @@ export function buildStationSnapshot(input: ObserverGraphInput): StationSnapshot
     projects,
     rows: allRows,
     sessions,
+    sessionGroups: [],
     counts,
     alerts,
     ...(input.featureFlags === undefined ? {} : { featureFlags: input.featureFlags }),

--- a/apps/observer/test/integration/diagnostics-collector.test.ts
+++ b/apps/observer/test/integration/diagnostics-collector.test.ts
@@ -39,7 +39,7 @@ describe("observer diagnostics collector", () => {
       };
 
       await expect(collectDiagnosticSnapshot(deps)).resolves.toMatchObject({
-        schemaVersion: "0.9.0",
+        schemaVersion: "0.10.0",
         observerHealth: {
           stateDir: "memory://state",
           socketPath: "memory://observer-socket",

--- a/apps/observer/test/integration/sqlite-persistence-ports.test.ts
+++ b/apps/observer/test/integration/sqlite-persistence-ports.test.ts
@@ -24,6 +24,110 @@ observerPersistenceContract("SQLite", ({ clock, idFactory }) => {
 });
 
 describe("SQLite-only Observer persistence behavior", () => {
+  it("upgrades a version-16 database and preserves Groups across reopen", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "station-session-groups-v16-"));
+    const path = join(directory, "observer.sqlite");
+    const legacyDatabase = openSqlDatabase(path);
+    try {
+      for (const migration of migrations.filter(({ version }) => version <= 16)) {
+        legacyDatabase.exec(migration.sql);
+        legacyDatabase
+          .prepare("INSERT INTO observer_migrations (version, name, applied_at) VALUES (?, ?, ?)")
+          .run(migration.version, migration.name, now);
+      }
+      legacyDatabase
+        .prepare(
+          "INSERT OR REPLACE INTO observer_meta (key, value) VALUES ('schema_version', '16')",
+        )
+        .run();
+    } finally {
+      legacyDatabase.close();
+    }
+
+    const upgraded = openObserverSqlite({ path, clock: { now: () => new Date(now) } });
+    try {
+      expect(upgraded.health().schemaVersion).toBe(17);
+      const persistence = createSqliteObserverPersistence({ sqlite: upgraded });
+      await persistence.createSessionGroup({
+        id: "group_durable",
+        projectId: "web",
+        name: "Durable",
+        initialMembers: [{ sessionId: "ses_durable", projectId: "web", expectedGroupId: null }],
+        createdAt: now,
+      });
+    } finally {
+      upgraded.close();
+    }
+
+    const reopened = openObserverSqlite({ path });
+    try {
+      const persistence = createSqliteObserverPersistence({ sqlite: reopened });
+      await expect(persistence.listSessionGroups()).resolves.toEqual([
+        expect.objectContaining({
+          id: "group_durable",
+          sessionIds: ["ses_durable"],
+          version: 1,
+        }),
+      ]);
+    } finally {
+      reopened.close();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("rolls back a trigger-rejected membership reassignment", async () => {
+    const sqlite = openObserverSqlite();
+    try {
+      const persistence = createSqliteObserverPersistence({ sqlite });
+      await persistence.createSessionGroup({
+        id: "group_source",
+        projectId: "web",
+        name: "Source",
+        initialMembers: [{ sessionId: "ses_atomic", projectId: "web", expectedGroupId: null }],
+        createdAt: now,
+      });
+      await persistence.createSessionGroup({
+        id: "group_target",
+        projectId: "web",
+        name: "Target",
+        createdAt: now,
+      });
+      sqlite.database.exec(`
+        CREATE TRIGGER reject_group_target_membership
+        BEFORE INSERT ON session_group_memberships
+        WHEN NEW.group_id = 'group_target'
+        BEGIN
+          SELECT RAISE(ABORT, 'forced Group membership failure');
+        END;
+      `);
+
+      await expect(
+        persistence.updateSessionGroupMembership({
+          id: "group_target",
+          expectedVersion: 1,
+          add: [
+            {
+              sessionId: "ses_atomic",
+              projectId: "web",
+              expectedGroupId: "group_source",
+            },
+          ],
+          updatedAt: "2026-05-20T12:01:00.000Z",
+        }),
+      ).rejects.toBeDefined();
+      await expect(persistence.listSessionGroups()).resolves.toEqual([
+        expect.objectContaining({
+          id: "group_source",
+          sessionIds: ["ses_atomic"],
+          version: 1,
+        }),
+        expect.objectContaining({ id: "group_target", sessionIds: [], version: 1 }),
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
   it("migrates historical session lifecycle without treating legacy NULL as open", async () => {
     const directory = await mkdtemp(join(tmpdir(), "station-session-lifecycle-"));
     const path = join(directory, "observer.sqlite");
@@ -372,6 +476,7 @@ describe("SQLite-only Observer persistence behavior", () => {
         [14, "native_binding_ingress_claims"],
         [15, "drop_recovery_breadcrumbs"],
         [16, "worktree_display_titles"],
+        [17, "session_groups"],
       ]);
       await expect(persistence.listSessions()).resolves.toEqual([
         expect.objectContaining({
@@ -395,7 +500,7 @@ describe("SQLite-only Observer persistence behavior", () => {
     }
   });
 
-  it("exposes healthy SQLite status in addition to the seven application ports", () => {
+  it("exposes healthy SQLite status in addition to the eight application ports", () => {
     const sqlite = openObserverSqlite({ clock: { now: () => new Date(now) } });
     try {
       const persistence = createSqliteObserverPersistence({

--- a/apps/observer/test/support/inMemoryObserverPersistence.ts
+++ b/apps/observer/test/support/inMemoryObserverPersistence.ts
@@ -44,6 +44,7 @@ import {
   providerObservationExpiresAt,
   providerObservationRetentionDays,
 } from "../../src/persistence/retention.js";
+import * as sessionGroupStore from "../../src/persistence/sessionGroups.js";
 import {
   sessionHarnessExecutionEqual,
   sessionTurnReadinessEqual,
@@ -104,6 +105,7 @@ type InMemoryObserverPersistenceState = {
   terminalTargets: Map<string, TerminalTargetObservation>;
   harnessRuns: Map<string, HarnessRunObservation>;
   sessions: Map<string, PersistedSession>;
+  sessionGroups: sessionGroupStore.SessionGroupPersistenceState;
   worktreeDisplayTitles: Map<string, PersistedWorktreeDisplayTitle>;
   sessionHarnessExecutions: Map<string, PersistedSessionHarnessExecution>;
   recoveryHandles: Map<string, SessionRecoveryHandle>;
@@ -594,6 +596,75 @@ export function createInMemoryObserverPersistence(
     deleteSessionTurnReadiness: (input) =>
       transaction((draft) => deleteSessionTurnReadiness(draft, input)),
 
+    listSessionGroups: () =>
+      transaction((draft) => sessionGroupStore.listSessionGroups(draft.sessionGroups)),
+
+    createSessionGroup: (input) =>
+      transaction((draft) =>
+        applySessionGroupMutation(
+          draft,
+          sessionGroupStore.createSessionGroup(draft.sessionGroups, {
+            ...input,
+            createdAt: input.createdAt ?? now(),
+          }),
+        ),
+      ),
+
+    renameSessionGroup: (input) =>
+      transaction((draft) =>
+        applySessionGroupMutation(
+          draft,
+          sessionGroupStore.renameSessionGroup(draft.sessionGroups, {
+            ...input,
+            updatedAt: input.updatedAt ?? now(),
+          }),
+        ),
+      ),
+
+    updateSessionGroupMembership: (input) =>
+      transaction((draft) =>
+        applySessionGroupMutation(
+          draft,
+          sessionGroupStore.updateSessionGroupMembership(draft.sessionGroups, {
+            ...input,
+            updatedAt: input.updatedAt ?? now(),
+          }),
+        ),
+      ),
+
+    reparentSessionGroup: (input) =>
+      transaction((draft) =>
+        applySessionGroupMutation(
+          draft,
+          sessionGroupStore.reparentSessionGroup(draft.sessionGroups, {
+            ...input,
+            updatedAt: input.updatedAt ?? now(),
+          }),
+        ),
+      ),
+
+    deleteSessionGroup: (input) =>
+      transaction((draft) =>
+        applySessionGroupMutation(
+          draft,
+          sessionGroupStore.deleteSessionGroup(draft.sessionGroups, {
+            ...input,
+            updatedAt: input.updatedAt ?? now(),
+          }),
+        ),
+      ),
+
+    pruneSessionGroupMemberships: (input) =>
+      transaction((draft) =>
+        applySessionGroupMutation(
+          draft,
+          sessionGroupStore.pruneSessionGroupMemberships(draft.sessionGroups, {
+            ...input,
+            updatedAt: input.updatedAt ?? now(),
+          }),
+        ),
+      ),
+
     upsertWorktreeMetadataCurrent: (input) =>
       transaction((draft) => {
         const updatedAt = input.updatedAt ?? now();
@@ -652,12 +723,21 @@ function emptyState(): InMemoryObserverPersistenceState {
     terminalTargets: new Map(),
     harnessRuns: new Map(),
     sessions: new Map(),
+    sessionGroups: sessionGroupStore.emptySessionGroupState(),
     worktreeDisplayTitles: new Map(),
     sessionHarnessExecutions: new Map(),
     recoveryHandles: new Map(),
     turnReadiness: new Map(),
     worktreeMetadata: new Map(),
   };
+}
+
+function applySessionGroupMutation(
+  state: InMemoryObserverPersistenceState,
+  mutation: sessionGroupStore.SessionGroupMutation,
+) {
+  state.sessionGroups = mutation.state;
+  return mutation.result;
 }
 
 function worktreeDisplayTitleKey(projectId: string, worktreeId: string): string {

--- a/apps/observer/test/support/observerPersistenceContract.ts
+++ b/apps/observer/test/support/observerPersistenceContract.ts
@@ -2197,6 +2197,229 @@ export function observerPersistenceContract(
       });
     });
 
+    describe("SessionGroupStore", () => {
+      it("persists empty Groups and assigns initial members with detached deterministic results", async () => {
+        await withPersistence(createFixture, async ({ persistence }) => {
+          await expect(persistence.listSessionGroups()).resolves.toEqual([]);
+          const created = await persistence.createSessionGroup({
+            id: "group_b",
+            projectId: "web",
+            name: "  Backend  ",
+            initialMembers: [
+              { sessionId: "ses_b", projectId: "web", expectedGroupId: null },
+              { sessionId: "ses_a", projectId: "web", expectedGroupId: null },
+            ],
+            createdAt: now,
+          });
+          expect(created).toEqual({
+            ok: true,
+            groups: [
+              {
+                id: "group_b",
+                projectId: "web",
+                name: "Backend",
+                sessionIds: ["ses_a", "ses_b"],
+                version: 1,
+                createdAt: now,
+                updatedAt: now,
+              },
+            ],
+          });
+          if (created.ok) created.groups[0]?.sessionIds.push("detached");
+          await persistence.createSessionGroup({
+            id: "group_a",
+            projectId: "web",
+            name: "Frontend",
+            createdAt: earlier,
+          });
+          expect((await persistence.listSessionGroups()).map((group) => group.id)).toEqual([
+            "group_a",
+            "group_b",
+          ]);
+          expect((await persistence.listSessionGroups())[1]?.sessionIds).toEqual([
+            "ses_a",
+            "ses_b",
+          ]);
+        });
+      });
+
+      it("atomically reassigns and ungroups members with stale and no-op protection", async () => {
+        await withPersistence(createFixture, async ({ persistence }) => {
+          await persistence.createSessionGroup({
+            id: "group_source",
+            projectId: "web",
+            name: "Source",
+            initialMembers: [{ sessionId: "ses_move", projectId: "web", expectedGroupId: null }],
+            createdAt: earlier,
+          });
+          await persistence.createSessionGroup({
+            id: "group_target",
+            projectId: "web",
+            name: "Target",
+            createdAt: earlier,
+          });
+          const moved = await persistence.updateSessionGroupMembership({
+            id: "group_target",
+            expectedVersion: 1,
+            add: [
+              {
+                sessionId: "ses_move",
+                projectId: "web",
+                expectedGroupId: "group_source",
+              },
+            ],
+            updatedAt: now,
+          });
+          expect(moved).toEqual({
+            ok: true,
+            groups: [
+              expect.objectContaining({ id: "group_source", version: 2, sessionIds: [] }),
+              expect.objectContaining({
+                id: "group_target",
+                version: 2,
+                sessionIds: ["ses_move"],
+              }),
+            ],
+          });
+          await expect(
+            persistence.updateSessionGroupMembership({
+              id: "group_target",
+              expectedVersion: 1,
+              remove: [
+                {
+                  sessionId: "ses_move",
+                  projectId: "web",
+                  expectedGroupId: "group_target",
+                },
+              ],
+            }),
+          ).resolves.toEqual({ ok: false, reason: "stale_version" });
+          await expect(
+            persistence.updateSessionGroupMembership({
+              id: "group_target",
+              expectedVersion: 2,
+              add: [
+                {
+                  sessionId: "ses_move",
+                  projectId: "web",
+                  expectedGroupId: "group_target",
+                },
+              ],
+            }),
+          ).resolves.toEqual({
+            ok: true,
+            groups: [expect.objectContaining({ id: "group_target", version: 2 })],
+          });
+          await expect(
+            persistence.updateSessionGroupMembership({
+              id: "group_target",
+              expectedVersion: 2,
+              remove: [
+                {
+                  sessionId: "ses_move",
+                  projectId: "web",
+                  expectedGroupId: "group_source",
+                },
+              ],
+            }),
+          ).resolves.toEqual({ ok: false, reason: "unexpected_assignment" });
+          await expect((await persistence.listSessionGroups())[1]).toMatchObject({
+            id: "group_target",
+            version: 2,
+            sessionIds: ["ses_move"],
+          });
+        });
+      });
+
+      it("validates parentage and reparents children when deleting a Group", async () => {
+        await withPersistence(createFixture, async ({ persistence }) => {
+          await persistence.createSessionGroup({
+            id: "group_root",
+            projectId: "web",
+            name: "Root",
+            createdAt: earlier,
+          });
+          await persistence.createSessionGroup({
+            id: "group_parent",
+            projectId: "web",
+            name: "Parent",
+            parentGroupId: "group_root",
+            createdAt: earlier,
+          });
+          await persistence.createSessionGroup({
+            id: "group_child",
+            projectId: "web",
+            name: "Child",
+            parentGroupId: "group_parent",
+            createdAt: earlier,
+          });
+          await expectPersistenceFailure(
+            persistence.reparentSessionGroup({
+              id: "group_root",
+              expectedVersion: 1,
+              parentGroupId: "group_child",
+            }),
+          );
+          await expect(
+            persistence.reparentSessionGroup({
+              id: "group_child",
+              expectedVersion: 1,
+              parentGroupId: "missing",
+            }),
+          ).resolves.toEqual({ ok: false, reason: "not_found" });
+          const deleted = await persistence.deleteSessionGroup({
+            id: "group_parent",
+            expectedVersion: 1,
+            updatedAt: now,
+          });
+          expect(deleted).toEqual({
+            ok: true,
+            groups: [
+              expect.objectContaining({
+                id: "group_child",
+                parentGroupId: "group_root",
+                version: 2,
+              }),
+            ],
+          });
+          expect((await persistence.listSessionGroups()).map((group) => group.id)).toEqual([
+            "group_root",
+            "group_child",
+          ]);
+        });
+      });
+
+      it("prunes invalid memberships while preserving empty definitions", async () => {
+        await withPersistence(createFixture, async ({ persistence }) => {
+          await persistence.createSessionGroup({
+            id: "group_prune",
+            projectId: "web",
+            name: "Prune",
+            initialMembers: [
+              { sessionId: "ses_keep", projectId: "web", expectedGroupId: null },
+              { sessionId: "ses_missing", projectId: "web", expectedGroupId: null },
+            ],
+            createdAt: earlier,
+          });
+          await expect(
+            persistence.pruneSessionGroupMemberships({
+              sessions: [{ id: "ses_keep", projectId: "other" }],
+              updatedAt: now,
+            }),
+          ).resolves.toEqual({
+            ok: true,
+            groups: [expect.objectContaining({ id: "group_prune", sessionIds: [], version: 2 })],
+          });
+          await expect(
+            persistence.pruneSessionGroupMemberships({ sessions: [], updatedAt: later }),
+          ).resolves.toEqual({ ok: true, groups: [] });
+          await expect(persistence.listSessionGroups()).resolves.toEqual([
+            expect.objectContaining({ id: "group_prune", sessionIds: [], version: 2 }),
+          ]);
+        });
+      });
+    });
+
     describe("WorktreeMetadataStore", () => {
       it("replaces rows, filters and orders kinds, marks expiry, and preserves stale errors", async () => {
         await withPersistence(createFixture, async ({ persistence }) => {

--- a/apps/observer/test/support/testObserver.ts
+++ b/apps/observer/test/support/testObserver.ts
@@ -40,6 +40,7 @@ export function emptyStationSnapshot(generatedAt: string): StationSnapshot {
     projects: [],
     rows: [],
     sessions: [],
+    sessionGroups: [],
     counts: {
       projects: 0,
       sessions: 0,

--- a/apps/observer/test/unit/observerEventHooks.test.ts
+++ b/apps/observer/test/unit/observerEventHooks.test.ts
@@ -197,6 +197,7 @@ function snapshot(rows: StationSnapshot["rows"]): StationSnapshot {
     projects: [],
     rows,
     sessions: [],
+    sessionGroups: [],
     counts: {
       projects: 0,
       sessions: 0,

--- a/apps/observer/test/unit/observerHandoff.test.ts
+++ b/apps/observer/test/unit/observerHandoff.test.ts
@@ -211,7 +211,7 @@ describe("negotiateObserverIncumbent", () => {
       fixture.listening = false;
       fixture.startToken = undefined;
       return {
-        schemaVersion: "0.9.0" as const,
+        schemaVersion: "0.10.0" as const,
         stopped: true,
         at: "2026-07-12T12:00:00.000Z",
       };
@@ -339,7 +339,7 @@ describe("negotiateObserverIncumbent", () => {
     fixture.stop.mockImplementation(async () => {
       fixture.listening = false;
       return {
-        schemaVersion: "0.9.0" as const,
+        schemaVersion: "0.10.0" as const,
         stopped: true,
         at: "2026-07-12T12:00:00.000Z",
       };
@@ -358,7 +358,7 @@ describe("negotiateObserverIncumbent", () => {
     fixture.stop.mockImplementation(async () => {
       fixture.startToken = undefined;
       return {
-        schemaVersion: "0.9.0" as const,
+        schemaVersion: "0.10.0" as const,
         stopped: true,
         at: "2026-07-12T12:00:00.000Z",
       };
@@ -391,7 +391,7 @@ describe("negotiateObserverIncumbent", () => {
         throw new Error("successor process evidence is unavailable");
       };
       return {
-        schemaVersion: "0.9.0" as const,
+        schemaVersion: "0.10.0" as const,
         stopped: true,
         at: "2026-07-12T12:00:00.000Z",
       };
@@ -408,7 +408,7 @@ describe("negotiateObserverIncumbent", () => {
       fixture.listening = false;
       fixture.startToken = undefined;
       return {
-        schemaVersion: "0.9.0" as const,
+        schemaVersion: "0.10.0" as const,
         stopped: true,
         at: "2026-07-12T12:00:00.000Z",
       };
@@ -450,7 +450,7 @@ function observerBuildVersion(version: string, buildIdentity: string): string {
 
 function handoffFixture() {
   const incumbentHealth: ObserverHealth = {
-    schemaVersion: "0.9.0",
+    schemaVersion: "0.10.0",
     status: "healthy",
     pid: 100,
     startedAt: "2026-07-12T11:00:00.000Z",
@@ -472,7 +472,7 @@ function handoffFixture() {
     incumbentHealth,
     health: vi.fn(async (_socketPath: string, _request: { timeoutMs: number }) => incumbentHealth),
     stop: vi.fn(async (_socketPath: string, _request: { timeoutMs: number }) => ({
-      schemaVersion: "0.9.0" as const,
+      schemaVersion: "0.10.0" as const,
       stopped: true,
       at: "2026-07-12T12:00:00.000Z",
     })),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,9 +56,10 @@ No single layer owns all truth.
 - Harness providers are authoritative for agent launch, discovery, event ingestion, status signals, and provider-native recovery artifacts they can prove.
 - A sealed session-rescue archive becomes temporary cutover authority only after the exact source sessions have stopped and every recovery-critical asset has been captured and hashed; a live-source archive remains evidence, not launch authority.
 - Repository providers are authoritative only for code-host metadata they fetch or cache through their integration boundary.
-- Observer SQLite is durable observer memory for commands, events, correlations, explicit Station-session lifecycle, canonical worktree display titles keyed by project and worktree, provider observations, and current metadata cache rows.
+- Observer SQLite is durable observer memory for commands, events, correlations, explicit Station-session lifecycle, project-local Session Group definitions and exclusive membership, canonical worktree display titles keyed by project and worktree, provider observations, and current metadata cache rows.
 - Observer snapshots are the normalized current graph exposed to clients. `rows` is configured
-  worktree inventory; `sessions` is canonical session membership. `WorktreeRow.title` is the
+  worktree inventory; `sessions` is canonical session membership; and `sessionGroups` is the
+  normalized project-local organizational projection. `WorktreeRow.title` is the
   display authority, while `SessionView.title` is its lifecycle projection. Session and activity
   counts derive from `sessions`, while worktree counts derive from `rows`.
 - JSONL logs and debug bundles are diagnostic evidence, not runtime truth.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -263,6 +263,11 @@ Nested project tables:
 | `[projects.env]` | any key | string | Extra env for project launches; local overlays cannot set it. |
 | `[projects.display]` | `group` | string | Optional grouping label. |
 | `[projects.display]` | `sort_order` | int | Optional sort order. |
+
+`[projects.display].group` is a static label for organizing whole projects. It is unrelated to
+dynamic Session Groups, which are Observer-owned state stored in SQLite and projected through
+`StationSnapshot.sessionGroups`. Session Groups are not configured under `[workspace]`, `[tui]`,
+the runtime `config.toml`, or project-local `.station/config.toml`.
 | `[projects.worktrunk]` | `enabled` | bool | Defaults to `true` when omitted. |
 | `[projects.worktrunk]` | `base` | string | Overrides `[worktree.worktrunk].base` for this project. |
 | `[projects.worktrunk]` | `managed_root` | string | Per-project authoritative managed root; relative paths resolve against `project.root`. If omitted and global `managed_root` is set, STATION derives a unique project child directory. |

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -5191,6 +5191,30 @@
           "purpose": null
         },
         {
+          "name": "SessionGroupMemberExpectation",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "SessionGroupStore",
+          "kind": "interface",
+          "role": "DRIVEN PORT",
+          "purpose": "Maintains durable project-local Group definitions, exclusive membership, and parentage through atomic stale-write-safe conversations."
+        },
+        {
+          "name": "SessionGroupStoreConflictReason",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "SessionGroupStoreResult",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
           "name": "SessionHarnessDerivedStateRepair",
           "kind": "type",
           "role": null,
@@ -6480,6 +6504,25 @@
       ]
     },
     {
+      "path": "apps/observer/src/migrations/017_session_groups.ts",
+      "exports": [
+        {
+          "name": "sessionGroupsMigration",
+          "kind": "const",
+          "role": null,
+          "purpose": null
+        }
+      ],
+      "imports": [
+        {
+          "specifier": "./migration.js",
+          "resolvedPath": "apps/observer/src/migrations/migration.ts",
+          "edgeKind": "type-only",
+          "bindings": ["ObserverSqliteMigration"]
+        }
+      ]
+    },
+    {
       "path": "apps/observer/src/migrations/index.ts",
       "exports": [
         {
@@ -6597,6 +6640,12 @@
           "resolvedPath": "apps/observer/src/migrations/016_worktree_display_titles.ts",
           "edgeKind": "runtime",
           "bindings": ["worktreeDisplayTitlesMigration"]
+        },
+        {
+          "specifier": "./017_session_groups.js",
+          "resolvedPath": "apps/observer/src/migrations/017_session_groups.ts",
+          "edgeKind": "runtime",
+          "bindings": ["sessionGroupsMigration"]
         },
         {
           "specifier": "./migration.js",
@@ -7195,6 +7244,30 @@
           "purpose": null
         },
         {
+          "name": "SessionGroupMemberExpectation",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "SessionGroupStore",
+          "kind": "interface",
+          "role": "DRIVEN PORT",
+          "purpose": "Maintains durable project-local Group definitions, exclusive membership, and parentage through atomic stale-write-safe conversations."
+        },
+        {
+          "name": "SessionGroupStoreConflictReason",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "SessionGroupStoreResult",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
           "name": "SessionHarnessDerivedStateRepair",
           "kind": "type",
           "role": null,
@@ -7511,6 +7584,12 @@
           "purpose": "Persists the Observer's correlated reconcile projection as one atomic capability. Missing canonical worktree titles initialize insert-only before session projections synchronize."
         },
         {
+          "name": "SessionGroupStore",
+          "kind": "interface",
+          "role": "DRIVEN PORT",
+          "purpose": "Maintains durable project-local Group definitions, exclusive membership, and parentage through atomic stale-write-safe conversations."
+        },
+        {
           "name": "SessionStore",
           "kind": "interface",
           "role": "DRIVEN PORT",
@@ -7549,6 +7628,8 @@
             "ProviderObservationKind",
             "ProviderObservationsIngressDedupeResult",
             "RecordProviderObservationInput",
+            "SessionGroupMemberExpectation",
+            "SessionGroupStoreResult",
             "SessionHarnessDerivedStateRepair",
             "SessionTurnReadinessMutation",
             "WorktreeMetadataCurrentKind",
@@ -7565,6 +7646,8 @@
             "ObserverHealth",
             "ProviderId",
             "SafeError",
+            "SessionGroupId",
+            "SessionGroupView",
             "SessionRecoveryHandle",
             "StationCommand",
             "StationEvent"
@@ -7674,6 +7757,12 @@
           "purpose": null
         },
         {
+          "name": "sessionGroupFromRow",
+          "kind": "function",
+          "role": null,
+          "purpose": null
+        },
+        {
           "name": "SqliteCommandErrorRow",
           "kind": "type",
           "role": null,
@@ -7693,6 +7782,12 @@
         },
         {
           "name": "SqliteProviderObservationRow",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "SqliteSessionGroupRow",
           "kind": "type",
           "role": null,
           "purpose": null
@@ -7751,6 +7846,7 @@
           "bindings": [
             "ErrorEnvelopeSchema",
             "SafeErrorSchema",
+            "SessionGroupViewSchema",
             "StationCommandSchema",
             "StationEventSchema"
           ]
@@ -7759,7 +7855,147 @@
           "specifier": "@station/contracts",
           "resolvedPath": "packages/contracts/src/index.ts",
           "edgeKind": "type-only",
-          "bindings": ["StationCommand"]
+          "bindings": ["SessionGroupView", "StationCommand"]
+        }
+      ]
+    },
+    {
+      "path": "apps/observer/src/persistence/sessionGroups.ts",
+      "exports": [
+        {
+          "name": "cloneSessionGroupState",
+          "kind": "function",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "createSessionGroup",
+          "kind": "function",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "deleteSessionGroup",
+          "kind": "function",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "emptySessionGroupState",
+          "kind": "function",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "listSessionGroups",
+          "kind": "function",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "pruneSessionGroupMemberships",
+          "kind": "function",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "renameSessionGroup",
+          "kind": "function",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "reparentSessionGroup",
+          "kind": "function",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "SessionGroupMutation",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "SessionGroupPersistenceState",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "updateSessionGroupMembership",
+          "kind": "function",
+          "role": null,
+          "purpose": null
+        }
+      ],
+      "imports": [
+        {
+          "specifier": "./types.js",
+          "resolvedPath": "apps/observer/src/persistence/types.ts",
+          "edgeKind": "type-only",
+          "bindings": ["SessionGroupMemberExpectation", "SessionGroupStoreResult"]
+        },
+        {
+          "specifier": "@station/contracts",
+          "resolvedPath": "packages/contracts/src/index.ts",
+          "edgeKind": "runtime",
+          "bindings": ["SessionGroupViewSchema"]
+        },
+        {
+          "specifier": "@station/contracts",
+          "resolvedPath": "packages/contracts/src/index.ts",
+          "edgeKind": "type-only",
+          "bindings": ["SessionGroupId", "SessionGroupView"]
+        }
+      ]
+    },
+    {
+      "path": "apps/observer/src/persistence/sessionGroupSqlite.ts",
+      "exports": [
+        {
+          "name": "readSessionGroupState",
+          "kind": "function",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "writeSessionGroupState",
+          "kind": "function",
+          "role": null,
+          "purpose": null
+        }
+      ],
+      "imports": [
+        {
+          "specifier": "./rows.js",
+          "resolvedPath": "apps/observer/src/persistence/rows.ts",
+          "edgeKind": "runtime",
+          "bindings": ["sessionGroupFromRow"]
+        },
+        {
+          "specifier": "./rows.js",
+          "resolvedPath": "apps/observer/src/persistence/rows.ts",
+          "edgeKind": "type-only",
+          "bindings": ["SqliteSessionGroupRow"]
+        },
+        {
+          "specifier": "./sessionGroups.js",
+          "resolvedPath": "apps/observer/src/persistence/sessionGroups.ts",
+          "edgeKind": "type-only",
+          "bindings": ["SessionGroupPersistenceState"]
+        },
+        {
+          "specifier": "../sqlite/driver.js",
+          "resolvedPath": "apps/observer/src/sqlite/driver.ts",
+          "edgeKind": "type-only",
+          "bindings": ["SqlDatabase"]
+        },
+        {
+          "specifier": "@station/contracts",
+          "resolvedPath": "packages/contracts/src/index.ts",
+          "edgeKind": "type-only",
+          "bindings": ["SessionGroupId", "SessionGroupView"]
         }
       ]
     },
@@ -8020,6 +8256,18 @@
           "resolvedPath": "apps/observer/src/persistence/retention.ts",
           "edgeKind": "runtime",
           "bindings": ["providerObservationRetentionDays"]
+        },
+        {
+          "specifier": "./sessionGroups.js",
+          "resolvedPath": "apps/observer/src/persistence/sessionGroups.ts",
+          "edgeKind": "runtime",
+          "bindings": ["* as sessionGroupStore"]
+        },
+        {
+          "specifier": "./sessionGroupSqlite.js",
+          "resolvedPath": "apps/observer/src/persistence/sessionGroupSqlite.ts",
+          "edgeKind": "runtime",
+          "bindings": ["* as sessionGroupSqlite"]
         },
         {
           "specifier": "./sessionHarnessDerivedState.js",
@@ -8290,6 +8538,24 @@
           "purpose": null
         },
         {
+          "name": "SessionGroupMemberExpectation",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "SessionGroupStoreConflictReason",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "SessionGroupStoreResult",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
           "name": "SessionHarnessDerivedStateRepair",
           "kind": "type",
           "role": null,
@@ -8337,6 +8603,9 @@
             "ProviderId",
             "ProviderProjectConfig",
             "SafeError",
+            "SessionGroupId",
+            "SessionGroupView",
+            "SessionId",
             "SessionRecoveryHandle",
             "StationCommand",
             "StationEvent",
@@ -12911,6 +13180,14 @@
       "kind": "interface",
       "role": "DRIVEN PORT",
       "purpose": "Persists the Observer's correlated reconcile projection as one atomic capability. Missing canonical worktree titles initialize insert-only before session projections synchronize.",
+      "dependencies": []
+    },
+    {
+      "path": "apps/observer/src/persistence/ports.ts",
+      "declaration": "SessionGroupStore",
+      "kind": "interface",
+      "role": "DRIVEN PORT",
+      "purpose": "Maintains durable project-local Group definitions, exclusive membership, and parentage through atomic stale-write-safe conversations.",
       "dependencies": []
     },
     {

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -192,7 +192,7 @@ ownership even where current ownership is still a deviation.
 | Managed terminal lifecycle | Driven | `ManagedTerminalLifecycle` | Station terminal adapter, optionally backed by Station Host | Explicit injected role returning only an opaque target identity and declaring whether launched processes persist beyond the caller; Host backing may add spawn/list/close/attachment lifecycle, while Station retains native presentation and host-backed targets remain externally non-focusable. |
 | Harness operations | Driven | `HarnessProvider`, `SessionRecoveryArtifactLocator` | Claude, Codex, Cursor, OpenCode, Pi, scripted, and test adapters | Strong purpose-owned ports with provider-local parsing, compatibility admission, and exact recovery-artifact location; unsupported artifact providers make migration ineligible. |
 | Repository metadata | Driven | `RepositoryProvider` | GitHub and test repository adapters | Adapters declare deterministic remote support; provider-neutral metadata policy selects zero or one match and rejects overlaps. |
-| Durable observer memory | Driven | `CommandJournal`, `EventJournal`, `IngressJournal`, `ObservationStore`, `ReconcileStore`, `SessionStore`, `WorktreeMetadataStore` | Production SQLite adapter and test-only in-memory adapter | Observer-private, application-purpose ports separate current conversations from storage representation. Consumers receive only the named ports they use; the unmarked `ObserverPersistenceBundle` intersection exists only at adapter and composition seams. |
+| Durable observer memory | Driven | `CommandJournal`, `EventJournal`, `IngressJournal`, `ObservationStore`, `ReconcileStore`, `SessionStore`, `SessionGroupStore`, `WorktreeMetadataStore` | Production SQLite adapter and test-only in-memory adapter | Observer-private, application-purpose ports separate current conversations from storage representation. Consumers receive only the named ports they use; the unmarked `ObserverPersistenceBundle` intersection exists only at adapter and composition seams. |
 | Persistence health | Driven | `PersistenceHealthSource` | SQLite adapter created by `createSqliteObserverPersistence` | Runtime health and diagnostics read the public SQLite health projection without receiving the concrete database handle. |
 | Logging and config mutation | Driven | `StationLogger` and `ProjectConfigWriter` | `runtime/logging.ts` JSONL adapter and `runtime/projectConfigWriter.ts` config adapter | Conforming ports expose only operational logging and the three project mutations; paths and representations remain adapter-owned. |
 | Worktree metadata evidence | Driven | `WorktreeChangeSource` and `WorktreeMetadataInvalidationSource` | local Git reader and ref-watcher adapters | Conforming path-free roles: one reads typed checkout-local change evidence; the other owns full-set watcher replacement and terminal shutdown. |
@@ -224,7 +224,7 @@ areas contain the following responsibilities:
 | `runtime/logging.ts`, `runtime/projectConfigWriter.ts` | Redacted JSONL writes and `@station/config` project mutation translation | Outbound adapters retaining log, config, and home paths at composition. |
 | `providers/` | provider aggregation and health cache | Provider aggregation and health only; provider modules must not own or import application orchestration. |
 | `metadata/` | metadata refresh, repository lookup, local Git execution, and ref watching | The refresh use case depends on path-free local-metadata ports; local Git command and filesystem adapters resolve Station identities privately, while runtime composition selects and shuts down both roles. |
-| `persistence/ports.ts`, `persistence/types.ts` | seven purpose-owned persistence ports, their seven-port composition bundle, the separate persistence-health port, and Observer application records and inputs | Observer-private application boundary; no SQL, SQLite handles, or SQLite row representations. The bundle is composition-only. |
+| `persistence/ports.ts`, `persistence/types.ts` | eight purpose-owned persistence ports, their eight-port composition bundle, the separate persistence-health port, and Observer application records and inputs | Observer-private application boundary; no SQL, SQLite handles, or SQLite row representations. The bundle is composition-only. |
 | `persistence/sqliteAdapter.ts`, SQLite implementation modules, `migrations/`, `sqlite.ts` | SQL and row translation, transactions, migrations, driver compatibility, health, and durable-handle mechanics | Production outbound adapter edge selected and lifecycle-managed by runtime composition. `migrations/migration.ts` owns the adapter-private `ObserverSqliteMigration` record; the ordered aggregator only re-exports that type. |
 | `test/support/inMemoryObserverPersistence.ts`, `persistence/observationParser.ts` | Process-local persistence test support plus representation-neutral observation parsing and coalescing | Test-only storage substitute and shared boundary translation used to prove substitution; production source and runtime remain SQLite-only. |
 | `diagnostics/` | doctor and diagnostic collection, the local-evidence port, and local representation translation | Diagnostic use cases aggregate core, journal, persistence-health, provider, configuration, and typed local evidence; `localEvidenceSource.ts` alone owns state, JSONL log, and hook-spool filesystem traversal. |
@@ -247,13 +247,13 @@ No single layer owns all truth.
 | Loaded config | Authoritative for managed projects, defaults, provider choices, feature policy, and configured hooks. Durable in TOML; loaded into process memory at startup and updated through explicit config operations. |
 | Provider observations | Each provider is authoritative only for external facts it can prove. Live reads and normalized ingress observations may be persisted with retention, but cached evidence does not outrank a newer provider read. |
 | Provider-owned identity | Worktree, target, harness-run, native execution, and external endpoint identity stays owned by the provider that minted it. Application code may carry opaque IDs but must not reconstruct their format. |
-| Observer-minted state | Command, event, error, report, session, correlation, readiness, and recovery identities are legitimate internal facts minted by the observer. The observer does not invent external facts. |
-| Observer SQLite | Durable observer memory for commands, events, ingress dedupe, observations, correlations, sessions, canonical worktree display titles, native-execution bindings, metadata caches, recovery handles, and readiness. Display-title authority is keyed by `(projectId, worktreeId)` and survives transient provider observation gaps; it is not branch or provider identity. |
+| Observer-minted state | Command, event, error, report, session, Session Group, correlation, readiness, and recovery identities are legitimate internal facts minted by the observer. The observer does not invent external facts. |
+| Observer SQLite | Durable observer memory for commands, events, ingress dedupe, observations, correlations, sessions, project-local Session Groups, canonical worktree display titles, native-execution bindings, metadata caches, recovery handles, and readiness. Group membership is exclusive per session, while Group deletion changes only organizational rows. Display-title authority is keyed by `(projectId, worktreeId)` and survives transient provider observation gaps; it is not branch or provider identity. |
 | Local Git metadata evidence | Local Git is authoritative only for checkout-local `HEAD`, refs, merge-base, and numstat at read time. Command failures retain cached evidence through the TTL and mark it stale, while a matching checkout reported unavailable clears its local-change row; superseded identities cannot mutate either row. Ref-watch notifications are hints that request reconcile, never metadata or UI mutations themselves. |
 | Observer boot claim | `dirname(resolvedSocket)/observer.claim.sqlite` is a persistent private transport-lifecycle file. Only its active SQLite write transaction owns boot exclusion; file or sidecar existence is never authority. It has no Observer migrations or application persistence role. |
 | Observer process identity | `<resolved socketPath>.pid` is the strict, socket-specific `{pid, osStartTime, processToken, version, socketPath}` identity published by the process that successfully bound the socket. The UUID v4 `processToken` identifies one launch and `version` is the Observer selector: display SemVer plus reserved `station.<sha256>` build metadata. They corroborate process and immutable-build identity for later handoff and diagnostics; `lsof` remains primary socket-ownership evidence, and the file alone is never liveness authority. |
-| In-memory persistence adapter | Process-local test state that preserves the seven persistence ports' observable transaction semantics. It is neither restart-durable nor selectable by production runtime composition. |
-| `StationSnapshot` | Current normalized graph held in memory. `rows` is configured worktree inventory; `sessions` is canonical session membership. Reconcile replaces its base projection; accepted harness reports can project status and readiness between reconciles. It is derived and not a durable replay log. |
+| In-memory persistence adapter | Process-local test state that preserves the eight persistence ports' observable transaction semantics. It is neither restart-durable nor selectable by production runtime composition. |
+| `StationSnapshot` | Current normalized graph held in memory. `rows` is configured worktree inventory; `sessions` is canonical session membership; and required `sessionGroups` carries normalized organizational state. Until Group reconcile projection is wired, production snapshots deliberately publish `sessionGroups: []`. Reconcile replaces the base projection; accepted harness reports can project status and readiness between reconciles. It is derived and not a durable replay log. |
 | Live event bus | Future-only, process-local delivery. Subscriber queues are currently unbounded, events have no sequence numbers, and reconnects cannot request replay. |
 | Persisted event rows | Historical and diagnostic observer memory. They are not currently the source for live subscription replay. |
 | Hook spool | Durable delivery fallback while ingress cannot reach the observer. A queued record is pending evidence, not current graph truth. Its stable spool identity drives replay completion after primary dedupe, and the filesystem record remains until all derived durable work finishes. |
@@ -288,7 +288,7 @@ Application composition proceeds around that boundary in this order:
    providers. Compiled composition materializes the Pi extension here; Observer
    code remains provider-neutral.
 3. The main Observer SQLite opens and applies pending migrations, then
-   `createSqliteObserverPersistence` binds the seven application persistence
+   `createSqliteObserverPersistence` binds the eight application persistence
    ports and `PersistenceHealthSource` to that handle. Runtime composition owns
    the concrete handle lifecycle and distributes narrow application views.
 4. Runtime composition creates the event bus, logging and project-config
@@ -691,6 +691,7 @@ The implemented persistence ports are:
 - `ObservationStore`
 - `ReconcileStore`
 - `SessionStore`
+- `SessionGroupStore`
 - `WorktreeMetadataStore`
 
 These Observer-private interfaces are the initial capability grouping for
@@ -714,13 +715,17 @@ when it changes several tables:
   recovery handles, turn readiness, and purpose-specific remembered-harness lookup. Rename,
   fresh-session seeding, confirmed worktree retirement, and canonical-title/recovery import keep
   their multi-table changes atomic.
+- `SessionGroupStore` owns Group definitions, exclusive direct membership, parent changes,
+  deletion-to-ungroup with child reparenting, and reconcile pruning. Stale versions and expected
+  assignments return conflicts without throwing; invariant or storage failures roll back the
+  complete conversation. Empty definitions remain durable.
 - `WorktreeMetadataStore` owns current change, pull-request, and check metadata
   plus its expiry.
 
 Each interface is a `DRIVEN PORT`. `PersistenceHealthSource` is a separate
 driven port that exposes only the public SQLite health projection needed by
 runtime health and diagnostics. `ObserverPersistenceBundle` is an unmarked
-intersection of the seven persistence ports rather than an eighth port. It is
+intersection of the eight persistence ports rather than a ninth port. It is
 restricted to persistence adapters and composition seams; core, handlers,
 policies, and use cases receive only the individual named ports they consume.
 Import diagnostics enforce those restrictions, keep SQLite imports out of
@@ -735,7 +740,7 @@ opens and closes the concrete SQLite handle around that adapter; application
 core never receives it.
 
 The typechecked `createInMemoryObserverPersistence` test fixture implements
-exactly the seven-port bundle over private process-local state, with synchronous
+exactly the eight-port bundle over private process-local state, with synchronous
 copy-on-write transactions so a failed ingress or reconcile mutation cannot
 partially commit. It lives under Observer test support, has no handle lifecycle,
 does not implement `PersistenceHealthSource`, exposes no backing state, and is
@@ -760,7 +765,7 @@ table. Historical applied migrations remain immutable even when a later
 migration removes storage that no production conversation uses.
 
 SQLite/core isolation and storage substitution are complete. One shared
-seven-port behavioral contract proves both adapters' atomicity, ordering,
+eight-port behavioral contract proves both adapters' atomicity, ordering,
 expiry, parsing, coalescing, and failure behavior. A separate complete
 ObserverApi lane composes fake providers, the real core, event bus, command
 queue, production handlers, and ingress against the in-memory adapter without
@@ -923,7 +928,7 @@ the runtime server adapter. `OBS-HEX-004` is resolved: runtime composition owns
 the SQLite handle lifecycle, runtime health and diagnostics depend on
 `PersistenceHealthSource`, and Observer core has no SQLite dependency.
 `OBS-HEX-005` is resolved: SQLite and process-local memory pass one shared
-seven-port contract, and a complete ObserverApi composition runs against memory
+eight-port contract, and a complete ObserverApi composition runs against memory
 without importing SQLite or its row translation.
 `OBS-HEX-006` is resolved: the two unsupported command members are gone, and
 production registration is constructed from one handler map that is exhaustive

--- a/packages/client/test/support/snapshots.ts
+++ b/packages/client/test/support/snapshots.ts
@@ -122,6 +122,7 @@ function snapshotFromRows(rows: WorktreeRow[]): StationSnapshot {
     projects,
     rows,
     sessions,
+    sessionGroups: [],
     counts: {
       projects: projects.length,
       ...counts,

--- a/packages/contracts/src/ids.ts
+++ b/packages/contracts/src/ids.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { nonEmptyStringSchema } from "./shared.js";
 
-export const STATION_SCHEMA_VERSION = "0.9.0" as const;
+export const STATION_SCHEMA_VERSION = "0.10.0" as const;
 
 const timestampSchema = z.string().datetime({ offset: true });
 declare const stationIdKind: unique symbol;
@@ -19,6 +19,10 @@ export const SchemaVersionSchema = z.literal(STATION_SCHEMA_VERSION);
 export const ProjectIdSchema = idSchema<"ProjectId">();
 export const WorktreeIdSchema = idSchema<"WorktreeId">();
 export const SessionIdSchema = idSchema<"SessionId">();
+export const SessionGroupIdSchema = z.string().trim().min(1) as z.ZodType<
+  StationId<"SessionGroupId">,
+  string
+>;
 export const TerminalTargetIdSchema = idSchema<"TerminalTargetId">();
 export const HarnessRunIdSchema = idSchema<"HarnessRunId">();
 export const CommandIdSchema = idSchema<"CommandId">();
@@ -28,6 +32,7 @@ export const TimestampSchema = timestampSchema;
 export type ProjectId = z.infer<typeof ProjectIdSchema>;
 export type WorktreeId = z.infer<typeof WorktreeIdSchema>;
 export type SessionId = z.infer<typeof SessionIdSchema>;
+export type SessionGroupId = z.infer<typeof SessionGroupIdSchema>;
 export type TerminalTargetId = z.infer<typeof TerminalTargetIdSchema>;
 export type HarnessRunId = z.infer<typeof HarnessRunIdSchema>;
 export type CommandId = z.infer<typeof CommandIdSchema>;

--- a/packages/contracts/src/snapshot.ts
+++ b/packages/contracts/src/snapshot.ts
@@ -5,6 +5,7 @@ import {
   ProjectIdSchema,
   ProviderIdSchema,
   SchemaVersionSchema,
+  SessionGroupIdSchema,
   SessionIdSchema,
   TerminalTargetIdSchema,
   TimestampSchema,
@@ -193,6 +194,37 @@ export const SessionViewSchema = z
 
 export type SessionView = z.infer<typeof SessionViewSchema>;
 
+export const SessionGroupViewSchema = z
+  .object({
+    id: SessionGroupIdSchema,
+    projectId: ProjectIdSchema,
+    name: z.string().trim().min(1),
+    sessionIds: z.array(SessionIdSchema),
+    parentGroupId: SessionGroupIdSchema.optional(),
+    version: z.number().int().positive(),
+    createdAt: TimestampSchema,
+    updatedAt: TimestampSchema,
+  })
+  .strict()
+  .superRefine((group, context) => {
+    if (new Set(group.sessionIds).size !== group.sessionIds.length) {
+      context.addIssue({
+        code: "custom",
+        message: "Group session ids must be unique.",
+        path: ["sessionIds"],
+      });
+    }
+    if (Date.parse(group.updatedAt) < Date.parse(group.createdAt)) {
+      context.addIssue({
+        code: "custom",
+        message: "Group updatedAt must not precede createdAt.",
+        path: ["updatedAt"],
+      });
+    }
+  });
+
+export type SessionGroupView = z.infer<typeof SessionGroupViewSchema>;
+
 export const StationAlertSchema = z
   .object({
     id: nonEmptyStringSchema,
@@ -258,6 +290,7 @@ export const StationSnapshotSchema = z
     projects: z.array(ProjectViewSchema),
     rows: z.array(WorktreeRowSchema),
     sessions: z.array(SessionViewSchema),
+    sessionGroups: z.array(SessionGroupViewSchema),
     counts: z
       .object({
         projects: z.number().int().nonnegative(),
@@ -274,6 +307,99 @@ export const StationSnapshotSchema = z
     featureFlags: ClientFeatureFlagsSchema.optional(),
     orphans: z.array(OrphanedRuntimeStateSchema).optional(),
   })
-  .strict();
+  .strict()
+  .superRefine((snapshot, context) => {
+    // Individual schemas validate records; this pass protects relationships across the snapshot graph.
+    const projectIds = new Set(snapshot.projects.map((project) => project.id));
+    const sessions = new Map(snapshot.sessions.map((session) => [session.id, session]));
+    const groups = new Map<string, SessionGroupView>();
+    const assignedSessions = new Map<string, string>();
+
+    for (const [index, group] of snapshot.sessionGroups.entries()) {
+      if (groups.has(group.id)) {
+        context.addIssue({
+          code: "custom",
+          message: "Group ids must be unique.",
+          path: ["sessionGroups", index, "id"],
+        });
+      } else {
+        groups.set(group.id, group);
+      }
+      if (!projectIds.has(group.projectId)) {
+        context.addIssue({
+          code: "custom",
+          message: "Group project must exist in the snapshot.",
+          path: ["sessionGroups", index, "projectId"],
+        });
+      }
+      for (const [memberIndex, sessionId] of group.sessionIds.entries()) {
+        const session = sessions.get(sessionId);
+        if (session === undefined) {
+          context.addIssue({
+            code: "custom",
+            message: "Group member must reference a snapshot session.",
+            path: ["sessionGroups", index, "sessionIds", memberIndex],
+          });
+        } else if (session.projectId !== group.projectId) {
+          context.addIssue({
+            code: "custom",
+            message: "Group member must belong to the Group project.",
+            path: ["sessionGroups", index, "sessionIds", memberIndex],
+          });
+        }
+        const assignedGroupId = assignedSessions.get(sessionId);
+        if (assignedGroupId !== undefined && assignedGroupId !== group.id) {
+          context.addIssue({
+            code: "custom",
+            message: "A session may belong to only one Group.",
+            path: ["sessionGroups", index, "sessionIds", memberIndex],
+          });
+        } else {
+          assignedSessions.set(sessionId, group.id);
+        }
+      }
+    }
+
+    for (const [index, group] of snapshot.sessionGroups.entries()) {
+      if (group.parentGroupId === undefined) continue;
+      const parent = groups.get(group.parentGroupId);
+      if (parent === undefined) {
+        context.addIssue({
+          code: "custom",
+          message: "Group parent must exist in the snapshot.",
+          path: ["sessionGroups", index, "parentGroupId"],
+        });
+      } else if (parent.id === group.id) {
+        context.addIssue({
+          code: "custom",
+          message: "A Group cannot parent itself.",
+          path: ["sessionGroups", index, "parentGroupId"],
+        });
+      } else if (parent.projectId !== group.projectId) {
+        context.addIssue({
+          code: "custom",
+          message: "Group parent must belong to the same project.",
+          path: ["sessionGroups", index, "parentGroupId"],
+        });
+      }
+    }
+
+    for (const [index, group] of snapshot.sessionGroups.entries()) {
+      const visited = new Set([group.id]);
+      let parentId = group.parentGroupId;
+      while (parentId !== undefined) {
+        if (visited.has(parentId)) {
+          context.addIssue({
+            code: "custom",
+            message: "Group parents must not form a cycle.",
+            path: ["sessionGroups", index, "parentGroupId"],
+          });
+          break;
+        }
+        visited.add(parentId);
+        parentId = groups.get(parentId)?.parentGroupId;
+      }
+    }
+  });
 
 export type StationSnapshot = z.infer<typeof StationSnapshotSchema>;

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -49,6 +49,7 @@ import {
   RepositoryPullRequestRequestSchema,
   RepositoryRemoteSchema,
   SafeErrorSchema,
+  SessionGroupViewSchema,
   SessionMigrationJournalEntrySchema,
   SessionMigrationLockSchema,
   SessionMigrationSealSchema,
@@ -161,7 +162,7 @@ describe("contract schemas", () => {
   });
 
   it("exports the shared schema version used by snapshot fixtures", async () => {
-    expect(STATION_SCHEMA_VERSION).toBe("0.9.0");
+    expect(STATION_SCHEMA_VERSION).toBe("0.10.0");
 
     const snapshots = (await loadJson("snapshots/snapshot-scenarios.json")) as Record<
       string,
@@ -170,6 +171,81 @@ describe("contract schemas", () => {
 
     for (const [name, snapshot] of Object.entries(snapshots)) {
       expect(snapshot.schemaVersion, name).toBe(STATION_SCHEMA_VERSION);
+    }
+  });
+
+  it("strictly validates Session Groups and snapshot graph relationships", async () => {
+    const group = {
+      id: "group_active",
+      projectId: "web",
+      name: "  Active work  ",
+      sessionIds: ["ses_web_idle"],
+      version: 1,
+      createdAt: "2026-05-20T11:00:00.000Z",
+      updatedAt: "2026-05-20T12:00:00.000Z",
+    };
+    expect(SessionGroupViewSchema.parse(group)).toMatchObject({ name: "Active work" });
+
+    const invalidGroups = [
+      { ...group, id: "   " },
+      { ...group, name: "   " },
+      { ...group, sessionIds: ["ses_web_idle", "ses_web_idle"] },
+      { ...group, version: 0 },
+      { ...group, createdAt: "invalid" },
+      {
+        ...group,
+        createdAt: "2026-05-20T13:00:00.000Z",
+        updatedAt: "2026-05-20T12:00:00.000Z",
+      },
+      { ...group, parentGroupId: "   " },
+      { ...group, extra: true },
+    ];
+    for (const [index, invalid] of invalidGroups.entries()) {
+      expectFails(SessionGroupViewSchema, invalid, `invalid Group ${index}`);
+    }
+
+    const scenarios = (await loadJson("snapshots/snapshot-scenarios.json")) as Record<
+      string,
+      Record<string, unknown>
+    >;
+    const base = scenarios.idleAgent;
+    if (base === undefined) throw new Error("idleAgent fixture is required.");
+    const snapshot = { ...base, sessionGroups: [group] };
+    expectParses(StationSnapshotSchema, snapshot, "snapshot with a membered Group");
+    expectParses(
+      StationSnapshotSchema,
+      {
+        ...base,
+        sessionGroups: [
+          { ...group, sessionIds: [] },
+          { ...group, id: "group_child", sessionIds: [], parentGroupId: group.id },
+        ],
+      },
+      "snapshot with empty and parented Groups",
+    );
+
+    const invalidGraphs = [
+      { ...base, sessionGroups: undefined },
+      { ...base, sessionGroups: [group, { ...group }] },
+      { ...base, sessionGroups: [{ ...group, projectId: "missing" }] },
+      { ...base, sessionGroups: [{ ...group, sessionIds: ["missing"] }] },
+      {
+        ...base,
+        sessionGroups: [group, { ...group, id: "group_other", sessionIds: group.sessionIds }],
+      },
+      { ...base, sessionGroups: [{ ...group, parentGroupId: "missing" }] },
+      { ...base, sessionGroups: [{ ...group, parentGroupId: group.id }] },
+      {
+        ...base,
+        sessionGroups: [
+          { ...group, id: "group_a", sessionIds: [], parentGroupId: "group_b" },
+          { ...group, id: "group_b", sessionIds: [], parentGroupId: "group_a" },
+        ],
+      },
+      { ...base, schemaVersion: "0.9.0", sessionGroups: [] },
+    ];
+    for (const [index, invalid] of invalidGraphs.entries()) {
+      expectFails(StationSnapshotSchema, invalid, `invalid Group graph ${index}`);
     }
   });
 
@@ -580,6 +656,7 @@ describe("contract schemas", () => {
         projects: [],
         rows: [],
         sessions: [],
+        sessionGroups: [],
         counts: {
           projects: 0,
           sessions: 0,
@@ -805,6 +882,7 @@ describe("contract schemas", () => {
       projects: [],
       rows: [row],
       sessions: [],
+      sessionGroups: [],
       counts: {
         projects: 0,
         sessions: 0,

--- a/packages/contracts/test/schema/diagnostics-schema.test.ts
+++ b/packages/contracts/test/schema/diagnostics-schema.test.ts
@@ -151,6 +151,7 @@ describe("diagnostics schemas", () => {
           projects: [],
           rows: [],
           sessions: [],
+          sessionGroups: [],
           counts: {
             projects: 0,
             sessions: 0,

--- a/packages/dashboard-core/test/fixtures/snapshots.ts
+++ b/packages/dashboard-core/test/fixtures/snapshots.ts
@@ -141,6 +141,7 @@ export function createNoProjectsSnapshot(): StationSnapshot {
     projects: [],
     rows: [],
     sessions: [],
+    sessionGroups: [],
     counts: {
       projects: 0,
       sessions: 0,
@@ -235,6 +236,7 @@ function snapshotFromRows(rows: WorktreeRow[]): StationSnapshot {
     projects,
     rows,
     sessions,
+    sessionGroups: [],
     counts: {
       projects: projects.length,
       ...counts,

--- a/packages/observability/test/unit/diagnostic-evidence.test.ts
+++ b/packages/observability/test/unit/diagnostic-evidence.test.ts
@@ -75,7 +75,7 @@ describe("diagnostic evidence index", () => {
     const index = buildDiagnosticEvidenceIndex(
       baseDiagnosticSnapshot({
         observerHealth: {
-          schemaVersion: "0.9.0",
+          schemaVersion: "0.10.0",
           status: "degraded",
           pid: 1234,
           startedAt: diagnosticNow,

--- a/packages/observability/test/unit/observability.test.ts
+++ b/packages/observability/test/unit/observability.test.ts
@@ -262,17 +262,17 @@ describe("observability helpers", () => {
 
 function minimalSnapshot(): DiagnosticSnapshot {
   return {
-    schemaVersion: "0.9.0",
+    schemaVersion: "0.10.0",
     collectedAt: now,
     observerHealth: {
-      schemaVersion: "0.9.0",
+      schemaVersion: "0.10.0",
       status: "healthy",
       pid: 1234,
       startedAt: now,
       version: "0.0.0",
     },
     snapshot: {
-      schemaVersion: "0.9.0",
+      schemaVersion: "0.10.0",
       generatedAt: now,
       observer: {
         pid: 1234,
@@ -284,6 +284,7 @@ function minimalSnapshot(): DiagnosticSnapshot {
       projects: [],
       rows: [],
       sessions: [],
+      sessionGroups: [],
       counts: {
         projects: 0,
         sessions: 0,

--- a/packages/protocol/test/fixtures/protocol-messages.json
+++ b/packages/protocol/test/fixtures/protocol-messages.json
@@ -1,16 +1,16 @@
 {
   "request": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "jsonrpc": "2.0",
     "id": "req_1",
     "method": "observer.health"
   },
   "successResponse": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "jsonrpc": "2.0",
     "id": "req_1",
     "result": {
-      "schemaVersion": "0.9.0",
+      "schemaVersion": "0.10.0",
       "status": "healthy",
       "pid": 1234,
       "startedAt": "2026-05-20T12:00:00.000Z",
@@ -18,7 +18,7 @@
     }
   },
   "errorResponse": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "jsonrpc": "2.0",
     "id": "req_1",
     "error": {
@@ -28,7 +28,7 @@
     }
   },
   "eventEnvelope": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "event": {
       "type": "providerHook.ingested",
       "at": "2026-05-20T12:02:00.000Z",
@@ -38,7 +38,7 @@
     }
   },
   "doctorRequest": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "jsonrpc": "2.0",
     "id": "req_doctor",
     "method": "doctor.run",
@@ -47,7 +47,7 @@
     }
   },
   "diagnosticsRequest": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "jsonrpc": "2.0",
     "id": "req_diag",
     "method": "diagnostics.collect",

--- a/packages/protocol/test/integration/client-server.test.ts
+++ b/packages/protocol/test/integration/client-server.test.ts
@@ -580,7 +580,7 @@ describe("protocol client/server", () => {
         tag: "ProtocolError",
         code: "PROTOCOL_SCHEMA_MISMATCH",
         message:
-          "Observer protocol schema mismatch: the observer responded with schema 9.9.9, but this CLI expects schema 0.9.0.",
+          "Observer protocol schema mismatch: the observer responded with schema 9.9.9, but this CLI expects schema 0.10.0.",
         hint: expect.stringContaining("A different STATION checkout"),
       });
     } finally {

--- a/packages/protocol/test/support/fixtures.ts
+++ b/packages/protocol/test/support/fixtures.ts
@@ -91,6 +91,7 @@ export function emptySnapshot(): StationSnapshot {
     projects: [],
     rows: [],
     sessions: [],
+    sessionGroups: [],
     counts: {
       projects: 0,
       sessions: 0,

--- a/packages/protocol/test/unit/messages.test.ts
+++ b/packages/protocol/test/unit/messages.test.ts
@@ -27,7 +27,7 @@ describe("protocol message envelopes", () => {
   it("rejects unknown protocol methods", () => {
     expect(
       ProtocolRequestSchema.safeParse({
-        schemaVersion: "0.9.0",
+        schemaVersion: "0.10.0",
         jsonrpc: "2.0",
         id: "req_bad",
         method: "provider.rawCall",

--- a/scripts/test-runners/run-sqlite-cross-runtime.mjs
+++ b/scripts/test-runners/run-sqlite-cross-runtime.mjs
@@ -9,10 +9,12 @@ const probePath = join(repoRoot, "scripts", "test-runners", "sqlite-runtime-prob
 const tempRoot = mkdtempSync(join(tmpdir(), "station-sqlite-cross-runtime-"));
 
 try {
-  runProbe("node", "create", join(tempRoot, "node-created.sqlite"), "created-by-node");
-  runProbe("bun", "read", join(tempRoot, "node-created.sqlite"), "created-by-node");
-  runProbe("bun", "create", join(tempRoot, "bun-created.sqlite"), "created-by-bun");
-  runProbe("node", "read", join(tempRoot, "bun-created.sqlite"), "created-by-bun");
+  runProbe("node", "seed-v16", join(tempRoot, "node-created.sqlite"), "created-by-node");
+  runProbe("bun", "upgrade-write", join(tempRoot, "node-created.sqlite"), "created-by-node");
+  runProbe("node", "read", join(tempRoot, "node-created.sqlite"), "created-by-node");
+  runProbe("bun", "seed-v16", join(tempRoot, "bun-created.sqlite"), "created-by-bun");
+  runProbe("node", "upgrade-write", join(tempRoot, "bun-created.sqlite"), "created-by-bun");
+  runProbe("bun", "read", join(tempRoot, "bun-created.sqlite"), "created-by-bun");
   console.log("Cross-runtime SQLite compatibility passed for Node and Bun.");
 } finally {
   rmSync(tempRoot, { recursive: true, force: true });

--- a/scripts/test-runners/sqlite-runtime-probe.mjs
+++ b/scripts/test-runners/sqlite-runtime-probe.mjs
@@ -1,13 +1,36 @@
 import assert from "node:assert/strict";
 
 const [, , action, databasePath, expectedLabel] = process.argv;
-assert.ok(action === "create" || action === "read", "Expected a create or read action.");
+assert.ok(
+  action === "seed-v16" || action === "upgrade-write" || action === "read",
+  "Expected a seed-v16, upgrade-write, or read action.",
+);
 assert.ok(databasePath, "Expected a SQLite database path.");
 assert.ok(expectedLabel, "Expected a probe label.");
 
-const { migrations, openObserverSqlite } = await import(
+const { createSqliteObserverPersistence, migrations, openObserverSqlite } = await import(
   new URL("../../apps/observer/dist/internal.js", import.meta.url).href
 );
+if (action === "seed-v16") {
+  const { openSqlDatabase } = await import(
+    new URL("../../apps/observer/dist/sqlite/driver.js", import.meta.url).href
+  );
+  const database = openSqlDatabase(databasePath);
+  try {
+    for (const migration of migrations.filter(({ version }) => version <= 16)) {
+      database.exec(migration.sql);
+      database
+        .prepare("INSERT INTO observer_migrations (version, name, applied_at) VALUES (?, ?, ?)")
+        .run(migration.version, migration.name, "2026-01-01T00:00:00.000Z");
+    }
+    database
+      .prepare("INSERT OR REPLACE INTO observer_meta (key, value) VALUES ('schema_version', '16')")
+      .run();
+  } finally {
+    database.close();
+  }
+  process.exit(0);
+}
 const roundTripInteger = 2_147_483_648;
 const sqlite = openObserverSqlite({
   path: databasePath,
@@ -35,7 +58,7 @@ try {
     undefined,
   );
 
-  if (action === "create") {
+  if (action === "upgrade-write") {
     const result = database
       .prepare("INSERT INTO station_runtime_probe (label, value) VALUES (?, ?)")
       .run(expectedLabel, roundTripInteger);
@@ -45,6 +68,53 @@ try {
       typeof result.lastInsertRowid === "number" || typeof result.lastInsertRowid === "bigint",
     );
     assert.equal(Number(result.lastInsertRowid), 1);
+
+    const persistence = createSqliteObserverPersistence({
+      sqlite,
+      clock: { now: () => new Date("2026-01-01T00:00:00.000Z") },
+    });
+    assert.deepEqual(
+      await persistence.createSessionGroup({
+        id: `group-${expectedLabel}`,
+        projectId: "project-cross-runtime",
+        name: "Cross-runtime parent",
+        initialMembers: [
+          {
+            sessionId: `session-${expectedLabel}`,
+            projectId: "project-cross-runtime",
+            expectedGroupId: null,
+          },
+        ],
+        createdAt: "2026-01-01T00:00:00.000Z",
+      }),
+      {
+        ok: true,
+        groups: [
+          {
+            id: `group-${expectedLabel}`,
+            projectId: "project-cross-runtime",
+            name: "Cross-runtime parent",
+            sessionIds: [`session-${expectedLabel}`],
+            version: 1,
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+      },
+    );
+    await persistence.createSessionGroup({
+      id: `child-${expectedLabel}`,
+      projectId: "project-cross-runtime",
+      name: "Cross-runtime child",
+      parentGroupId: `group-${expectedLabel}`,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    await persistence.renameSessionGroup({
+      id: `group-${expectedLabel}`,
+      expectedVersion: 1,
+      name: "Cross-runtime renamed",
+      updatedAt: "2026-01-01T00:01:00.000Z",
+    });
   }
 
   const row = database
@@ -52,6 +122,29 @@ try {
     .get(expectedLabel);
   assert.equal(row?.label, expectedLabel);
   assert.equal(row?.value, roundTripInteger);
+
+  const persistence = createSqliteObserverPersistence({ sqlite });
+  assert.deepEqual(await persistence.listSessionGroups(), [
+    {
+      id: `group-${expectedLabel}`,
+      projectId: "project-cross-runtime",
+      name: "Cross-runtime renamed",
+      sessionIds: [`session-${expectedLabel}`],
+      version: 2,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:01:00.000Z",
+    },
+    {
+      id: `child-${expectedLabel}`,
+      projectId: "project-cross-runtime",
+      name: "Cross-runtime child",
+      sessionIds: [],
+      parentGroupId: `group-${expectedLabel}`,
+      version: 1,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    },
+  ]);
 } finally {
   sqlite.close();
 }

--- a/station/src/sources/fixtures/mockObserverSnapshot.ts
+++ b/station/src/sources/fixtures/mockObserverSnapshot.ts
@@ -16,7 +16,7 @@ const harnessCapabilities = {
 };
 
 export const mockObserverSnapshot = {
-  schemaVersion: "0.9.0",
+  schemaVersion: "0.10.0",
   generatedAt: fixtureNow,
   observer: {
     pid: 4242,
@@ -264,6 +264,7 @@ export const mockObserverSnapshot = {
       tags: ["codex", "tmux"],
     },
   ],
+  sessionGroups: [],
   counts: {
     projects: 1,
     sessions: 2,

--- a/station/src/station/fixtures/scenarios.ts
+++ b/station/src/station/fixtures/scenarios.ts
@@ -389,6 +389,7 @@ function snapshotFromRows(rows: WorktreeRow[], extras: SnapshotExtras): StationS
     projects,
     rows,
     sessions,
+    sessionGroups: [],
     counts: {
       projects: projects.length,
       ...counts,

--- a/tests/agent/scenarios/diagnosis/harness-unexpected-exit.json
+++ b/tests/agent/scenarios/diagnosis/harness-unexpected-exit.json
@@ -2,7 +2,7 @@
   "name": "harness-unexpected-exit",
   "expectedRootCause": "HARNESS_UNEXPECTED_EXIT",
   "evidenceIndex": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/hook-spool-fallback.json
+++ b/tests/agent/scenarios/diagnosis/hook-spool-fallback.json
@@ -2,7 +2,7 @@
   "name": "hook-spool-fallback",
   "expectedRootCause": "HOOK_SPOOL_FALLBACK",
   "evidenceIndex": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/invalid-config.json
+++ b/tests/agent/scenarios/diagnosis/invalid-config.json
@@ -2,7 +2,7 @@
   "name": "invalid-config",
   "expectedRootCause": "INVALID_CONFIG",
   "evidenceIndex": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "unavailable",

--- a/tests/agent/scenarios/diagnosis/missing-worktrunk-binary.json
+++ b/tests/agent/scenarios/diagnosis/missing-worktrunk-binary.json
@@ -2,7 +2,7 @@
   "name": "missing-worktrunk-binary",
   "expectedRootCause": "MISSING_WORKTRUNK_BINARY",
   "evidenceIndex": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/provider-timeout.json
+++ b/tests/agent/scenarios/diagnosis/provider-timeout.json
@@ -2,7 +2,7 @@
   "name": "provider-timeout",
   "expectedRootCause": "PROVIDER_TIMEOUT",
   "evidenceIndex": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/sqlite-write-failure.json
+++ b/tests/agent/scenarios/diagnosis/sqlite-write-failure.json
@@ -2,7 +2,7 @@
   "name": "sqlite-write-failure",
   "expectedRootCause": "SQLITE_WRITE_FAILURE",
   "evidenceIndex": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/stale-terminal-target.json
+++ b/tests/agent/scenarios/diagnosis/stale-terminal-target.json
@@ -2,7 +2,7 @@
   "name": "stale-terminal-target",
   "expectedRootCause": "STALE_TERMINAL_TARGET",
   "evidenceIndex": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/contract-fixtures/diagnostics/debug-bundle-manifest.json
+++ b/tests/contract-fixtures/diagnostics/debug-bundle-manifest.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.9.0",
+  "schemaVersion": "0.10.0",
   "bundleId": "diag_2026-05-20T120000Z",
   "createdAt": "2026-05-20T12:00:00.000Z",
   "bundlePath": "/tmp/station/diagnostics/diag_2026-05-20T120000Z",

--- a/tests/contract-fixtures/diagnostics/diagnostic-evidence-index.json
+++ b/tests/contract-fixtures/diagnostics/diagnostic-evidence-index.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.9.0",
+  "schemaVersion": "0.10.0",
   "generatedAt": "2026-05-22T12:00:00.000Z",
   "source": {
     "collectedAt": "2026-05-22T11:59:59.000Z",

--- a/tests/contract-fixtures/diagnostics/doctor-report.json
+++ b/tests/contract-fixtures/diagnostics/doctor-report.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.9.0",
+  "schemaVersion": "0.10.0",
   "generatedAt": "2026-05-20T12:00:00.000Z",
   "status": "degraded",
   "checks": [
@@ -15,7 +15,7 @@
     }
   ],
   "observer": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "status": "healthy",
     "pid": 1234,
     "startedAt": "2026-05-20T12:00:00.000Z",
@@ -68,7 +68,7 @@
     }
   },
   "snapshot": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 1234,
@@ -103,7 +103,8 @@
       "unknown": 0,
       "sessions": 0
     },
-    "alerts": []
+    "alerts": [],
+    "sessionGroups": []
   },
   "logs": {
     "paths": ["/tmp/station/state/logs/observer.jsonl"],

--- a/tests/contract-fixtures/hooks/invalid-provider-hook-event.json
+++ b/tests/contract-fixtures/hooks/invalid-provider-hook-event.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.9.0",
+  "schemaVersion": "0.10.0",
   "provider": "",
   "kind": "harness",
   "event": "",

--- a/tests/contract-fixtures/hooks/provider-hook-events.json
+++ b/tests/contract-fixtures/hooks/provider-hook-events.json
@@ -1,6 +1,6 @@
 {
   "worktrunkWorktreeCreated": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "hookId": "hook_worktrunk_1",
     "provider": "worktrunk",
     "kind": "worktree",
@@ -13,7 +13,7 @@
     }
   },
   "codexRunUpdated": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "hookId": "hook_codex_1",
     "provider": "codex",
     "kind": "harness",

--- a/tests/contract-fixtures/snapshots/invalid-snapshot.json
+++ b/tests/contract-fixtures/snapshots/invalid-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.9.0",
+  "schemaVersion": "0.10.0",
   "generatedAt": "not-a-date",
   "observer": {
     "pid": 0,
@@ -21,5 +21,6 @@
     "attention": 0,
     "unknown": 0
   },
-  "alerts": []
+  "alerts": [],
+  "sessionGroups": []
 }

--- a/tests/contract-fixtures/snapshots/snapshot-scenarios.json
+++ b/tests/contract-fixtures/snapshots/snapshot-scenarios.json
@@ -1,6 +1,6 @@
 {
   "noProjects": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -22,10 +22,11 @@
       "unknown": 0,
       "sessions": 0
     },
-    "alerts": []
+    "alerts": [],
+    "sessionGroups": []
   },
   "multipleProjects": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -110,10 +111,11 @@
       "unknown": 0,
       "sessions": 0
     },
-    "alerts": []
+    "alerts": [],
+    "sessionGroups": []
   },
   "zeroWorktreeProject": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -161,10 +163,11 @@
       "unknown": 0,
       "sessions": 0
     },
-    "alerts": []
+    "alerts": [],
+    "sessionGroups": []
   },
   "noAgentWorktree": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -234,10 +237,11 @@
       "unknown": 0,
       "sessions": 0
     },
-    "alerts": []
+    "alerts": [],
+    "sessionGroups": []
   },
   "idleAgent": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -365,10 +369,11 @@
       "unknown": 0,
       "sessions": 1
     },
-    "alerts": []
+    "alerts": [],
+    "sessionGroups": []
   },
   "workingAgent": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -453,10 +458,11 @@
       "unknown": 0,
       "sessions": 0
     },
-    "alerts": []
+    "alerts": [],
+    "sessionGroups": []
   },
   "needsAttentionAgent": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -540,10 +546,11 @@
       "unknown": 0,
       "sessions": 0
     },
-    "alerts": []
+    "alerts": [],
+    "sessionGroups": []
   },
   "stuckAgent": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -628,10 +635,11 @@
       "unknown": 0,
       "sessions": 0
     },
-    "alerts": []
+    "alerts": [],
+    "sessionGroups": []
   },
   "exitedAgent": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -713,10 +721,11 @@
       "unknown": 0,
       "sessions": 0
     },
-    "alerts": []
+    "alerts": [],
+    "sessionGroups": []
   },
   "unknownLowConfidence": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -800,10 +809,11 @@
       "unknown": 1,
       "sessions": 0
     },
-    "alerts": []
+    "alerts": [],
+    "sessionGroups": []
   },
   "orphanedTerminalTarget": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -835,10 +845,11 @@
         "reason": "Terminal target has no matching configured project or worktree.",
         "observedAt": "2026-05-20T12:00:00.000Z"
       }
-    ]
+    ],
+    "sessionGroups": []
   },
   "providerFailure": {
-    "schemaVersion": "0.9.0",
+    "schemaVersion": "0.10.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -920,6 +931,7 @@
         "provider": "worktrunk",
         "createdAt": "2026-05-20T12:00:00.000Z"
       }
-    ]
+    ],
+    "sessionGroups": []
   }
 }

--- a/tests/diagnostics/injected-failures/provider-timeout.test.ts
+++ b/tests/diagnostics/injected-failures/provider-timeout.test.ts
@@ -7,7 +7,7 @@ describe("provider timeout diagnostic", () => {
     const index = buildDiagnosticEvidenceIndex(
       baseDiagnosticSnapshot({
         observerHealth: {
-          schemaVersion: "0.9.0",
+          schemaVersion: "0.10.0",
           status: "degraded",
           pid: 1234,
           startedAt: diagnosticNow,

--- a/tests/diagnostics/injected-failures/sqlite-write-failure.test.ts
+++ b/tests/diagnostics/injected-failures/sqlite-write-failure.test.ts
@@ -7,7 +7,7 @@ describe("SQLite write failure diagnostic", () => {
     const index = buildDiagnosticEvidenceIndex(
       baseDiagnosticSnapshot({
         observerHealth: {
-          schemaVersion: "0.9.0",
+          schemaVersion: "0.10.0",
           status: "degraded",
           pid: 1234,
           startedAt: diagnosticNow,

--- a/tests/e2e/observer-lifecycle.test.ts
+++ b/tests/e2e/observer-lifecycle.test.ts
@@ -86,7 +86,7 @@ describe("observer lifecycle e2e", () => {
         code: "ENOENT",
       });
       await expect(client.getSnapshot()).resolves.toMatchObject({
-        schemaVersion: "0.9.0",
+        schemaVersion: "0.10.0",
         observer: { version: build.version },
         counts: { projects: 0 },
       });
@@ -873,7 +873,7 @@ describe("observer lifecycle e2e", () => {
         stateDir: fixture.stateDir,
       });
       await expect(client.getSnapshot()).resolves.toMatchObject({
-        schemaVersion: "0.9.0",
+        schemaVersion: "0.10.0",
         counts: { projects: 0 },
       });
     } finally {

--- a/tests/e2e/observer-sqlite-smoke.test.ts
+++ b/tests/e2e/observer-sqlite-smoke.test.ts
@@ -65,6 +65,7 @@ describe("production Observer SQLite smoke", () => {
         path: databasePath,
         open: true,
         status: "healthy",
+        schemaVersion: 17,
       });
       expect((await stat(databasePath)).size).toBeGreaterThan(0);
 
@@ -86,6 +87,7 @@ describe("production Observer SQLite smoke", () => {
         path: databasePath,
         open: true,
         status: "healthy",
+        schemaVersion: 17,
       });
     } finally {
       await client.stop().catch(() => undefined);

--- a/tests/support/diagnostics/index.ts
+++ b/tests/support/diagnostics/index.ts
@@ -44,10 +44,10 @@ export function baseDiagnosticSnapshot(
   overrides: Partial<DiagnosticSnapshot> = {},
 ): DiagnosticSnapshot {
   const snapshot: DiagnosticSnapshot = {
-    schemaVersion: "0.9.0",
+    schemaVersion: "0.10.0",
     collectedAt: diagnosticNow,
     observerHealth: {
-      schemaVersion: "0.9.0",
+      schemaVersion: "0.10.0",
       status: "healthy",
       pid: 1234,
       startedAt: diagnosticNow,
@@ -65,7 +65,7 @@ export function baseDiagnosticSnapshot(
 
 export function baseStationSnapshot(overrides: Partial<StationSnapshot> = {}): StationSnapshot {
   const snapshot: StationSnapshot = {
-    schemaVersion: "0.9.0",
+    schemaVersion: "0.10.0",
     generatedAt: diagnosticNow,
     observer: {
       pid: 1234,
@@ -77,6 +77,7 @@ export function baseStationSnapshot(overrides: Partial<StationSnapshot> = {}): S
     projects: [],
     rows: [],
     sessions: [],
+    sessionGroups: [],
     counts: {
       projects: 0,
       sessions: 0,


### PR DESCRIPTION
## What this fixes

The Observer needs one strict, durable authority for organizing sessions into project-local Groups before commands, events, projection, or dashboard behavior can safely depend on them. Without shared graph validation and transactional persistence, clients could accept inconsistent memberships, stale writes could silently win, and Node/Bun runtimes could diverge.

Closes #533 and provides the foundational persistence slice for #489.

## What changed

- Defines branded Group IDs and strict Group views, makes `snapshot.sessionGroups` required, and advances the protocol schema to `0.10.0`.
- Validates Group membership, project ownership, parentage, exclusivity, timestamps, versions, and cycles across the complete snapshot graph.
- Adds migration 017 plus an Observer-owned `SessionGroupStore` for atomic creation, rename, reassignment, reparenting, deletion, and reconcile pruning.
- Gives SQLite and the in-memory fixture the same copy-on-write semantics, non-throwing conflict outcomes, deterministic ordering, and version behavior.
- Extends Node/Bun cross-runtime probes to preserve Group definitions, parents, memberships, versions, and timestamps in both directions.
- Keeps live projection and dashboard behavior out of scope; production snapshots expose an empty `sessionGroups` array until #534 wires projection.

## Testing

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:contracts` — 75 passed
- `pnpm test:integration` — 612 passed after rebasing onto current `main`
- `pnpm architecture:observer:generate`
- `pnpm architecture:observer:check`
- `pnpm test:sqlite:bun`
- `pnpm smoke:install`
- Isolated `stn snapshot --json` returned schema `0.10.0` with `"sessionGroups":[]`.

`pnpm test:all` reaches Observer E2E, where 18/20 tests pass; the two handoff replacement cases reproducibly time out on incumbent health convergence after 1 second (`OBSERVER_INCUMBENT_HEALTH_TIMEOUT`).