### PR TITLE
refactor(setup): centralize tool metadata

### DIFF
--- a/apps/cli/src/commands/setup/adapters/config.ts
+++ b/apps/cli/src/commands/setup/adapters/config.ts
@@ -14,6 +14,7 @@ import type {
   SetupOperationOutcome,
   SupportedHarnessId,
 } from "@station/setup-core";
+import { SETUP_TOOL_DEFINITIONS } from "../toolDefinitions.js";
 import type { SetupFacts } from "./inspectionTypes.js";
 
 export type SetupConfigAdapterOptions = {
@@ -143,10 +144,10 @@ export function setupConfigMutationInput(
         installHooks: operation.trackingHarnessIds.includes(harnessId),
       };
     }),
-    worktrunkCommand: detectedCommand(facts.worktrunk, "wt"),
+    worktrunkCommand: detectedCommand(facts.worktrunk, SETUP_TOOL_DEFINITIONS.worktrunk.command),
     installWorktrunkHooks: operation.installWorktrunkTracking,
   };
-  const tmuxCommand = detectedOptionalCommand(facts.tmux, "tmux");
+  const tmuxCommand = detectedOptionalCommand(facts.tmux, SETUP_TOOL_DEFINITIONS.tmux.command);
   if (tmuxCommand !== undefined) desired.tmuxCommand = tmuxCommand;
 
   let current: SetupConfigMutationInput["current"];

--- a/apps/cli/src/commands/setup/adapters/inspection.ts
+++ b/apps/cli/src/commands/setup/adapters/inspection.ts
@@ -14,6 +14,7 @@ import {
   type SupportedHarnessId,
 } from "@station/setup-core";
 import { type CollectSetupFactsOptions, collectSetupFacts } from "../checks/system.js";
+import { setupToolDefinitions } from "../toolDefinitions.js";
 import type { SetupCommandDeps, SetupCommandOptions } from "../types.js";
 import { planSetupConfigMutationForInspection } from "./config.js";
 import type { SetupFacts, SetupHarnessTrackingFact, SetupMode } from "./inspectionTypes.js";
