### PR TITLE
feat(observer): record session group parent relationships

### DIFF
--- a/apps/observer/src/commands/queue.ts
+++ b/apps/observer/src/commands/queue.ts
@@ -383,6 +383,7 @@ function commandScope(command: StationCommand): string {
     case "sessionGroup.create":
     case "sessionGroup.rename":
     case "sessionGroup.updateMembership":
+    case "sessionGroup.reparent":
     case "sessionGroup.delete":
       return `project:${command.payload.projectId}`;
     case "observer.reconcile":

--- a/apps/observer/src/commands/sessionGroups.ts
+++ b/apps/observer/src/commands/sessionGroups.ts
@@ -57,6 +57,7 @@ export function createSessionGroupCommandHandlers(
           ? undefined
           : requireProjectGroup(beforeById, command.payload.groupId, projectId);
       validateCommandSessions(command, snapshot, beforeById);
+      validateReparentCommand(command, target, beforeById);
 
       const at = nowIso(options.clock);
       context.beginCommit();
@@ -110,6 +111,7 @@ export function createSessionGroupCommandHandlers(
     "sessionGroup.create": handle,
     "sessionGroup.rename": handle,
     "sessionGroup.updateMembership": handle,
+    "sessionGroup.reparent": handle,
     "sessionGroup.delete": handle,
   };
 }
@@ -119,6 +121,7 @@ function sessionGroupCommand(context: CommandHandlerContext): SessionGroupComman
     case "sessionGroup.create":
     case "sessionGroup.rename":
     case "sessionGroup.updateMembership":
+    case "sessionGroup.reparent":
     case "sessionGroup.delete":
       return context.command;
     default:
@@ -177,12 +180,58 @@ async function mutateSessionGroups(input: {
       }
       return persistence.updateSessionGroupMembership(membershipInput);
     }
+    case "sessionGroup.reparent": {
+      const reparentInput: Parameters<SessionGroupStore["reparentSessionGroup"]>[0] = {
+        id: command.payload.groupId,
+        expectedVersion: command.payload.expectedVersion,
+        updatedAt: at,
+      };
+      if (command.payload.parentGroupId !== undefined) {
+        reparentInput.parentGroupId = command.payload.parentGroupId;
+      }
+      return persistence.reparentSessionGroup(reparentInput);
+    }
     case "sessionGroup.delete":
       return persistence.deleteSessionGroup({
         id: command.payload.groupId,
         expectedVersion: command.payload.expectedVersion,
         updatedAt: at,
       });
+  }
+}
+
+function validateReparentCommand(
+  command: SessionGroupCommand,
+  target: SessionGroupView | undefined,
+  groups: ReadonlyMap<string, SessionGroupView>,
+): void {
+  if (command.type !== "sessionGroup.reparent" || command.payload.parentGroupId === undefined) {
+    return;
+  }
+  if (target === undefined) {
+    throw groupMissingError(command.payload.groupId, command.payload.projectId);
+  }
+  if (command.payload.parentGroupId === target.id) {
+    throw groupParentSelfError(target.projectId);
+  }
+
+  let ancestor = requireProjectGroup(
+    groups,
+    command.payload.parentGroupId,
+    command.payload.projectId,
+  );
+  const visited = new Set<SessionGroupId>();
+  while (true) {
+    // Reaching the target rejects the proposed edge; revisiting anything else exposes prior corruption.
+    if (ancestor.id === target.id) throw groupParentCycleError(target.projectId);
+    if (visited.has(ancestor.id)) throw groupParentGraphInvalidError(target.projectId);
+    visited.add(ancestor.id);
+    if (ancestor.parentGroupId === undefined) return;
+    const parent = groups.get(ancestor.parentGroupId);
+    if (parent === undefined || parent.projectId !== target.projectId) {
+      throw groupParentGraphInvalidError(target.projectId);
+    }
+    ancestor = parent;
   }
 }
 
@@ -261,7 +310,11 @@ function sessionGroupConflict(
       };
     case "not_found":
       return groupMissingError(
-        command.type === "sessionGroup.create" ? "generated" : command.payload.groupId,
+        command.type === "sessionGroup.create"
+          ? "generated"
+          : command.type === "sessionGroup.reparent"
+            ? (command.payload.parentGroupId ?? command.payload.groupId)
+            : command.payload.groupId,
         projectId,
       );
     case "stale_version":
@@ -281,6 +334,36 @@ function sessionGroupConflict(
         projectId,
       };
   }
