### PR TITLE
fix(tui): resync widgets after system sleep

### DIFF
--- a/packages/dashboard-core/src/widgets/useTopRowWidgets.ts
+++ b/packages/dashboard-core/src/widgets/useTopRowWidgets.ts
@@ -42,6 +42,7 @@ export function createUseTopRowWidgets(hooks: TopRowWidgetHookRuntime) {
   return function useTopRowWidgets(
     widgets: DashboardStateView["widgets"],
     deps: TopRowWidgetRuntimeDeps = {},
+    refreshKey?: unknown,
   ): TopRowWidgetView[] {
     const now = deps.now ?? defaultNow;
     const [currentMinute, setCurrentMinute] = hooks.useState(() => now());
@@ -80,11 +81,13 @@ export function createUseTopRowWidgets(hooks: TopRowWidgetHookRuntime) {
       [activeWidgets],
     );
 
+    // Terminal focus or surface activation re-arms both cadences after system sleep.
     hooks.useEffect(() => {
       if (!needsClock) {
         return;
       }
 
+      setCurrentMinute(now());
       let interval: ReturnType<typeof setInterval> | undefined;
       const timeout = setTimeout(() => {
         setCurrentMinute(now());
@@ -99,7 +102,7 @@ export function createUseTopRowWidgets(hooks: TopRowWidgetHookRuntime) {
           clearInterval(interval);
         }
       };
-    }, [needsClock, now]);
+    }, [needsClock, now, refreshKey]);
 
     hooks.useEffect(() => {
       if (weatherEntries.length === 0) {
@@ -145,7 +148,7 @@ export function createUseTopRowWidgets(hooks: TopRowWidgetHookRuntime) {
           clearInterval(interval);
         }
       };
-    }, [weatherEntries, weatherClient, now, setWeatherText]);
+    }, [weatherEntries, weatherClient, now, refreshKey, setWeatherText]);
 
     return hooks.useMemo(
       () =>

--- a/station/src/app/StationApp.test.tsx
+++ b/station/src/app/StationApp.test.tsx
@@ -224,6 +224,53 @@ describe("Station app composition", () => {
     expect(frame).toContain("NYC · 72°");
   });
 
+  it("resynchronizes clock and weather after terminal focus and overlay reopen", async () => {
+    let now = new Date(2026, 7, 8, 23, 48);
+    let temperature = 75;
+    let weatherCalls = 0;
+    const station = await renderComposedStation({
+      tuiConfig: {
+        widgets: [
+          { type: "time", timeFormat: "24h" },
+          { type: "weather", city: "New York, NY", label: "NYC" },
+        ],
+      },
+      topRowWidgetDeps: {
+        now: () => now,
+        weatherClient: {
+          getCurrentWeather: async () => {
+            weatherCalls += 1;
+            return { temperature, weatherCode: 0, isDay: true };
+          },
+        },
+      },
+    });
+
+    station.setup.mockInput.pressKey("o", { ctrl: true });
+    await waitFor(() => overlayVisible(station));
+    expect(
+      await waitForFrame(station, (frame) => frame.includes("23:48") && frame.includes("NYC · 75°")),
+    ).toContain("NYC · 75°");
+
+    now = new Date(2026, 7, 9, 12, 6);
+    temperature = 92;
+    station.setup.renderer.emit("focus");
+    expect(
+      await waitForFrame(station, (frame) => frame.includes("12:06") && frame.includes("NYC · 92°")),
+    ).toContain("NYC · 92°");
+
+    station.setup.mockInput.pressKey("o", { ctrl: true });
+    await waitFor(() => !overlayVisible(station));
+    now = new Date(2026, 7, 9, 13, 7);
+    temperature = 89;
+    station.setup.mockInput.pressKey("o", { ctrl: true });
+    await waitFor(() => overlayVisible(station));
+    expect(
+      await waitForFrame(station, (frame) => frame.includes("13:07") && frame.includes("NYC · 89°")),
+    ).toContain("NYC · 89°");
+    expect(weatherCalls).toBe(3);
+  });
+
   it("closes STATION on click-away without writing mouse bytes to the pane underneath", async () => {
     const station = await renderComposedStation();
     const screen = station.composition.registry.get(MAIN_PANE_ID)?.screen;

--- a/station/src/app/StationApp.tsx
+++ b/station/src/app/StationApp.tsx
@@ -47,7 +47,7 @@ export function StationApp({
   const welcomeCanContinue = useStoreValue(store, selectWelcomeCanContinue);
   // The live session widget set: seeded from config, edited by the panel.
   const widgets = useStore(dashboardState, (state) => state.widgets);
-  const topRowWidgets = useTopRowWidgets(widgets, topRowWidgetDeps);
+  const topRowWidgets = useTopRowWidgets(widgets, topRowWidgetDeps, overlayVisible);
 
   return (
     <box

--- a/station/src/station/widgets/useTopRowWidgets.ts
+++ b/station/src/station/widgets/useTopRowWidgets.ts
@@ -1,10 +1,21 @@
 import { createUseTopRowWidgets } from "@station/dashboard-core/widgets";
+import { useFocus } from "@opentui/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-export const useTopRowWidgets = createUseTopRowWidgets({
+const useTopRowWidgetsCore = createUseTopRowWidgets({
   useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
 });
+
+export function useTopRowWidgets(
+  widgets: Parameters<typeof useTopRowWidgetsCore>[0],
+  deps?: Parameters<typeof useTopRowWidgetsCore>[1],
+  surfaceVisible = true,
+): ReturnType<typeof useTopRowWidgetsCore> {
+  const [focusEpoch, setFocusEpoch] = useState(0);
+  useFocus(() => setFocusEpoch((previous) => previous + 1));
+  return useTopRowWidgetsCore(widgets, deps, `${focusEpoch}:${surfaceVisible ? 1 : 0}`);
+}


### PR DESCRIPTION
## What this fixes

Station’s top-row clock and weather widgets rely on timer-driven refresh cadences. After a long system sleep, those timers can remain stale, leaving the header frozen at its pre-sleep time and weather even though the TUI is otherwise responsive.

## What changed

- Immediately resynchronize time-derived widgets when the terminal regains focus.
- Re-arm clock and weather refresh cadences when terminal focus returns or the STATION overlay is reopened.
- Preserve the configured minute and weather refresh behavior during normal operation.
- Add a regression covering both a sleep-sized time jump and reopening a warm hidden overlay.

## Testing

- `pnpm build`
- `pnpm typecheck`
- `pnpm exec vitest run --config config/vitest/vitest.unit.config.ts packages/dashboard-core/test/unit/widgets/time.test.ts packages/dashboard-core/test/unit/widgets/useTopRowWidgets.test.ts packages/dashboard-core/test/unit/widgets/weatherClient.test.ts` (15 passed)
- `cd station && bun run typecheck`
- `cd station && bun test src/app/StationApp.test.tsx src/dashboardRenderer/FullscreenDashboard.test.tsx` (48 passed)
- Pre-commit and pre-push lint hooks