### PR TITLE
feat(dashboard): project session groups into tree

### DIFF
--- a/docs/dashboard-architecture.md
+++ b/docs/dashboard-architecture.md
@@ -95,16 +95,32 @@ Station renderers
 
 `selectors/dashboardTree.ts` is the sole dashboard hierarchy adapter. It joins
 canonical sessions to worktree metadata, merges optimistic creates, applies
-filter and collapse state, and projects Project roots, children, and inert gaps.
+filter and collapse state, and projects Project roots, direct Group blocks,
+project-root sessions, and inert gaps. `snapshot.sessionGroups` is the exclusive
+membership authority; optional parent links are deliberately flattened, while
+optimistic create rows remain at the project root until canonical replacement.
+The renderer-local `GroupOrderingMode` chooses Groups-first or whole-block
+alphabetical interleaving without changing canonical arrays.
 The internal `treeGrid.ts` controller knows only immutable nodes, ordered cells,
 visibility, and a supplied eligibility policy; it has no dashboard or terminal
 knowledge and is not a package entrypoint.
+
+Project and Group collapse sets remain renderer-local and survive snapshot
+replacement even when an ID is temporarily absent. Persistent filtering admits
+session rows through one candidate projection while retaining durable Project
+and Group containers; Group-name matches provide member text context, member
+matches retain their Group header, and container match ranges remain semantic
+renderer inputs. Group payload counts distinguish canonical direct membership
+from filter-admitted renderable members before collapse and viewport clipping.
 
 Dashboard state owns one stable `{ rowId, cellId }` cursor. Named policies bind
 the generic controller to ordinary dashboard traversal, canonical-session-only
 chooser traversal, and needs-attention traversal. Reconciliation preserves the
 exact row and cell when possible, moves a collapse-hidden child to its visible
 collapsed ancestor, and otherwise uses deterministic next/previous fallback.
+Group rows use `identity`, `quickSession`, and `menu`; only identity toggles
+collapse in this slice. A focused direct visible member decorates its Group with
+`containsFocusedRow`, leaving color and ring presentation to the renderer.
 
 The selectors entrypoint exposes branded dashboard row IDs, dashboard cell IDs,
 decorated tree rows, and the viewport contract. `DashboardViewport.rows` is the

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -357,6 +357,8 @@ reattach; pane borders and neighboring panes must remain unlinked.
 - Treat `snapshot.sessions` as session-membership and session/activity-count truth. Dashboard rows,
   filtering, selection, and actions project those sessions and join `snapshot.rows` only for checkout
   metadata; bare worktrees remain inventory and do not appear in the primary session list.
+  `snapshot.sessionGroups` exclusively organizes those sessions under their Project; the current
+  dashboard flattens optional parent links and leaves optimistic creates at the Project root.
 - `terminal.focusable` describes external dashboard control, not native Station
   interaction. Native row activation resolves an advertised managed attachment
   and creates or reveals the local pane without dispatching `terminal.focus`;
@@ -388,10 +390,10 @@ reattach; pane borders and neighboring panes must remain unlinked.
 `/` opens a single-line editor in the complete table-header row. Its draft starts
 from the dashboard-local applied free text and structured conditions. Editing performs a
 deterministic, locale-neutral case-insensitive soft preview over the complete session and
-optimistic-row universe plus project labels. Folded match offsets map back to source text before
+optimistic-row universe plus Project and Group labels. Folded match offsets map back to source text before
 highlighting. Every rendered row keeps its current order, slot, collapse visibility, and viewport
-position; visible text matches receive bounded highlight spans, while nonmatching rows and project
-headers are dimmed. Matches inside collapsed projects contribute to the global count and header
+position; visible text matches receive bounded highlight spans, while nonmatching rows and container
+headers are dimmed. Matches inside collapsed Projects or Groups contribute to the global count and header
 state without revealing the children during editing. The header includes the live row count and any
 above-viewport context. A valid zero-result draft stays editable and uses an amber `0/N matches`
 cue rather than an error state. Long drafts follow the caret horizontally and never wrap into the
@@ -423,16 +425,16 @@ markers ensure mode and selection do not rely on color.
 
 `Enter` from text editing applies any draft containing free text or conditions to optional
 dashboard-local state; applying a completely blank draft removes that state. `Ctrl-U` clears both
-parts of the draft. An applied filter is a hard projection: nonmatching sessions, optimistic rows,
-projects, and orphaned project gaps are omitted without changing canonical order. A project-label
-text match or a Project condition retains all of that project's children unless another row
-condition narrows them, while Status and Agent matches retain only matching rows and their project
-context. Matching children of a collapsed project remain hidden until its disclosure is expanded.
-Project collapse stays interactive while the filter is applied, so the marker and visible children
-always agree; clearing the filter leaves the user's latest collapse choices intact.
+parts of the draft. An applied filter is a hard row projection: nonmatching sessions and optimistic
+rows are omitted without changing canonical order, while durable Project and Group containers and
+their existing gaps remain. A Project- or Group-label text match retains its direct candidate rows
+unless another row condition narrows them; a member match retains both containers as context.
+Matching children of a collapsed Project or Group remain hidden until disclosure is expanded.
+Both collapse sets stay interactive while the filter is applied, and clearing the filter leaves the
+latest collapse choices intact.
 
-Free text is intentionally limited to text visible in project headers and session rows: project
-label, displayed title, agent, and activity. Hidden branch values, provider identifiers, raw status
+Free text is intentionally limited to text visible in Project/Group headers and session rows:
+Project label, Group name, displayed title, agent, and activity. Hidden branch values, provider identifiers, raw status
 values, and generated diagnostic reasons are not searched because they cannot provide a stable,
 user-verifiable result. Structured matching is `free text AND Status AND Project AND Agent`, with
 OR across selected values inside one field. Status uses normalized `AgentState`; Project and Agent
@@ -455,7 +457,7 @@ applied filter; covered footer targets remain inert outside dashboard mode.
 | `/` at wide and minimum width | Header editor; live highlights/dimming/global count; no wrapping |
 | Editing `Esc` | Restores the prior hard applied projection |
 | `Enter`, then dashboard `Esc` | Hard-projects matches, then restores the unfiltered/collapsed view without closing |
-| Zero matches | Amber, recoverable soft preview; applying yields an empty dashboard projection |
+| Zero matches | Amber, recoverable soft preview; applying retains durable Project/Group context with zero admitted rows |
 | Hidden metadata only | Ignores metadata that is not rendered in the dashboard |
 | Condition entry | `Tab`, `S/P/A`, slots/arrows/Space, header back/close, bottom Done, and final `F` Apply share core transitions |
 | Applied footer pointer | `/ edit` and `Esc clear` share the keyboard transitions |
@@ -478,11 +480,12 @@ dispatches `dashboard.cell.activate`, the same activation used by focused Enter.
 filtered, pending, or stale cells remain inert. Wheel events over child rows use
 dashboard scrolling, and active modal surfaces intercept background clicks and scrolling.
 
-Dashboard focus follows rendered order through each project header, its visible session rows, or the
-stable Add Session action rendered when that project is empty. The cursor is one branded
+Dashboard focus follows rendered order through each Project header, its direct Group blocks and
+project-root sessions, or the stable Add Session action rendered when that Project is empty. The cursor is one branded
 `{ rowId, cellId }` identity. Entering a header vertically always selects `identity`; Left/Right then
-moves, without wrapping, through `identity` → `shell` →
-`quickSession` → `defaultAgent`. Up/Down leaves any header segment immediately, and Left/Right on a
+moves without wrapping through `identity` → `shell` → `quickSession` → `defaultAgent` for Projects
+and `identity` → `quickSession` → `menu` for Groups. Group identity toggles collapse; Group quick
+session and menu remain focus-preserving no-ops until their workflow slices land. Up/Down leaves any header segment immediately, and Left/Right on a
 session row or empty-project action is inert. Remove, rename, and fork row choosers retain a separate
 visible, selectable canonical-session traversal; slots and Enter resolve through that same chooser
 policy. Next-needs-me uses its own canonical-session policy. `N` continues to open the session flow
@@ -497,14 +500,20 @@ remain inert and unpainted. Wide and compact labels preserve the same control id
 component-local, temporarily supersedes the focus background, and reveals persistent keyboard focus
 again when the pointer leaves; no focus glyph is added.
 
-Collapse moves focus from a hidden session or empty-project action to that project's header
-`identity` cell and clamps scrolling; expanding and moving Down reaches the first visible child again.
+Group collapse moves a hidden direct member to that Group's identity; Project collapse remains the
+outer ancestor and moves any hidden descendant to the Project identity. A focused Group identity
+stays focused when toggled, and a focused member exposes semantic `containsFocusedRow` containment.
+Expanding and moving Down reaches the first visible child again.
 Snapshot replacement and accepted filter changes preserve stable focus identity, otherwise choose
 the next focusable item at the old position before the preceding item; resize preserves identity
 and scrolls it into view. The Default Agent picker retains its header focus beneath the screen, so
 Escape, click-away, unchanged selection, and a successful change return to `defaultAgent`; project
 removal while open uses the same deterministic focus fallback. The dashboard footer describes Enter
 as `activate` because it may activate a session row, project-header control, or empty-project action.
+
+This dashboard-core contract intentionally adds no Group pixels or hit boxes. #538 owns the explicit
+OpenTUI Group row, disclosure/count layout, colors, focus and containment rings, responsive shedding,
+hover, and native/standalone pointer presentation; it consumes the same tree rows and activation path.
 
 Bounded screens use one active-screen overlay layer. Dashboard-core exposes the narrow
 `TuiScreenBehavior` contract, and the owning screen module supplies its safe `clickAway`

--- a/packages/dashboard-core/src/entrypoints/selectors.ts
+++ b/packages/dashboard-core/src/entrypoints/selectors.ts
@@ -99,6 +99,7 @@ export {
 } from "../selectors/dashboardFilterConditions.js";
 
 export type {
+  DashboardPersistentFilterGroupMatch,
   DashboardPersistentFilterProjection,
   DashboardPersistentFilterProjectMatch,
 } from "../selectors/dashboardPersistentFilter.js";