+}
+
+function groupParentSelfError(projectId: string): SafeError {
+  return {
+    tag: "CommandValidationError",
+    code: "SESSION_GROUP_PARENT_SELF",
+    message: "A Session Group cannot be its own parent.",
+    hint: "Choose another Group in the same project or move this Group to the project root.",
+    projectId,
+  };
+}
+
+function groupParentCycleError(projectId: string): SafeError {
+  return {
+    tag: "CommandValidationError",
+    code: "SESSION_GROUP_PARENT_CYCLE",
+    message: "The requested parent would create a Session Group cycle.",
+    hint: "Choose a Group outside the target Group's descendants.",
+    projectId,
+  };
+}
+
+function groupParentGraphInvalidError(projectId: string): SafeError {
+  return {
+    tag: "CommandValidationError",
+    code: "SESSION_GROUP_PARENT_GRAPH_INVALID",
+    message: "The requested parent belongs to an invalid persisted Group ancestry.",
+    hint: "Reconcile the Observer to repair Group parentage, then refresh and retry.",
+    projectId,
+  };
 }
 
 function projectMissingError(projectId: string): SafeError {

--- a/apps/observer/src/persistence/ports.ts
+++ b/apps/observer/src/persistence/ports.ts
@@ -32,6 +32,7 @@ import type {
   ProviderObservationsIngressDedupeResult,
   RecordProviderObservationInput,
   SessionGroupMemberExpectation,
+  SessionGroupRepairResult,
   SessionGroupStoreResult,
   SessionHarnessDerivedStateRepair,
   SessionTurnReadinessMutation,
@@ -218,7 +219,7 @@ export interface SessionStore {
 /**
  * DRIVEN PORT
  *
- * Maintains durable project-local Group definitions, exclusive membership, and parentage through atomic stale-write-safe conversations.
+ * Maintains durable project-local Group definitions, exclusive membership, parentage, and atomic reconcile repair of parseable relationships.
  */
 export interface SessionGroupStore {
   listSessionGroups(): Promise<SessionGroupView[]>;
@@ -254,10 +255,10 @@ export interface SessionGroupStore {
     expectedVersion: number;
     updatedAt?: string;
   }): Promise<SessionGroupStoreResult>;
-  pruneSessionGroupMemberships(input: {
+  repairSessionGroups(input: {
     sessions: Array<{ id: string; projectId: string }>;
     updatedAt?: string;
-  }): Promise<SessionGroupStoreResult>;
+  }): Promise<SessionGroupRepairResult>;
 }
 
 /**

--- a/apps/observer/src/persistence/sessionGroups.ts
+++ b/apps/observer/src/persistence/sessionGroups.ts
@@ -3,7 +3,12 @@ import {
   type SessionGroupView,
   SessionGroupViewSchema,
 } from "@station/contracts";
-import type { SessionGroupMemberExpectation, SessionGroupStoreResult } from "./types.js";
+import type {
+  SessionGroupMemberExpectation,
+  SessionGroupRepairEvidence,
+  SessionGroupRepairResult,
+  SessionGroupStoreResult,
+} from "./types.js";
 
 type Assignment = { groupId: SessionGroupId; projectId: string };
 
@@ -15,6 +20,12 @@ export type SessionGroupPersistenceState = {
 export type SessionGroupMutation = {
   state: SessionGroupPersistenceState;
   result: SessionGroupStoreResult;
+  changed: boolean;
+};
+
+export type SessionGroupRepairMutation = {
+  state: SessionGroupPersistenceState;
+  result: SessionGroupRepairResult;
   changed: boolean;
 };
 
@@ -53,11 +64,17 @@ export function listSessionGroups(state: SessionGroupPersistenceState): SessionG
     const projectGroups = byProject.get(projectId) ?? [];
     const groupsById = new Map(projectGroups.map((group) => [group.id, group]));
     const emitted = new Set<string>();
+    const visiting = new Set<string>();
     const emit = (group: SessionGroupView): void => {
       if (emitted.has(group.id)) return;
-      const parent =
-        group.parentGroupId === undefined ? undefined : groupsById.get(group.parentGroupId);
-      if (parent !== undefined) emit(parent);
+      if (!visiting.has(group.id)) {
+        visiting.add(group.id);
+        const parent =
+          group.parentGroupId === undefined ? undefined : groupsById.get(group.parentGroupId);
+        if (parent !== undefined) emit(parent);
+        visiting.delete(group.id);
+      }
+      if (emitted.has(group.id)) return;
       emitted.add(group.id);
       ordered.push(structuredClone(group));
     };
@@ -195,10 +212,20 @@ export function reparentSessionGroup(
       throw new Error("Group parent must share its project.");
     }
     let ancestor: SessionGroupView | undefined = parent;
+    const visited = new Set<SessionGroupId>();
     while (ancestor !== undefined) {
       if (ancestor.id === child.value.id) throw new Error("Group parents must not form a cycle.");
-      ancestor =
-        ancestor.parentGroupId === undefined ? undefined : state.groups.get(ancestor.parentGroupId);
+      if (visited.has(ancestor.id)) throw new Error("Group parent ancestry must be acyclic.");
+      visited.add(ancestor.id);
+      if (ancestor.parentGroupId === undefined) break;
+      const parentAncestor = state.groups.get(ancestor.parentGroupId);
+      if (parentAncestor === undefined) {
+        throw new Error("Group parent ancestry references a missing Group.");
+      }
+      if (parentAncestor.projectId !== child.value.projectId) {
+        throw new Error("Group parent ancestry must stay within its project.");
+      }
+      ancestor = parentAncestor;
     }
   }
   const draft = cloneSessionGroupState(state);
@@ -232,26 +259,122 @@ export function deleteSessionGroup(
   return success(draft, [...touched], true);
 }
 
-export function pruneSessionGroupMemberships(
+export function repairSessionGroups(
   state: SessionGroupPersistenceState,
   input: { sessions: Array<{ id: string; projectId: string }>; updatedAt: string },
-): SessionGroupMutation {
+): SessionGroupRepairMutation {
   const validSessions = new Map(input.sessions.map((session) => [session.id, session.projectId]));
   const draft = cloneSessionGroupState(state);
   const touched = new Set<SessionGroupId>();
+  const repairs: SessionGroupRepairEvidence[] = [];
+  const repairKeys = new Set<string>();
+  const recordRepair = (repair: SessionGroupRepairEvidence): void => {
+    const key = `${repair.groupId}\u0000${repair.reason}`;
+    if (repairKeys.has(key)) return;
+    repairKeys.add(key);
+    repairs.push(repair);
+  };
   for (const [sessionId, assignment] of draft.assignments) {
     const group = draft.groups.get(assignment.groupId);
+    if (group === undefined) {
+      throw new Error("Session Group assignment references a missing Group.");
+    }
     if (
-      group === undefined ||
       validSessions.get(sessionId) !== group.projectId ||
       assignment.projectId !== group.projectId
     ) {
       draft.assignments.delete(sessionId);
-      if (group !== undefined) touched.add(group.id);
+      touched.add(group.id);
+      recordRepair({
+        reason: "invalid_membership",
+        groupId: group.id,
+        projectId: group.projectId,
+      });
     }
   }
+
+  const orderedGroups = [...draft.groups.values()].sort(
+    (left, right) =>
+      left.projectId.localeCompare(right.projectId) || left.id.localeCompare(right.id),
+  );
+  for (const group of orderedGroups) {
+    if (group.parentGroupId === undefined) continue;
+    const parent = draft.groups.get(group.parentGroupId);
+    const reason =
+      parent === undefined
+        ? "missing_parent"
+        : parent.projectId !== group.projectId
+          ? "cross_project_parent"
+          : undefined;
+    if (reason === undefined) continue;
+    const next = { ...group };
+    delete next.parentGroupId;
+    draft.groups.set(group.id, SessionGroupViewSchema.parse(next));
+    touched.add(group.id);
+    recordRepair({
+      reason,
+      groupId: group.id,
+      projectId: group.projectId,
+      parentGroupId: group.parentGroupId,
+    });
+  }
+
+  const resolved = new Set<SessionGroupId>();
+  for (const start of orderedGroups) {
+    if (resolved.has(start.id)) continue;
+    const path: SessionGroupId[] = [];
+    const pathIndex = new Map<SessionGroupId, number>();
+    let currentId: SessionGroupId | undefined = start.id;
+    while (currentId !== undefined && !resolved.has(currentId)) {
+      const cycleStart = pathIndex.get(currentId);
+      if (cycleStart !== undefined) {
+        // Root only cycle participants so incoming non-cycle descendants keep their repaired attachment.
+        for (const groupId of path.slice(cycleStart)) {
+          const group = draft.groups.get(groupId);
+          if (group?.parentGroupId === undefined) {
+            throw new Error("Session Group cycle repair lost its parent edge.");
+          }
+          const parentGroupId = group.parentGroupId;
+          const next = { ...group };
+          delete next.parentGroupId;
+          draft.groups.set(group.id, SessionGroupViewSchema.parse(next));
+          touched.add(group.id);
+          recordRepair({
+            reason: "parent_cycle",
+            groupId: group.id,
+            projectId: group.projectId,
+            parentGroupId,
+          });
+        }
+        break;
+      }
+      pathIndex.set(currentId, path.length);
+      path.push(currentId);
+      const group = draft.groups.get(currentId);
+      if (group === undefined) throw new Error("Session Group parent references a missing Group.");
+      currentId = group.parentGroupId;
+    }
+    for (const groupId of path) resolved.add(groupId);
+  }
+
   touchGroups(draft, touched, input.updatedAt);
-  return success(draft, [...touched], touched.size > 0);
+  const reasonOrder = {
+    invalid_membership: 0,
+    missing_parent: 1,
+    cross_project_parent: 2,
+    parent_cycle: 3,
+  } as const;
+  repairs.sort(
+    (left, right) =>
+      left.projectId.localeCompare(right.projectId) ||
+      left.groupId.localeCompare(right.groupId) ||
+      reasonOrder[left.reason] - reasonOrder[right.reason],
+  );
+  return {
+    state: draft,
+    changed: touched.size > 0,
+    result: { groups: listSessionGroups(draft), repairs },
+  };
 }
 
 function expectedGroup(

--- a/apps/observer/src/persistence/sessionGroups.ts
+++ b/apps/observer/src/persistence/sessionGroups.ts
@@ -17,15 +17,9 @@ export type SessionGroupPersistenceState = {
   assignments: Map<string, Assignment>;
 };
 
-export type SessionGroupMutation = {
+export type SessionGroupMutation<TResult = SessionGroupStoreResult> = {
   state: SessionGroupPersistenceState;
-  result: SessionGroupStoreResult;
-  changed: boolean;
-};
-
-export type SessionGroupRepairMutation = {
-  state: SessionGroupPersistenceState;
-  result: SessionGroupRepairResult;
+  result: TResult;
   changed: boolean;
 };
 
@@ -262,7 +256,7 @@ export function deleteSessionGroup(
 export function repairSessionGroups(
   state: SessionGroupPersistenceState,
   input: { sessions: Array<{ id: string; projectId: string }>; updatedAt: string },
-): SessionGroupRepairMutation {
+): SessionGroupMutation<SessionGroupRepairResult> {
   const validSessions = new Map(input.sessions.map((session) => [session.id, session.projectId]));
   const draft = cloneSessionGroupState(state);
   const touched = new Set<SessionGroupId>();

--- a/apps/observer/src/persistence/sqliteAdapter.ts
+++ b/apps/observer/src/persistence/sqliteAdapter.ts
@@ -48,11 +48,13 @@ export function createSqliteObserverPersistence(
   const now = () => toIsoTimestamp(clock.now());
   const transaction = <T>(task: (database: SqlDatabase) => T): Promise<T> =>
     Effect.runPromise(runSqliteTransactionEffect(options.sqlite, task));
-  const sessionGroupMutation = (
-    mutate: (
-      state: sessionGroupStore.SessionGroupPersistenceState,
-    ) => sessionGroupStore.SessionGroupMutation,
-  ) =>
+  const sessionGroupMutation = <T>(
+    mutate: (state: sessionGroupStore.SessionGroupPersistenceState) => {
+      state: sessionGroupStore.SessionGroupPersistenceState;
+      result: T;
+      changed: boolean;
+    },
+  ): Promise<T> =>
     transaction((database) => {
       const before = sessionGroupSqlite.readSessionGroupState(database);
       const mutation = mutate(before);
@@ -332,9 +334,9 @@ export function createSqliteObserverPersistence(
         }),
       ),
 
-    pruneSessionGroupMemberships: (input) =>
+    repairSessionGroups: (input) =>
       sessionGroupMutation((state) =>
-        sessionGroupStore.pruneSessionGroupMemberships(state, {
+        sessionGroupStore.repairSessionGroups(state, {
           ...input,
           updatedAt: input.updatedAt ?? now(),
         }),

--- a/apps/observer/src/persistence/types.ts
+++ b/apps/observer/src/persistence/types.ts
@@ -39,6 +39,24 @@ export type SessionGroupStoreResult =
   | { ok: true; groups: SessionGroupView[] }
   | { ok: false; reason: SessionGroupStoreConflictReason };
 
+export type SessionGroupRepairEvidence =
+  | {
+      reason: "invalid_membership";
+      groupId: SessionGroupId;
+      projectId: string;
+    }
+  | {
+      reason: "missing_parent" | "cross_project_parent" | "parent_cycle";
+      groupId: SessionGroupId;
+      projectId: string;
+      parentGroupId: SessionGroupId;
+    };
+
+export type SessionGroupRepairResult = {
+  groups: SessionGroupView[];
+  repairs: SessionGroupRepairEvidence[];
+};
+
 export type PersistedCommandStatus = "accepted" | "started" | "succeeded" | "failed";
 
 export type ObserverIdFactory = {

--- a/apps/observer/src/reconcile/sessionGroups.ts
+++ b/apps/observer/src/reconcile/sessionGroups.ts
@@ -4,7 +4,7 @@ import type {
   SessionGroupView,
   SessionView,
 } from "@station/contracts";
-import type { SessionGroupStore } from "../persistence/index.js";
+import type { SessionGroupRepairEvidence, SessionGroupStore } from "../persistence/index.js";
 
 export type SessionGroupProjection = {
   sessionGroups: SessionGroupView[];
@@ -14,7 +14,7 @@ export type SessionGroupProjection = {
 /**
  * USE CASE
  *
- * Repairs durable Group membership against canonical sessions and projects configured Groups.
+ * Repairs durable Group membership and parentage against canonical state, then projects configured Groups with reason-specific diagnostics.
  */
 export async function reconcileSessionGroups(input: {
   store?: SessionGroupStore | undefined;
@@ -26,23 +26,13 @@ export async function reconcileSessionGroups(input: {
     return { sessionGroups: [], errors: [] };
   }
 
-  const pruned = await input.store.pruneSessionGroupMemberships({
+  const repaired = await input.store.repairSessionGroups({
     sessions: input.sessions.map((session) => ({ id: session.id, projectId: session.projectId })),
     updatedAt: input.updatedAt,
   });
-  if (!pruned.ok) {
-    throw new Error(`Unexpected Session Group prune conflict: ${pruned.reason}`);
-  }
-
-  const groups = await input.store.listSessionGroups();
+  const groups = repaired.groups;
   const configuredProjectIds = new Set(input.projects.map((project) => project.id));
-  const errors: SafeError[] = pruned.groups.map((group) => ({
-    tag: "SessionGroupReconcileError",
-    code: "SESSION_GROUP_MEMBERSHIP_REPAIRED",
-    message: `Session Group ${group.id} contained membership outside the canonical project sessions.`,
-    hint: "The invalid membership was removed while the Group definition was preserved.",
-    projectId: group.projectId,
-  }));
+  const errors: SafeError[] = repaired.repairs.map((repair) => repairError(repair));
   for (const group of groups) {
     if (configuredProjectIds.has(group.projectId)) continue;
     errors.push({
@@ -67,7 +57,7 @@ export async function reconcileSessionGroups(input: {
 /**
  * POLICY
  *
- * Selects configured Groups and orders their canonical direct membership deterministically.
+ * Projects configured Groups as a flat deterministic parent-before-child array with canonical direct membership.
  */
 export function projectSessionGroups(input: {
   groups: readonly SessionGroupView[];
@@ -106,6 +96,7 @@ export function projectSessionGroups(input: {
         if (parent !== undefined && parent.projectId === group.projectId) emit(parent);
         visiting.delete(group.id);
       }
+      if (emitted.has(group.id)) return;
       emitted.add(group.id);
       ordered.push(group);
     };
@@ -114,4 +105,41 @@ export function projectSessionGroups(input: {
     }
   }
   return ordered;
+}
+
+function repairError(repair: SessionGroupRepairEvidence): SafeError {
+  switch (repair.reason) {
+    case "invalid_membership":
+      return {
+        tag: "SessionGroupReconcileError",
+        code: "SESSION_GROUP_MEMBERSHIP_REPAIRED",
+        message: `Session Group ${repair.groupId} contained membership outside the canonical project sessions.`,
+        hint: "The invalid membership was removed while the Group definition was preserved.",
+        projectId: repair.projectId,
+      };
+    case "missing_parent":
+      return {
+        tag: "SessionGroupReconcileError",
+        code: "SESSION_GROUP_PARENT_MISSING_REPAIRED",
+        message: `Session Group ${repair.groupId} referenced a missing parent Group.`,
+        hint: "The invalid parent relationship was cleared while the Group definition was preserved.",
+        projectId: repair.projectId,
+      };
+    case "cross_project_parent":
+      return {
+        tag: "SessionGroupReconcileError",
+        code: "SESSION_GROUP_PARENT_PROJECT_REPAIRED",
+        message: `Session Group ${repair.groupId} referenced a parent Group in another project.`,
+        hint: "The cross-project parent relationship was cleared while both definitions were preserved.",
+        projectId: repair.projectId,
+      };
+    case "parent_cycle":
+      return {
+        tag: "SessionGroupReconcileError",
+        code: "SESSION_GROUP_PARENT_CYCLE_REPAIRED",
+        message: `Session Group ${repair.groupId} participated in a parent cycle.`,
+        hint: "The cycle participant was moved to the project root while its definition was preserved.",
+        projectId: repair.projectId,
+      };
+  }
 }

--- a/apps/observer/test/integration/command-queue.test.ts
+++ b/apps/observer/test/integration/command-queue.test.ts
@@ -73,21 +73,21 @@ const closeTerminalCommand: StationCommand = {
   },
 };
 
-const renameSessionGroupCommand: StationCommand = {
-  type: "sessionGroup.rename",
-  payload: {
-    projectId: "web",
-    groupId: "grp_web",
-    expectedVersion: 1,
-    name: "Web",
-  },
-};
-
 const createSessionGroupCommand: StationCommand = {
   type: "sessionGroup.create",
   payload: {
     projectId: "web",
     name: "Another web Group",
+  },
+};
+
+const reparentSessionGroupCommand: StationCommand = {
+  type: "sessionGroup.reparent",
+  payload: {
+    projectId: "web",
+    groupId: "grp_web",
+    expectedVersion: 1,
+    parentGroupId: "grp_parent",
   },
 };
 
@@ -380,11 +380,11 @@ describe("observer command queue", () => {
       starts.push(commandId);
       if (commandId === "cmd_1") await firstBlocked;
     };
-    queue.registerHandler("sessionGroup.rename", handler);
+    queue.registerHandler("sessionGroup.reparent", handler);
     queue.registerHandler("sessionGroup.create", handler);
 
     await Promise.all([
-      queue.dispatch(renameSessionGroupCommand),
+      queue.dispatch(reparentSessionGroupCommand),
       queue.dispatch(createSessionGroupCommand),
       queue.dispatch(createApiSessionGroupCommand),
     ]);

--- a/apps/observer/test/integration/reconcile-persistence.test.ts
+++ b/apps/observer/test/integration/reconcile-persistence.test.ts
@@ -211,6 +211,133 @@ describe("observer reconcile persistence", () => {
     sqlite.close();
   });
 
+  it("repairs missing, cross-project, and cyclic Group parentage deterministically", async () => {
+    const groupConfig: StationConfig = {
+      ...config,
+      projects: [
+        ...config.projects,
+        {
+          id: "api",
+          label: "api",
+          root: "/tmp/station/api",
+          defaults: {
+            harness: "fake-harness",
+            terminal: "fake-terminal",
+            layout: "agent-shell",
+          },
+          worktrunk: { enabled: true },
+        },
+      ],
+    };
+    const { sqlite, persistence, core } = createTestObserverCore({
+      config: groupConfig,
+      providers: providersWithOneSession(),
+      clock: { now: () => new Date(now) },
+    });
+    await persistence.createSessionGroup({
+      id: "grp_a_combined",
+      projectId: "web",
+      name: "Combined",
+      initialMembers: [{ sessionId: "ses_missing", projectId: "web", expectedGroupId: null }],
+      createdAt: now,
+    });
+    for (const [id, projectId] of [
+      ["grp_b_cross", "web"],
+      ["grp_c_api_parent", "api"],
+      ["grp_d_self", "web"],
+      ["grp_e_cycle_a", "web"],
+      ["grp_e_cycle_b", "web"],
+      ["grp_f_descendant", "web"],
+    ] as const) {
+      await persistence.createSessionGroup({ id, projectId, name: id, createdAt: now });
+    }
+    const setParent = sqlite.database.prepare(
+      "UPDATE session_groups SET parent_group_id = ? WHERE id = ?",
+    );
+    setParent.run("grp_missing", "grp_a_combined");
+    setParent.run("grp_c_api_parent", "grp_b_cross");
+    setParent.run("grp_d_self", "grp_d_self");
+    setParent.run("grp_e_cycle_b", "grp_e_cycle_a");
+    setParent.run("grp_e_cycle_a", "grp_e_cycle_b");
+    setParent.run("grp_e_cycle_a", "grp_f_descendant");
+
+    const snapshot = await core.reconcile("session-group-parent-repair");
+    expect(() => StationSnapshotSchema.parse(snapshot)).not.toThrow();
+    const groups = new Map(snapshot.sessionGroups.map((group) => [group.id, group]));
+    for (const id of [
+      "grp_a_combined",
+      "grp_b_cross",
+      "grp_d_self",
+      "grp_e_cycle_a",
+      "grp_e_cycle_b",
+    ]) {
+      expect(groups.get(id)).not.toHaveProperty("parentGroupId");
+      expect(groups.get(id)).toMatchObject({ version: 2 });
+    }
+    expect(groups.get("grp_a_combined")).toMatchObject({ sessionIds: [] });
+    expect(groups.get("grp_f_descendant")).toMatchObject({
+      parentGroupId: "grp_e_cycle_a",
+      version: 1,
+    });
+    expect(groups.get("grp_c_api_parent")).toMatchObject({ version: 1 });
+    expect(core.getHealth().lastReconcile?.errors.map((error) => error.code)).toEqual([
+      "SESSION_GROUP_MEMBERSHIP_REPAIRED",
+      "SESSION_GROUP_PARENT_MISSING_REPAIRED",
+      "SESSION_GROUP_PARENT_PROJECT_REPAIRED",
+      "SESSION_GROUP_PARENT_CYCLE_REPAIRED",
+      "SESSION_GROUP_PARENT_CYCLE_REPAIRED",
+      "SESSION_GROUP_PARENT_CYCLE_REPAIRED",
+    ]);
+
+    const repeated = await core.reconcile("session-group-parent-repair-repeat");
+    expect(() => StationSnapshotSchema.parse(repeated)).not.toThrow();
+    expect((await persistence.listSessionGroups()).map((group) => group.version)).toEqual([
+      1, 2, 2, 2, 2, 2, 1,
+    ]);
+    expect(
+      core.getHealth().lastReconcile?.errors.filter((error) => error.code.includes("_REPAIRED")),
+    ).toEqual([]);
+    sqlite.close();
+  });
+
+  it("rolls back the complete Group relationship repair when a later write fails", async () => {
+    const { sqlite, persistence } = createTestObserverCore({
+      config,
+      providers: providersWithOneSession(),
+      clock: { now: () => new Date(now) },
+    });
+    for (const id of ["grp_a", "grp_b"]) {
+      await persistence.createSessionGroup({
+        id,
+        projectId: "web",
+        name: id,
+        createdAt: now,
+      });
+    }
+    sqlite.database.exec(`
+      UPDATE session_groups SET parent_group_id = 'missing' WHERE id IN ('grp_a', 'grp_b');
+      CREATE TRIGGER reject_group_b_repair
+      BEFORE UPDATE ON session_groups
+      WHEN OLD.id = 'grp_b'
+      BEGIN
+        SELECT RAISE(ABORT, 'forced Group repair failure');
+      END;
+    `);
+
+    await expect(
+      persistence.repairSessionGroups({ sessions: [], updatedAt: "2026-05-20T12:01:00.000Z" }),
+    ).rejects.toBeDefined();
+    expect(
+      sqlite.database
+        .prepare("SELECT id, parent_group_id, version FROM session_groups ORDER BY id")
+        .all(),
+    ).toEqual([
+      { id: "grp_a", parent_group_id: "missing", version: 1 },
+      { id: "grp_b", parent_group_id: "missing", version: 1 },
+    ]);
+    sqlite.close();
+  });
+
   it("preserves empty Groups and retains excluded-project definitions outside the snapshot", async () => {
     const { sqlite, persistence, core } = createTestObserverCore({
       config,
@@ -229,6 +356,9 @@ describe("observer reconcile persistence", () => {
       name: "Retained",
       createdAt: now,
     });
+    sqlite.database
+      .prepare("UPDATE session_groups SET parent_group_id = ? WHERE id = ?")
+      .run("grp_missing", "grp_removed_empty");
 
     const snapshot = await core.reconcile("session-group-excluded-project");
 
@@ -236,9 +366,16 @@ describe("observer reconcile persistence", () => {
       expect.objectContaining({ id: "grp_web_empty", sessionIds: [], version: 1 }),
     ]);
     await expect(persistence.listSessionGroups()).resolves.toEqual([
-      expect.objectContaining({ id: "grp_removed_empty", projectId: "removed" }),
+      expect.objectContaining({ id: "grp_removed_empty", projectId: "removed", version: 2 }),
       expect.objectContaining({ id: "grp_web_empty", projectId: "web" }),
     ]);
+    expect((await persistence.listSessionGroups())[0]).not.toHaveProperty("parentGroupId");
+    expect(core.getHealth().lastReconcile?.errors).toContainEqual(
+      expect.objectContaining({
+        code: "SESSION_GROUP_PARENT_MISSING_REPAIRED",
+        projectId: "removed",
+      }),
+    );
     expect(core.getHealth().lastReconcile?.errors).toContainEqual(
       expect.objectContaining({
         code: "SESSION_GROUP_PROJECT_EXCLUDED",

--- a/apps/observer/test/integration/session-group-commands.test.ts
+++ b/apps/observer/test/integration/session-group-commands.test.ts
@@ -116,6 +116,208 @@ describe.each(storageKinds)("recorded Session Group commands with %s persistence
     }
   });
 
+  it("reparents and detaches Groups with immediate flat snapshot convergence", async () => {
+    const test = await fixture();
+    const providerReads = vi.spyOn(test.providers.worktree, "listWorktrees");
+    await test.dispatch({
+      type: "sessionGroup.create",
+      payload: { projectId: "web", name: "Parent" },
+    });
+    await test.dispatch({
+      type: "sessionGroup.create",
+      payload: { projectId: "web", name: "Child" },
+    });
+
+    const reparent = await test.dispatch({
+      type: "sessionGroup.reparent",
+      payload: {
+        projectId: "web",
+        groupId: "grp_2",
+        expectedVersion: 1,
+        parentGroupId: "grp_1",
+      },
+    });
+    expect(reparent.status).toBe("succeeded");
+    expect(test.core.getSnapshot().sessionGroups).toEqual([
+      expect.objectContaining({ id: "grp_1", version: 1 }),
+      expect.objectContaining({ id: "grp_2", parentGroupId: "grp_1", version: 2 }),
+    ]);
+    expect(
+      (await test.persistence.listEvents({ commandId: reparent.id })).map((event) => event.type),
+    ).toEqual(["command.accepted", "command.started", "sessionGroup.updated", "command.succeeded"]);
+
+    const sameParent = await test.dispatch({
+      type: "sessionGroup.reparent",
+      payload: {
+        projectId: "web",
+        groupId: "grp_2",
+        expectedVersion: 2,
+        parentGroupId: "grp_1",
+      },
+    });
+    const rootToRoot = await test.dispatch({
+      type: "sessionGroup.reparent",
+      payload: { projectId: "web", groupId: "grp_1", expectedVersion: 1 },
+    });
+    for (const commandId of [sameParent.id, rootToRoot.id]) {
+      expect((await test.persistence.listEvents({ commandId })).map((event) => event.type)).toEqual(
+        ["command.accepted", "command.started", "command.succeeded"],
+      );
+    }
+
+    const detach = await test.dispatch({
+      type: "sessionGroup.reparent",
+      payload: { projectId: "web", groupId: "grp_2", expectedVersion: 2 },
+    });
+    expect(detach.status).toBe("succeeded");
+    expect(test.core.getSnapshot().sessionGroups).toEqual([
+      expect.objectContaining({ id: "grp_1", version: 1 }),
+      expect.not.objectContaining({ parentGroupId: expect.anything() }),
+    ]);
+    expect(test.core.getSnapshot().sessionGroups[1]).toMatchObject({ id: "grp_2", version: 3 });
+    expect(providerReads).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid reparent ancestry with typed errors and no Group mutation", async () => {
+    const test = await fixture();
+    for (const [projectId, name] of [
+      ["web", "Parent"],
+      ["web", "Child"],
+      ["web", "Grandchild"],
+      ["api", "API"],
+    ] as const) {
+      await test.dispatch({ type: "sessionGroup.create", payload: { projectId, name } });
+    }
+    await test.dispatch({
+      type: "sessionGroup.reparent",
+      payload: {
+        projectId: "web",
+        groupId: "grp_2",
+        expectedVersion: 1,
+        parentGroupId: "grp_1",
+      },
+    });
+    await test.dispatch({
+      type: "sessionGroup.reparent",
+      payload: {
+        projectId: "web",
+        groupId: "grp_3",
+        expectedVersion: 1,
+        parentGroupId: "grp_2",
+      },
+    });
+    const before = await test.persistence.listSessionGroups();
+
+    const cases: Array<{ command: StationCommand; code: string }> = [
+      {
+        command: {
+          type: "sessionGroup.reparent",
+          payload: {
+            projectId: "web",
+            groupId: "grp_2",
+            expectedVersion: 2,
+            parentGroupId: "grp_missing",
+          },
+        },
+        code: "SESSION_GROUP_NOT_FOUND",
+      },
+      {
+        command: {
+          type: "sessionGroup.reparent",
+          payload: {
+            projectId: "web",
+            groupId: "grp_2",
+            expectedVersion: 2,
+            parentGroupId: "grp_4",
+          },
+        },
+        code: "SESSION_GROUP_PROJECT_MISMATCH",
+      },
+      {
+        command: {
+          type: "sessionGroup.reparent",
+          payload: {
+            projectId: "web",
+            groupId: "grp_2",
+            expectedVersion: 2,
+            parentGroupId: "grp_2",
+          },
+        },
+        code: "SESSION_GROUP_PARENT_SELF",
+      },
+      {
+        command: {
+          type: "sessionGroup.reparent",
+          payload: {
+            projectId: "web",
+            groupId: "grp_1",
+            expectedVersion: 1,
+            parentGroupId: "grp_3",
+          },
+        },
+        code: "SESSION_GROUP_PARENT_CYCLE",
+      },
+      {
+        command: {
+          type: "sessionGroup.reparent",
+          payload: { projectId: "web", groupId: "grp_2", expectedVersion: 1 },
+        },
+        code: "SESSION_GROUP_VERSION_CONFLICT",
+      },
+    ];
+    for (const { command, code } of cases) {
+      const failed = await test.dispatch(command);
+      expect(failed).toMatchObject({ status: "failed", error: { code } });
+      expect(
+        (await test.persistence.listEvents({ commandId: failed.id })).map((event) => event.type),
+      ).toEqual(["command.accepted", "command.started", "command.failed"]);
+    }
+    await expect(test.persistence.listSessionGroups()).resolves.toEqual(before);
+  });
+
+  it("terminates on corrupt persisted ancestry and rejects it before commit", async () => {
+    if (storage !== "SQLite") return;
+    const test = await fixture();
+    for (const name of ["A", "B", "X"]) {
+      await test.dispatch({
+        type: "sessionGroup.create",
+        payload: { projectId: "web", name },
+      });
+    }
+    if (test.sqlite === undefined) throw new Error("Expected SQLite persistence.");
+    const setParent = test.sqlite.database.prepare(
+      "UPDATE session_groups SET parent_group_id = ? WHERE id = ?",
+    );
+    setParent.run("grp_2", "grp_1");
+    setParent.run("grp_1", "grp_2");
+
+    const listed = await test.persistence.listSessionGroups();
+    expect(listed.map((group) => group.id)).toEqual(["grp_1", "grp_2", "grp_3"]);
+    await expect(
+      test.persistence.reparentSessionGroup({
+        id: "grp_3",
+        expectedVersion: 1,
+        parentGroupId: "grp_1",
+      }),
+    ).rejects.toBeDefined();
+    const failed = await test.dispatch({
+      type: "sessionGroup.reparent",
+      payload: {
+        projectId: "web",
+        groupId: "grp_3",
+        expectedVersion: 1,
+        parentGroupId: "grp_1",
+      },
+    });
+    expect(failed).toMatchObject({
+      status: "failed",
+      error: { code: "SESSION_GROUP_PARENT_GRAPH_INVALID" },
+    });
+    expect(
+      (await test.persistence.listSessionGroups()).find((group) => group.id === "grp_3"),
+    ).not.toHaveProperty("parentGroupId");
+  });
+
   it("projects only the command project without repairing durable memberships", async () => {
     const test = await fixture();
     await test.dispatch({
@@ -321,6 +523,81 @@ describe.each(storageKinds)("recorded Session Group commands with %s persistence
     ]);
   });
 
+  it("deletes one Group, reparents direct children, and publishes canonical child updates first", async () => {
+    const test = await fixture();
+    const before = test.core.getSnapshot();
+    for (const [name, initialSessionIds] of [
+      ["Root", undefined],
+      ["Parent", ["ses_web_a"]],
+      ["Child A", undefined],
+      ["Child B", undefined],
+      ["Grandchild", undefined],
+    ] as const) {
+      await test.dispatch({
+        type: "sessionGroup.create",
+        payload: {
+          projectId: "web",
+          name,
+          ...(initialSessionIds === undefined ? {} : { initialSessionIds: [...initialSessionIds] }),
+        },
+      });
+    }
+    for (const [groupId, parentGroupId] of [
+      ["grp_2", "grp_1"],
+      ["grp_3", "grp_2"],
+      ["grp_4", "grp_2"],
+      ["grp_5", "grp_3"],
+    ] as const) {
+      await test.dispatch({
+        type: "sessionGroup.reparent",
+        payload: { projectId: "web", groupId, expectedVersion: 1, parentGroupId },
+      });
+    }
+
+    const deleted = await test.dispatch({
+      type: "sessionGroup.delete",
+      payload: { projectId: "web", groupId: "grp_2", expectedVersion: 2 },
+    });
+    expect(deleted.status).toBe("succeeded");
+    expect(test.core.getSnapshot().sessionGroups).toEqual([
+      expect.objectContaining({ id: "grp_1", version: 1, sessionIds: [] }),
+      expect.objectContaining({ id: "grp_3", parentGroupId: "grp_1", version: 3 }),
+      expect.objectContaining({ id: "grp_4", parentGroupId: "grp_1", version: 3 }),
+      expect.objectContaining({ id: "grp_5", parentGroupId: "grp_3", version: 2 }),
+    ]);
+    expect(test.core.getSnapshot().sessions).toEqual(before.sessions);
+    expect(test.core.getSnapshot().rows).toEqual(before.rows);
+    expect(
+      (await test.persistence.listEvents({ commandId: deleted.id })).map((event) =>
+        event.event.type === "sessionGroup.updated"
+          ? `${event.type}:${event.event.group.id}`
+          : event.type,
+      ),
+    ).toEqual([
+      "command.accepted",
+      "command.started",
+      "sessionGroup.updated:grp_3",
+      "sessionGroup.updated:grp_4",
+      "sessionGroup.removed",
+      "command.succeeded",
+    ]);
+
+    const repeated = await test.dispatch({
+      type: "sessionGroup.delete",
+      payload: { projectId: "web", groupId: "grp_2", expectedVersion: 2 },
+    });
+    expect(repeated).toMatchObject({
+      status: "failed",
+      error: { code: "SESSION_GROUP_NOT_FOUND" },
+    });
+    expect(test.core.getSnapshot().sessionGroups).toEqual([
+      expect.objectContaining({ id: "grp_1", version: 1 }),
+      expect.objectContaining({ id: "grp_3", version: 3 }),
+      expect.objectContaining({ id: "grp_4", version: 3 }),
+      expect.objectContaining({ id: "grp_5", version: 2 }),
+    ]);
+  });
+
   it("deletes only Group organization and reports generated id collisions", async () => {
     const test = await fixture({ repeatedGroupId: true });
     const before = test.core.getSnapshot();
@@ -356,6 +633,7 @@ type GroupCommandFixture = {
   providers: ProviderRegistry;
   core: ObserverCore;
   queue: CommandQueue;
+  sqlite: ReturnType<typeof openObserverSqlite> | undefined;
   publishedEvents: StationEvent[];
   dispatch(
     command: StationCommand,
@@ -422,6 +700,7 @@ async function createFixture(
     providers,
     core,
     queue,
+    sqlite,
     publishedEvents,
     dispatch: async (command) => {
       const receipt = await queue.dispatch(command);

--- a/apps/observer/test/integration/session-group-commands.test.ts
+++ b/apps/observer/test/integration/session-group-commands.test.ts
@@ -275,7 +275,7 @@ describe.each(storageKinds)("recorded Session Group commands with %s persistence
     await expect(test.persistence.listSessionGroups()).resolves.toEqual(before);
   });
 
-  it("terminates on corrupt persisted ancestry and rejects it before commit", async () => {
+  it("rejects missing, cross-project, and cyclic corrupt ancestry before commit", async () => {
     if (storage !== "SQLite") return;
     const test = await fixture();
     for (const name of ["A", "B", "X"]) {
@@ -288,34 +288,54 @@ describe.each(storageKinds)("recorded Session Group commands with %s persistence
     const setParent = test.sqlite.database.prepare(
       "UPDATE session_groups SET parent_group_id = ? WHERE id = ?",
     );
+    const rejectCorruptAncestry = async (): Promise<void> => {
+      await expect(
+        test.persistence.reparentSessionGroup({
+          id: "grp_3",
+          expectedVersion: 1,
+          parentGroupId: "grp_1",
+        }),
+      ).rejects.toBeDefined();
+      const failed = await test.dispatch({
+        type: "sessionGroup.reparent",
+        payload: {
+          projectId: "web",
+          groupId: "grp_3",
+          expectedVersion: 1,
+          parentGroupId: "grp_1",
+        },
+      });
+      expect(failed).toMatchObject({
+        status: "failed",
+        error: { code: "SESSION_GROUP_PARENT_GRAPH_INVALID" },
+      });
+      const target = (await test.persistence.listSessionGroups()).find(
+        (group) => group.id === "grp_3",
+      );
+      expect(target).toMatchObject({ version: 1 });
+      expect(target).not.toHaveProperty("parentGroupId");
+    };
+
     setParent.run("grp_2", "grp_1");
     setParent.run("grp_1", "grp_2");
+    expect((await test.persistence.listSessionGroups()).map((group) => group.id)).toEqual([
+      "grp_1",
+      "grp_2",
+      "grp_3",
+    ]);
+    await rejectCorruptAncestry();
 
-    const listed = await test.persistence.listSessionGroups();
-    expect(listed.map((group) => group.id)).toEqual(["grp_1", "grp_2", "grp_3"]);
-    await expect(
-      test.persistence.reparentSessionGroup({
-        id: "grp_3",
-        expectedVersion: 1,
-        parentGroupId: "grp_1",
-      }),
-    ).rejects.toBeDefined();
-    const failed = await test.dispatch({
-      type: "sessionGroup.reparent",
-      payload: {
-        projectId: "web",
-        groupId: "grp_3",
-        expectedVersion: 1,
-        parentGroupId: "grp_1",
-      },
+    setParent.run("grp_missing", "grp_1");
+    setParent.run(null, "grp_2");
+    await rejectCorruptAncestry();
+
+    await test.persistence.createSessionGroup({
+      id: "grp_api",
+      projectId: "api",
+      name: "API",
     });
-    expect(failed).toMatchObject({
-      status: "failed",
-      error: { code: "SESSION_GROUP_PARENT_GRAPH_INVALID" },
-    });
-    expect(
-      (await test.persistence.listSessionGroups()).find((group) => group.id === "grp_3"),
-    ).not.toHaveProperty("parentGroupId");
+    setParent.run("grp_api", "grp_1");
+    await rejectCorruptAncestry();
   });
 
   it("projects only the command project without repairing durable memberships", async () => {

--- a/apps/observer/test/support/inMemoryObserverPersistence.ts
+++ b/apps/observer/test/support/inMemoryObserverPersistence.ts
@@ -654,11 +654,11 @@ export function createInMemoryObserverPersistence(
         ),
       ),
 
-    pruneSessionGroupMemberships: (input) =>
+    repairSessionGroups: (input) =>
       transaction((draft) =>
         applySessionGroupMutation(
           draft,
-          sessionGroupStore.pruneSessionGroupMemberships(draft.sessionGroups, {
+          sessionGroupStore.repairSessionGroups(draft.sessionGroups, {
             ...input,
             updatedAt: input.updatedAt ?? now(),
           }),
@@ -732,10 +732,10 @@ function emptyState(): InMemoryObserverPersistenceState {
   };
 }
 
-function applySessionGroupMutation(
+function applySessionGroupMutation<T>(
   state: InMemoryObserverPersistenceState,
-  mutation: sessionGroupStore.SessionGroupMutation,
-) {
+  mutation: { state: sessionGroupStore.SessionGroupPersistenceState; result: T },
+): T {
   state.sessionGroups = mutation.state;
   return mutation.result;
 }

--- a/apps/observer/test/support/observerPersistenceContract.ts
+++ b/apps/observer/test/support/observerPersistenceContract.ts
@@ -2331,7 +2331,7 @@ export function observerPersistenceContract(
         });
       });
 
-      it("validates parentage and reparents children when deleting a Group", async () => {
+      it("reparents, detaches, and rejects invalid parentage atomically", async () => {
         await withPersistence(createFixture, async ({ persistence }) => {
           await persistence.createSessionGroup({
             id: "group_root",
@@ -2350,9 +2350,55 @@ export function observerPersistenceContract(
             id: "group_child",
             projectId: "web",
             name: "Child",
-            parentGroupId: "group_parent",
             createdAt: earlier,
           });
+          await persistence.createSessionGroup({
+            id: "group_other_project",
+            projectId: "api",
+            name: "Other project",
+            createdAt: earlier,
+          });
+          await expect(
+            persistence.reparentSessionGroup({
+              id: "group_child",
+              expectedVersion: 1,
+              parentGroupId: "group_parent",
+              updatedAt: now,
+            }),
+          ).resolves.toEqual({
+            ok: true,
+            groups: [
+              expect.objectContaining({
+                id: "group_child",
+                parentGroupId: "group_parent",
+                version: 2,
+              }),
+            ],
+          });
+          await expect(
+            persistence.reparentSessionGroup({
+              id: "group_child",
+              expectedVersion: 2,
+              parentGroupId: "group_parent",
+              updatedAt: later,
+            }),
+          ).resolves.toEqual({
+            ok: true,
+            groups: [expect.objectContaining({ id: "group_child", version: 2 })],
+          });
+          await expect(
+            persistence.reparentSessionGroup({
+              id: "group_child",
+              expectedVersion: 1,
+            }),
+          ).resolves.toEqual({ ok: false, reason: "stale_version" });
+          await expect(
+            persistence.reparentSessionGroup({
+              id: "group_child",
+              expectedVersion: 2,
+              parentGroupId: "missing",
+            }),
+          ).resolves.toEqual({ ok: false, reason: "not_found" });
           await expectPersistenceFailure(
             persistence.reparentSessionGroup({
               id: "group_root",
@@ -2360,13 +2406,83 @@ export function observerPersistenceContract(
               parentGroupId: "group_child",
             }),
           );
+          await expectPersistenceFailure(
+            persistence.reparentSessionGroup({
+              id: "group_child",
+              expectedVersion: 2,
+              parentGroupId: "group_child",
+            }),
+          );
+          await expectPersistenceFailure(
+            persistence.reparentSessionGroup({
+              id: "group_child",
+              expectedVersion: 2,
+              parentGroupId: "group_other_project",
+            }),
+          );
           await expect(
             persistence.reparentSessionGroup({
               id: "group_child",
-              expectedVersion: 1,
-              parentGroupId: "missing",
+              expectedVersion: 2,
+              updatedAt: later,
             }),
-          ).resolves.toEqual({ ok: false, reason: "not_found" });
+          ).resolves.toEqual({
+            ok: true,
+            groups: [expect.not.objectContaining({ parentGroupId: expect.anything() })],
+          });
+          await expect(
+            persistence.reparentSessionGroup({ id: "group_root", expectedVersion: 1 }),
+          ).resolves.toEqual({
+            ok: true,
+            groups: [expect.objectContaining({ id: "group_root", version: 1 })],
+          });
+          expect(
+            (await persistence.listSessionGroups()).map((group) => ({
+              id: group.id,
+              parentGroupId: group.parentGroupId,
+              version: group.version,
+            })),
+          ).toEqual([
+            { id: "group_other_project", parentGroupId: undefined, version: 1 },
+            { id: "group_child", parentGroupId: undefined, version: 3 },
+            { id: "group_root", parentGroupId: undefined, version: 1 },
+            { id: "group_parent", parentGroupId: "group_root", version: 1 },
+          ]);
+        });
+      });
+
+      it("deletes only direct organization and reparents direct children once", async () => {
+        await withPersistence(createFixture, async ({ persistence }) => {
+          await persistence.createSessionGroup({
+            id: "group_root",
+            projectId: "web",
+            name: "Root",
+            createdAt: earlier,
+          });
+          await persistence.createSessionGroup({
+            id: "group_parent",
+            projectId: "web",
+            name: "Parent",
+            parentGroupId: "group_root",
+            initialMembers: [{ sessionId: "ses_direct", projectId: "web", expectedGroupId: null }],
+            createdAt: earlier,
+          });
+          for (const id of ["group_child_a", "group_child_b"]) {
+            await persistence.createSessionGroup({
+              id,
+              projectId: "web",
+              name: id,
+              parentGroupId: "group_parent",
+              createdAt: earlier,
+            });
+          }
+          await persistence.createSessionGroup({
+            id: "group_grandchild",
+            projectId: "web",
+            name: "Grandchild",
+            parentGroupId: "group_child_a",
+            createdAt: earlier,
+          });
           const deleted = await persistence.deleteSessionGroup({
             id: "group_parent",
             expectedVersion: 1,
@@ -2376,20 +2492,46 @@ export function observerPersistenceContract(
             ok: true,
             groups: [
               expect.objectContaining({
-                id: "group_child",
+                id: "group_child_a",
+                parentGroupId: "group_root",
+                version: 2,
+              }),
+              expect.objectContaining({
+                id: "group_child_b",
                 parentGroupId: "group_root",
                 version: 2,
               }),
             ],
           });
-          expect((await persistence.listSessionGroups()).map((group) => group.id)).toEqual([
-            "group_root",
-            "group_child",
+          await expect(
+            persistence.deleteSessionGroup({
+              id: "group_parent",
+              expectedVersion: 1,
+              updatedAt: later,
+            }),
+          ).resolves.toEqual({ ok: false, reason: "not_found" });
+          expect(await persistence.listSessionGroups()).toEqual([
+            expect.objectContaining({ id: "group_root", version: 1, sessionIds: [] }),
+            expect.objectContaining({
+              id: "group_child_a",
+              parentGroupId: "group_root",
+              version: 2,
+            }),
+            expect.objectContaining({
+              id: "group_child_b",
+              parentGroupId: "group_root",
+              version: 2,
+            }),
+            expect.objectContaining({
+              id: "group_grandchild",
+              parentGroupId: "group_child_a",
+              version: 1,
+            }),
           ]);
         });
       });
 
-      it("prunes invalid memberships while preserving empty definitions", async () => {
+      it("repairs invalid memberships once and returns all durable Groups with evidence", async () => {
         await withPersistence(createFixture, async ({ persistence }) => {
           await persistence.createSessionGroup({
             id: "group_prune",
@@ -2401,21 +2543,33 @@ export function observerPersistenceContract(
             ],
             createdAt: earlier,
           });
+          await persistence.createSessionGroup({
+            id: "group_untouched",
+            projectId: "web",
+            name: "Untouched",
+            createdAt: earlier,
+          });
           await expect(
-            persistence.pruneSessionGroupMemberships({
+            persistence.repairSessionGroups({
               sessions: [{ id: "ses_keep", projectId: "other" }],
               updatedAt: now,
             }),
           ).resolves.toEqual({
-            ok: true,
-            groups: [expect.objectContaining({ id: "group_prune", sessionIds: [], version: 2 })],
+            groups: [
+              expect.objectContaining({ id: "group_prune", sessionIds: [], version: 2 }),
+              expect.objectContaining({ id: "group_untouched", sessionIds: [], version: 1 }),
+            ],
+            repairs: [{ reason: "invalid_membership", groupId: "group_prune", projectId: "web" }],
           });
           await expect(
-            persistence.pruneSessionGroupMemberships({ sessions: [], updatedAt: later }),
-          ).resolves.toEqual({ ok: true, groups: [] });
-          await expect(persistence.listSessionGroups()).resolves.toEqual([
-            expect.objectContaining({ id: "group_prune", sessionIds: [], version: 2 }),
-          ]);
+            persistence.repairSessionGroups({ sessions: [], updatedAt: later }),
+          ).resolves.toEqual({
+            groups: [
+              expect.objectContaining({ id: "group_prune", sessionIds: [], version: 2 }),
+              expect.objectContaining({ id: "group_untouched", sessionIds: [], version: 1 }),
+            ],
+            repairs: [],
+          });
         });
       });
     });

--- a/apps/observer/test/unit/graph.test.ts
+++ b/apps/observer/test/unit/graph.test.ts
@@ -199,23 +199,28 @@ describe("observer graph derivation", () => {
       ...input,
     });
 
-    expect(
-      projectSessionGroups({
-        projects,
-        sessions: snapshot.sessions,
-        groups: [
-          group({
-            id: "grp_web_child",
-            projectId: "web",
-            parentGroupId: "grp_web_parent",
-            sessionIds: ["ses_wt_web_group", "ses_missing"],
-          }),
-          group({ id: "grp_removed_project", projectId: "removed" }),
-          group({ id: "grp_api_empty", projectId: "api" }),
-          group({ id: "grp_web_parent", projectId: "web" }),
-        ],
-      }),
-    ).toEqual([
+    const projected = projectSessionGroups({
+      projects,
+      sessions: snapshot.sessions,
+      groups: [
+        group({
+          id: "grp_web_grandchild",
+          projectId: "web",
+          parentGroupId: "grp_web_child",
+        }),
+        group({
+          id: "grp_web_child",
+          projectId: "web",
+          parentGroupId: "grp_web_parent",
+          sessionIds: ["ses_wt_web_group", "ses_missing"],
+        }),
+        group({ id: "grp_removed_project", projectId: "removed" }),
+        group({ id: "grp_api_empty", projectId: "api" }),
+        group({ id: "grp_web_parent", projectId: "web" }),
+      ],
+    });
+
+    expect(projected).toEqual([
       expect.objectContaining({ id: "grp_api_empty", sessionIds: [] }),
       expect.objectContaining({ id: "grp_web_parent", sessionIds: [] }),
       expect.objectContaining({
@@ -223,7 +228,14 @@ describe("observer graph derivation", () => {
         parentGroupId: "grp_web_parent",
         sessionIds: ["ses_wt_web_group"],
       }),
+      expect.objectContaining({
+        id: "grp_web_grandchild",
+        parentGroupId: "grp_web_child",
+        sessionIds: [],
+      }),
     ]);
+    expect(projected.every((item) => !("children" in item))).toBe(true);
+    expect(projected.flatMap((item) => item.sessionIds)).toEqual(["ses_wt_web_group"]);
   });
 
   it("projects one provider health result without rebuilding unrelated alerts", () => {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,7 +59,8 @@ No single layer owns all truth.
 - Observer SQLite is durable observer memory for commands, events, correlations, explicit Station-session lifecycle, project-local Session Group definitions and exclusive membership, canonical worktree display titles keyed by project and worktree, provider observations, and current metadata cache rows.
 - Observer snapshots are the normalized current graph exposed to clients. `rows` is configured
   worktree inventory; `sessions` is canonical session membership; and `sessionGroups` is the
-  normalized project-local organizational projection. `WorktreeRow.title` is the
+  flat project-local organizational projection, retaining optional parent relationships in
+  deterministic parent-before-child order. `WorktreeRow.title` is the
   display authority, while `SessionView.title` is its lifecycle projection. Session and activity
   counts derive from `sessions`, while worktree counts derive from `rows`.
 - JSONL logs and debug bundles are diagnostic evidence, not runtime truth.

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -5294,10 +5294,22 @@
           "purpose": null
         },
         {
+          "name": "SessionGroupRepairEvidence",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "SessionGroupRepairResult",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
           "name": "SessionGroupStore",
           "kind": "interface",
           "role": "DRIVEN PORT",
-          "purpose": "Maintains durable project-local Group definitions, exclusive membership, and parentage through atomic stale-write-safe conversations."
+          "purpose": "Maintains durable project-local Group definitions, exclusive membership, parentage, and atomic reconcile repair of parseable relationships."
         },
         {
           "name": "SessionGroupStoreConflictReason",
@@ -7347,10 +7359,22 @@
           "purpose": null
         },
         {
+          "name": "SessionGroupRepairEvidence",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "SessionGroupRepairResult",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
           "name": "SessionGroupStore",
           "kind": "interface",
           "role": "DRIVEN PORT",
-          "purpose": "Maintains durable project-local Group definitions, exclusive membership, and parentage through atomic stale-write-safe conversations."
+          "purpose": "Maintains durable project-local Group definitions, exclusive membership, parentage, and atomic reconcile repair of parseable relationships."
         },
         {
           "name": "SessionGroupStoreConflictReason",
@@ -7684,7 +7708,7 @@
           "name": "SessionGroupStore",
           "kind": "interface",
           "role": "DRIVEN PORT",
-          "purpose": "Maintains durable project-local Group definitions, exclusive membership, and parentage through atomic stale-write-safe conversations."
+          "purpose": "Maintains durable project-local Group definitions, exclusive membership, parentage, and atomic reconcile repair of parseable relationships."
         },
         {
           "name": "SessionStore",
@@ -7726,6 +7750,7 @@
             "ProviderObservationsIngressDedupeResult",
             "RecordProviderObservationInput",
             "SessionGroupMemberExpectation",
+            "SessionGroupRepairResult",
             "SessionGroupStoreResult",
             "SessionHarnessDerivedStateRepair",
             "SessionTurnReadinessMutation",
@@ -7990,13 +8015,13 @@
           "purpose": null
         },
         {
-          "name": "pruneSessionGroupMemberships",
+          "name": "renameSessionGroup",
           "kind": "function",
           "role": null,
           "purpose": null
         },
         {
-          "name": "renameSessionGroup",
+          "name": "repairSessionGroups",
           "kind": "function",
           "role": null,
           "purpose": null
@@ -8020,6 +8045,12 @@
           "purpose": null
         },
         {
+          "name": "SessionGroupRepairMutation",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
           "name": "updateSessionGroupMembership",
           "kind": "function",
           "role": null,
@@ -8031,7 +8062,12 @@
           "specifier": "./types.js",
           "resolvedPath": "apps/observer/src/persistence/types.ts",
           "edgeKind": "type-only",
-          "bindings": ["SessionGroupMemberExpectation", "SessionGroupStoreResult"]
+          "bindings": [
+            "SessionGroupMemberExpectation",
+            "SessionGroupRepairEvidence",
+            "SessionGroupRepairResult",
+            "SessionGroupStoreResult"
+          ]
         },
         {
           "specifier": "@station/contracts",
@@ -8636,6 +8672,18 @@
         },
         {
           "name": "SessionGroupMemberExpectation",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "SessionGroupRepairEvidence",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "SessionGroupRepairResult",
           "kind": "type",
           "role": null,
           "purpose": null
@@ -9472,13 +9520,13 @@
           "name": "projectSessionGroups",
           "kind": "function",
           "role": "POLICY",
-          "purpose": "Selects configured Groups and orders their canonical direct membership deterministically."
+          "purpose": "Projects configured Groups as a flat deterministic parent-before-child array with canonical direct membership."
         },
         {
           "name": "reconcileSessionGroups",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Repairs durable Group membership against canonical sessions and projects configured Groups."
+          "purpose": "Repairs durable Group membership and parentage against canonical state, then projects configured Groups with reason-specific diagnostics."
         },
         {
           "name": "SessionGroupProjection",
@@ -9492,7 +9540,7 @@
           "specifier": "../persistence/index.js",
           "resolvedPath": "apps/observer/src/persistence/index.ts",
           "edgeKind": "type-only",
-          "bindings": ["SessionGroupStore"]
+          "bindings": ["SessionGroupRepairEvidence", "SessionGroupStore"]
         },
         {
           "specifier": "@station/contracts",
@@ -13359,7 +13407,7 @@
       "declaration": "SessionGroupStore",
       "kind": "interface",
       "role": "DRIVEN PORT",
-      "purpose": "Maintains durable project-local Group definitions, exclusive membership, and parentage through atomic stale-write-safe conversations.",
+      "purpose": "Maintains durable project-local Group definitions, exclusive membership, parentage, and atomic reconcile repair of parseable relationships.",
       "dependencies": []
     },
     {
@@ -13530,7 +13578,7 @@
       "declaration": "projectSessionGroups",
       "kind": "function",
       "role": "POLICY",
-      "purpose": "Selects configured Groups and orders their canonical direct membership deterministically.",
+      "purpose": "Projects configured Groups as a flat deterministic parent-before-child array with canonical direct membership.",
       "dependencies": []
     },
     {
@@ -13538,7 +13586,7 @@
       "declaration": "reconcileSessionGroups",
       "kind": "function",
       "role": "USE CASE",
-      "purpose": "Repairs durable Group membership against canonical sessions and projects configured Groups.",
+      "purpose": "Repairs durable Group membership and parentage against canonical state, then projects configured Groups with reason-specific diagnostics.",
       "dependencies": [
         {
           "path": "apps/observer/src/persistence/ports.ts",

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -8045,12 +8045,6 @@
           "purpose": null
         },
         {
-          "name": "SessionGroupRepairMutation",
-          "kind": "type",
-          "role": null,
-          "purpose": null
-        },
-        {
           "name": "updateSessionGroupMembership",
           "kind": "function",
           "role": null,

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -381,10 +381,11 @@ persisted with trace correlation, and published. A failed command does not
 poison the following command in its scope.
 
 Recorded `sessionGroup.create`, `sessionGroup.rename`,
-`sessionGroup.updateMembership`, and `sessionGroup.delete` commands serialize by
+`sessionGroup.updateMembership`, `sessionGroup.reparent`, and `sessionGroup.delete` commands serialize by
 project. Inside the snapshot-writer turn they validate configured-project and
-canonical-session identity, enter a non-cancellable commit immediately before calling
-`SessionGroupStore`, and project only the command project without reconcile repair.
+canonical-session identity plus requested parent ancestry, enter a non-cancellable commit
+immediately before calling `SessionGroupStore`, and project only the command project without
+reconcile repair.
 Changed Group events derive from the mutation result and are persisted and published in
 canonical order before command success; validated no-ops emit no Group event. This path
 does not read providers or publish `observer.reconciled`.
@@ -428,11 +429,12 @@ target agents.
 
 Reconcile reads worktree and terminal actors, derives the worktree context for
 harness reads, applies cached metadata and durable overlays, resolves one effective display title
-per current worktree, and correlates canonical sessions. It then prunes durable Group memberships
-against those sessions, excludes but retains definitions for unconfigured projects, projects
-configured Groups deterministically, persists the same title records with the result, and replaces
-the in-memory snapshot. Membership repair and excluded definitions contribute provider-neutral
-errors to the reconcile timing record. Existing canonical titles win; missing authority initializes from
+per current worktree, and correlates canonical sessions. It then atomically repairs durable Group
+membership and parent relationships, excludes but retains definitions for unconfigured projects,
+projects configured Groups as a flat deterministic parent-before-child array, persists the same
+title records with the result, and replaces the in-memory snapshot. Reason-specific relationship
+repair and excluded definitions contribute provider-neutral errors to the reconcile timing record.
+Existing canonical titles win; missing authority initializes from
 the best non-ended custom session evidence before branch fallback, using insert-only reconcile
 persistence so stale evidence cannot overwrite a concurrent rename. It then
 publishes state-change and reconcile events and schedules metadata refresh.
@@ -734,9 +736,10 @@ when it changes several tables:
   fresh-session seeding, confirmed worktree retirement, and canonical-title/recovery import keep
   their multi-table changes atomic.
 - `SessionGroupStore` owns Group definitions, exclusive direct membership, parent changes,
-  deletion-to-ungroup with child reparenting, and reconcile pruning. Stale versions and expected
-  assignments return conflicts without throwing; invariant or storage failures roll back the
-  complete conversation. Empty definitions remain durable.
+  deletion-to-ungroup with child reparenting, and atomic reconcile repair of parseable membership
+  and parent relationships. Stale versions and expected assignments return conflicts without
+  throwing; invariant or storage failures roll back the complete conversation. Empty definitions
+  remain durable.
 - `WorktreeMetadataStore` owns current change, pull-request, and check metadata
   plus its expiry.
 

--- a/packages/contracts/src/commands.ts
+++ b/packages/contracts/src/commands.ts
@@ -306,6 +306,17 @@ export type UpdateSessionGroupMembershipPayload = z.infer<
   typeof UpdateSessionGroupMembershipPayloadSchema
 >;
 
+export const ReparentSessionGroupPayloadSchema = z
+  .object({
+    projectId: ProjectIdSchema,
+    groupId: SessionGroupIdSchema,
+    expectedVersion: z.number().int().positive(),
+    parentGroupId: SessionGroupIdSchema.optional(),
+  })
+  .strict();
+
+export type ReparentSessionGroupPayload = z.infer<typeof ReparentSessionGroupPayloadSchema>;
+
 export const DeleteSessionGroupPayloadSchema = z
   .object({
     projectId: ProjectIdSchema,
@@ -337,6 +348,7 @@ export const StationCommandTypeSchema = z.enum([
   "sessionGroup.create",
   "sessionGroup.rename",
   "sessionGroup.updateMembership",
+  "sessionGroup.reparent",
   "sessionGroup.delete",
 ]);
 
@@ -429,6 +441,10 @@ export const UpdateSessionGroupMembershipCommandSchema = z
   })
   .strict();
 
+export const ReparentSessionGroupCommandSchema = z
+  .object({ type: z.literal("sessionGroup.reparent"), payload: ReparentSessionGroupPayloadSchema })
+  .strict();
+
 export const DeleteSessionGroupCommandSchema = z
   .object({ type: z.literal("sessionGroup.delete"), payload: DeleteSessionGroupPayloadSchema })
   .strict();
@@ -454,6 +470,7 @@ export const StationCommandSchema = z.discriminatedUnion("type", [
   CreateSessionGroupCommandSchema,
   RenameSessionGroupCommandSchema,
   UpdateSessionGroupMembershipCommandSchema,
+  ReparentSessionGroupCommandSchema,
   DeleteSessionGroupCommandSchema,
 ]);
 

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -1369,6 +1369,27 @@ describe("contract schemas", () => {
       },
       "atomic reassignment and ungrouping expectations",
     );
+    expectParses(
+      StationCommandSchema,
+      {
+        type: "sessionGroup.reparent",
+        payload: {
+          projectId: "web",
+          groupId: "grp_child",
+          expectedVersion: 3,
+          parentGroupId: "grp_parent",
+        },
+      },
+      "Group reparenting",
+    );
+    expectParses(
+      StationCommandSchema,
+      {
+        type: "sessionGroup.reparent",
+        payload: { projectId: "web", groupId: "grp_child", expectedVersion: 3 },
+      },
+      "Group root detachment",
+    );
 
     const invalidCommands = [
       {
@@ -1425,6 +1446,41 @@ describe("contract schemas", () => {
       {
         type: "sessionGroup.delete",
         payload: { projectId: "web", groupId: "grp_target", expectedVersion: 1, extra: true },
+      },
+      {
+        type: "sessionGroup.reparent",
+        payload: {
+          projectId: "web",
+          groupId: "grp_target",
+          expectedVersion: 1,
+          parentGroupId: null,
+        },
+      },
+      {
+        type: "sessionGroup.reparent",
+        payload: {
+          projectId: "web",
+          groupId: "grp_target",
+          expectedVersion: 1,
+          parentGroupId: "   ",
+        },
+      },
+      {
+        type: "sessionGroup.reparent",
+        payload: {
+          projectId: "web",
+          groupId: "grp_target",
+          expectedVersion: 0,
+        },
+      },
+      {
+        type: "sessionGroup.reparent",
+        payload: {
+          projectId: "web",
+          groupId: "grp_target",
+          expectedVersion: 1,
+          unexpected: true,
+        },
       },
       {
         type: "sessionGroup.updateMembership",

--- a/tests/contract-fixtures/commands/commands.json
+++ b/tests/contract-fixtures/commands/commands.json
@@ -231,6 +231,15 @@
       "remove": []
     }
   },
+  "sessionGroupReparent": {
+    "type": "sessionGroup.reparent",
+    "payload": {
+      "projectId": "web",
+      "groupId": "grp_active",
+      "expectedVersion": 3,
+      "parentGroupId": "grp_parent"
+    }
+  },
   "sessionGroupDelete": {
     "type": "sessionGroup.delete",
     "payload": {

--- a/tests/e2e/observer-sqlite-smoke.test.ts
+++ b/tests/e2e/observer-sqlite-smoke.test.ts
@@ -58,13 +58,39 @@ describe("production Observer SQLite smoke", () => {
           ),
         ).status,
       ).toBe("succeeded");
+      for (const name of ["Durable parent", "Durable child"]) {
+        const created = jsonObject(
+          runStnJson(
+            ["--config", configPath, "command", "dispatch", "--stdin", "--wait"],
+            env,
+            JSON.stringify({
+              type: "sessionGroup.create",
+              payload: { projectId, name },
+            }),
+          ),
+        );
+        expect(created.status).toBe("succeeded");
+      }
+      const createdGroups = StationSnapshotSchema.parse(
+        runStnJson(["--config", configPath, "snapshot", "--json"], env),
+      ).sessionGroups;
+      const parent = createdGroups.find((group) => group.name === "Durable parent");
+      const child = createdGroups.find((group) => group.name === "Durable child");
+      if (parent === undefined || child === undefined) {
+        throw new Error("Expected both durable Group definitions.");
+      }
       const dispatchedOutput = jsonObject(
         runStnJson(
           ["--config", configPath, "command", "dispatch", "--stdin", "--wait"],
           env,
           JSON.stringify({
-            type: "sessionGroup.create",
-            payload: { projectId, name: "Durable empty Group" },
+            type: "sessionGroup.reparent",
+            payload: {
+              projectId,
+              groupId: child.id,
+              expectedVersion: child.version,
+              parentGroupId: parent.id,
+            },
           }),
         ),
       );
@@ -75,10 +101,30 @@ describe("production Observer SQLite smoke", () => {
       expect(command).toMatchObject({
         status: "succeeded",
         command: {
-          type: "sessionGroup.create",
-          payload: { projectId, name: "Durable empty Group" },
+          type: "sessionGroup.reparent",
+          payload: { projectId, groupId: child.id, parentGroupId: parent.id },
         },
       });
+      expect(
+        StationSnapshotSchema.parse(runStnJson(["--config", configPath, "snapshot", "--json"], env))
+          .sessionGroups,
+      ).toEqual([
+        expect.objectContaining({
+          id: parent.id,
+          projectId,
+          name: "Durable parent",
+          sessionIds: [],
+          version: 1,
+        }),
+        expect.objectContaining({
+          id: child.id,
+          projectId,
+          name: "Durable child",
+          parentGroupId: parent.id,
+          sessionIds: [],
+          version: 2,
+        }),
+      ]);
       const firstHealth = await client.health();
       expect(firstHealth.sqlite).toMatchObject({
         path: databasePath,
@@ -105,11 +151,19 @@ describe("production Observer SQLite smoke", () => {
           .sessionGroups,
       ).toEqual([
         expect.objectContaining({
-          id: expect.stringMatching(/^grp_/),
+          id: parent.id,
           projectId,
-          name: "Durable empty Group",
+          name: "Durable parent",
           sessionIds: [],
           version: 1,
+        }),
+        expect.objectContaining({
+          id: child.id,
+          projectId,
+          name: "Durable child",
+          parentGroupId: parent.id,
+          sessionIds: [],
+          version: 2,
         }),
       ]);
       const secondHealth = await client.health();


### PR DESCRIPTION
## What this fixes

Station can persist Session Group parent relationships, but it did not have a recorded command for changing them and reconcile did not repair invalid persisted ancestry. That left parent changes outside the durable command lifecycle and allowed missing, cross-project, or cyclic parent edges to survive reconciliation.

Closes #535.

## What changed

- Adds a strict `sessionGroup.reparent` command serialized with other Group writes for the same project.
- Validates target ownership and proposed ancestry before committing, with typed failures for missing, mismatched, self-parented, cyclic, or already-corrupt graphs.
- Makes memory and SQLite listing and reparent walks terminate safely on corrupt cycles.
- Replaces membership-only pruning with one atomic repair that fixes invalid memberships and parent edges, emits reason-specific diagnostics, and increments each changed Group once.
- Keeps `StationSnapshot.sessionGroups` flat and deterministic, retaining `parentGroupId` and direct membership in parent-before-child order.
- Expands shared persistence, command, reconcile, projection, delete, and restart-durability coverage and updates the Observer architecture documentation.

## Testing

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm architecture:observer:generate`
- `pnpm architecture:observer:check`
- Focused contract, unit, command, reconcile, and memory/SQLite persistence suites
- `pnpm test:e2e:setup:sqlite`
- `pnpm test:sqlite:bun`
- `pnpm smoke:install`
- `pnpm test:all` passed build, typecheck, lint, unit, contract, integration, diagnostics, scripted, and setup E2E lanes. Its Observer lifecycle lane has two build-handoff failures that reproduce unchanged on clean `origin/main`; the other 18 lifecycle/migration tests pass.

## Safety and scope

- No dashboard controls, visual nesting, client reducer behavior, protocol method, migration, snapshot schema version, or new event type.
- Reparent no-ops do not bump versions or publish Group events.
- Reconcile remains the sole repair path for corrupt persisted relationships; command-local mutation fails closed.