### PR TITLE
fix(status): complete canonical alert consumers

### DIFF
--- a/apps/cli/src/commands/observe/formatters.ts
+++ b/apps/cli/src/commands/observe/formatters.ts
@@ -1,11 +1,12 @@
 import type {
+  AgentState,
   ProviderHealth,
   SafeError,
   StationEvent,
   StationSnapshot,
   WorktreeRow,
 } from "@station/contracts";
-import { stationEventTimestamp } from "@station/contracts";
+import { AGENT_STATUS, stationEventTimestamp } from "@station/contracts";
 import {
   commandTypeLabel,
   type ObserveSnapshotContext,
@@ -108,7 +109,7 @@ export function formatEventLines(
           ),
         ];
       }
-      return [line(at, "agent", `${event.worktreeId}  none`)];
+      return [line(at, "agent", `${event.worktreeId}  ${AGENT_STATUS.none.label}`)];
     }
     case "session.created":
       return [
@@ -126,7 +127,7 @@ export function formatEventLines(
       ];
     case "session.updated": {
       const changedStatus =
-        event.patch.status === undefined ? undefined : `status:${event.patch.status.value}`;
+        event.patch.status === undefined ? undefined : statusPart(event.patch.status.value);
       return [
         line(
           at,
@@ -187,7 +188,7 @@ export function formatEventLines(
 function formatAgentRow(at: string, row: WorktreeRow): string {
   const agent = row.agent;
   if (agent === undefined) {
-    return line(at, "agent", `${rowLabel(row)}  none  ${terminalPart(row)}`);
+    return line(at, "agent", `${rowLabel(row)}  ${AGENT_STATUS.none.label}  ${terminalPart(row)}`);
   }
   return line(
     at,
@@ -260,15 +261,15 @@ function formatClockTime(timestamp: string): string {
   return timestamp;
 }
 
-function agentLineLabel(state: string): string {
-  return state === "needs_attention" || state === "stuck" ? "agent!" : "agent";
+function agentLineLabel(state: AgentState): string {
+  return AGENT_STATUS[state].alert ? "agent!" : "agent";
 }
 
-function displayAgentState(state: string): string {
-  return state.replaceAll("_", " ");
+function displayAgentState(state: AgentState): string {
+  return AGENT_STATUS[state].label;
 }
 
-function statusPart(status: string): string {
+function statusPart(status: AgentState): string {
   return `status:${displayAgentState(status)}`;
 }
 

--- a/apps/cli/test/unit/observe-formatters.test.ts
+++ b/apps/cli/test/unit/observe-formatters.test.ts
@@ -49,6 +49,35 @@ describe("observe formatters", () => {
     ]);
   });
 
+  it("uses canonical alert and no-agent presentation without cached rows", () => {
+    const context = createObserveSnapshotContext();
+
+    expect(
+      formatEventLines(
+        {
+          type: "worktree.agentStateChanged",
+          worktreeId: "wt_missing",
+          agent: {
+            harness: "codex",
+            state: "stuck",
+            confidence: "high",
+            reason: "stalled",
+            updatedAt: now,
+          },
+        },
+        context,
+        now,
+      ),
+    ).toEqual(["12:00:00  agent!     wt_missing  stuck  codex high"]);
+    expect(
+      formatEventLines(
+        { type: "worktree.agentStateChanged", worktreeId: "wt_missing" },
+        context,
+        now,
+      ),
+    ).toEqual(["12:00:00  agent      wt_missing  no agent"]);
+  });
+
   it("renders command failures with command, trace, diagnostic, message, and hint lines", () => {
     const context = createObserveSnapshotContext(snapshotFixture());
     applyEventToSnapshotContext(context, {

--- a/apps/observer/src/reconcile/graph.ts
+++ b/apps/observer/src/reconcile/graph.ts
@@ -290,7 +290,7 @@ type BuildWorktreeRowInput = {
 function buildWorktreeRow(input: BuildWorktreeRowInput): WorktreeRow {
   const display = worktreeDisplayForAgentState(input.harnessRun?.status.value);
   const warning = warningFor(input.harnessRun, input.terminal, display.warning === true);
-  const reason = displayReason(input.harnessRun, warning);
+  const reason = displayReason(input.harnessRun, display.alert || warning);
   const worktree: WorktreeRow["worktree"] = {
     state: input.worktree.state,
     source: input.worktree.source,
@@ -791,16 +791,12 @@ function compareHarnessRuns(left: ObserverHarnessRun, right: ObserverHarnessRun)
 
 function displayReason(
   harnessRun: ObserverHarnessRun | undefined,
-  warning: boolean,
+  includeReason: boolean,
 ): string | undefined {
   if (harnessRun === undefined) {
     return "No harness run is associated with this worktree.";
   }
-  if (
-    harnessRun.status.value === "needs_attention" ||
-    harnessRun.status.value === "stuck" ||
-    warning
-  ) {
+  if (includeReason) {
     return harnessRun.status.reason;
   }
   return undefined;

--- a/packages/client/test/support/snapshots.ts
+++ b/packages/client/test/support/snapshots.ts
@@ -209,11 +209,10 @@ function countsForRows(rows: readonly WorktreeRow[]) {
     sessions: rows.filter((candidate) => candidate.agent?.sessionId !== undefined).length,
     worktrees: rows.length,
     agents: rows.filter((candidate) => candidate.agent !== undefined).length,
-    working: rows.filter((candidate) => candidate.display.statusLabel === "working").length,
-    idle: rows.filter((candidate) => candidate.display.statusLabel === "idle").length,
-    attention: rows.filter((candidate) => candidate.display.statusLabel === "needs attention")
-      .length,
-    unknown: rows.filter((candidate) => candidate.display.statusLabel === "unknown").length,
+    working: rows.filter((candidate) => candidate.agent?.state === "working").length,
+    idle: rows.filter((candidate) => candidate.agent?.state === "idle").length,
+    attention: rows.filter((candidate) => candidate.agent?.state === "needs_attention").length,
+    unknown: rows.filter((candidate) => candidate.agent?.state === "unknown").length,
   };
 }
 

--- a/packages/dashboard-core/src/selectors/dashboardFilterConditions.ts
+++ b/packages/dashboard-core/src/selectors/dashboardFilterConditions.ts
@@ -1,4 +1,4 @@
-import type { StationSnapshot } from "@station/contracts";
+import { AGENT_STATUS, type AgentState, type StationSnapshot } from "@station/contracts";
 import type {
   DashboardFilterCondition,
   DashboardFilterConditionField,
@@ -8,16 +8,26 @@ import type {
 } from "../state/types.js";
 import { SELECTION_KEYS } from "./selectors.js";
 
-export const DASHBOARD_FILTER_STATUS_VALUES: readonly DashboardFilterStatusConditionValue[] = [
-  { id: "needs_attention", label: "Needs attention" },
-  { id: "stuck", label: "Stuck" },
-  { id: "working", label: "Working" },
-  { id: "starting", label: "Starting" },
-  { id: "idle", label: "Idle" },
-  { id: "exited", label: "Exited" },
-  { id: "none", label: "No agent" },
-  { id: "unknown", label: "Unknown" },
-];
+const DASHBOARD_FILTER_STATUS_RANK = {
+  needs_attention: 0,
+  stuck: 1,
+  working: 2,
+  starting: 3,
+  idle: 4,
+  exited: 5,
+  none: 6,
+  unknown: 7,
+} as const satisfies Record<AgentState, number>;
+
+const dashboardFilterStatusOrder = (Object.keys(DASHBOARD_FILTER_STATUS_RANK) as AgentState[]).sort(
+  (left, right) => DASHBOARD_FILTER_STATUS_RANK[left] - DASHBOARD_FILTER_STATUS_RANK[right],
+);
+
+export const DASHBOARD_FILTER_STATUS_VALUES: readonly DashboardFilterStatusConditionValue[] =
+  dashboardFilterStatusOrder.map((id) => {
+    const label = AGENT_STATUS[id].label;
+    return { id, label: `${label.charAt(0).toUpperCase()}${label.slice(1)}` };
+  });
 
 type DashboardFilterConditionOptionContext = {
   snapshot: StationSnapshot | undefined;

--- a/packages/dashboard-core/src/state/dashboardFocus.ts
+++ b/packages/dashboard-core/src/state/dashboardFocus.ts
@@ -239,7 +239,7 @@ function collapsedParentHeaderIndex(
 }
 
 export function rowNeedsYou(row: DashboardSessionRow): boolean {
-  return row.session.status.value === "needs_attention" || row.session.status.value === "stuck";
+  return row.presentation.display.alert;
 }
 
 function moveFocus(

--- a/packages/dashboard-core/test/fixtures/snapshots.ts
+++ b/packages/dashboard-core/test/fixtures/snapshots.ts
@@ -348,11 +348,10 @@ function countsForRows(rows: readonly WorktreeRow[]) {
     sessions: rows.filter((candidate) => candidate.agent?.sessionId !== undefined).length,
     worktrees: rows.length,
     agents: rows.filter((candidate) => candidate.agent !== undefined).length,
-    working: rows.filter((candidate) => candidate.display.statusLabel === "working").length,
-    idle: rows.filter((candidate) => candidate.display.statusLabel === "idle").length,
-    attention: rows.filter((candidate) => candidate.display.statusLabel === "needs attention")
-      .length,
-    unknown: rows.filter((candidate) => candidate.display.statusLabel === "unknown").length,
+    working: rows.filter((candidate) => candidate.agent?.state === "working").length,
+    idle: rows.filter((candidate) => candidate.agent?.state === "idle").length,
+    attention: rows.filter((candidate) => candidate.agent?.state === "needs_attention").length,
+    unknown: rows.filter((candidate) => candidate.agent?.state === "unknown").length,
   };
 }
 

--- a/packages/dashboard-core/test/unit/selectors/dashboardFilterConditions.test.ts
+++ b/packages/dashboard-core/test/unit/selectors/dashboardFilterConditions.test.ts
@@ -1,3 +1,4 @@
+import { AGENT_STATUS } from "@station/contracts";
 import { describe, expect, it } from "vitest";
 import {
   dashboardFilterConditionFieldForKey,
@@ -59,16 +60,19 @@ describe("dashboard filter conditions", () => {
 
     const options = selectDashboardFilterConditionOptions(snapshot, state, conditions);
 
-    expect(options.status.map((option) => option.id)).toEqual([
-      "needs_attention",
-      "stuck",
-      "working",
-      "starting",
-      "idle",
-      "exited",
-      "none",
-      "unknown",
+    expect(options.status).toEqual([
+      { id: "needs_attention", label: "Needs attention" },
+      { id: "stuck", label: "Stuck" },
+      { id: "working", label: "Working" },
+      { id: "starting", label: "Starting" },
+      { id: "idle", label: "Idle" },
+      { id: "exited", label: "Exited" },
+      { id: "none", label: "No agent" },
+      { id: "unknown", label: "Unknown" },
     ]);
+    expect(new Set(options.status.map((option) => option.id))).toEqual(
+      new Set(Object.keys(AGENT_STATUS)),
+    );
     expect(options.project).toEqual([
       { id: "api", label: "api" },
       { id: "removed", label: "Removed project" },

--- a/station/src/sources/attentionEvents.test.ts
+++ b/station/src/sources/attentionEvents.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { isNeedsAttentionEvent } from "./attentionEvents.js";
+import { isStationAttentionEvent } from "./attentionEvents.js";
 
 const agent = {
   harness: "codex",
@@ -9,10 +9,10 @@ const agent = {
   updatedAt: "2026-07-02T00:00:00.000Z",
 } as const;
 
-describe("isNeedsAttentionEvent", () => {
+describe("isStationAttentionEvent", () => {
   it("matches needs_attention events carrying a typed attention kind", () => {
     expect(
-      isNeedsAttentionEvent({
+      isStationAttentionEvent({
         type: "worktree.agentStateChanged",
         worktreeId: "wt_1",
         agent: { ...agent, attention: "question" },
@@ -22,7 +22,7 @@ describe("isNeedsAttentionEvent", () => {
 
   it("matches needs_attention events without a typed attention kind", () => {
     expect(
-      isNeedsAttentionEvent({
+      isStationAttentionEvent({
         type: "worktree.agentStateChanged",
         worktreeId: "wt_1",
         agent,
@@ -30,9 +30,19 @@ describe("isNeedsAttentionEvent", () => {
     ).toBe(true);
   });
 
-  it("ignores non-attention states", () => {
+  it("matches every canonical alert state", () => {
     expect(
-      isNeedsAttentionEvent({
+      isStationAttentionEvent({
+        type: "worktree.agentStateChanged",
+        worktreeId: "wt_1",
+        agent: { ...agent, state: "stuck" },
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores non-alert states", () => {
+    expect(
+      isStationAttentionEvent({
         type: "worktree.agentStateChanged",
         worktreeId: "wt_1",
         agent: { ...agent, state: "working", attention: "question" },

--- a/station/src/sources/attentionEvents.ts
+++ b/station/src/sources/attentionEvents.ts
@@ -1,12 +1,15 @@
-import type { StationEvent } from "@station/contracts";
+import { AGENT_STATUS, type StationEvent } from "@station/contracts";
 
 type AgentStateChangedEvent = Extract<StationEvent, { type: "worktree.agentStateChanged" }>;
 export type StationAttentionEvent = AgentStateChangedEvent & {
   agent: NonNullable<AgentStateChangedEvent["agent"]>;
 };
 
-// Some harness error states (cursor turn error, opencode session error) reach
-// needs_attention with no typed attention kind; they must still alert.
-export function isNeedsAttentionEvent(event: StationEvent): event is StationAttentionEvent {
-  return event.type === "worktree.agentStateChanged" && event.agent?.state === "needs_attention";
+// Canonical display alerts also drive the attention sound, including harness errors without a kind.
+export function isStationAttentionEvent(event: StationEvent): event is StationAttentionEvent {
+  return (
+    event.type === "worktree.agentStateChanged" &&
+    event.agent !== undefined &&
+    AGENT_STATUS[event.agent.state].alert
+  );
 }

--- a/station/src/sources/fixtures/mockObserverSnapshot.ts
+++ b/station/src/sources/fixtures/mockObserverSnapshot.ts
@@ -1,4 +1,4 @@
-import type { StationSnapshot } from "@station/contracts";
+import { type StationSnapshot, worktreeDisplayForAgentState } from "@station/contracts";
 
 const fixtureNow = "2026-06-11T12:00:00.000Z";
 
@@ -125,9 +125,7 @@ export const mockObserverSnapshot = {
         updatedAt: fixtureNow,
       },
       display: {
-        statusLabel: "working",
-        sortPriority: 30,
-        alert: false,
+        ...worktreeDisplayForAgentState("working"),
         reason: "Harness reported active generation.",
       },
     },
@@ -166,9 +164,7 @@ export const mockObserverSnapshot = {
         updatedAt: fixtureNow,
       },
       display: {
-        statusLabel: "idle",
-        sortPriority: 40,
-        alert: false,
+        ...worktreeDisplayForAgentState("idle"),
         reason: "Harness reported the turn completed.",
       },
     },
@@ -187,9 +183,7 @@ export const mockObserverSnapshot = {
         behind: 1,
       },
       display: {
-        statusLabel: "no agent",
-        sortPriority: 70,
-        alert: false,
+        ...worktreeDisplayForAgentState(undefined),
         reason: "No harness run is associated with this worktree.",
       },
     },

--- a/station/src/sources/observerStationClient.ts
+++ b/station/src/sources/observerStationClient.ts
@@ -3,7 +3,7 @@ import {
   createStationClientRuntime,
   type ObserverService,
 } from "@station/client";
-import { isNeedsAttentionEvent, type StationAttentionEvent } from "./attentionEvents.js";
+import { isStationAttentionEvent, type StationAttentionEvent } from "./attentionEvents.js";
 import type { StationClient } from "./types.js";
 
 export type CreateObserverStationClientOptions = {
@@ -38,7 +38,7 @@ export function createObserverStationClient(
     clientLabel: "Station",
     hooks: {
       onEvent: (event) => {
-        if (!isNeedsAttentionEvent(event)) {
+        if (!isStationAttentionEvent(event)) {
           return;
         }
         try {

--- a/station/src/station/fixtures/scenarios.ts
+++ b/station/src/station/fixtures/scenarios.ts
@@ -538,9 +538,9 @@ function countsForRows(rows: readonly WorktreeRow[]) {
     sessions: rows.filter((candidate) => candidate.agent?.sessionId !== undefined).length,
     worktrees: rows.length,
     agents: rows.filter((candidate) => candidate.agent !== undefined).length,
-    working: rows.filter((candidate) => candidate.display.statusLabel === "working").length,
-    idle: rows.filter((candidate) => candidate.display.statusLabel === "idle").length,
-    attention: rows.filter((candidate) => candidate.display.statusLabel === "needs attention").length,
-    unknown: rows.filter((candidate) => candidate.display.statusLabel === "unknown").length,
+    working: rows.filter((candidate) => candidate.agent?.state === "working").length,
+    idle: rows.filter((candidate) => candidate.agent?.state === "idle").length,
+    attention: rows.filter((candidate) => candidate.agent?.state === "needs_attention").length,
+    unknown: rows.filter((candidate) => candidate.agent?.state === "unknown").length,
   };
 }

--- a/station/src/station/statusUi.test.ts
+++ b/station/src/station/statusUi.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { FLEET_STATUS_ORDER, stationAgentStatusTone } from "./statusUi.js";
+
+describe("status UI metadata", () => {
+  it("keeps fleet order and agent tones centralized", () => {
+    expect(FLEET_STATUS_ORDER).toEqual([
+      "ready",
+      "working",
+      "needsYou",
+      "unknown",
+      "exited",
+      "idle",
+      "starting",
+    ]);
+    expect(
+      [
+        "needs_attention",
+        "stuck",
+        "working",
+        "starting",
+        "idle",
+        "unknown",
+        "exited",
+        "none",
+      ].map(stationAgentStatusTone),
+    ).toEqual([
+      "danger",
+      "danger",
+      "working",
+      "working",
+      "success",
+      "warning",
+      "neutral",
+      "neutral",
+    ]);
+  });
+});

--- a/station/src/station/statusUi.ts
+++ b/station/src/station/statusUi.ts
@@ -1,3 +1,4 @@
+import type { AgentState } from "@station/contracts";
 import type { FleetSummary } from "@station/dashboard-core/selectors";
 
 export type ProjectRollupStatus = "needsYou" | "working" | "ready" | "idle";
@@ -11,16 +12,38 @@ type StatusUi = {
   projectPriority: number | null;
 };
 
+type StatusTone = StatusUi["tone"];
+
+const STATION_AGENT_STATUS_TONES = {
+  needs_attention: "danger",
+  stuck: "danger",
+  working: "working",
+  starting: "working",
+  idle: "success",
+  unknown: "warning",
+  exited: "neutral",
+  none: "neutral",
+} as const satisfies Record<AgentState, StatusTone>;
+
+const stationAgentStatusTones = new Map<string, StatusTone>(
+  Object.entries(STATION_AGENT_STATUS_TONES),
+);
+
+export function stationAgentStatusTone(state: string | undefined): StatusTone {
+  return state === undefined ? "neutral" : (stationAgentStatusTones.get(state) ?? "neutral");
+}
+
+// Declaration order is the fleet presentation order, including hidden lanes.
 export const STATION_STATUS_UI = {
   ready: { label: "ready", glyph: "●", tone: "success", animate: false, fleet: "always", projectPriority: 1 },
   working: { label: "working", glyph: "⠿", tone: "working", animate: true, fleet: "always", projectPriority: 2 },
   needsYou: { label: "needs you", glyph: "!", tone: "danger", animate: false, fleet: "always", projectPriority: 3 },
-  idle: { label: "idle", glyph: "○", tone: "neutral", animate: false, fleet: "always", projectPriority: 0 },
-  starting: { label: "starting", glyph: "+", tone: "neutral", animate: false, fleet: "hidden", projectPriority: null },
   unknown: { label: "unknown", glyph: "?", tone: "warning", animate: false, fleet: "nonzero", projectPriority: null },
   exited: { label: "exited", glyph: "x", tone: "neutral", animate: false, fleet: "nonzero", projectPriority: null },
+  idle: { label: "idle", glyph: "○", tone: "neutral", animate: false, fleet: "always", projectPriority: 0 },
+  starting: { label: "starting", glyph: "+", tone: "neutral", animate: false, fleet: "hidden", projectPriority: null },
 } as const satisfies Record<keyof FleetSummary, StatusUi>;
 
-export const FLEET_STATUS_ORDER = [
-  "ready", "working", "needsYou", "unknown", "exited", "idle", "starting",
-] as const satisfies readonly (keyof FleetSummary)[];
+export const FLEET_STATUS_ORDER: readonly (keyof FleetSummary)[] = Object.keys(
+  STATION_STATUS_UI,
+) as (keyof FleetSummary)[];

--- a/station/src/station/view/DashboardFilterConditionView.tsx
+++ b/station/src/station/view/DashboardFilterConditionView.tsx
@@ -9,6 +9,7 @@ import {
   type StationColor,
   type StationTheme,
 } from "../../theme/index.js";
+import { stationAgentStatusTone } from "../statusUi.js";
 import {
   stationMouseProps,
   useStationHoverState,
@@ -316,20 +317,7 @@ function conditionRowForeground(
   if (row.kind === "field") return theme.text.primary;
   if (row.field === "project") return theme.action.primary;
   if (row.field === "agent") return theme.status.accent;
-  switch (row.valueId) {
-    case "needs_attention":
-    case "stuck":
-      return theme.status.danger;
-    case "working":
-    case "starting":
-      return theme.status.working;
-    case "idle":
-      return theme.status.success;
-    case "unknown":
-      return theme.status.warning;
-    default:
-      return theme.status.neutral;
-  }
+  return theme.status[stationAgentStatusTone(row.valueId)];
 }
 
 function fitConditionLine(value: string, width: number): string {

--- a/station/src/station/view/DashboardFilterView.tsx
+++ b/station/src/station/view/DashboardFilterView.tsx
@@ -7,6 +7,7 @@ import {
   type StationColor,
   type StationTheme,
 } from "../../theme/index.js";
+import { stationAgentStatusTone } from "../statusUi.js";
 
 export function DashboardFilterView({ model }: { model: DashboardFilterHeaderModel }) {
   const theme = useStationTheme();
@@ -66,22 +67,7 @@ function conditionValueForeground(
 ): StationColor {
   if (segment.field === "project") return theme.action.primary;
   if (segment.field === "agent") return theme.status.accent;
-  switch (segment.valueId) {
-    case "needs_attention":
-    case "stuck":
-      return theme.status.danger;
-    case "working":
-    case "starting":
-      return theme.status.working;
-    case "idle":
-      return theme.status.success;
-    case "unknown":
-      return theme.status.warning;
-    case "none":
-    case "exited":
-    default:
-      return theme.status.neutral;
-  }
+  return theme.status[stationAgentStatusTone(segment.valueId)];
 }
 
 function filterSegmentAttributes(segment: DashboardFilterHeaderSegment): number {


### PR DESCRIPTION
## What this fixes

Agent status display metadata is canonical in `AGENT_STATUS`, but several CLI, Observer, Dashboard Core, and Station consumers still re-encoded labels or alert state. That left `stuck` sessions visually alerting without the Station attention sound and allowed filters, focus navigation, fixtures, and fleet order to drift.

## What changed

- route CLI observe labels and alert punctuation, Observer reason projection, Dashboard "needs me" focus, and Station attention events through canonical status projections
- make `stuck` trigger the existing Station attention sound because it is canonically alerting
- derive filter labels from `AGENT_STATUS`, with exhaustive consumer-local rank and Station tone tables
- derive fleet presentation order from the exhaustive Station UI definition table
- build mock displays from `worktreeDisplayForAgentState` and count fixture states semantically instead of using display copy

## Testing

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `cd station && bun run typecheck`
- focused root unit tests: 59 passed
- focused Station tests: 14 passed
- full root unit, contracts, integration, diagnostics, and scripted suites passed
- guided setup sandbox focused rerun: 4 passed
- install smoke passed
- Station full suite: 1,527/1,528 passed; the unrelated `useMergeCelebration` TTL test passed on immediate focused rerun
- Observer E2E: 18/20 passed; two local handoff cases outside this diff remain reproducibly red because the replacement Observer exits during handoff