@@ -297,12 +298,9 @@ export function normalizeSetupPlanningFacts(
         : facts.brew.status === "missing"
           ? "missing"
           : "skipped",
-    tools: [
-      normalizeTool("worktrunk", facts.worktrunk.status === "ok", facts),
-      normalizeTool("tmux", facts.tmux.status === "ok", facts),
-      normalizeTool("bun", facts.bun.status === "ok", facts),
-      normalizeTool("diff-viewer", facts.diffViewer.status === "ok", facts),
-    ],
+    tools: setupToolDefinitions.map(({ id, factKey }) =>
+      normalizeTool(id, facts[factKey].status === "ok", facts),
+    ),
     runtimeUi: normalizeRuntimeUi(facts),
     git:
       facts.git.status === "missing"

--- a/apps/cli/src/commands/setup/adapters/operations.ts
+++ b/apps/cli/src/commands/setup/adapters/operations.ts
@@ -18,7 +18,6 @@ import {
   type SetupPackageInstallerCommit,
   type SetupPackageInstallOperation,
   type SetupTmuxPopupOperation,
-  type SetupToolInstallOperation,
   type SetupWorktrunkTrackingOperation,
 } from "@station/setup-core";
 import { runWorktrunkHooksCommand } from "../../providerHookAdapters.js";
@@ -28,7 +27,7 @@ import {
   tmuxPopupBindingBlock,
   tmuxPopupBindingEndMarker,
 } from "../checks/tmuxBinding.js";
-import { defaultDiffViewer } from "../defaultDiffViewer.js";
+import { SETUP_TOOL_DEFINITIONS } from "../toolDefinitions.js";
 import type { SetupApplyFileSystem, SetupCommandDeps } from "../types.js";
 import { createSetupConfigAdapter } from "./config.js";
 import { createHarnessTrackingAdapter } from "./harnessTracking.js";
@@ -153,7 +152,7 @@ function packageInstallCommand(
 ): readonly string[] {
   switch (operation.kind) {
     case "install-tool":
-      return ["brew", "install", toolFormula(operation.tool)];
+      return ["brew", "install", SETUP_TOOL_DEFINITIONS[operation.tool].formula];
     case "install-harness": {
       const currentFacts = requireFacts(facts);
       return harnessInstallCommand({
@@ -641,21 +640,6 @@ function ensureTrailingNewline(value: string): string {
 function requireFacts(facts: SetupFacts | undefined): SetupFacts {
   if (facts === undefined) throw new Error("This setup operation requires collected setup facts.");
   return facts;
-}
-
-function toolFormula(tool: SetupToolInstallOperation["tool"]): string {
-  switch (tool) {
-    case "worktrunk":
-      return "worktrunk";
-    case "tmux":
-      return "tmux";
-    case "bun":
-      return "bun";
-    case "diff-viewer":
-      return defaultDiffViewer.formula;
-    default:
-      return assertNever(tool);
-  }
 }
 
 function unexpectedOperationFallback(operation: SetupOperation): {

--- a/apps/cli/src/commands/setup/checks/bun.ts
+++ b/apps/cli/src/commands/setup/checks/bun.ts
@@ -1,13 +1,12 @@
 import { type ResolveExecutablePathOptions, resolveExecutablePath } from "@station/runtime";
 import type { SetupDependencyFact } from "../adapters/inspectionTypes.js";
+import { SETUP_TOOL_DEFINITIONS } from "../toolDefinitions.js";
 import { setupEnv } from "./env.js";
 import type { SetupDependencyCheckOptions } from "./system.js";
 
-export const defaultBunCommand = "bun";
-
-export function bunInstallHint(command = defaultBunCommand): string {
+export function bunInstallHint(command = SETUP_TOOL_DEFINITIONS.bun.command): string {
   return [
-    "Install Bun with brew install bun to run the STATION terminal UI.",
+    `Install Bun with brew install ${SETUP_TOOL_DEFINITIONS.bun.formula} to run the STATION terminal UI.`,
     `Bare stn launches the dashboard through ${command} run.`,
   ].join(" ");
 }
@@ -21,7 +20,7 @@ export async function checkSetupBun(
   options: SetupDependencyCheckOptions = {},
 ): Promise<SetupDependencyFact> {
   const env = setupEnv(options.env);
-  const command = defaultBunCommand;
+  const command = SETUP_TOOL_DEFINITIONS.bun.command;
   // Mirror tui.ts and doctor's rendererRuntimeCheck: a STATION_DASHBOARD_COMMAND
   // override replaces `bun run`, so Bun is not required to launch the dashboard and
   // must not block core setup (else doctor reports healthy while setup check exits 1).

--- a/apps/cli/src/commands/setup/checks/bun.ts
+++ b/apps/cli/src/commands/setup/checks/bun.ts
@@ -4,9 +4,11 @@ import { SETUP_TOOL_DEFINITIONS } from "../toolDefinitions.js";
 import { setupEnv } from "./env.js";
 import type { SetupDependencyCheckOptions } from "./system.js";
 
-export function bunInstallHint(command = SETUP_TOOL_DEFINITIONS.bun.command): string {
+const bunDefinition = SETUP_TOOL_DEFINITIONS.bun;
+
+export function bunInstallHint(command = bunDefinition.command): string {
   return [
-    `Install Bun with brew install ${SETUP_TOOL_DEFINITIONS.bun.formula} to run the STATION terminal UI.`,
+    `Install ${bunDefinition.displayName} with brew install ${bunDefinition.formula} to run the STATION terminal UI.`,
     `Bare stn launches the dashboard through ${command} run.`,
   ].join(" ");
 }
@@ -20,7 +22,7 @@ export async function checkSetupBun(
   options: SetupDependencyCheckOptions = {},
 ): Promise<SetupDependencyFact> {
   const env = setupEnv(options.env);
-  const command = SETUP_TOOL_DEFINITIONS.bun.command;
+  const command = bunDefinition.command;
   // Mirror tui.ts and doctor's rendererRuntimeCheck: a STATION_DASHBOARD_COMMAND
   // override replaces `bun run`, so Bun is not required to launch the dashboard and
   // must not block core setup (else doctor reports healthy while setup check exits 1).

--- a/apps/cli/src/commands/setup/checks/diffViewer.ts
+++ b/apps/cli/src/commands/setup/checks/diffViewer.ts
@@ -1,11 +1,13 @@
 import { type ResolveExecutablePathOptions, resolveExecutablePath } from "@station/runtime";
 import type { SetupDependencyFact } from "../adapters/inspectionTypes.js";
-import { defaultDiffViewer } from "../defaultDiffViewer.js";
+import { SETUP_TOOL_DEFINITIONS } from "../toolDefinitions.js";
 import { setupEnv } from "./env.js";
 import type { SetupDependencyCheckOptions } from "./system.js";
 
-export function diffViewerInstallHint(command = defaultDiffViewer.command): string {
-  return `${defaultDiffViewer.installHint} stn tried ${command}.`;
+const diffViewerDefinition = SETUP_TOOL_DEFINITIONS["diff-viewer"];
+
+export function diffViewerInstallHint(command = diffViewerDefinition.command): string {
+  return `Install ${diffViewerDefinition.displayName} with brew install ${diffViewerDefinition.formula} for the STATION 'See diff' automation. stn tried ${command}.`;
 }
 
 /** Maps setup's semantic diff-viewer capability to the Hunk executable shipped by Homebrew. */
@@ -16,13 +18,13 @@ export async function checkSetupDiffViewer(
   const resolveOptions: ResolveExecutablePathOptions = {};
   if (env.PATH !== undefined) resolveOptions.pathEnv = env.PATH;
   if (options.access !== undefined) resolveOptions.access = options.access;
-  const resolvedPath = await resolveExecutablePath(defaultDiffViewer.command, resolveOptions);
+  const resolvedPath = await resolveExecutablePath(diffViewerDefinition.command, resolveOptions);
   if (resolvedPath !== undefined) {
-    return { status: "ok", command: defaultDiffViewer.command, resolvedPath };
+    return { status: "ok", command: diffViewerDefinition.command, resolvedPath };
   }
   return {
     status: "missing",
-    command: defaultDiffViewer.command,
+    command: diffViewerDefinition.command,
     message: diffViewerInstallHint(),
   };
 }

--- a/apps/cli/src/commands/setup/checks/system.ts
+++ b/apps/cli/src/commands/setup/checks/system.ts
@@ -21,6 +21,7 @@ import type {
   SetupMode,
   SetupStationUiFact,
 } from "../adapters/inspectionTypes.js";
+import { SETUP_TOOL_DEFINITIONS } from "../toolDefinitions.js";
 import { checkBrewDependency } from "./brew.js";
 import { checkSetupBun } from "./bun.js";
 import {
@@ -157,7 +158,10 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
     worktrunkPromise,
     checkSetupTmux(dependencyOptions),
     compiled
-      ? Promise.resolve({ status: "ok" as const, command: "bun" })
+      ? Promise.resolve({
+          status: "ok" as const,
+          command: SETUP_TOOL_DEFINITIONS.bun.command,
+        })
       : checkSetupBun(dependencyOptions),
     checkSetupDiffViewer(dependencyOptions),
     checkBrewDependency({

--- a/apps/cli/src/commands/setup/checks/tmux.ts
+++ b/apps/cli/src/commands/setup/checks/tmux.ts
@@ -1,5 +1,6 @@
 import { checkTmuxDependency } from "@station/tmux";
 import type { SetupDependencyFact } from "../adapters/inspectionTypes.js";
+import { SETUP_TOOL_DEFINITIONS } from "../toolDefinitions.js";
 import { setupProbeTimeoutMs } from "./constants.js";
 import { setupEnv } from "./env.js";
 import type { SetupDependencyCheckOptions } from "./system.js";
@@ -8,7 +9,7 @@ export async function checkSetupTmux(
   options: SetupDependencyCheckOptions = {},
 ): Promise<SetupDependencyFact> {
   const env = setupEnv(options.env);
-  const command = env.STATION_TMUX_BIN ?? "tmux";
+  const command = env.STATION_TMUX_BIN ?? SETUP_TOOL_DEFINITIONS.tmux.command;
   const dependencyOptions: Parameters<typeof checkTmuxDependency>[0] = {
     command,
     timeoutMs: setupProbeTimeoutMs,

--- a/apps/cli/src/commands/setup/checks/tmuxBinding.ts
+++ b/apps/cli/src/commands/setup/checks/tmuxBinding.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { type ExternalCommandRunner, runExternalCommand } from "@station/runtime";
 import { persistentUiOwnerClientOption } from "@station/tmux";
 import type { SetupTmuxBindingFact } from "../adapters/inspectionTypes.js";
+import { SETUP_TOOL_DEFINITIONS } from "../toolDefinitions.js";
 import type { SetupFileSystemReader } from "./config.js";
 import { setupProbeTimeoutMs } from "./constants.js";
 
@@ -513,10 +514,11 @@ async function checkLiveTmuxBinding(input: {
   if (!input.insideTmux) {
     return "unknown";
   }
+  const tmuxCommand = input.tmuxCommand ?? SETUP_TOOL_DEFINITIONS.tmux.command;
   try {
     const listed = await runExternalCommand(
       {
-        command: input.tmuxCommand ?? "tmux",
+        command: tmuxCommand,
         args: ["list-keys", "-T", "prefix"],
         timeoutMs: setupProbeTimeoutMs,
         maxOutputChars: 32_768,
@@ -534,7 +536,7 @@ async function checkLiveTmuxBinding(input: {
     if (binding !== "station") return "missing";
     const startup = await runExternalCommand(
       {
-        command: input.tmuxCommand ?? "tmux",
+        command: tmuxCommand,
         args: [
           "run-shell",
           `env STATION_SETUP_LAUNCHER_PROBE=1 ${quoteShellValue(escapeTmuxFormat(input.launcherCommand))} --help >/dev/null 2>&1`,

--- a/apps/cli/src/commands/setup/checks/worktrunk.ts
+++ b/apps/cli/src/commands/setup/checks/worktrunk.ts
@@ -10,6 +10,7 @@ import type {
   SetupWorktrunkAutomationFact,
   SetupWorktrunkShellIntegrationFact,
 } from "../adapters/inspectionTypes.js";
+import { SETUP_TOOL_DEFINITIONS } from "../toolDefinitions.js";
 import { setupProbeTimeoutMs } from "./constants.js";
 import { commandEnv, setupEnv } from "./env.js";
 import type { SetupDependencyCheckOptions } from "./system.js";
@@ -18,7 +19,8 @@ export async function checkSetupWorktrunk(
   options: SetupDependencyCheckOptions & { command?: string } = {},
 ): Promise<SetupDependencyFact> {
   const env = setupEnv(options.env);
-  const command = options.command ?? env.STATION_WORKTRUNK_BIN ?? "wt";
+  const command =
+    options.command ?? env.STATION_WORKTRUNK_BIN ?? SETUP_TOOL_DEFINITIONS.worktrunk.command;
   const dependencyOptions: Parameters<typeof checkWorktrunkDependency>[0] = {
     command,
     timeoutMs: setupProbeTimeoutMs,

--- a/apps/cli/src/commands/setup/defaultDiffViewer.ts
+++ b/apps/cli/src/commands/setup/defaultDiffViewer.ts
@@ -1,8 +1,0 @@
-export const defaultDiffViewer = {
-  id: "diff-viewer",
-  command: "hunk",
-  formula: "hunk",
-  formulaUrl: "https://formulae.brew.sh/formula/hunk",
-  displayName: "Hunk",
-  installHint: "Install Hunk with brew install hunk for the STATION 'See diff' automation.",
-} as const;

--- a/apps/cli/src/commands/setup/presentation/projectSetupActions.ts
+++ b/apps/cli/src/commands/setup/presentation/projectSetupActions.ts
@@ -2,7 +2,7 @@ import type { SetupConfigMutationPlan } from "@station/config";
 import type { SetupOperation, SetupToolInstallOperation } from "@station/setup-core";
 import { setupMessageRef } from "@station/setup-messages";
 import type { SetupFacts } from "../adapters/inspectionTypes.js";
-import { defaultDiffViewer } from "../defaultDiffViewer.js";
+import { SETUP_TOOL_DEFINITIONS } from "../toolDefinitions.js";
 import type { SetupPresentationHarnessSelection, SetupViewAction } from "./setupViewTypes.js";
 
 export function projectSetupActions(input: {
@@ -196,40 +196,22 @@ function projectInstallToolAction(input: {
   readonly facts: SetupFacts;
 }): SetupViewAction {
   const { operation, facts } = input;
-  const presentation = toolPresentation(operation.tool);
+  const definition = SETUP_TOOL_DEFINITIONS[operation.tool];
   const installerAvailable = facts.brew.status === "ok";
   return {
-    id: `install-${operation.tool}`,
+    id: `install-${definition.id}`,
     operationId: operation.id,
     kind: operation.kind,
     tier: "required",
     selected: operation.selected,
-    label: setupMessageRef("action.install-label", { label: presentation.label }),
+    label: setupMessageRef("action.install-label", { label: definition.displayName }),
     explanation: installerAvailable
-      ? setupMessageRef("action.install-homebrew", { label: presentation.label })
+      ? setupMessageRef("action.install-homebrew", { label: definition.displayName })
       : setupMessageRef("action.install-manually", {
-          label: presentation.label,
-          formula: presentation.formula,
+          label: definition.displayName,
+          formula: definition.formula,
         }),
   };
-}
-
-function toolPresentation(tool: SetupToolInstallOperation["tool"]): {
-  readonly label: string;
-  readonly formula: string;
-} {
-  switch (tool) {
-    case "worktrunk":
-      return { label: "Worktrunk", formula: "worktrunk" };
-    case "tmux":
-      return { label: "tmux", formula: "tmux" };
-    case "bun":
-      return { label: "Bun", formula: "bun" };
-    case "diff-viewer":
-      return { label: defaultDiffViewer.displayName, formula: defaultDiffViewer.formula };
-    default:
-      return assertNeverTool(tool);
-  }
 }
 
 function projectConfigWriteActions(input: {
@@ -285,10 +267,6 @@ function projectConfigWriteActions(input: {
 
 function assertNeverOperation(operation: never): never {
   throw new Error(`Unsupported setup operation: ${String(operation)}`);
-}
-
-function assertNeverTool(tool: never): never {
-  throw new Error(`Unsupported setup tool: ${String(tool)}`);
 }
 
 function assertNeverHarness(harness: never): never {

--- a/apps/cli/src/commands/setup/presentation/projectSetupChecks.ts
+++ b/apps/cli/src/commands/setup/presentation/projectSetupChecks.ts
@@ -3,6 +3,7 @@ import { setupMessageRef } from "@station/setup-messages";
 import { stationUiInstallHint } from "../../../stationWorkspace.js";
 import type { SetupFacts } from "../adapters/inspectionTypes.js";
 import { setupLauncherExecutable } from "../checks/launchers.js";
+import { SETUP_TOOL_DEFINITIONS } from "../toolDefinitions.js";
 import type { SetupDisplayDetail, SetupViewCheck } from "./setupViewTypes.js";
 
 export function projectSetupEnvironmentChecks(facts: SetupFacts): readonly SetupViewCheck[] {
@@ -11,24 +12,21 @@ export function projectSetupEnvironmentChecks(facts: SetupFacts): readonly Setup
     socketEvidenceCheck(facts),
     ...(facts.compiled || facts.xcode.status !== "missing" ? [] : [xcodeCheck(facts)]),
     dependencyCheck(
-      "worktrunk",
-      setupMessageRef("label.worktrunk"),
-      facts.worktrunk,
+      SETUP_TOOL_DEFINITIONS.worktrunk,
+      facts,
       "Worktrunk is required for core worktree setup.",
     ),
     dependencyCheck(
-      "tmux",
-      setupMessageRef("label.tmux"),
-      facts.tmux,
+      SETUP_TOOL_DEFINITIONS.tmux,
+      facts,
       "tmux is required for the reference terminal workflow.",
     ),
     ...(facts.compiled
       ? []
       : [
           dependencyCheck(
-            "bun",
-            setupMessageRef("label.bun"),
-            facts.bun,
+            SETUP_TOOL_DEFINITIONS.bun,
+            facts,
             "Bun is required to run the STATION terminal UI (bare stn).",
           ),
         ]),
@@ -44,10 +42,8 @@ export function projectSetupOperationalChecks(facts: SetupFacts): readonly Setup
     tmuxPopupBindingCheck(facts),
     worktrunkHooksCheck(facts),
     toolCheck(
-      "diff-viewer",
-      setupMessageRef("label.diff-viewer"),
-      facts.diffViewer,
-      setupMessageRef("check.available", { label: "Hunk" }),
+      SETUP_TOOL_DEFINITIONS["diff-viewer"],
+      facts,
       setupMessageRef("check.evidence", {
         message: "Hunk is required for the STATION 'See diff' automation.",
       }),
@@ -108,11 +104,11 @@ function xcodeCheck(facts: SetupFacts): SetupViewCheck {
 }
 
 function dependencyCheck(
-  id: string,
-  label: SetupViewCheck["label"],
-  dependency: SetupFacts["worktrunk"],
+  definition: (typeof SETUP_TOOL_DEFINITIONS)[keyof typeof SETUP_TOOL_DEFINITIONS],
+  facts: SetupFacts,
   fallback: string,
 ): SetupViewCheck {
+  const dependency = facts[definition.factKey];
   const details: SetupDisplayDetail[] = [];
   if (dependency.version !== undefined) {
     details.push({ label: setupMessageRef("detail.version"), value: dependency.version });
@@ -124,29 +120,16 @@ function dependencyCheck(
     });
   }
   return {
-    id,
+    id: definition.id,
     tier: "required",
     status: dependency.status === "ok" ? "ok" : "missing",
-    label,
+    label: definition.label,
     explanation:
       dependency.status === "ok"
-        ? setupMessageRef("check.available", { label: messageLabel(label) })
+        ? setupMessageRef("check.available", { label: definition.availabilityName })
         : setupMessageRef("check.evidence", { message: dependency.message ?? fallback }),
     details,
   };
-}
-
-function messageLabel(label: SetupViewCheck["label"]): string {
-  switch (label.id) {
-    case "label.worktrunk":
-      return "Worktrunk / wt";
-    case "label.tmux":
-      return "tmux";
-    case "label.bun":
-      return "Bun";
-    default:
-      throw new Error(`Unsupported setup dependency label: ${label.id}`);
-  }
 }
 
 function gitCheck(facts: SetupFacts): SetupViewCheck {
@@ -386,12 +369,11 @@ function worktrunkAutomationDetails(facts: SetupFacts): SetupDisplayDetail[] {
 }
 
 function toolCheck(
-  id: string,
-  label: SetupViewCheck["label"],
-  fact: SetupFacts["worktrunk"],
-  ready: SetupViewCheck["explanation"],
+  definition: (typeof SETUP_TOOL_DEFINITIONS)[keyof typeof SETUP_TOOL_DEFINITIONS],
+  facts: SetupFacts,
   missing: SetupViewCheck["explanation"],
 ): SetupViewCheck {
+  const fact = facts[definition.factKey];
   const details: SetupDisplayDetail[] = [];
   if (fact.resolvedPath !== undefined) {
     details.push({
@@ -400,13 +382,13 @@ function toolCheck(
     });
   }
   return {
-    id,
+    id: definition.id,
     tier: "required",
     status: fact.status === "ok" ? "ok" : "missing",
-    label,
+    label: definition.label,
     explanation:
       fact.status === "ok"
-        ? ready
+        ? setupMessageRef("check.available", { label: definition.availabilityName })
         : fact.message === undefined
           ? missing
           : setupMessageRef("check.evidence", { message: fact.message }),

--- a/apps/cli/src/commands/setup/presentation/projectSetupView.ts
+++ b/apps/cli/src/commands/setup/presentation/projectSetupView.ts
@@ -3,6 +3,7 @@ import type { SetupPlan } from "@station/setup-core";
 import { setupMessageRef } from "@station/setup-messages";
 import type { SetupFacts } from "../adapters/inspectionTypes.js";
 import { SetupHarnessTrackingFactSchema } from "../adapters/inspectionTypes.js";
+import { SETUP_TOOL_DEFINITIONS } from "../toolDefinitions.js";
 import { projectSetupActions } from "./projectSetupActions.js";
 import {
   projectSetupEnvironmentChecks,
@@ -134,7 +135,9 @@ function projectRecovery(plan: SetupPlan, facts: SetupFacts): readonly SetupReco
     return [
       {
         kind: "instruction",
-        message: setupMessageRef("next.install-bun"),
+        message: setupMessageRef("next.install-bun", {
+          formula: SETUP_TOOL_DEFINITIONS.bun.formula,
+        }),
         command: ["stn", "setup", "check"],
       },
     ];
@@ -151,7 +154,9 @@ function projectRecovery(plan: SetupPlan, facts: SetupFacts): readonly SetupReco
     return [
       {
         kind: "instruction",
-        message: setupMessageRef("next.install-diff-viewer"),
+        message: setupMessageRef("next.install-diff-viewer", {
+          formula: SETUP_TOOL_DEFINITIONS["diff-viewer"].formula,
+        }),
         command: ["stn", "setup", "check"],
       },
     ];

--- a/apps/cli/src/commands/setup/presenters/json.ts
+++ b/apps/cli/src/commands/setup/presenters/json.ts
@@ -1048,13 +1048,19 @@ function nextSteps(requiredMissing: number, facts: SetupFacts): string[] {
     return ["Install tmux, then run: stn setup check"];
   }
   if (facts.bun.status === "missing") {
-    return ["Install Bun (brew install bun), then run: stn setup check"];
+    const definition = SETUP_TOOL_DEFINITIONS.bun;
+    return [
+      `Install ${definition.displayName} (brew install ${definition.formula}), then run: stn setup check`,
+    ];
   }
   if (facts.git.status === "missing") {
     return [facts.git.message];
   }
   if (facts.diffViewer.status === "missing") {
-    return ["Install Hunk (brew install hunk), then run: stn setup check"];
+    const definition = SETUP_TOOL_DEFINITIONS["diff-viewer"];
+    return [
+      `Install ${definition.displayName} (brew install ${definition.formula}), then run: stn setup check`,
+    ];
   }
   return ["Resolve the missing required setup items, then run: stn setup check"];
 }

--- a/apps/cli/src/commands/setup/presenters/json.ts
+++ b/apps/cli/src/commands/setup/presenters/json.ts
@@ -19,7 +19,7 @@ import type { SetupFacts } from "../adapters/inspectionTypes.js";
 import { SetupHarnessTrackingFactSchema } from "../adapters/inspectionTypes.js";
 import { setupLauncherExecutable } from "../checks/launchers.js";
 import { tmuxPopupBindingBlock, tmuxPopupBindingEndMarker } from "../checks/tmuxBinding.js";
-import { defaultDiffViewer } from "../defaultDiffViewer.js";
+import { SETUP_TOOL_DEFINITIONS } from "../toolDefinitions.js";
 
 type SetupHarnessSelection = {
   readonly source: CliSetupPlan["summary"]["selectionSource"];
@@ -114,26 +114,23 @@ function setupChecks(
     socketEvidenceCheck(facts),
     ...(facts.compiled ? [] : xcodeChecks(facts)),
     dependencyCheck({
-      id: "worktrunk",
-      label: "Worktrunk / wt",
+      definition: SETUP_TOOL_DEFINITIONS.worktrunk,
+      facts,
       missingMessage: facts.worktrunk.message ?? "Worktrunk is required for core worktree setup.",
-      dependency: facts.worktrunk,
     }),
     dependencyCheck({
-      id: "tmux",
-      label: "tmux",
+      definition: SETUP_TOOL_DEFINITIONS.tmux,
+      facts,
       missingMessage: facts.tmux.message ?? "tmux is required for the reference terminal workflow.",
-      dependency: facts.tmux,
     }),
     ...(facts.compiled
       ? []
       : [
           dependencyCheck({
-            id: "bun",
-            label: "Bun",
+            definition: SETUP_TOOL_DEFINITIONS.bun,
+            facts,
             missingMessage:
               facts.bun.message ?? "Bun is required to run the STATION terminal UI (bare stn).",
-            dependency: facts.bun,
           }),
         ]),
     gitCheck(facts),
@@ -147,11 +144,10 @@ function setupChecks(
     worktrunkHooksCheck(facts),
     ...harnessTrackingChecks(plan, facts, harnessSelection),
     dependencyCheck({
-      id: "diff-viewer",
-      label: "Hunk",
+      definition: SETUP_TOOL_DEFINITIONS["diff-viewer"],
+      facts,
       missingMessage:
         facts.diffViewer.message ?? "Hunk is required for the STATION 'See diff' automation.",
-      dependency: facts.diffViewer,
     }),
     {
       id: "doctor",
@@ -544,23 +540,25 @@ function xcodeChecks(facts: SetupFacts): CliSetupCheck[] {
 }
 
 function dependencyCheck(input: {
-  id: string;
-  label: string;
+  definition: (typeof SETUP_TOOL_DEFINITIONS)[keyof typeof SETUP_TOOL_DEFINITIONS];
+  facts: SetupFacts;
   missingMessage: string;
-  dependency: SetupFacts["worktrunk"];
 }): CliSetupCheck {
-  const details: Record<string, string> = { command: input.dependency.command };
-  if (input.dependency.version !== undefined) details.version = input.dependency.version;
-  if (input.dependency.resolvedPath !== undefined) {
-    details.resolvedPath = input.dependency.resolvedPath;
+  const dependency = input.facts[input.definition.factKey];
+  const details: Record<string, string> = { command: dependency.command };
+  if (dependency.version !== undefined) details.version = dependency.version;
+  if (dependency.resolvedPath !== undefined) {
+    details.resolvedPath = dependency.resolvedPath;
   }
   return {
-    id: input.id,
+    id: input.definition.id,
     tier: "required",
-    status: input.dependency.status === "ok" ? "ok" : "missing",
-    label: input.label,
+    status: dependency.status === "ok" ? "ok" : "missing",
+    label: input.definition.availabilityName,
     message:
-      input.dependency.status === "ok" ? `${input.label} is available.` : input.missingMessage,
+      dependency.status === "ok"
+        ? `${input.definition.availabilityName} is available.`
+        : input.missingMessage,
     details,
   };
 }
@@ -791,12 +789,12 @@ function setupActions(
   for (const operation of operations) {
     switch (operation.kind) {
       case "install-tool": {
-        const presentation = installToolPresentation(operation.tool);
+        const definition = SETUP_TOOL_DEFINITIONS[operation.tool];
         actions.push(
           installAction(
-            presentation.id,
-            presentation.label,
-            presentation.formula,
+            `install-${definition.id}`,
+            definition.displayName,
+            definition.formula,
             facts.brew,
             operation.selected,
           ),
@@ -897,29 +895,6 @@ function setupActions(
     );
   }
   return actions;
-}
-
-function installToolPresentation(tool: Extract<SetupOperation, { kind: "install-tool" }>["tool"]): {
-  id: string;
-  label: string;
-  formula: string;
-} {
-  switch (tool) {
-    case "worktrunk":
-      return { id: "install-worktrunk", label: "Worktrunk", formula: "worktrunk" };
-    case "tmux":
-      return { id: "install-tmux", label: "tmux", formula: "tmux" };
-    case "bun":
-      return { id: "install-bun", label: "Bun", formula: "bun" };
-    case "diff-viewer":
-      return {
-        id: "install-diff-viewer",
-        label: defaultDiffViewer.displayName,
-        formula: defaultDiffViewer.formula,
-      };
-    default:
-      throw new Error(`Unsupported semantic setup tool: ${tool}`);
-  }
 }
 
 function persistedTmuxPopupAction(facts: SetupFacts, selected: boolean): CliSetupAction {

--- a/apps/cli/src/commands/setup/session/runGuidedSetupSession.ts
+++ b/apps/cli/src/commands/setup/session/runGuidedSetupSession.ts
@@ -15,7 +15,7 @@ import type { SetupComposition, SetupSessionProjection } from "../composition.js
 import { overlaySetupOperationOutcomes } from "../presentation/projectSetupResult.js";
 import type { TextSetupPresenter } from "../presenters/text.js";
 import { formatSetupCommand } from "../presenters/text.js";
-import { SETUP_TOOL_DEFINITIONS } from "../toolDefinitions.js";
+import { SETUP_TOOL_DEFINITIONS, setupToolDefinitions } from "../toolDefinitions.js";
 import type {
   SetupCommandOptions,
   SetupCommandResult,
@@ -595,12 +595,7 @@ function unavailableRequiredHarnesses(
 }
 
 function coreToolsNeedHomebrew(facts: SetupFacts): boolean {
-  return (
-    facts.worktrunk.status !== "ok" ||
-    facts.tmux.status !== "ok" ||
-    facts.bun.status !== "ok" ||
-    facts.diffViewer.status !== "ok"
-  );
+  return setupToolDefinitions.some(({ factKey }) => facts[factKey].status !== "ok");
 }
 
 function shouldOfferHomebrew(facts: SetupFacts): boolean {

--- a/apps/cli/src/commands/setup/session/runGuidedSetupSession.ts
+++ b/apps/cli/src/commands/setup/session/runGuidedSetupSession.ts
@@ -7,16 +7,15 @@ import {
   type SetupOperationOutcome,
   type SetupOperationProgress,
   type SetupSessionState,
-  type SetupToolInstallOperation,
   type SupportedHarnessId,
 } from "@station/setup-core";
-import { type SetupMessageRef, setupMessageRef } from "@station/setup-messages";
+import { setupMessageRef } from "@station/setup-messages";
 import type { SetupFacts } from "../adapters/inspectionTypes.js";
 import type { SetupComposition, SetupSessionProjection } from "../composition.js";
-import { defaultDiffViewer } from "../defaultDiffViewer.js";
 import { overlaySetupOperationOutcomes } from "../presentation/projectSetupResult.js";
 import type { TextSetupPresenter } from "../presenters/text.js";
 import { formatSetupCommand } from "../presenters/text.js";
+import { SETUP_TOOL_DEFINITIONS } from "../toolDefinitions.js";
 import type {
   SetupCommandOptions,
   SetupCommandResult,
@@ -35,20 +34,6 @@ type GuidedHarnessSelection =
   | { readonly kind: "selected"; readonly harnessIds: SupportedHarnessId[] }
   | { readonly kind: "cancelled" }
   | { readonly kind: "blocked" };
-
-const homebrewFormulaUrls = {
-  worktrunk: "https://formulae.brew.sh/formula/worktrunk",
-  tmux: "https://formulae.brew.sh/formula/tmux",
-  bun: "https://formulae.brew.sh/formula/bun",
-  [defaultDiffViewer.id]: defaultDiffViewer.formulaUrl,
-} satisfies Record<SetupToolInstallOperation["tool"], string>;
-
-const setupToolLabelRefs = {
-  worktrunk: setupMessageRef("label.worktrunk"),
-  tmux: setupMessageRef("label.tmux"),
-  bun: setupMessageRef("label.bun"),
-  [defaultDiffViewer.id]: setupMessageRef("label.diff-viewer"),
-} satisfies Record<SetupToolInstallOperation["tool"], SetupMessageRef>;
 
 /**
  * ADAPTER
@@ -750,9 +735,10 @@ function operationLabel(composition: SetupComposition, operation: SetupOperation
     if (action !== undefined) return composition.text.text(action.label);
   }
   if (operation.kind === "install-tool") {
+    const definition = SETUP_TOOL_DEFINITIONS[operation.tool];
     return composition.text.text(
       setupMessageRef("action.install-label", {
-        label: setupToolLabel(composition.text, operation.tool),
+        label: composition.text.text(definition.label),
       }),
     );
   }
@@ -781,13 +767,6 @@ function operationLabel(composition: SetupComposition, operation: SetupOperation
     );
   }
   return composition.text.text(setupMessageRef("label.setup-operation"));
-}
-
-function setupToolLabel(
-  presenter: TextSetupPresenter,
-  tool: SetupToolInstallOperation["tool"],
-): string {
-  return presenter.text(setupToolLabelRefs[tool]);
 }
 
 function harnessLabel(facts: SetupFacts | undefined, harnessId: SupportedHarnessId): string {
@@ -866,7 +845,10 @@ function renderRequiredToolsReview(
       action === undefined ? operationLabel(composition, operation) : presenter.text(action.label);
     const sourceLabel = presenter.text(setupMessageRef("guided.required-tool-source"));
     const source = presenter.detail(
-      presenter.link({ label: sourceLabel, url: homebrewFormulaUrls[operation.tool] }),
+      presenter.link({
+        label: sourceLabel,
+        url: SETUP_TOOL_DEFINITIONS[operation.tool].formulaUrl,
+      }),
     );
     return [`- ${description}  ${source}`];
   });

--- a/apps/cli/src/commands/setup/systemCommand.ts
+++ b/apps/cli/src/commands/setup/systemCommand.ts
@@ -1,6 +1,6 @@
 import { isCompiledBinary } from "@station/runtime";
 import type { SetupToolInstallOperation } from "@station/setup-core";
-import { resolveSetupMessage, setupMessageRef } from "@station/setup-messages";
+import { setupMessageRef } from "@station/setup-messages";
 import type { CliEnv } from "../../env.js";
 import { createSetupOperationAdapter } from "./adapters/operations.js";
 import { checkBrewDependency } from "./checks/brew.js";
@@ -16,6 +16,7 @@ import type {
   TextSetupSystemRow,
   TextSetupSystemView,
 } from "./presenters/text.js";
+import { SETUP_TOOL_DEFINITIONS, setupToolDefinitions } from "./toolDefinitions.js";
 import type { SetupCommandDeps, SetupCommandOptions, SetupCommandResult } from "./types.js";
 
 export async function runSetupSystemCommand(
@@ -31,16 +32,9 @@ export async function runSetupSystemCommand(
 
   let operationFailed = false;
   if (args.yes && initial.brew.status === "ok") {
-    const operations: SetupToolInstallOperation[] = [];
-    if (initial.worktrunk.status === "missing")
-      operations.push(systemInstallOperation("worktrunk"));
-    if (initial.tmux.status === "missing") operations.push(systemInstallOperation("tmux"));
-    if (!initial.compiled && initial.bun.status === "missing") {
-      operations.push(systemInstallOperation("bun"));
-    }
-    if (initial.diffViewer.status === "missing") {
-      operations.push(systemInstallOperation("diff-viewer"));
-    }
+    const operations = applicableSystemTools(initial).flatMap(({ id, factKey }) =>
+      initial[factKey].status === "missing" ? [systemInstallOperation(id)] : [],
+    );
     const executeOperation = createSetupOperationAdapter({ deps });
     // System prerequisites are ordered and fail-fast, so later installs never run after a required package failure.
     for (const operation of operations) {
@@ -94,7 +88,7 @@ async function collectSystemFacts(
     checkSetupWorktrunk(dependencyOptions),
     checkSetupTmux(dependencyOptions),
     compiled
-      ? Promise.resolve({ status: "ok" as const, command: "bun" })
+      ? Promise.resolve({ status: "ok" as const, command: SETUP_TOOL_DEFINITIONS.bun.command })
       : checkSetupBun(dependencyOptions),
     checkSetupDiffViewer(dependencyOptions),
     checkBrewDependency({
@@ -118,12 +112,9 @@ function projectSystemView(
   facts: SystemFacts,
 ): TextSetupSystemView {
   const rows: TextSetupSystemRow[] = [
-    dependencySystemRow(facts.worktrunk.status, setupMessageRef("label.worktrunk")),
-    dependencySystemRow(facts.tmux.status, setupMessageRef("label.tmux")),
-    ...(facts.compiled
-      ? []
-      : [dependencySystemRow(facts.bun.status, setupMessageRef("label.bun"))]),
-    dependencySystemRow(facts.diffViewer.status, setupMessageRef("label.diff-viewer")),
+    ...applicableSystemTools(facts).map(({ factKey, label }) =>
+      dependencySystemRow(facts[factKey].status, label),
+    ),
     {
       status: facts.brew.status === "ok" ? "ok" : facts.brew.status,
       label: setupMessageRef("label.homebrew"),
@@ -154,13 +145,14 @@ function toolchainSystemRow(
 
 function systemReady(facts: SystemFacts): boolean {
   return (
-    facts.worktrunk.status === "ok" &&
-    facts.tmux.status === "ok" &&
-    (facts.compiled || facts.bun.status === "ok") &&
-    facts.diffViewer.status === "ok" &&
+    applicableSystemTools(facts).every(({ factKey }) => facts[factKey].status === "ok") &&
     facts.toolchain.node.status === "ok" &&
     facts.toolchain.pnpm.status === "ok"
   );
+}
+
+function applicableSystemTools(facts: SystemFacts) {
+  return setupToolDefinitions.filter(({ id }) => id !== "bun" || !facts.compiled);
 }
 
 function systemInstallOperation(
@@ -180,17 +172,10 @@ function systemToolInstallLabel(input: {
   readonly text: (reference: ReturnType<typeof setupMessageRef>) => string;
 }): string {
   const { operation, text } = input;
-  const label =
-    operation.tool === "worktrunk"
-      ? setupMessageRef("label.worktrunk")
-      : operation.tool === "tmux"
-        ? setupMessageRef("label.tmux")
-        : operation.tool === "bun"
-          ? setupMessageRef("label.bun")
-          : setupMessageRef("label.diff-viewer");
+  const definition = SETUP_TOOL_DEFINITIONS[operation.tool];
   return text(
     setupMessageRef("action.install-label", {
-      label: resolveSetupMessage(label),
+      label: text(definition.label),
     }),
   );
 }

--- a/apps/cli/src/commands/setup/toolDefinitions.ts
+++ b/apps/cli/src/commands/setup/toolDefinitions.ts
@@ -1,0 +1,61 @@
+import type { SetupToolInstallOperation } from "@station/setup-core";
+import { type SetupMessageRef, setupMessageRef } from "@station/setup-messages";
+
+type SetupToolDefinition = {
+  readonly factKey: "worktrunk" | "tmux" | "bun" | "diffViewer";
+  readonly label: SetupMessageRef;
+  readonly displayName: string;
+  readonly availabilityName: string;
+  readonly command: string;
+  readonly formula: string;
+  readonly formulaUrl: string;
+};
+
+type SetupToolDefinitionMap = {
+  readonly [Tool in SetupToolInstallOperation["tool"]]: SetupToolDefinition & { readonly id: Tool };
+};
+/** Canonical CLI metadata for setup-managed tools; declaration order preserves prerequisite installation and presentation order, while applicability and readiness remain setup-core policy. */
+export const SETUP_TOOL_DEFINITIONS = {
+  worktrunk: {
+    id: "worktrunk",
+    factKey: "worktrunk",
+    label: setupMessageRef("label.worktrunk"),
+    displayName: "Worktrunk",
+    availabilityName: "Worktrunk / wt",
+    command: "wt",
+    formula: "worktrunk",
+    formulaUrl: "https://formulae.brew.sh/formula/worktrunk",
+  },
+  tmux: {
+    id: "tmux",
+    factKey: "tmux",
+    label: setupMessageRef("label.tmux"),
+    displayName: "tmux",
+    availabilityName: "tmux",
+    command: "tmux",
+    formula: "tmux",
+    formulaUrl: "https://formulae.brew.sh/formula/tmux",
+  },
+  bun: {
+    id: "bun",
+    factKey: "bun",
+    label: setupMessageRef("label.bun"),
+    displayName: "Bun",
+    availabilityName: "Bun",
+    command: "bun",
+    formula: "bun",
+    formulaUrl: "https://formulae.brew.sh/formula/bun",
+  },
+  "diff-viewer": {
+    id: "diff-viewer",
+    factKey: "diffViewer",
+    label: setupMessageRef("label.diff-viewer"),
+    displayName: "Hunk",
+    availabilityName: "Hunk",
+    command: "hunk",
+    formula: "hunk",
+    formulaUrl: "https://formulae.brew.sh/formula/hunk",
+  },
+} as const satisfies SetupToolDefinitionMap;
+
+export const setupToolDefinitions = Object.values(SETUP_TOOL_DEFINITIONS);

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -1308,17 +1308,50 @@ describe("CLI setup command", () => {
     });
 
     expect(result.code).toBe(0);
+    expect(
+      calls
+        .filter((call) => call.command === "brew" && call.args?.[0] === "install")
+        .map((call) => [call.command, ...(call.args ?? [])].join(" ")),
+    ).toEqual([
+      "brew install worktrunk",
+      "brew install tmux",
+      "brew install bun",
+      "brew install hunk",
+    ]);
     expect(calls).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ command: "brew", args: ["install", "worktrunk"] }),
-        expect.objectContaining({ command: "brew", args: ["install", "tmux"] }),
-        expect.objectContaining({ command: "brew", args: ["install", "bun"] }),
         expect.objectContaining({ command: "/fake/bin/wt", args: ["--version"] }),
         expect.objectContaining({ command: "/fake/bin/tmux", args: ["-V"] }),
       ]),
     );
     expect(chunks.join("")).toContain("stn setup system final");
     expect(chunks.join("")).toContain("OK Worktrunk / wt");
+  });
+
+  it("setup system omits Bun rows and installation in compiled mode", async () => {
+    const calls: ExternalCommandInput[] = [];
+    const chunks: string[] = [];
+
+    const result = await runCli(["setup", "system", "--yes"], {
+      setupDeps: {
+        compiled: true,
+        env: { PATH: "/fake/bin" },
+        runner: fakeRunner(calls, {
+          "brew --version": "Homebrew 4.0.0\n",
+          "pnpm --version": "11.0.0\n",
+          "wt --version": "worktrunk 1.2.3\n",
+          "tmux -V": "tmux 3.5a\n",
+        }),
+        access: fakeAccess(["/fake/bin/wt", "/fake/bin/tmux", "/fake/bin/hunk"]),
+        writeStdout: (chunk) => {
+          chunks.push(chunk);
+        },
+      },
+    });
+
+    expect(result.code).toBe(0);
+    expect(calls.some((call) => call.args?.join(" ") === "install bun")).toBe(false);
+    expect(chunks.join("")).not.toMatch(/(?:OK|MISSING) Bun/);
   });
 });
 

--- a/apps/cli/test/unit/setup-inspection-adapter.test.ts
+++ b/apps/cli/test/unit/setup-inspection-adapter.test.ts
@@ -14,13 +14,30 @@ import type { SetupCommandDeps } from "../../src/commands/setup/types.js";
 
 describe("setup inspection adapter", () => {
   it("normalizes machine facts without exposing config source or provider payloads to core", () => {
-    const planning = normalizeSetupPlanningFacts(facts(), selection(), {
-      operation: "update",
-      path: "/tmp/config.toml",
-      before: "private TOML",
-      content: "private TOML",
-    });
+    const input = facts();
+    const planning = normalizeSetupPlanningFacts(
+      {
+        ...input,
+        worktrunk: { status: "missing", command: "wt", message: "missing Worktrunk" },
+        tmux: { status: "ok", command: "tmux" },
+        bun: { status: "missing", command: "bun", message: "missing Bun" },
+        diffViewer: { status: "ok", command: "hunk" },
+      },
+      selection(),
+      {
+        operation: "update",
+        path: "/tmp/config.toml",
+        before: "private TOML",
+        content: "private TOML",
+      },
+    );
 
+    expect(planning.tools).toEqual([
+      { id: "worktrunk", available: false, installerAvailable: true },
+      { id: "tmux", available: true, installerAvailable: true },
+      { id: "bun", available: false, installerAvailable: true },
+      { id: "diff-viewer", available: true, installerAvailable: true },
+    ]);
     expect(planning.config).toEqual({ state: "valid", write: "update", diagnostics: [] });
     expect(planning.homebrew).toBe("available");
     expect(planning.installableHarnessIds).toEqual(["codex"]);

--- a/apps/cli/test/unit/setup-json-presenter.test.ts
+++ b/apps/cli/test/unit/setup-json-presenter.test.ts
@@ -416,11 +416,12 @@ describe("setup plan projection", () => {
   });
 
   it("plans a Homebrew install for missing Bun", () => {
-    const plan = buildSetupPlan(
+    const built = buildSetupPlans(
       facts({
         bun: { status: "missing", command: "bun", message: "Bun missing." },
       }),
     );
+    const plan = built.jsonPlan;
 
     expect(plan.summary.requiredMissing).toBe(1);
     expect(plan.actions.find((action) => action.id === "install-bun")).toMatchObject({
@@ -429,6 +430,13 @@ describe("setup plan projection", () => {
       selected: true,
       command: ["brew", "install", "bun"],
     });
+    expect(plan.nextSteps).toEqual(["Install Bun (brew install bun), then run: stn setup check"]);
+    const recovery = built.presentationView.recovery.find(
+      (instruction) => instruction.kind === "instruction",
+    );
+    expect(
+      recovery?.kind === "instruction" ? resolveSetupMessage(recovery.message) : undefined,
+    ).toBe("Install Bun (brew install bun).");
   });
 
   it("keeps compiled launch ready without source Bun or Station UI rows", () => {
@@ -483,11 +491,12 @@ describe("setup plan projection", () => {
   });
 
   it("plans one required Homebrew install for a missing diff viewer", () => {
-    const plan = buildSetupPlan(
+    const built = buildSetupPlans(
       facts({
         diffViewer: { status: "missing", command: "hunk", message: "Hunk missing." },
       }),
     );
+    const plan = built.jsonPlan;
 
     expect(plan.summary.requiredMissing).toBe(1);
     expect(plan.checks.find((check) => check.id === "diff-viewer")).toMatchObject({
@@ -500,6 +509,13 @@ describe("setup plan projection", () => {
       selected: true,
       command: ["brew", "install", "hunk"],
     });
+    expect(plan.nextSteps).toEqual(["Install Hunk (brew install hunk), then run: stn setup check"]);
+    const recovery = built.presentationView.recovery.find(
+      (instruction) => instruction.kind === "instruction",
+    );
+    expect(
+      recovery?.kind === "instruction" ? resolveSetupMessage(recovery.message) : undefined,
+    ).toBe("Install Hunk (brew install hunk).");
   });
 
   it("blocks config writes when no harness is available", () => {

--- a/apps/cli/test/unit/setup-package-installation-adapter.test.ts
+++ b/apps/cli/test/unit/setup-package-installation-adapter.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import type {
   SetupHarnessInstallOperation,
   SetupPackageInstallOperation,
+  SetupToolInstallOperation,
   SupportedHarnessId,
 } from "@station/setup-core";
 import { afterEach, describe, expect, it } from "vitest";
@@ -19,8 +20,9 @@ describe("setup package installation adapter", () => {
     );
   });
 
-  it("uses official Homebrew packages for every supported macOS agent except Cursor", async () => {
+  it("uses canonical installers for setup tools and supported macOS agents", async () => {
     const commands = new Map<SupportedHarnessId, readonly string[]>();
+    const toolCommands: string[] = [];
     let activeHarness: SupportedHarnessId | undefined;
     const execute = createSetupOperationAdapter({
       facts: packageFacts({ brewAvailable: true, macos: true }),
@@ -28,6 +30,8 @@ describe("setup package installation adapter", () => {
         runner: async (input) => {
           if (activeHarness !== undefined) {
             commands.set(activeHarness, [input.command, ...(input.args ?? [])]);
+          } else {
+            toolCommands.push([input.command, ...(input.args ?? [])].join(" "));
           }
           return {
             command: input.command,
@@ -40,11 +44,27 @@ describe("setup package installation adapter", () => {
       },
     });
 
+    const tools: SetupToolInstallOperation["tool"][] = ["worktrunk", "tmux", "bun", "diff-viewer"];
+    for (const tool of tools) {
+      await execute({
+        id: `install:${tool}`,
+        kind: "install-tool",
+        tier: "required",
+        selected: true,
+        tool,
+      });
+    }
     for (const harnessId of harnessInstallOrder) {
       activeHarness = harnessId;
       await execute(harnessInstallOperation(harnessId));
     }
 
+    expect(toolCommands).toEqual([
+      "brew install worktrunk",
+      "brew install tmux",
+      "brew install bun",
+      "brew install hunk",
+    ]);
     expect(Object.fromEntries(commands)).toMatchObject({
       codex: ["brew", "install", "--cask", "homebrew/cask/codex"],
       opencode: ["brew", "install", "homebrew/core/opencode"],

--- a/apps/cli/test/unit/setup-tool-definitions.test.ts
+++ b/apps/cli/test/unit/setup-tool-definitions.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { setupToolDefinitions } from "../../src/commands/setup/toolDefinitions.js";
+
+describe("setup tool definitions", () => {
+  it("pins the complete CLI metadata and canonical tool order", () => {
+    const metadata = setupToolDefinitions.map(
+      ({ id, factKey, label, displayName, availabilityName, command, formula, formulaUrl }) =>
+        [id, factKey, label.id, displayName, availabilityName, command, formula, formulaUrl].join(
+          "|",
+        ),
+    );
+
+    expect(metadata).toEqual([
+      "worktrunk|worktrunk|label.worktrunk|Worktrunk|Worktrunk / wt|wt|worktrunk|https://formulae.brew.sh/formula/worktrunk",
+      "tmux|tmux|label.tmux|tmux|tmux|tmux|tmux|https://formulae.brew.sh/formula/tmux",
+      "bun|bun|label.bun|Bun|Bun|bun|bun|https://formulae.brew.sh/formula/bun",
+      "diff-viewer|diffViewer|label.diff-viewer|Hunk|Hunk|hunk|hunk|https://formulae.brew.sh/formula/hunk",
+    ]);
+  });
+});

--- a/apps/cli/test/unit/setup-tool-definitions.test.ts
+++ b/apps/cli/test/unit/setup-tool-definitions.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { setupToolDefinitions } from "../../src/commands/setup/toolDefinitions.js";
 
@@ -16,5 +17,23 @@ describe("setup tool definitions", () => {
       "bun|bun|label.bun|Bun|Bun|bun|bun|https://formulae.brew.sh/formula/bun",
       "diff-viewer|diffViewer|label.diff-viewer|Hunk|Hunk|hunk|hunk|https://formulae.brew.sh/formula/hunk",
     ]);
+  });
+
+  it("keeps setup-owned command and formula metadata behind the canonical definitions", () => {
+    const source = (path: string) => readFileSync(new URL(path, import.meta.url), "utf8");
+    const system = source("../../src/commands/setup/checks/system.ts");
+    const config = source("../../src/commands/setup/adapters/config.ts");
+    const tmuxBinding = source("../../src/commands/setup/checks/tmuxBinding.ts");
+    const guided = source("../../src/commands/setup/session/runGuidedSetupSession.ts");
+    const json = source("../../src/commands/setup/presenters/json.ts");
+    const messages = source("../../../../packages/setup-messages/src/catalog.ts");
+
+    expect(system).not.toContain('command: "bun"');
+    expect(config).not.toContain('detectedCommand(facts.worktrunk, "wt")');
+    expect(config).not.toContain('detectedOptionalCommand(facts.tmux, "tmux")');
+    expect(tmuxBinding).not.toContain('?? "tmux"');
+    expect(guided).toContain("setupToolDefinitions.some");
+    expect(json).not.toMatch(/brew install (?:bun|hunk)/);
+    expect(messages).not.toMatch(/brew install (?:bun|hunk)/);
   });
 });

--- a/packages/setup-messages/src/catalog.ts
+++ b/packages/setup-messages/src/catalog.ts
@@ -224,9 +224,9 @@ export const setupMessageCatalog = {
   "action.config-blocked-label": { terminal: "Update STATION config" },
   "next.install-worktrunk": { terminal: "Install Worktrunk." },
   "next.install-tmux": { terminal: "Install tmux." },
-  "next.install-bun": { terminal: "Install Bun (brew install bun)." },
+  "next.install-bun": { terminal: "Install Bun (brew install {formula})." },
   "next.install-diff-viewer": {
-    terminal: "Install Hunk (brew install hunk).",
+    terminal: "Install Hunk (brew install {formula}).",
   },
   "next.resolve-required": { terminal: "Resolve the missing required setup items." },
   "progress.start": { terminal: "Applying: {label}" },

--- a/packages/setup-messages/src/types.ts
+++ b/packages/setup-messages/src/types.ts
@@ -124,8 +124,8 @@ export type SetupMessageArguments = {
   "action.config-blocked-label": undefined;
   "next.install-worktrunk": undefined;
   "next.install-tmux": undefined;
-  "next.install-bun": undefined;
-  "next.install-diff-viewer": undefined;
+  "next.install-bun": { formula: string };
+  "next.install-diff-viewer": { formula: string };
   "next.resolve-required": undefined;
   "progress.start": { label: string };
   "progress.complete": { label: string };

--- a/packages/setup-messages/test/unit/resolve.test.ts
+++ b/packages/setup-messages/test/unit/resolve.test.ts
@@ -17,6 +17,19 @@ describe("resolveSetupMessage", () => {
     expect(resolveSetupMessage(ref, "graphical")).toBe("Core setup complete.");
   });
 
+  it("interpolates setup-managed formulas into recovery copy", () => {
+    expect(
+      resolveSetupMessage(
+        setupMessageRef("next.install-bun", { formula: "canonical-bun-formula" }),
+      ),
+    ).toBe("Install Bun (brew install canonical-bun-formula).");
+    expect(
+      resolveSetupMessage(
+        setupMessageRef("next.install-diff-viewer", { formula: "canonical-hunk-formula" }),
+      ),
+    ).toBe("Install Hunk (brew install canonical-hunk-formula).");
+  });
+
   it("rejects unknown ids and missing interpolation arguments at runtime", () => {
     expect(() =>
       resolveSetupMessage({ id: "unknown.message" } as unknown as SetupMessageRef),


### PR DESCRIPTION
## What this fixes

Station setup owns inspection, orchestration, IO, and presentation for four setup-managed tools. Their commands, Homebrew formulas, labels, fact mappings, and trusted Formulae links were repeated across those paths, so changes required synchronized edits and could drift.

Addresses finding 2 in #464.

## What changed

- Added one exhaustive CLI-owned definition table for Worktrunk, tmux, Bun, and Hunk; declaration order preserves Worktrunk → tmux → Bun → Hunk.
- Reused the metadata for dependency and live probes, config command selection, fact normalization, Homebrew operations, text and JSON presentation, guided links, recovery formulas, and setup-system iteration.
- Kept applicability, readiness, override precedence, custom explanatory policy, and provider behavior at their existing setup-core and CLI boundaries.
- Added independent metadata, ownership, fact mapping, formula command, recovery interpolation, install-order, and compiled Bun omission coverage.
- Reduced production source by 44 lines; the total diff is 94 lines larger after focused regression coverage.

## Testing

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- Focused setup unit suite: 204 tests passed
- Focused setup integration suite: 30 tests passed
- `pnpm test:e2e:setup:core`: 5 tests passed
- `pnpm test:e2e:setup:guided:all-shells`: 24 tests passed
- `pnpm smoke:install`
- `pnpm setup:guided:sandbox -- --profile missing-tools --keep`: completed with Worktrunk → tmux → Bun → Hunk ordering and trusted Formulae links intact
- `pnpm test:all` passed build, typecheck, lint, unit, contracts, integration, diagnostics, scripted-agent, and setup E2E lanes, then stopped on two unrelated Observer handoff tests with `OBSERVER_INCUMBENT_HEALTH_TIMEOUT`; this PR does not change Observer files.

## User-visible behavior

No visible change is expected: setup labels, commands, ordering, JSON, recovery text, and guided Formulae links remain unchanged.