@@ -109,8 +110,10 @@ export {
 } from "../selectors/dashboardSessionRows.js";
 export type {
   DashboardCellId,
+  DashboardGroupHeaderPayload,
   DashboardRowId,
   DashboardTreeRow,
+  GroupOrderingMode,
 } from "../selectors/dashboardTree.js";
 export { dashboardRowIds } from "../selectors/dashboardTree.js";
 export type {

--- a/packages/dashboard-core/src/selectors/dashboardPersistentFilter.ts
+++ b/packages/dashboard-core/src/selectors/dashboardPersistentFilter.ts
@@ -98,7 +98,7 @@ export function selectDashboardPersistentFilter({
 }: {
   candidates: readonly DashboardPersistentFilterCandidate[];
   projects: readonly DashboardPersistentFilterProjectCandidate[];
-  groups?: readonly DashboardPersistentFilterGroupCandidate[];
+  groups: readonly DashboardPersistentFilterGroupCandidate[];
   screen: DashboardScreenView;
   applied?: DashboardPersistentFilterView;
 }): DashboardPersistentFilterProjection | undefined {
@@ -119,7 +119,7 @@ export function selectDashboardPersistentFilter({
     projectLabelRanges.set(project.projectId, matchRanges(project.projectLabel, foldedQuery));
   }
   const groupLabelRanges = new Map<SessionGroupId, DashboardPersistentFilterMatchRange[]>();
-  for (const group of groups ?? []) {
+  for (const group of groups) {
     groupLabelRanges.set(group.groupId, matchRanges(group.groupLabel, foldedQuery));
   }
 
@@ -165,7 +165,7 @@ export function selectDashboardPersistentFilter({
 
   const groupMatches = new Map<SessionGroupId, DashboardPersistentFilterGroupMatch>();
   const projectsWithMatchedGroups = new Set<ProjectId>();
-  for (const group of groups ?? []) {
+  for (const group of groups) {
     const labelRanges = groupLabelRanges.get(group.groupId) ?? [];
     const projectAllowed = selectedProjects.size === 0 || selectedProjects.has(group.projectId);
     const textAllowsGroup = foldedQuery.length === 0 || labelRanges.length > 0;

--- a/packages/dashboard-core/src/selectors/dashboardPersistentFilter.ts
+++ b/packages/dashboard-core/src/selectors/dashboardPersistentFilter.ts
@@ -1,4 +1,4 @@
-import type { AgentState, ProjectId, ProviderId } from "@station/contracts";
+import type { AgentState, ProjectId, ProviderId, SessionGroupId } from "@station/contracts";
 import type {
   DashboardFilterCondition,
   DashboardScreenView,
@@ -30,10 +30,17 @@ export type DashboardPersistentFilterProjectCandidate = {
   projectLabel: string;
 };
 
+export type DashboardPersistentFilterGroupCandidate = {
+  groupId: SessionGroupId;
+  projectId: ProjectId;
+  groupLabel: string;
+};
+
 export type DashboardPersistentFilterCandidate = {
   kind: "session" | "optimistic";
   id: string;
   projectId: ProjectId;
+  groupId?: SessionGroupId;
   visibleFields: DashboardPersistentFilterVisibleFields;
   conditionValues: {
     status?: AgentState;
@@ -49,6 +56,7 @@ export type DashboardPersistentFilterRowMatch = {
     agent: readonly DashboardPersistentFilterMatchRange[];
     activity: readonly DashboardPersistentFilterMatchRange[];
     projectLabel: readonly DashboardPersistentFilterMatchRange[];
+    groupLabel: readonly DashboardPersistentFilterMatchRange[];
   };
 };
 
@@ -57,9 +65,14 @@ export type DashboardPersistentFilterProjectMatch = {
   labelRanges: readonly DashboardPersistentFilterMatchRange[];
 };
 
+export type DashboardPersistentFilterGroupMatch = {
+  matched: boolean;
+  labelRanges: readonly DashboardPersistentFilterMatchRange[];
+};
+
 /**
  * Draft state previews all rows softly; applied free text and conditions hard-project rows while
- * text highlighting stays visible-only and project headers remain as context for matching rows.
+ * text highlighting stays visible-only and durable Project and Group headers remain as context.
  */
 export type DashboardPersistentFilterProjection = {
   source: "draft" | "applied";
@@ -73,16 +86,19 @@ export type DashboardPersistentFilterProjection = {
   zeroMatches: boolean;
   rows: ReadonlyMap<string, DashboardPersistentFilterRowMatch>;
   projects: ReadonlyMap<ProjectId, DashboardPersistentFilterProjectMatch>;
+  groups: ReadonlyMap<SessionGroupId, DashboardPersistentFilterGroupMatch>;
 };
 
 export function selectDashboardPersistentFilter({
   candidates,
   projects,
+  groups,
   screen,
   applied,
 }: {
   candidates: readonly DashboardPersistentFilterCandidate[];
   projects: readonly DashboardPersistentFilterProjectCandidate[];
+  groups?: readonly DashboardPersistentFilterGroupCandidate[];
   screen: DashboardScreenView;
   applied?: DashboardPersistentFilterView;
 }): DashboardPersistentFilterProjection | undefined {
@@ -102,9 +118,14 @@ export function selectDashboardPersistentFilter({
   for (const project of projects) {
     projectLabelRanges.set(project.projectId, matchRanges(project.projectLabel, foldedQuery));
   }
+  const groupLabelRanges = new Map<SessionGroupId, DashboardPersistentFilterMatchRange[]>();
+  for (const group of groups ?? []) {
+    groupLabelRanges.set(group.groupId, matchRanges(group.groupLabel, foldedQuery));
+  }
 
   const rows = new Map<string, DashboardPersistentFilterRowMatch>();
   const projectsWithMatchedRows = new Set<ProjectId>();
+  const groupsWithMatchedRows = new Set<SessionGroupId>();
   let matchCount = 0;
   for (const candidate of candidates) {
     const ranges = {
@@ -112,13 +133,16 @@ export function selectDashboardPersistentFilter({
       agent: matchRanges(candidate.visibleFields.agent ?? "", foldedQuery),
       activity: matchRanges(candidate.visibleFields.activity ?? "", foldedQuery),
       projectLabel: projectLabelRanges.get(candidate.projectId) ?? [],
+      groupLabel:
+        candidate.groupId === undefined ? [] : (groupLabelRanges.get(candidate.groupId) ?? []),
     };
     const textMatched =
       foldedQuery.length === 0 ||
       ranges.title.length > 0 ||
       ranges.agent.length > 0 ||
       ranges.activity.length > 0 ||
-      ranges.projectLabel.length > 0;
+      ranges.projectLabel.length > 0 ||
+      ranges.groupLabel.length > 0;
     const statusMatched =
       selectedStatuses.size === 0 ||
       (candidate.conditionValues.status !== undefined &&
@@ -132,8 +156,27 @@ export function selectDashboardPersistentFilter({
     if (matched) {
       matchCount += 1;
       projectsWithMatchedRows.add(candidate.projectId);
+      if (candidate.groupId !== undefined) {
+        groupsWithMatchedRows.add(candidate.groupId);
+      }
     }
     rows.set(candidate.id, { matched, dimmed: !matched, ranges });
+  }
+
+  const groupMatches = new Map<SessionGroupId, DashboardPersistentFilterGroupMatch>();
+  const projectsWithMatchedGroups = new Set<ProjectId>();
+  for (const group of groups ?? []) {
+    const labelRanges = groupLabelRanges.get(group.groupId) ?? [];
+    const projectAllowed = selectedProjects.size === 0 || selectedProjects.has(group.projectId);
+    const textAllowsGroup = foldedQuery.length === 0 || labelRanges.length > 0;
+    const rowConditionRequiresEvidence = selectedStatuses.size > 0 || selectedAgents.size > 0;
+    const matched =
+      groupsWithMatchedRows.has(group.groupId) ||
+      (!rowConditionRequiresEvidence && projectAllowed && textAllowsGroup);
+    if (matched) {
+      projectsWithMatchedGroups.add(group.projectId);
+    }
+    groupMatches.set(group.groupId, { matched, labelRanges });
   }
 
   const projectMatches = new Map<ProjectId, DashboardPersistentFilterProjectMatch>();
@@ -143,6 +186,7 @@ export function selectDashboardPersistentFilter({
     const rowConditionRequiresEvidence = selectedStatuses.size > 0 || selectedAgents.size > 0;
     const matched =
       projectsWithMatchedRows.has(projectId) ||
+      projectsWithMatchedGroups.has(projectId) ||
       (!rowConditionRequiresEvidence && projectAllowed && textAllowsProject);
     projectMatches.set(projectId, { matched, labelRanges });
   }
@@ -158,6 +202,7 @@ export function selectDashboardPersistentFilter({
     zeroMatches: active && matchCount === 0,
     rows,
     projects: projectMatches,
+    groups: groupMatches,
   };
   if (screen.name === "persistentFilter") {
     projection.draft = screen.draft;

--- a/packages/dashboard-core/src/selectors/dashboardTree.ts
+++ b/packages/dashboard-core/src/selectors/dashboardTree.ts
@@ -1,4 +1,4 @@
-import type { ProjectId, SessionId } from "@station/contracts";
+import type { ProjectId, SessionGroupId, SessionId } from "@station/contracts";
 import { worktreeRowVisibleFields } from "../components/WorktreeRow/rowInput.js";
 import type {
   DashboardScreenView,
@@ -14,6 +14,7 @@ import {
 } from "../treeGrid.js";
 import {
   type DashboardPersistentFilterCandidate,
+  type DashboardPersistentFilterGroupMatch,
   type DashboardPersistentFilterProjection,
   type DashboardPersistentFilterProjectMatch,
   type DashboardPersistentFilterRowMatch,
@@ -36,17 +37,28 @@ export type DashboardRowId = string & {
 /** Sole constructors for dashboard row IDs; consumers resolve IDs instead of parsing them. */
 export const dashboardRowIds = {
   project: (projectId: ProjectId): DashboardRowId => `project:${projectId}` as DashboardRowId,
+  group: (groupId: SessionGroupId): DashboardRowId => `group:${groupId}` as DashboardRowId,
   session: (sessionId: SessionId): DashboardRowId => `session:${sessionId}` as DashboardRowId,
   create: (localId: string): DashboardRowId => `create:${localId}` as DashboardRowId,
   empty: (projectId: ProjectId): DashboardRowId => `empty:${projectId}` as DashboardRowId,
   gap: (projectId: ProjectId): DashboardRowId => `gap:${projectId}` as DashboardRowId,
 } as const;
 
-export type DashboardCellId = "identity" | "shell" | "quickSession" | "defaultAgent" | "addSession";
+export type DashboardCellId =
+  | "identity"
+  | "shell"
+  | "quickSession"
+  | "defaultAgent"
+  | "addSession"
+  | "menu";
+
+/** Determines whether Group blocks precede or interleave with project-root session rows. */
+export type GroupOrderingMode = "groups-first" | "alphabetical-interleaved";
 
 export type DashboardFocus = TreeGridCursor<DashboardRowId, DashboardCellId>;
 
 type DashboardProjectView = DashboardSnapshotView["projects"][number];
+type DashboardGroupView = DashboardSnapshotView["sessionGroups"][number];
 type DashboardPendingCreateSessionRowView =
   DashboardViewState["localRows"]["pendingCreate"][number];
 type DashboardFailedCreateSessionRowView = DashboardViewState["localRows"]["failedCreate"][number];
@@ -63,6 +75,19 @@ export type DashboardProjectHeaderPayload = {
   readonly project: DashboardProjectView;
   readonly collapsed: boolean;
   readonly persistentFilterMatch?: DashboardPersistentFilterProjectMatch;
+};
+
+/**
+ * Canonical snapshots enforce exclusive direct membership; the dashboard flattens parent links,
+ * and only the viewport assigns keys to visible sessions.
+ */
+export type DashboardGroupHeaderPayload = {
+  readonly type: "groupHeader";
+  readonly group: DashboardGroupView;
+  readonly collapsed: boolean;
+  readonly sessionCount: number;
+  readonly visibleSessionCount: number;
+  readonly persistentFilterMatch?: DashboardPersistentFilterGroupMatch;
 };
 
 export type DashboardSessionPayload = {
@@ -94,6 +119,7 @@ export type DashboardProjectGapPayload = {
 
 export type DashboardTreePayload =
   | DashboardProjectHeaderPayload
+  | DashboardGroupHeaderPayload
   | DashboardSessionPayload
   | DashboardCreateLocalRowPayload
   | DashboardEmptyProjectPayload
@@ -104,8 +130,10 @@ export type DashboardTreeRow = TreeGridRow<
   DashboardCellId,
   DashboardTreePayload
 > & {
-  /** Cursor decoration rebuilds row objects; row identity is not cursor-independent. */
+  /** Focus and containment decoration rebuild rows; row identity is not cursor-independent. */
   readonly focusedCellId?: DashboardCellId;
+  /** Present when this Group contains the directly focused visible row. */
+  readonly containsFocusedRow?: true;
 };
 
 export type DashboardTreeProjection = Omit<
@@ -127,9 +155,19 @@ type ProjectRows = {
   readonly project: DashboardProjectView;
   readonly collapsed: boolean;
   readonly rows: readonly (DashboardSessionPayload | DashboardCreateLocalRowPayload)[];
+  readonly rootRows: readonly (DashboardSessionPayload | DashboardCreateLocalRowPayload)[];
+  readonly groups: readonly ProjectGroupRows[];
+  readonly orderingMode: GroupOrderingMode;
+};
+
+type ProjectGroupRows = {
+  readonly group: DashboardGroupView;
+  readonly collapsed: boolean;
+  readonly rows: readonly DashboardSessionPayload[];
 };
 
 const PROJECT_CELLS = ["identity", "shell", "quickSession", "defaultAgent"] as const;
+const GROUP_CELLS = ["identity", "quickSession", "menu"] as const;
 const SESSION_CELLS = ["identity"] as const;
 const EMPTY_PROJECT_CELLS = ["addSession"] as const;
 
@@ -140,24 +178,56 @@ export function selectDashboardTree(
 ): DashboardTreeProjection {
   const sessionRows = selectDashboardSessionRows(snapshot);
   const localRows = visibleCreateSessionLocalRows(snapshot, state);
-  const projects = snapshot.projects.map((project) => ({
-    project,
-    collapsed: state.collapsedProjectIds.has(project.id),
-    rows: mergeDashboardRows(
+  const groupBySessionId = new Map<SessionId, DashboardGroupView>();
+  for (const group of snapshot.sessionGroups) {
+    for (const sessionId of group.sessionIds) {
+      groupBySessionId.set(sessionId, group);
+    }
+  }
+  const projects = snapshot.projects.map((project): ProjectRows => {
+    const rows = mergeDashboardRows(
       sessionRows.filter((row) => row.worktree.projectId === project.id),
       localRows.filter((row) => row.projectId === project.id),
       state,
     ).map((row) =>
       row.type === "session" ? sessionPayload(row.row, state) : createLocalPayload(row.row),
-    ),
-  }));
+    );
+    const groups = snapshot.sessionGroups
+      .filter((group) => group.projectId === project.id)
+      .map((group) => ({
+        group,
+        collapsed: state.collapsedGroupIds.has(group.id),
+        rows: rows.filter(
+          (row): row is DashboardSessionPayload =>
+            row.type === "session" && groupBySessionId.get(row.row.id)?.id === group.id,
+        ),
+      }));
+    return {
+      project,
+      collapsed: state.collapsedProjectIds.has(project.id),
+      rows,
+      rootRows: rows.filter(
+        (row) => row.type === "createLocalRow" || groupBySessionId.get(row.row.id) === undefined,
+      ),
+      groups,
+      orderingMode: state.groupOrderingMode,
+    };
+  });
   const persistentFilter = selectDashboardPersistentFilter({
-    candidates: projects.flatMap((project) =>
-      project.rows.map((row) => persistentFilterCandidate(rowIdForPayload(row), row)),
-    ),
+    candidates: projects.flatMap((project) => [
+      ...project.rootRows.map((row) => persistentFilterCandidate(rowIdForPayload(row), row)),
+      ...project.groups.flatMap(({ group, rows }) =>
+        rows.map((row) => persistentFilterCandidate(rowIdForPayload(row), row, group.id)),
+      ),
+    ]),
     projects: projects.map(({ project }) => ({
       projectId: project.id,
       projectLabel: project.label,
+    })),
+    groups: snapshot.sessionGroups.map((group) => ({
+      groupId: group.id,
+      projectId: group.projectId,
+      groupLabel: group.name,
     })),
     screen: activeScreen,
     ...(state.persistentFilter === undefined ? {} : { applied: state.persistentFilter }),
@@ -175,10 +245,7 @@ function dashboardRoots(
   projection: DashboardPersistentFilterProjection | undefined,
 ): DashboardTreeNode[] {
   const applied = projection?.source === "applied" && projection.active;
-  const visibleProjects = applied
-    ? projects.filter(({ project }) => projection.projects.get(project.id)?.matched === true)
-    : projects;
-  return visibleProjects.flatMap((projectRows, index) => [
+  return projects.flatMap((projectRows, index) => [
     ...(index === 0 ? [] : [projectGapNode(projectRows.project.id)]),
     projectNode(projectRows, projection, applied),
   ]);
@@ -189,10 +256,15 @@ function projectNode(
   projection: DashboardPersistentFilterProjection | undefined,
   applied: boolean,
 ): DashboardTreeNode {
-  const visibleRows = applied
-    ? projectRows.rows.filter((row) => projection?.rows.get(rowIdForPayload(row))?.matched === true)
-    : projectRows.rows;
-  const children: DashboardTreeNode[] = visibleRows.map((row) => rowNode(row, projection));
+  const visibleRootRows = admittedRows(projectRows.rootRows, projection, applied);
+  const groupNodes = [...projectRows.groups]
+    .sort(compareProjectGroups)
+    .map((group) => groupNode(group, projection, applied));
+  const rootNodes = visibleRootRows.map((row) => rowNode(row, projection));
+  const children =
+    projectRows.orderingMode === "groups-first"
+      ? [...groupNodes, ...rootNodes]
+      : interleaveGroupAndRootNodes(groupNodes, rootNodes);
   if (projectRows.rows.length === 0) {
     children.push(emptyProjectNode(projectRows.project));
   }
@@ -210,6 +282,83 @@ function projectNode(
     defaultCell: "identity",
     ...(children.length === 0 ? {} : { children, expanded: !projectRows.collapsed }),
   };
+}
+
+function groupNode(
+  groupRows: ProjectGroupRows,
+  projection: DashboardPersistentFilterProjection | undefined,
+  applied: boolean,
+): DashboardTreeNode {
+  const visibleRows = admittedRows(groupRows.rows, projection, applied);
+  const match = projection?.groups.get(groupRows.group.id);
+  const payload: DashboardGroupHeaderPayload = {
+    type: "groupHeader",
+    group: groupRows.group,
+    collapsed: groupRows.collapsed,
+    sessionCount: groupRows.group.sessionIds.length,
+    visibleSessionCount: visibleRows.length,
+    ...(match === undefined ? {} : { persistentFilterMatch: match }),
+  };
+  const children = visibleRows.map((row) => rowNode(row, projection));
+  return {
+    id: dashboardRowIds.group(groupRows.group.id),
+    payload,
+    cells: GROUP_CELLS,
+    defaultCell: "identity",
+    ...(children.length === 0 ? {} : { children, expanded: !groupRows.collapsed }),
+  };
+}
+
+function admittedRows<Row extends DashboardSessionPayload | DashboardCreateLocalRowPayload>(
+  rows: readonly Row[],
+  projection: DashboardPersistentFilterProjection | undefined,
+  applied: boolean,
+): Row[] {
+  return applied
+    ? rows.filter((row) => projection?.rows.get(rowIdForPayload(row))?.matched === true)
+    : [...rows];
+}
+
+function compareProjectGroups(left: ProjectGroupRows, right: ProjectGroupRows): number {
+  return (
+    left.group.name.localeCompare(right.group.name) || left.group.id.localeCompare(right.group.id)
+  );
+}
+
+function interleaveGroupAndRootNodes(
+  groupNodes: readonly DashboardTreeNode[],
+  rootNodes: readonly DashboardTreeNode[],
+): DashboardTreeNode[] {
+  return [
+    ...groupNodes.map((node, index) => ({
+      kind: "group" as const,
+      label: node.payload.type === "groupHeader" ? node.payload.group.name : "",
+      index,
+      node,
+    })),
+    ...rootNodes.map((node, index) => ({
+      kind: "row" as const,
+      label:
+        node.payload.type === "session" || node.payload.type === "createLocalRow"
+          ? node.payload.presentation.title
+          : "",
+      index,
+      node,
+    })),
+  ]
+    .sort((left, right) => {
+      const labelOrder = left.label.localeCompare(right.label);
+      if (labelOrder !== 0) {
+        return labelOrder;
+      }
+      if (left.kind !== right.kind) {
+        return left.kind === "group" ? -1 : 1;
+      }
+      return left.kind === "group"
+        ? left.node.id.localeCompare(right.node.id)
+        : left.index - right.index;
+    })
+    .map(({ node }) => node);
 }
 
 function rowNode(
@@ -309,12 +458,14 @@ function createSessionRowPresentation(
 function persistentFilterCandidate(
   id: DashboardRowId,
   payload: DashboardSessionPayload | DashboardCreateLocalRowPayload,
+  groupId?: SessionGroupId,
 ): DashboardPersistentFilterCandidate {
   if (payload.type === "session") {
     return {
       kind: "session",
       id,
       projectId: payload.row.worktree.projectId,
+      ...(groupId === undefined ? {} : { groupId }),
       visibleFields: payload.presentation,
       conditionValues: {
         status: payload.pendingStart === undefined ? payload.row.session.status.value : "starting",
@@ -410,13 +561,18 @@ function decorateDashboardProjection(
   persistentFilter: DashboardPersistentFilterProjection | undefined,
 ): DashboardTreeProjection {
   const rowById = new Map<DashboardRowId, DashboardTreeRow>();
+  const focusedRow =
+    focus === undefined || !projection.visibleIndexById.has(focus.rowId)
+      ? undefined
+      : projection.rowById.get(focus.rowId);
   for (const row of projection.rowById.values()) {
-    const decorated: DashboardTreeRow = {
-      ...row,
-      ...(focus?.rowId === row.id && row.cells.includes(focus.cellId)
-        ? { focusedCellId: focus.cellId }
-        : {}),
-    };
+    let decorated: DashboardTreeRow = row;
+    if (focus?.rowId === row.id && row.cells.includes(focus.cellId)) {
+      decorated = { ...decorated, focusedCellId: focus.cellId };
+    }
+    if (row.payload.type === "groupHeader" && focusedRow?.parentId === row.id) {
+      decorated = { ...decorated, containsFocusedRow: true };
+    }
     rowById.set(row.id, decorated);
   }
   const visibleRows = projection.visibleRows.map((row) => {

--- a/packages/dashboard-core/src/selectors/dashboardTree.ts
+++ b/packages/dashboard-core/src/selectors/dashboardTree.ts
@@ -157,7 +157,6 @@ type ProjectRows = {
   readonly rows: readonly (DashboardSessionPayload | DashboardCreateLocalRowPayload)[];
   readonly rootRows: readonly (DashboardSessionPayload | DashboardCreateLocalRowPayload)[];
   readonly groups: readonly ProjectGroupRows[];
-  readonly orderingMode: GroupOrderingMode;
 };
 
 type ProjectGroupRows = {
@@ -171,11 +170,32 @@ const GROUP_CELLS = ["identity", "quickSession", "menu"] as const;
 const SESSION_CELLS = ["identity"] as const;
 const EMPTY_PROJECT_CELLS = ["addSession"] as const;
 
+/** Projects canonical snapshot and local dashboard state through one normalized tree-grid path. */
 export function selectDashboardTree(
   snapshot: DashboardSnapshotView,
   state: DashboardViewState,
   activeScreen: DashboardScreenView,
 ): DashboardTreeProjection {
+  // Normalize membership once so filtering and tree construction cannot diverge.
+  const projects = projectRowsForSnapshot(snapshot, state);
+  // Filtering annotates and admits rows from that model; it never creates a parallel hierarchy.
+  const persistentFilter = selectTreePersistentFilter(
+    projects,
+    snapshot.sessionGroups,
+    activeScreen,
+    state.persistentFilter,
+  );
+  const projection = projectTreeGrid(
+    dashboardRoots(projects, persistentFilter, state.groupOrderingMode),
+  );
+  // Focus decorates the finished projection and never becomes structural authority.
+  return decorateDashboardProjection(projection, state.dashboardFocus, persistentFilter);
+}
+
+function projectRowsForSnapshot(
+  snapshot: DashboardSnapshotView,
+  state: DashboardViewState,
+): ProjectRows[] {
   const sessionRows = selectDashboardSessionRows(snapshot);
   const localRows = visibleCreateSessionLocalRows(snapshot, state);
   const groupBySessionId = new Map<SessionId, DashboardGroupView>();
@@ -210,10 +230,149 @@ export function selectDashboardTree(
         (row) => row.type === "createLocalRow" || groupBySessionId.get(row.row.id) === undefined,
       ),
       groups,
-      orderingMode: state.groupOrderingMode,
     };
   });
-  const persistentFilter = selectDashboardPersistentFilter({
+  return projects;
+}
+
+function visibleCreateSessionLocalRows(
+  snapshot: DashboardSnapshotView,
+  state: DashboardViewState,
+): DashboardCreateSessionLocalRow[] {
+  const rowsById = new Map(snapshot.rows.map((row) => [row.id, row]));
+  const canonicalProjectBranches = new Set(
+    snapshot.sessions.flatMap((session) => {
+      const row = rowsById.get(session.worktreeId);
+      return row === undefined ? [] : [`${session.projectId}\u0000${row.branch}`];
+    }),
+  );
+  return [
+    ...state.localRows.pendingCreate
+      .filter((row) => !canonicalProjectBranches.has(`${row.projectId}\u0000${row.branch}`))
+      .map((row) => ({ ...row, status: "pending" as const })),
+    ...state.localRows.failedCreate.map((row) => ({ ...row, status: "failed" as const })),
+  ];
+}
+
+function mergeDashboardRows(
+  rows: readonly DashboardSessionRow[],
+  localRows: readonly DashboardCreateSessionLocalRow[],
+  state: DashboardViewState,
+): MergedDashboardRow[] {
+  return [
+    ...rows.map((row) => ({ type: "session" as const, row })),
+    ...localRows.map((row) => ({ type: "createLocalRow" as const, row })),
+  ].sort((left, right) => compareDashboardRows(left, right, state));
+}
+
+function compareDashboardRows(
+  left: MergedDashboardRow,
+  right: MergedDashboardRow,
+  state: DashboardViewState,
+): number {
+  return (
+    rowTitle(left, state).localeCompare(rowTitle(right, state)) ||
+    rowBranch(left).localeCompare(rowBranch(right)) ||
+    (left.type === right.type
+      ? rowStableId(left).localeCompare(rowStableId(right))
+      : left.type === "session"
+        ? -1
+        : 1)
+  );
+}
+
+function rowTitle(row: MergedDashboardRow, state: DashboardViewState): string {
+  return row.type === "session" ? sessionRowDisplayTitle(row.row, state.localRows) : row.row.title;
+}
+
+function rowBranch(row: MergedDashboardRow): string {
+  return row.type === "session" ? row.row.worktree.branch : row.row.branch;
+}
+
+function rowStableId(row: MergedDashboardRow): string {
+  return row.type === "session" ? row.row.id : row.row.localId;
+}
+
+function sessionPayload(
+  row: DashboardSessionRow,
+  state: DashboardViewState,
+): DashboardSessionPayload {
+  const displayTitle = sessionRowDisplayTitle(row, state.localRows);
+  const pendingRemove = state.localRows.pendingRemove.find(
+    (localRow) => localRow.worktreeId === row.worktree.id,
+  );
+  const pendingStart = state.localRows.pendingStart.find(
+    (localRow) => localRow.worktreeId === row.worktree.id,
+  );
+  return {
+    type: "session",
+    row,
+    displayTitle,
+    presentation: sessionRowPresentation(row, displayTitle, pendingRemove, pendingStart),
+    ...(pendingRemove === undefined ? {} : { pendingRemove }),
+    ...(pendingStart === undefined ? {} : { pendingStart }),
+  };
+}
+
+function createLocalPayload(row: DashboardCreateSessionLocalRow): DashboardCreateLocalRowPayload {
+  return {
+    type: "createLocalRow",
+    row,
+    presentation: createSessionRowPresentation(row),
+  };
+}
+
+function sessionRowPresentation(
+  row: DashboardSessionRow,
+  displayTitle: string,
+  pendingRemove: DashboardPendingRemoveWorktreeRowView | undefined,
+  pendingStart: DashboardPendingStartAgentRowView | undefined,
+): DashboardPersistentFilterVisibleFields {
+  if (pendingRemove !== undefined) {
+    return { title: displayTitle, activity: "removing session..." };
+  }
+  if (pendingStart !== undefined) {
+    return {
+      title: displayTitle,
+      activity: pendingStart.operation === "resumeAgent" ? "resuming..." : "starting...",
+    };
+  }
+  const visibleFields = worktreeRowVisibleFields(row.presentation, displayTitle);
+  return {
+    title: visibleFields.title,
+    agent: visibleFields.agent,
+    activity: visibleFields.activity,
+  };
+}
+
+function createSessionRowPresentation(
+  row: DashboardCreateSessionLocalRow,
+): DashboardPersistentFilterVisibleFields {
+  if (row.status === "failed") {
+    return { title: row.title, activity: row.error.message };
+  }
+  return {
+    title: row.title,
+    agent: row.harnessProvider ?? "",
+    activity: "starting session...",
+  };
+}
+
+function rowIdForPayload(
+  payload: DashboardSessionPayload | DashboardCreateLocalRowPayload,
+): DashboardRowId {
+  return payload.type === "session"
+    ? dashboardRowIds.session(payload.row.id)
+    : dashboardRowIds.create(payload.row.localId);
+}
+
+function selectTreePersistentFilter(
+  projects: readonly ProjectRows[],
+  groups: readonly DashboardGroupView[],
+  screen: DashboardScreenView,
+  applied: DashboardViewState["persistentFilter"],
+): DashboardPersistentFilterProjection | undefined {
+  return selectDashboardPersistentFilter({
     candidates: projects.flatMap((project) => [
       ...project.rootRows.map((row) => persistentFilterCandidate(rowIdForPayload(row), row)),
       ...project.groups.flatMap(({ group, rows }) =>
@@ -224,30 +383,59 @@ export function selectDashboardTree(
       projectId: project.id,
       projectLabel: project.label,
     })),
-    groups: snapshot.sessionGroups.map((group) => ({
+    groups: groups.map((group) => ({
       groupId: group.id,
       projectId: group.projectId,
       groupLabel: group.name,
     })),
-    screen: activeScreen,
-    ...(state.persistentFilter === undefined ? {} : { applied: state.persistentFilter }),
+    screen,
+    ...(applied === undefined ? {} : { applied }),
   });
-  const roots = dashboardRoots(projects, persistentFilter);
-  return decorateDashboardProjection(
-    projectTreeGrid(roots),
-    state.dashboardFocus,
-    persistentFilter,
-  );
+}
+
+function persistentFilterCandidate(
+  id: DashboardRowId,
+  payload: DashboardSessionPayload | DashboardCreateLocalRowPayload,
+  groupId?: SessionGroupId,
+): DashboardPersistentFilterCandidate {
+  if (payload.type === "session") {
+    return {
+      kind: "session",
+      id,
+      projectId: payload.row.worktree.projectId,
+      ...(groupId === undefined ? {} : { groupId }),
+      visibleFields: payload.presentation,
+      conditionValues: {
+        status: payload.pendingStart === undefined ? payload.row.session.status.value : "starting",
+        agent: payload.row.session.harness.provider,
+      },
+    };
+  }
+  const conditionValues: DashboardPersistentFilterCandidate["conditionValues"] = {};
+  if (payload.row.status === "pending") {
+    conditionValues.status = "starting";
+    if (payload.row.harnessProvider !== undefined) {
+      conditionValues.agent = payload.row.harnessProvider;
+    }
+  }
+  return {
+    kind: "optimistic",
+    id,
+    projectId: payload.row.projectId,
+    visibleFields: payload.presentation,
+    conditionValues,
+  };
 }
 
 function dashboardRoots(
   projects: readonly ProjectRows[],
   projection: DashboardPersistentFilterProjection | undefined,
+  orderingMode: GroupOrderingMode,
 ): DashboardTreeNode[] {
   const applied = projection?.source === "applied" && projection.active;
   return projects.flatMap((projectRows, index) => [
     ...(index === 0 ? [] : [projectGapNode(projectRows.project.id)]),
-    projectNode(projectRows, projection, applied),
+    projectNode(projectRows, projection, applied, orderingMode),
   ]);
 }
 
@@ -255,6 +443,7 @@ function projectNode(
   projectRows: ProjectRows,
   projection: DashboardPersistentFilterProjection | undefined,
   applied: boolean,
+  orderingMode: GroupOrderingMode,
 ): DashboardTreeNode {
   const visibleRootRows = admittedRows(projectRows.rootRows, projection, applied);
   const groupNodes = [...projectRows.groups]
@@ -262,7 +451,7 @@ function projectNode(
     .map((group) => groupNode(group, projection, applied));
   const rootNodes = visibleRootRows.map((row) => rowNode(row, projection));
   const children =
-    projectRows.orderingMode === "groups-first"
+    orderingMode === "groups-first"
       ? [...groupNodes, ...rootNodes]
       : interleaveGroupAndRootNodes(groupNodes, rootNodes);
   if (projectRows.rows.length === 0) {
@@ -313,10 +502,10 @@ function admittedRows<Row extends DashboardSessionPayload | DashboardCreateLocal
   rows: readonly Row[],
   projection: DashboardPersistentFilterProjection | undefined,
   applied: boolean,
-): Row[] {
+): readonly Row[] {
   return applied
     ? rows.filter((row) => projection?.rows.get(rowIdForPayload(row))?.matched === true)
-    : [...rows];
+    : rows;
 }
 
 function compareProjectGroups(left: ProjectGroupRows, right: ProjectGroupRows): number {
@@ -390,184 +579,23 @@ function projectGapNode(projectId: ProjectId): DashboardTreeNode {
   };
 }
 
-function sessionPayload(
-  row: DashboardSessionRow,
-  state: DashboardViewState,
-): DashboardSessionPayload {
-  const displayTitle = sessionRowDisplayTitle(row, state.localRows);
-  const pendingRemove = state.localRows.pendingRemove.find(
-    (localRow) => localRow.worktreeId === row.worktree.id,
-  );
-  const pendingStart = state.localRows.pendingStart.find(
-    (localRow) => localRow.worktreeId === row.worktree.id,
-  );
-  return {
-    type: "session",
-    row,
-    displayTitle,
-    presentation: sessionRowPresentation(row, displayTitle, pendingRemove, pendingStart),
-    ...(pendingRemove === undefined ? {} : { pendingRemove }),
-    ...(pendingStart === undefined ? {} : { pendingStart }),
-  };
-}
-
-function createLocalPayload(row: DashboardCreateSessionLocalRow): DashboardCreateLocalRowPayload {
-  return {
-    type: "createLocalRow",
-    row,
-    presentation: createSessionRowPresentation(row),
-  };
-}
-
-function sessionRowPresentation(
-  row: DashboardSessionRow,
-  displayTitle: string,
-  pendingRemove: DashboardPendingRemoveWorktreeRowView | undefined,
-  pendingStart: DashboardPendingStartAgentRowView | undefined,
-): DashboardPersistentFilterVisibleFields {
-  if (pendingRemove !== undefined) {
-    return { title: displayTitle, activity: "removing session..." };
-  }
-  if (pendingStart !== undefined) {
-    return {
-      title: displayTitle,
-      activity: pendingStart.operation === "resumeAgent" ? "resuming..." : "starting...",
-    };
-  }
-  const visibleFields = worktreeRowVisibleFields(row.presentation, displayTitle);
-  return {
-    title: visibleFields.title,
-    agent: visibleFields.agent,
-    activity: visibleFields.activity,
-  };
-}
-
-function createSessionRowPresentation(
-  row: DashboardCreateSessionLocalRow,
-): DashboardPersistentFilterVisibleFields {
-  if (row.status === "failed") {
-    return { title: row.title, activity: row.error.message };
-  }
-  return {
-    title: row.title,
-    agent: row.harnessProvider ?? "",
-    activity: "starting session...",
-  };
-}
-
-function persistentFilterCandidate(
-  id: DashboardRowId,
-  payload: DashboardSessionPayload | DashboardCreateLocalRowPayload,
-  groupId?: SessionGroupId,
-): DashboardPersistentFilterCandidate {
-  if (payload.type === "session") {
-    return {
-      kind: "session",
-      id,
-      projectId: payload.row.worktree.projectId,
-      ...(groupId === undefined ? {} : { groupId }),
-      visibleFields: payload.presentation,
-      conditionValues: {
-        status: payload.pendingStart === undefined ? payload.row.session.status.value : "starting",
-        agent: payload.row.session.harness.provider,
-      },
-    };
-  }
-  const conditionValues: DashboardPersistentFilterCandidate["conditionValues"] = {};
-  if (payload.row.status === "pending") {
-    conditionValues.status = "starting";
-    if (payload.row.harnessProvider !== undefined) {
-      conditionValues.agent = payload.row.harnessProvider;
-    }
-  }
-  return {
-    kind: "optimistic",
-    id,
-    projectId: payload.row.projectId,
-    visibleFields: payload.presentation,
-    conditionValues,
-  };
-}
-
-function visibleCreateSessionLocalRows(
-  snapshot: DashboardSnapshotView,
-  state: DashboardViewState,
-): DashboardCreateSessionLocalRow[] {
-  const rowsById = new Map(snapshot.rows.map((row) => [row.id, row]));
-  const canonicalProjectBranches = new Set(
-    snapshot.sessions.flatMap((session) => {
-      const row = rowsById.get(session.worktreeId);
-      return row === undefined ? [] : [`${session.projectId}\u0000${row.branch}`];
-    }),
-  );
-  return [
-    ...state.localRows.pendingCreate
-      .filter((row) => !canonicalProjectBranches.has(`${row.projectId}\u0000${row.branch}`))
-      .map((row) => ({ ...row, status: "pending" as const })),
-    ...state.localRows.failedCreate.map((row) => ({ ...row, status: "failed" as const })),
-  ];
-}
-
-function mergeDashboardRows(
-  rows: readonly DashboardSessionRow[],
-  localRows: readonly DashboardCreateSessionLocalRow[],
-  state: DashboardViewState,
-): MergedDashboardRow[] {
-  return [
-    ...rows.map((row) => ({ type: "session" as const, row })),
-    ...localRows.map((row) => ({ type: "createLocalRow" as const, row })),
-  ].sort((left, right) => compareDashboardRows(left, right, state));
-}
-
-function compareDashboardRows(
-  left: MergedDashboardRow,
-  right: MergedDashboardRow,
-  state: DashboardViewState,
-): number {
-  return (
-    rowTitle(left, state).localeCompare(rowTitle(right, state)) ||
-    rowBranch(left).localeCompare(rowBranch(right)) ||
-    (left.type === right.type
-      ? rowStableId(left).localeCompare(rowStableId(right))
-      : left.type === "session"
-        ? -1
-        : 1)
-  );
-}
-
-function rowTitle(row: MergedDashboardRow, state: DashboardViewState): string {
-  return row.type === "session" ? sessionRowDisplayTitle(row.row, state.localRows) : row.row.title;
-}
-
-function rowBranch(row: MergedDashboardRow): string {
-  return row.type === "session" ? row.row.worktree.branch : row.row.branch;
-}
-
-function rowStableId(row: MergedDashboardRow): string {
-  return row.type === "session" ? row.row.id : row.row.localId;
-}
-
-function rowIdForPayload(
-  payload: DashboardSessionPayload | DashboardCreateLocalRowPayload,
-): DashboardRowId {
-  return payload.type === "session"
-    ? dashboardRowIds.session(payload.row.id)
-    : dashboardRowIds.create(payload.row.localId);
-}
-
 function decorateDashboardProjection(
   projection: TreeGridProjection<DashboardRowId, DashboardCellId, DashboardTreePayload>,
   focus: DashboardFocus | undefined,
   persistentFilter: DashboardPersistentFilterProjection | undefined,
 ): DashboardTreeProjection {
   const rowById = new Map<DashboardRowId, DashboardTreeRow>();
-  const focusedRow =
+  const focusedRowCandidate =
     focus === undefined || !projection.visibleIndexById.has(focus.rowId)
       ? undefined
       : projection.rowById.get(focus.rowId);
+  const focusedRow =
+    focus !== undefined && focusedRowCandidate?.cells.includes(focus.cellId)
+      ? focusedRowCandidate
+      : undefined;
   for (const row of projection.rowById.values()) {
     let decorated: DashboardTreeRow = row;
-    if (focus?.rowId === row.id && row.cells.includes(focus.cellId)) {
+    if (focus !== undefined && focusedRow?.id === row.id) {
       decorated = { ...decorated, focusedCellId: focus.cellId };
     }
     if (row.payload.type === "groupHeader" && focusedRow?.parentId === row.id) {

--- a/packages/dashboard-core/src/state/dashboardCells.ts
+++ b/packages/dashboard-core/src/state/dashboardCells.ts
@@ -1,9 +1,10 @@
+import type { SessionGroupId } from "@station/contracts";
 import {
   type DashboardCellId,
   type DashboardRowId,
   selectDashboardTree,
 } from "../selectors/dashboardTree.js";
-import { focusResolvedDashboardCursor } from "./dashboardFocus.js";
+import { focusResolvedDashboardCursor, reconcileDashboardFocus } from "./dashboardFocus.js";
 import { activateDashboardRow } from "./rowActivation.js";
 import { toggleDashboardProjectCollapsed } from "./screens/projectCollapse.js";
 import { openProjectDefaultAgentPicker } from "./screens/projectDefaultAgent.js";
@@ -28,6 +29,10 @@ export function activateDashboardCell(
   switch (row.payload.type) {
     case "projectHeader":
       return activateProjectCell(focused, row.payload.project.id, cellId);
+    case "groupHeader":
+      return cellId === "identity"
+        ? { state: toggleDashboardGroupCollapsed(focused, row.payload.group.id) }
+        : { state: focused };
     case "session":
       return cellId === "identity" &&
         row.payload.pendingRemove === undefined &&
@@ -67,6 +72,20 @@ function activateProjectCell(
     case "defaultAgent":
       return { state: openProjectDefaultAgentPicker(state, projectId) };
     case "addSession":
+    case "menu":
       return { state };
   }
+}
+
+function toggleDashboardGroupCollapsed(
+  state: DashboardState,
+  groupId: SessionGroupId,
+): DashboardState {
+  const collapsedGroupIds = new Set(state.collapsedGroupIds);
+  if (collapsedGroupIds.has(groupId)) {
+    collapsedGroupIds.delete(groupId);
+  } else {
+    collapsedGroupIds.add(groupId);
+  }
+  return reconcileDashboardFocus(state, { ...state, collapsedGroupIds });
 }

--- a/packages/dashboard-core/src/state/dashboardFocus.ts
+++ b/packages/dashboard-core/src/state/dashboardFocus.ts
@@ -27,7 +27,10 @@ type DashboardPolicy = TreeGridNavigationPolicy<
 >;
 
 const dashboardPolicy: DashboardPolicy = ({ payload }) =>
-  payload.type === "projectHeader" || payload.type === "session" || payload.type === "emptyProject";
+  payload.type === "projectHeader" ||
+  payload.type === "groupHeader" ||
+  payload.type === "session" ||
+  payload.type === "emptyProject";
 
 // This one policy protects canonical-session-only chooser entry, movement,
 // reconciliation, Enter, and slot behavior; callers use only the bound wrappers below.
@@ -66,7 +69,7 @@ export function clearDashboardFocus(state: DashboardState): DashboardState {
   return cleared;
 }
 
-/** Moves vertically through project, canonical-session, and empty-action rows. */
+/** Moves vertically through Project, Group, canonical-session, and empty-action rows. */
 export function moveDashboardCursor(state: DashboardState, delta: -1 | 1): DashboardState {
   return moveCursor(state, delta, dashboardPolicy);
 }

--- a/packages/dashboard-core/src/state/screen.ts
+++ b/packages/dashboard-core/src/state/screen.ts
@@ -10,6 +10,8 @@ export function createInitialTuiState(options: CreateInitialTuiStateOptions = {}
     toasts: [],
     observerConnectionStatus: { state: "connected" },
     collapsedProjectIds: new Set(options.collapsedProjectIds ?? []),
+    collapsedGroupIds: new Set(options.collapsedGroupIds ?? []),
+    groupOrderingMode: options.groupOrderingMode ?? "groups-first",
     scrollOffset: options.scrollOffset ?? 0,
     terminalRows: options.terminalRows ?? 24,
     localRows: options.localRows ?? createEmptyTuiLocalRows(),

--- a/packages/dashboard-core/src/state/types.ts
+++ b/packages/dashboard-core/src/state/types.ts
@@ -3,6 +3,7 @@ import type {
   ProjectId,
   ProviderId,
   SafeError,
+  SessionGroupId,
   SessionId,
   StationSnapshot,
   TuiWidgetConfig,
@@ -11,7 +12,7 @@ import type {
 import type { EditableTextInputState } from "../components/EditableTextInput/editing.js";
 import type { AddProjectFlowState } from "../flows/addProject/types.js";
 import type { NewSessionFlowState } from "../flows/newSession.js";
-import type { DashboardFocus } from "../selectors/dashboardTree.js";
+import type { DashboardFocus, GroupOrderingMode } from "../selectors/dashboardTree.js";
 import type { ClientNotice } from "../services/types.js";
 import type { TuiLocalRows } from "./localRows.js";
 import type { ReadonlyDeep } from "./readonly.js";
@@ -71,6 +72,8 @@ export type TuiViewState = {
   /** Dashboard-local applied filter; absence means no persistent filter is applied. */
   persistentFilter?: DashboardPersistentFilter;
   collapsedProjectIds: ReadonlySet<string>;
+  collapsedGroupIds: ReadonlySet<SessionGroupId>;
+  groupOrderingMode: GroupOrderingMode;
   scrollOffset: number;
   terminalRows: number;
   localRows: TuiLocalRows;
@@ -200,6 +203,8 @@ export type CreateInitialTuiStateOptions = {
   initialSnapshot?: StationSnapshot;
   persistentFilter?: DashboardPersistentFilter;
   collapsedProjectIds?: Iterable<string>;
+  collapsedGroupIds?: Iterable<SessionGroupId>;
+  groupOrderingMode?: GroupOrderingMode;
   scrollOffset?: number;
   terminalRows?: number;
   localRows?: TuiLocalRows;

--- a/packages/dashboard-core/test/fixtures/snapshots.ts
+++ b/packages/dashboard-core/test/fixtures/snapshots.ts
@@ -42,6 +42,52 @@ export function createDashboardSnapshot(): StationSnapshot {
   ]);
 }
 
+export function createGroupedDashboardSnapshot(): StationSnapshot {
+  const snapshot = createDashboardSnapshot();
+  return {
+    ...snapshot,
+    sessionGroups: [
+      {
+        id: "group_active",
+        projectId: "web",
+        name: "Active work",
+        sessionIds: ["ses_wt_web_attention", "ses_wt_web_idle"],
+        version: 1,
+        createdAt: fixtureNow,
+        updatedAt: fixtureNow,
+      },
+      {
+        id: "group_build",
+        projectId: "web",
+        name: "Build",
+        sessionIds: ["ses_wt_web_working"],
+        parentGroupId: "group_active",
+        version: 1,
+        createdAt: fixtureNow,
+        updatedAt: fixtureNow,
+      },
+      {
+        id: "group_empty",
+        projectId: "web",
+        name: "Empty",
+        sessionIds: [],
+        version: 1,
+        createdAt: fixtureNow,
+        updatedAt: fixtureNow,
+      },
+      {
+        id: "group_api",
+        projectId: "api",
+        name: "Queue",
+        sessionIds: ["ses_wt_api_working"],
+        version: 1,
+        createdAt: fixtureNow,
+        updatedAt: fixtureNow,
+      },
+    ],
+  };
+}
+
 export function createCommandSnapshot(
   state: "none" | "idle" = "idle",
   options: { dirty?: boolean } = {},

--- a/packages/dashboard-core/test/unit/components/dashboardTableHeader.test.ts
+++ b/packages/dashboard-core/test/unit/components/dashboardTableHeader.test.ts
@@ -31,6 +31,7 @@ function projection(
     zeroMatches: false,
     rows: new Map(),
     projects: new Map(),
+    groups: new Map(),
     ...overrides,
   };
 }

--- a/packages/dashboard-core/test/unit/entrypoints.typecheck.test.ts
+++ b/packages/dashboard-core/test/unit/entrypoints.typecheck.test.ts
@@ -19,6 +19,8 @@ import type {
   DashboardFilterFooterSegment,
   DashboardFilterHeaderModel,
   DashboardFooterModel,
+  DashboardGroupHeaderPayload,
+  DashboardPersistentFilterGroupMatch,
   DashboardRowId,
   DashboardSessionRow,
   DashboardTableHeaderModel,
@@ -26,6 +28,7 @@ import type {
   DashboardViewport,
   EditableTextInputState,
   FleetSummary,
+  GroupOrderingMode,
   RowGridLayout,
 } from "../../src/entrypoints/selectors.js";
 import type {
@@ -79,6 +82,9 @@ export type EntrypointTypecheckWitness = [
   DashboardRowId,
   DashboardCellId,
   DashboardTreeRow,
+  DashboardGroupHeaderPayload,
+  DashboardPersistentFilterGroupMatch,
+  GroupOrderingMode,
   DashboardViewport,
   FleetSummary,
   DashboardTableHeaderModel,

--- a/packages/dashboard-core/test/unit/selectors/dashboardPersistentFilter.test.ts
+++ b/packages/dashboard-core/test/unit/selectors/dashboardPersistentFilter.test.ts
@@ -64,6 +64,7 @@ describe("dashboard persistent filter selector", () => {
         agent: [],
         activity: [],
         projectLabel: [],
+        groupLabel: [],
       },
     });
     expect(projection?.rows.get("create:beta")?.dimmed).toBe(true);
@@ -243,6 +244,41 @@ describe("dashboard persistent filter selector", () => {
       labelRanges: [{ start: 0, end: 5 }],
     });
     expect(unmatched?.projects.get("empty")).toEqual({ matched: false, labelRanges: [] });
+  });
+
+  it("uses Group names as member context and member matches as retained Group context", () => {
+    const sessionCandidate = candidates[0];
+    if (sessionCandidate === undefined) throw new Error("expected session candidate");
+    const groupedCandidates: DashboardPersistentFilterCandidate[] = [
+      { ...sessionCandidate, groupId: "group_active" },
+    ];
+    const groups = [
+      { groupId: "group_active", projectId: "web", groupLabel: "Active work" },
+      { groupId: "group_empty", projectId: "web", groupLabel: "Empty" },
+    ];
+    const byGroup = selectDashboardPersistentFilter({
+      candidates: groupedCandidates,
+      projects,
+      groups,
+      screen: { name: "dashboard" },
+      applied: { query: "active" },
+    });
+    const byMember = selectDashboardPersistentFilter({
+      candidates: groupedCandidates,
+      projects,
+      groups,
+      screen: { name: "dashboard" },
+      applied: { query: "alpha" },
+    });
+
+    expect(byGroup?.rows.get("session:alpha")?.ranges.groupLabel).toEqual([{ start: 0, end: 6 }]);
+    expect(byGroup?.groups.get("group_active")).toEqual({
+      matched: true,
+      labelRanges: [{ start: 0, end: 6 }],
+    });
+    expect(byMember?.groups.get("group_active")?.matched).toBe(true);
+    expect(byMember?.groups.get("group_empty")?.matched).toBe(false);
+    expect(byMember?.projects.get("web")?.matched).toBe(true);
   });
 
   it("treats a blank editing query as a recoverable all-match preview", () => {

--- a/packages/dashboard-core/test/unit/selectors/dashboardPersistentFilter.test.ts
+++ b/packages/dashboard-core/test/unit/selectors/dashboardPersistentFilter.test.ts
@@ -32,12 +32,14 @@ const projects = [
   { projectId: "api", projectLabel: "API" },
   { projectId: "empty", projectLabel: "Empty Project" },
 ];
+const groups = [];
 
 describe("dashboard persistent filter selector", () => {
   it("lets an editing draft override the applied query and returns every visible match range", () => {
     const projection = selectDashboardPersistentFilter({
       candidates,
       projects,
+      groups,
       screen: {
         name: "persistentFilter",
         draft: { value: "  ALPHA  ", cursor: 9 },
@@ -74,6 +76,7 @@ describe("dashboard persistent filter selector", () => {
     const projection = selectDashboardPersistentFilter({
       candidates,
       projects,
+      groups,
       screen: {
         name: "persistentFilter",
         draft: { value: "", cursor: 0 },
@@ -105,18 +108,21 @@ describe("dashboard persistent filter selector", () => {
     const byAgent = selectDashboardPersistentFilter({
       candidates,
       projects,
+      groups,
       screen: { name: "dashboard" },
       applied: { query: "pi" },
     });
     const byStatus = selectDashboardPersistentFilter({
       candidates,
       projects,
+      groups,
       screen: { name: "dashboard" },
       applied: { query: "WORK" },
     });
     const byProject = selectDashboardPersistentFilter({
       candidates,
       projects,
+      groups,
       screen: { name: "dashboard" },
       applied: { query: "console" },
     });
@@ -133,6 +139,7 @@ describe("dashboard persistent filter selector", () => {
     const byStatuses = selectDashboardPersistentFilter({
       candidates,
       projects,
+      groups,
       screen: { name: "dashboard" },
       applied: {
         query: "",
@@ -150,6 +157,7 @@ describe("dashboard persistent filter selector", () => {
     const byProjectAndAgent = selectDashboardPersistentFilter({
       candidates,
       projects,
+      groups,
       screen: { name: "dashboard" },
       applied: {
         query: "pending",
@@ -170,6 +178,7 @@ describe("dashboard persistent filter selector", () => {
     const projection = selectDashboardPersistentFilter({
       candidates,
       projects,
+      groups,
       screen: { name: "dashboard" },
       applied: {
         query: "",
@@ -187,6 +196,7 @@ describe("dashboard persistent filter selector", () => {
     const projection = selectDashboardPersistentFilter({
       candidates,
       projects,
+      groups,
       screen: { name: "dashboard" },
       applied: { query: "feature" },
     });
@@ -211,12 +221,14 @@ describe("dashboard persistent filter selector", () => {
     const byExpansion = selectDashboardPersistentFilter({
       candidates: sourceCandidates,
       projects,
+      groups,
       screen: { name: "dashboard" },
       applied: { query: "X" },
     });
     const byAccent = selectDashboardPersistentFilter({
       candidates: sourceCandidates,
       projects,
+      groups,
       screen: { name: "dashboard" },
       applied: { query: "é" },
     });
@@ -229,12 +241,14 @@ describe("dashboard persistent filter selector", () => {
     const byLabel = selectDashboardPersistentFilter({
       candidates: [],
       projects,
+      groups,
       screen: { name: "dashboard" },
       applied: { query: "empty" },
     });
     const unmatched = selectDashboardPersistentFilter({
       candidates: [],
       projects,
+      groups,
       screen: { name: "dashboard" },
       applied: { query: "missing" },
     });
@@ -285,6 +299,7 @@ describe("dashboard persistent filter selector", () => {
     const projection = selectDashboardPersistentFilter({
       candidates,
       projects,
+      groups,
       screen: {
         name: "persistentFilter",
         draft: { value: "   ", cursor: 3 },
@@ -306,6 +321,7 @@ describe("dashboard persistent filter selector", () => {
     const projection = selectDashboardPersistentFilter({
       candidates,
       projects,
+      groups,
       screen: { name: "dashboard" },
       applied: { query: "missing" },
     });
@@ -317,7 +333,12 @@ describe("dashboard persistent filter selector", () => {
 
   it("returns no projection when neither a draft nor applied state exists", () => {
     expect(
-      selectDashboardPersistentFilter({ candidates, projects, screen: { name: "dashboard" } }),
+      selectDashboardPersistentFilter({
+        candidates,
+        projects,
+        groups,
+        screen: { name: "dashboard" },
+      }),
     ).toBeUndefined();
   });
 });

--- a/packages/dashboard-core/test/unit/selectors/dashboardTree.test.ts
+++ b/packages/dashboard-core/test/unit/selectors/dashboardTree.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 import { createEditableTextInputState } from "../../../src/components/EditableTextInput/editing.js";
 import { dashboardRowIds, selectDashboardTree } from "../../../src/selectors/dashboardTree.js";
 import { createInitialTuiState } from "../../../src/state/screen.js";
-import { createDashboardSnapshot } from "../../fixtures/snapshots.js";
+import {
+  createDashboardSnapshot,
+  createGroupedDashboardSnapshot,
+  fixtureNow,
+} from "../../fixtures/snapshots.js";
 
 describe("dashboard tree", () => {
   it("projects the current Project to Session hierarchy with stable ids, gaps, and cells", () => {
@@ -174,6 +178,199 @@ describe("dashboard tree", () => {
     expect(tree.collapsedAncestorById.get(sessionId)).toBe(dashboardRowIds.project("web"));
   });
 
+  it("projects flat Group blocks with direct canonical counts and groups-first ordering", () => {
+    const snapshot = createGroupedDashboardSnapshot();
+    const state = createInitialTuiState({ initialSnapshot: snapshot });
+    const tree = selectDashboardTree(snapshot, state, state.screen);
+
+    expect(tree.visibleRows.map((row) => row.id)).toEqual([
+      "project:web",
+      "group:group_active",
+      "session:ses_wt_web_attention",
+      "session:ses_wt_web_idle",
+      "group:group_build",
+      "session:ses_wt_web_working",
+      "group:group_empty",
+      "session:ses_wt_web_exited",
+      "session:ses_wt_web_unknown",
+      "session:ses_wt_web_stuck",
+      "gap:api",
+      "project:api",
+      "group:group_api",
+      "session:ses_wt_api_working",
+    ]);
+    expect(tree.rowById.get(dashboardRowIds.group("group_build"))).toMatchObject({
+      depth: 1,
+      parentId: "project:web",
+      cells: ["identity", "quickSession", "menu"],
+      defaultCell: "identity",
+      payload: {
+        type: "groupHeader",
+        collapsed: false,
+        sessionCount: 1,
+        visibleSessionCount: 1,
+        group: { id: "group_build", parentGroupId: "group_active" },
+      },
+    });
+    expect(tree.rowById.get(dashboardRowIds.session("ses_wt_web_working"))).toMatchObject({
+      depth: 2,
+      parentId: "group:group_build",
+    });
+    expect(tree.rowById.get(dashboardRowIds.group("group_empty"))?.payload).toMatchObject({
+      type: "groupHeader",
+      sessionCount: 0,
+      visibleSessionCount: 0,
+    });
+  });
+
+  it("interleaves whole Group blocks with root rows and keeps optimistic rows ungrouped", () => {
+    const snapshot = createGroupedDashboardSnapshot();
+    const state = createInitialTuiState({
+      initialSnapshot: snapshot,
+      groupOrderingMode: "alphabetical-interleaved",
+      localRows: {
+        pendingCreate: [
+          {
+            localId: "pending",
+            projectId: "web",
+            title: "Draft",
+            branch: "draft",
+            createdAt: fixtureNow,
+          },
+        ],
+        failedCreate: [],
+        pendingRemove: [],
+        pendingStart: [],
+      },
+    });
+    const tree = selectDashboardTree(snapshot, state, state.screen);
+    const webChildren = tree.visibleRows
+      .filter((row) => row.parentId === dashboardRowIds.project("web"))
+      .map((row) => row.id);
+
+    expect(webChildren).toEqual([
+      "group:group_active",
+      "group:group_build",
+      "session:ses_wt_web_exited",
+      "create:pending",
+      "group:group_empty",
+      "session:ses_wt_web_unknown",
+      "session:ses_wt_web_stuck",
+    ]);
+  });
+
+  it("orders equal labels by Group precedence and stable Group identity", () => {
+    const base = createGroupedDashboardSnapshot();
+    const snapshot = {
+      ...base,
+      sessionGroups: base.sessionGroups.map((group) =>
+        group.id === "group_empty"
+          ? { ...group, name: "done-run" }
+          : group.id === "group_active" || group.id === "group_build"
+            ? { ...group, name: "same" }
+            : group,
+      ),
+    };
+    const originalGroups = snapshot.sessionGroups.map((group) => group.id);
+    const originalSessions = snapshot.sessions.map((session) => session.id);
+    const state = createInitialTuiState({
+      initialSnapshot: snapshot,
+      groupOrderingMode: "alphabetical-interleaved",
+    });
+    const tree = selectDashboardTree(snapshot, state, state.screen);
+    const webChildren = tree.visibleRows
+      .filter((row) => row.parentId === dashboardRowIds.project("web"))
+      .map((row) => row.id);
+
+    expect(webChildren.indexOf("group:group_empty")).toBeLessThan(
+      webChildren.indexOf("session:ses_wt_web_exited"),
+    );
+    expect(webChildren.indexOf("group:group_active")).toBeLessThan(
+      webChildren.indexOf("group:group_build"),
+    );
+    expect(snapshot.sessionGroups.map((group) => group.id)).toEqual(originalGroups);
+    expect(snapshot.sessions.map((session) => session.id)).toEqual(originalSessions);
+  });
+
+  it("uses Group and Project collapse as nested visible-ancestor recovery", () => {
+    const snapshot = createGroupedDashboardSnapshot();
+    const memberId = dashboardRowIds.session("ses_wt_web_idle");
+    const groupState = createInitialTuiState({
+      initialSnapshot: snapshot,
+      collapsedGroupIds: ["group_active"],
+    });
+    const groupTree = selectDashboardTree(snapshot, groupState, groupState.screen);
+
+    expect(groupTree.visibleIndexById.has(memberId)).toBe(false);
+    expect(groupTree.collapsedAncestorById.get(memberId)).toBe(
+      dashboardRowIds.group("group_active"),
+    );
+
+    const projectState = { ...groupState, collapsedProjectIds: new Set(["web"]) };
+    const projectTree = selectDashboardTree(snapshot, projectState, projectState.screen);
+    expect(projectTree.collapsedAncestorById.get(memberId)).toBe(dashboardRowIds.project("web"));
+  });
+
+  it("marks a Group whose direct visible member owns focus", () => {
+    const snapshot = createGroupedDashboardSnapshot();
+    const state = createInitialTuiState({
+      initialSnapshot: snapshot,
+      dashboardFocus: {
+        rowId: dashboardRowIds.session("ses_wt_web_idle"),
+        cellId: "identity",
+      },
+    });
+    const tree = selectDashboardTree(snapshot, state, state.screen);
+
+    expect(tree.rowById.get(dashboardRowIds.group("group_active"))?.containsFocusedRow).toBe(true);
+    expect(
+      tree.rowById.get(dashboardRowIds.group("group_build"))?.containsFocusedRow,
+    ).toBeUndefined();
+  });
+
+  it("retains Group containers and reports admitted direct members under an applied filter", () => {
+    const snapshot = createGroupedDashboardSnapshot();
+    const state = createInitialTuiState({
+      initialSnapshot: snapshot,
+      persistentFilter: { query: "active work" },
+      collapsedGroupIds: ["group_build"],
+    });
+    const tree = selectDashboardTree(snapshot, state, state.screen);
+
+    expect(tree.rowById.get(dashboardRowIds.group("group_active"))?.payload).toMatchObject({
+      type: "groupHeader",
+      sessionCount: 2,
+      visibleSessionCount: 2,
+      persistentFilterMatch: { matched: true },
+    });
+    expect(tree.rowById.get(dashboardRowIds.group("group_build"))?.payload).toMatchObject({
+      type: "groupHeader",
+      collapsed: true,
+      sessionCount: 1,
+      visibleSessionCount: 0,
+      persistentFilterMatch: { matched: false },
+    });
+    expect(tree.visibleRows.map((row) => row.id)).toContain("group:group_empty");
+    expect(state.collapsedGroupIds.has("group_build")).toBe(true);
+  });
+
+  it("keeps canonical Group counts when a direct member lacks renderable metadata", () => {
+    const base = createGroupedDashboardSnapshot();
+    const snapshot = {
+      ...base,
+      rows: base.rows.filter((row) => row.id !== "wt_web_idle"),
+    };
+    const state = createInitialTuiState({ initialSnapshot: snapshot });
+    const tree = selectDashboardTree(snapshot, state, state.screen);
+
+    expect(tree.rowById.get(dashboardRowIds.group("group_active"))?.payload).toMatchObject({
+      type: "groupHeader",
+      sessionCount: 2,
+      visibleSessionCount: 1,
+    });
+    expect(tree.rowById.has(dashboardRowIds.session("ses_wt_web_idle"))).toBe(false);
+  });
+
   it("keeps draft filtering soft and decorates row and project matches", () => {
     const snapshot = createDashboardSnapshot();
     const state = {
@@ -198,7 +395,7 @@ describe("dashboard tree", () => {
     });
   });
 
-  it("hard-projects applied matches and rebuilds gaps between retained projects", () => {
+  it("hard-projects applied rows while retaining durable Project context", () => {
     const snapshot = createDashboardSnapshot();
     const state = createInitialTuiState({
       initialSnapshot: snapshot,
@@ -207,10 +404,11 @@ describe("dashboard tree", () => {
     const tree = selectDashboardTree(snapshot, state, state.screen);
 
     expect(tree.visibleRows.map((row) => row.id)).toEqual([
+      "project:web",
+      "gap:api",
       "project:api",
       "session:ses_wt_api_working",
     ]);
-    expect(tree.visibleRows.some(({ payload }) => payload.type === "projectGap")).toBe(false);
   });
 
   it("does not fabricate an empty action when an applied filter removes a nonempty project's rows", () => {

--- a/packages/dashboard-core/test/unit/selectors/dashboardTree.test.ts
+++ b/packages/dashboard-core/test/unit/selectors/dashboardTree.test.ts
@@ -328,6 +328,21 @@ describe("dashboard tree", () => {
     ).toBeUndefined();
   });
 
+  it("does not decorate containment for an invalid focused cell", () => {
+    const snapshot = createGroupedDashboardSnapshot();
+    const memberId = dashboardRowIds.session("ses_wt_web_idle");
+    const state = {
+      ...createInitialTuiState({ initialSnapshot: snapshot }),
+      dashboardFocus: { rowId: memberId, cellId: "menu" } as const,
+    };
+    const tree = selectDashboardTree(snapshot, state, state.screen);
+
+    expect(tree.rowById.get(memberId)?.focusedCellId).toBeUndefined();
+    expect(
+      tree.rowById.get(dashboardRowIds.group("group_active"))?.containsFocusedRow,
+    ).toBeUndefined();
+  });
+
   it("retains Group containers and reports admitted direct members under an applied filter", () => {
     const snapshot = createGroupedDashboardSnapshot();
     const state = createInitialTuiState({

--- a/packages/dashboard-core/test/unit/selectors/dashboardViewport.test.ts
+++ b/packages/dashboard-core/test/unit/selectors/dashboardViewport.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 import { dashboardRowIds } from "../../../src/selectors/dashboardTree.js";
 import { selectDashboardViewport } from "../../../src/selectors/dashboardViewport.js";
 import { createInitialTuiState } from "../../../src/state/screen.js";
-import { createDashboardSnapshot } from "../../fixtures/snapshots.js";
+import {
+  createDashboardSnapshot,
+  createGroupedDashboardSnapshot,
+} from "../../fixtures/snapshots.js";
 
 describe("dashboard viewport selector", () => {
   it("clips projected rows and reports terminal hidden counts", () => {
@@ -51,6 +54,34 @@ describe("dashboard viewport selector", () => {
       ["2", "ses_wt_web_unknown"],
       ["3", "ses_wt_web_stuck"],
     ]);
+  });
+
+  it("assigns continuous visible-session slots across Group boundaries", () => {
+    const snapshot = createGroupedDashboardSnapshot();
+    const expanded = selectDashboardViewport(
+      snapshot,
+      createInitialTuiState({ initialSnapshot: snapshot, terminalRows: 30 }),
+    );
+    const collapsed = selectDashboardViewport(
+      snapshot,
+      createInitialTuiState({
+        initialSnapshot: snapshot,
+        terminalRows: 30,
+        collapsedGroupIds: ["group_active"],
+      }),
+    );
+
+    expect(expanded.rowChoices.map((choice) => [choice.key, choice.value.id])).toEqual([
+      ["1", "ses_wt_web_attention"],
+      ["2", "ses_wt_web_idle"],
+      ["3", "ses_wt_web_working"],
+      ["4", "ses_wt_web_exited"],
+      ["5", "ses_wt_web_unknown"],
+      ["6", "ses_wt_web_stuck"],
+      ["7", "ses_wt_api_working"],
+    ]);
+    expect(collapsed.rowChoices.map((choice) => choice.key)).toEqual(["1", "2", "3", "4", "5"]);
+    expect(collapsed.rowChoices.map((choice) => choice.value.id)).not.toContain("ses_wt_web_idle");
   });
 
   it("keeps pending-start sessions displayable but not actionable", () => {
@@ -179,6 +210,8 @@ describe("dashboard viewport selector", () => {
     );
 
     expect(viewport.rows.map((row) => row.id)).toEqual([
+      "project:web",
+      "gap:api",
       "project:api",
       "session:ses_wt_api_working",
     ]);

--- a/packages/dashboard-core/test/unit/state/actions.test.ts
+++ b/packages/dashboard-core/test/unit/state/actions.test.ts
@@ -26,7 +26,10 @@ import {
 } from "../../../src/state/screens/widgetSettings.js";
 import { handleTuiKey } from "../../../src/state/transition.js";
 import type { DashboardState } from "../../../src/state/types.js";
-import { createDashboardSnapshot } from "../../fixtures/snapshots.js";
+import {
+  createDashboardSnapshot,
+  createGroupedDashboardSnapshot,
+} from "../../fixtures/snapshots.js";
 
 const context = {
   cwd: "/workspace",
@@ -359,6 +362,30 @@ describe("dashboard state actions", () => {
     ).toEqual({ state });
   });
 
+  it("toggles Group identity while keeping Group quick and menu cells inert", () => {
+    const state = createInitialTuiState({ initialSnapshot: createGroupedDashboardSnapshot() });
+    const rowId = dashboardRowIds.group("group_active");
+    const collapsed = handleTuiAction(
+      state,
+      { type: "dashboard.cell.activate", rowId, cellId: "identity" },
+      context,
+    );
+
+    expect(collapsed.state.collapsedGroupIds.has("group_active")).toBe(true);
+    expect(collapsed.state.dashboardFocus).toEqual({ rowId, cellId: "identity" });
+
+    for (const cellId of ["quickSession", "menu"] as const) {
+      const inert = handleTuiAction(
+        state,
+        { type: "dashboard.cell.activate", rowId, cellId },
+        context,
+      );
+      expect(inert.operations).toBeUndefined();
+      expect(inert.state.dashboardFocus).toEqual({ rowId, cellId });
+      expect(inert.state.collapsedGroupIds.size).toBe(0);
+    }
+  });
+
   it("keeps stale, hidden, filtered, and wrong-cell dashboard targets inert", () => {
     const state = dashboardState();
     const stale = {
@@ -394,6 +421,22 @@ describe("dashboard state actions", () => {
         context,
       ),
     ).toEqual({ state: hidden });
+
+    const hiddenGroup = createInitialTuiState({
+      initialSnapshot: createGroupedDashboardSnapshot(),
+      collapsedProjectIds: ["web"],
+    });
+    expect(
+      handleTuiAction(
+        hiddenGroup,
+        {
+          type: "dashboard.cell.activate",
+          rowId: dashboardRowIds.group("group_active"),
+          cellId: "menu",
+        },
+        context,
+      ),
+    ).toEqual({ state: hiddenGroup });
 
     const filtered = { ...state, persistentFilter: { query: "api" } };
     expect(

--- a/packages/dashboard-core/test/unit/state/dashboardFocus.test.ts
+++ b/packages/dashboard-core/test/unit/state/dashboardFocus.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { dashboardRowIds } from "../../../src/selectors/dashboardTree.js";
+import { activateDashboardCell } from "../../../src/state/dashboardCells.js";
 import {
   clearDashboardFocus,
   focusDashboardSession,
@@ -12,7 +13,10 @@ import {
 } from "../../../src/state/dashboardFocus.js";
 import { createInitialTuiState, replaceSnapshot } from "../../../src/state/screen.js";
 import { toggleDashboardProjectCollapsed } from "../../../src/state/screens/projectCollapse.js";
-import { createDashboardSnapshot } from "../../fixtures/snapshots.js";
+import {
+  createDashboardSnapshot,
+  createGroupedDashboardSnapshot,
+} from "../../fixtures/snapshots.js";
 
 describe("dashboard cursor", () => {
   it("bridges a canonical session id to its branded identity cell", () => {
@@ -93,6 +97,21 @@ describe("dashboard cursor", () => {
       },
     });
     expect(moveDashboardCursorHorizontal(state, 1)).toBe(state);
+  });
+
+  it("clamps horizontal movement across the three ordered Group cells", () => {
+    const snapshot = createGroupedDashboardSnapshot();
+    let state = createInitialTuiState({
+      initialSnapshot: snapshot,
+      dashboardFocus: { rowId: dashboardRowIds.group("group_active"), cellId: "identity" },
+    });
+
+    state = moveDashboardCursorHorizontal(state, 1);
+    expect(state.dashboardFocus?.cellId).toBe("quickSession");
+    state = moveDashboardCursorHorizontal(state, 1);
+    expect(state.dashboardFocus?.cellId).toBe("menu");
+    expect(moveDashboardCursorHorizontal(state, 1)).toBe(state);
+    expect(moveDashboardCursorHorizontal(state, -1).dashboardFocus?.cellId).toBe("quickSession");
   });
 
   it("uses a chooser policy that skips headers, gaps, local rows, and pending sessions", () => {
@@ -192,6 +211,90 @@ describe("dashboard cursor", () => {
       rowId: dashboardRowIds.project("web"),
       cellId: "identity",
     });
+  });
+
+  it("keeps Group identity focused on collapse and recovers a hidden member to it", () => {
+    const snapshot = createGroupedDashboardSnapshot();
+    const groupId = dashboardRowIds.group("group_active");
+    const focusedGroup = createInitialTuiState({
+      initialSnapshot: snapshot,
+      dashboardFocus: { rowId: groupId, cellId: "identity" },
+    });
+    const collapsed = activateDashboardCell(focusedGroup, groupId, "identity").state;
+
+    expect(collapsed.collapsedGroupIds.has("group_active")).toBe(true);
+    expect(collapsed.dashboardFocus).toEqual({ rowId: groupId, cellId: "identity" });
+
+    const focusedMember = createInitialTuiState({
+      initialSnapshot: snapshot,
+      dashboardFocus: {
+        rowId: dashboardRowIds.session("ses_wt_web_idle"),
+        cellId: "identity",
+      },
+    });
+    const hidden = reconcileDashboardFocus(focusedMember, {
+      ...focusedMember,
+      collapsedGroupIds: new Set(["group_active"]),
+    });
+    expect(hidden.dashboardFocus).toEqual({ rowId: groupId, cellId: "identity" });
+  });
+
+  it("follows a focused session across canonical Group membership replacement", () => {
+    const snapshot = createGroupedDashboardSnapshot();
+    const sessionId = dashboardRowIds.session("ses_wt_web_idle");
+    const previous = createInitialTuiState({
+      initialSnapshot: snapshot,
+      dashboardFocus: { rowId: sessionId, cellId: "identity" },
+      collapsedGroupIds: ["group_build"],
+    });
+    const moved = {
+      ...snapshot,
+      sessionGroups: snapshot.sessionGroups.map((group) => {
+        if (group.id === "group_active") {
+          return {
+            ...group,
+            sessionIds: group.sessionIds.filter((id) => id !== "ses_wt_web_idle"),
+          };
+        }
+        return group.id === "group_build"
+          ? { ...group, sessionIds: [...group.sessionIds, "ses_wt_web_idle"] }
+          : group;
+      }),
+    };
+
+    expect(replaceSnapshot(previous, moved).dashboardFocus).toEqual({
+      rowId: dashboardRowIds.group("group_build"),
+      cellId: "identity",
+    });
+  });
+
+  it("uses positional fallback when a focused Group disappears without pruning collapse state", () => {
+    const snapshot = createGroupedDashboardSnapshot();
+    const previous = createInitialTuiState({
+      initialSnapshot: snapshot,
+      dashboardFocus: {
+        rowId: dashboardRowIds.group("group_active"),
+        cellId: "menu",
+      },
+      collapsedGroupIds: ["group_active", "missing_group"],
+    });
+    const removed = {
+      ...snapshot,
+      sessionGroups: snapshot.sessionGroups
+        .filter((group) => group.id !== "group_active")
+        .map((group) => {
+          if (group.id !== "group_build") return group;
+          const { parentGroupId: _removedParent, ...rootGroup } = group;
+          return rootGroup;
+        }),
+    };
+    const next = replaceSnapshot(previous, removed);
+
+    expect(next.dashboardFocus).toEqual({
+      rowId: dashboardRowIds.group("group_build"),
+      cellId: "identity",
+    });
+    expect(next.collapsedGroupIds).toEqual(previous.collapsedGroupIds);
   });
 
   it("preserves exact identity through resize and follows it into view", () => {

--- a/packages/dashboard-core/test/unit/state/interactionParity.test.ts
+++ b/packages/dashboard-core/test/unit/state/interactionParity.test.ts
@@ -17,7 +17,11 @@ import {
 import { openForkDetailsForRow } from "../../../src/state/screens/fork.js";
 import { openRemoveWorktreeConfirmForRow } from "../../../src/state/screens/removeWorktree.js";
 import { handleTuiKey } from "../../../src/state/transition.js";
-import { createDashboardSnapshot, createZeroWorktreeSnapshot } from "../../fixtures/snapshots.js";
+import {
+  createDashboardSnapshot,
+  createGroupedDashboardSnapshot,
+  createZeroWorktreeSnapshot,
+} from "../../fixtures/snapshots.js";
 
 const context = { cwd: "/workspace", homeDir: "/home/example" };
 
@@ -317,6 +321,26 @@ describe("primary workflow interaction parity", () => {
       type: "quickCreateManagedSession",
       project: { id: "web" },
     });
+  });
+
+  it("converges all three Group targets through semantic and focused activation", () => {
+    const rowId = dashboardRowIds.group("group_active");
+    for (const cellId of ["identity", "quickSession", "menu"] as const) {
+      const base = createInitialTuiState({
+        initialSnapshot: createGroupedDashboardSnapshot(),
+        dashboardFocus: { rowId, cellId },
+      });
+      const semantic = handleTuiAction(
+        base,
+        { type: "dashboard.cell.activate", rowId, cellId },
+        context,
+      );
+      const keyboard = handleTuiKey(base, { input: "\r", return: true }, context);
+
+      expect(semantic.state.dashboardFocus).toEqual(keyboard.state.dashboardFocus);
+      expect(semantic.state.collapsedGroupIds).toEqual(keyboard.state.collapsedGroupIds);
+      expect(semantic.operations).toEqual(keyboard.operations);
+    }
   });
 
   it("validates header and empty-project Quick Session before capability execution", () => {

--- a/packages/dashboard-core/test/unit/state/readonlyStateSource.typecheck.test.ts
+++ b/packages/dashboard-core/test/unit/state/readonlyStateSource.typecheck.test.ts
@@ -25,6 +25,8 @@ function verifyReadonlyStateSource(
   state.localRows.pendingCreate.push(pendingCreateRow);
   // @ts-expect-error Readonly sets do not expose mutation methods.
   state.collapsedProjectIds.add("project");
+  // @ts-expect-error Group collapse is renderer-local but remains readonly across the public source.
+  state.collapsedGroupIds.add("group");
   // @ts-expect-error Readonly maps do not expose mutation methods.
   readonlyMap.set("project", { values: [] });
   // @ts-expect-error Values nested inside readonly maps remain readonly.

--- a/packages/dashboard-core/test/unit/state/screens/persistentFilter.test.ts
+++ b/packages/dashboard-core/test/unit/state/screens/persistentFilter.test.ts
@@ -71,7 +71,7 @@ describe("persistent-filter screen", () => {
 
     expect(applied.screen).toEqual({ name: "dashboard" });
     expect(applied.persistentFilter).toEqual({ query: "NaV" });
-    expect(applied.scrollOffset).toBe(0);
+    expect(applied.scrollOffset).toBe(1);
     expect(applied.dashboardFocus).toEqual(base.dashboardFocus);
   });
 

--- a/packages/dashboard-core/test/unit/state/screens/rowChoose.test.ts
+++ b/packages/dashboard-core/test/unit/state/screens/rowChoose.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import { dashboardRowIds } from "../../../../src/selectors/dashboardTree.js";
 import { createInitialTuiState } from "../../../../src/state/screen.js";
 import { handleDashboardRowChoiceKey } from "../../../../src/state/screens/rowChoose.js";
-import { createDashboardSnapshot } from "../../../fixtures/snapshots.js";
+import {
+  createDashboardSnapshot,
+  createGroupedDashboardSnapshot,
+} from "../../../fixtures/snapshots.js";
 
 describe("dashboard row chooser", () => {
   it.each([
@@ -116,5 +119,39 @@ describe("dashboard row chooser", () => {
     ).state;
     expect(moved.scrollOffset).toBe(1);
     expect(moved.dashboardFocus).toEqual(state.dashboardFocus);
+  });
+
+  it("skips Group headers while preserving grouped session slots", () => {
+    const snapshot = createGroupedDashboardSnapshot();
+    const state = {
+      ...createInitialTuiState({
+        initialSnapshot: snapshot,
+        terminalRows: 30,
+        dashboardFocus: {
+          rowId: dashboardRowIds.group("group_active"),
+          cellId: "identity" as const,
+        },
+      }),
+      screen: { name: "renameSession" as const, step: "chooseSlot" as const },
+    };
+    const committed: string[] = [];
+    const moved = handleDashboardRowChoiceKey(
+      state,
+      { input: "", downArrow: true },
+      (current, rowId) => {
+        committed.push(rowId);
+        return { state: current };
+      },
+    ).state;
+
+    expect(moved.dashboardFocus).toEqual({
+      rowId: dashboardRowIds.session("ses_wt_web_attention"),
+      cellId: "identity",
+    });
+    handleDashboardRowChoiceKey(moved, { input: "1" }, (current, rowId) => {
+      committed.push(rowId);
+      return { state: current };
+    });
+    expect(committed).toEqual(["ses_wt_web_attention"]);
   });
 });

--- a/packages/dashboard-core/test/unit/state/transition.test.ts
+++ b/packages/dashboard-core/test/unit/state/transition.test.ts
@@ -13,6 +13,7 @@ import {
   createCommandSnapshot,
   createDashboardSnapshot,
   createExternalAgentSnapshot,
+  createGroupedDashboardSnapshot,
   createZeroWorktreeSnapshot,
 } from "../../fixtures/snapshots.js";
 
@@ -1168,7 +1169,7 @@ describe("TUI screen transitions", () => {
     });
   });
 
-  it("resets dashboard scroll when a filter is applied", () => {
+  it("clamps dashboard scroll across durable filter containers", () => {
     const opened = handleTuiKey(
       createInitialTuiState({
         initialSnapshot: createDashboardSnapshot(),
@@ -1181,7 +1182,24 @@ describe("TUI screen transitions", () => {
     const transition = handleTuiKey(typed.state, { input: "\r", return: true });
 
     expect(transition.state.persistentFilter).toEqual({ query: "nav" });
-    expect(transition.state.scrollOffset).toBe(0);
+    expect(transition.state.scrollOffset).toBe(1);
+  });
+
+  it("preserves Group collapse and ordering while applying and clearing a filter", () => {
+    const base = createInitialTuiState({
+      initialSnapshot: createGroupedDashboardSnapshot(),
+      collapsedGroupIds: ["group_active"],
+      groupOrderingMode: "alphabetical-interleaved",
+    });
+    const opened = handleTuiKey(base, { input: "/" });
+    const typed = handleTuiKey(opened.state, { input: "active" });
+    const applied = handleTuiKey(typed.state, { input: "\r", return: true }).state;
+    const cleared = handleTuiKey(applied, { input: "", escape: true }).state;
+
+    expect(applied.collapsedGroupIds).toEqual(base.collapsedGroupIds);
+    expect(applied.groupOrderingMode).toBe("alphabetical-interleaved");
+    expect(cleared.collapsedGroupIds).toEqual(base.collapsedGroupIds);
+    expect(cleared.groupOrderingMode).toBe("alphabetical-interleaved");
   });
 
   it("clamps dashboard scroll after collapsing a project", () => {

--- a/station/src/contextMenu/items.test.ts
+++ b/station/src/contextMenu/items.test.ts
@@ -436,6 +436,47 @@ describe("buildContextMenuItems", () => {
     });
   });
 
+  it("keeps every Group-header target inert", () => {
+    const store = createStationStore();
+    const snapshot = manyProjectsSnapshot();
+    const session = snapshot.sessions.find(({ id }) => id === STATION_IDLE_SESSION_ID);
+    if (session === undefined) throw new Error("fixture is missing the Station session");
+    const stationState = createInitialTuiState({
+      initialSnapshot: {
+        ...snapshot,
+        sessionGroups: [
+          {
+            id: "grp_station_active",
+            projectId: session.projectId,
+            name: "Active work",
+            sessionIds: [session.id],
+            version: 1,
+            createdAt: snapshot.generatedAt,
+            updatedAt: snapshot.generatedAt,
+          },
+        ],
+      },
+    });
+
+    for (const cellId of ["identity", "quickSession", "menu"] as const) {
+      const items = buildContextMenuItems(
+        {
+          kind: "station",
+          target: {
+            kind: "dashboardCell",
+            rowId: dashboardRowIds.group("grp_station_active"),
+            cellId,
+          },
+        },
+        store.getState(),
+        stationState,
+      );
+
+      expect(items.map(({ id }) => id)).toEqual(["station.noActions"]);
+      expect(resolveContextMenuAction(items[0])).toBeUndefined();
+    }
+  });
+
   it("keeps STATION row actions inert off the dashboard screen", () => {
     const store = createStationStore();
     const stationState = {

--- a/station/src/contextMenu/items.ts
+++ b/station/src/contextMenu/items.ts
@@ -109,6 +109,8 @@ function buildStationItems(
   switch (row.payload.type) {
     case "projectHeader":
       return buildProjectItems(row.payload.project.id, state);
+    case "groupHeader":
+      return [noActionsItem()];
     case "session": {
       const sessionRow = row.payload.row;
       return viewport.rowChoices.some((choice) => choice.value.id === sessionRow.id)

--- a/station/src/station/view/DashboardFilterView.test.tsx
+++ b/station/src/station/view/DashboardFilterView.test.tsx
@@ -36,6 +36,7 @@ function projection(
     zeroMatches: false,
     rows: new Map(),
     projects: new Map(),
+    groups: new Map(),
     ...overrides,
   };
 }

--- a/station/src/station/view/DashboardRoot.tsx
+++ b/station/src/station/view/DashboardRoot.tsx
@@ -43,6 +43,8 @@ export function DashboardRoot({ state, actions, columns, rows, onCopyNotice }: D
   const screen = useStore(state, (state) => state.screen);
   const persistentFilter = useStore(state, (state) => state.persistentFilter);
   const collapsedProjectIds = useStore(state, (state) => state.collapsedProjectIds);
+  const collapsedGroupIds = useStore(state, (state) => state.collapsedGroupIds);
+  const groupOrderingMode = useStore(state, (state) => state.groupOrderingMode);
   const scrollOffset = useStore(state, (state) => state.scrollOffset);
   const dashboardFocus = useStore(state, (state) => state.dashboardFocus);
   const selection = useStore(state, (state) => state.selection);
@@ -126,6 +128,8 @@ export function DashboardRoot({ state, actions, columns, rows, onCopyNotice }: D
           snapshot={snapshot}
           viewState={{
             collapsedProjectIds,
+            collapsedGroupIds,
+            groupOrderingMode,
             scrollOffset,
             terminalRows: rows,
             localRows,

--- a/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
@@ -407,9 +407,9 @@ FILTER working · Status=Working                2/10 matches
 ▼ observer  3 sessions · 3 agents             [sh] [qs] [▾] 
  [2] ⠋ provider-hooks          opencode  working      #16 … 
                                                             
+▼ scripts  2 sessions · 2 agents              [sh] [qs] [▾] 
                                                             
-                                                            
-                                                            
+▼ empty-project  0 sessions                   [sh] [qs] [▾] 
                                                             
 ─────────────────────────────────────────────────────────── 
 / edit  Esc clear  ↵ activate  N new  Q:close               

--- a/station/src/station/view/dashboard.golden.test.tsx
+++ b/station/src/station/view/dashboard.golden.test.tsx
@@ -253,6 +253,8 @@ describe("dashboard golden frames", () => {
     const frame = setup.captureCharFrame();
     expect(frame).toMatchSnapshot();
     expect(frame).toContain("FILTER working · Status=Working");
+    expect(frame).toContain("▼ scripts");
+    expect(frame).toContain("▼ empty-project");
     expect(frame).toContain("/ edit");
     expect(frame).toContain("Esc clear");
   });


### PR DESCRIPTION
## What this fixes

The dashboard core previously projected canonical sessions directly beneath Projects, leaving canonical Session Groups without shared ordering, filtering, collapse, focus recovery, or semantic activation. This supplies the renderer-independent model required by #538 while preserving the single normalized tree, cursor, and activation path established by #546.

## What changed

- Projects canonical Groups as flat direct Project children while preserving root sessions, optimistic rows, empty Groups, canonical direct counts, and existing session ordering.
- Supports groups-first and alphabetical-interleaved ordering with deterministic Group and root-row ties.
- Extends persistent filtering with required Group context, retained durable containers, semantic label ranges, and filter-visible direct-member counts.
- Adds renderer-local Group collapse, collapsed-ancestor recovery, stable membership movement, and containment decoration that ignores stale or invalid focused cells.
- Keeps chooser entry, attention traversal, slots, and commits canonical-session-only; Group Quick Session and menu cells remain focus-preserving no-ops.
- Refactors the sole dashboard hierarchy adapter into a short source → filter → tree → focus pipeline with helpers grouped by responsibility.
- Wires Group collapse and ordering state into the Station composition and keeps all Group-header context-menu targets explicitly inert.

## Testing

- pnpm --filter @station/dashboard-core build
- pnpm --filter @station/dashboard-core typecheck
- Dashboard-core unit suite: 65 files, 567 tests passed
- bun run typecheck in station
- Focused Station rendering, input, context-menu, and boundary suite: 231 tests and 18 snapshots passed
- pnpm typecheck
- pnpm lint
- git diff --check

## Safety and scope

This is the core half of #537 plus the minimum Station composition wiring needed to keep the repository exhaustive and type-safe. It intentionally adds no Group pixels, layout, colors, rings, hit boxes, hover, or pointer presentation; #538 remains the owner of that renderer work.

Refs #537.