### PR TITLE
fix(pi): pass canonical ingress launcher into sessions

### DIFF
--- a/apps/cli/src/commands/setup/adapters/config.ts
+++ b/apps/cli/src/commands/setup/adapters/config.ts
@@ -14,6 +14,7 @@ import type {
   SetupConfigWriteOperation,
   SetupOperationOutcome,
 } from "@station/setup-core";
+import { SETUP_HARNESS_DEFINITIONS } from "../harnessDefinitions.js";
 import { SETUP_TOOL_DEFINITIONS } from "../toolDefinitions.js";
 import type { SetupFacts } from "./inspectionTypes.js";
 
@@ -140,7 +141,7 @@ export function setupConfigMutationInput(
       }
       return {
         id: harnessId,
-        command: harness.command,
+        command: detectedHarnessCommand(harness),
         installHooks: operation.trackingHarnessIds.includes(harnessId),
       };
     }),
@@ -198,6 +199,12 @@ function completedConfigOutcome(
           backupPath: result.backupPath,
         },
       };
+}
+
+function detectedHarnessCommand(fact: SetupFacts["harnesses"][number]): string {
+  if (!fact.command.includes("/") && fact.resolvedPath !== undefined) return fact.resolvedPath;
+  const defaultCommand = SETUP_HARNESS_DEFINITIONS[fact.id].commandFallback;
+  return detectedCommand(fact, defaultCommand);
 }
 
 function detectedCommand(

--- a/apps/cli/src/commands/setup/adapters/inspectionTypes.ts
+++ b/apps/cli/src/commands/setup/adapters/inspectionTypes.ts
@@ -119,6 +119,7 @@ export type SetupHarnessFact = {
   label: string;
   status: "ok" | "missing";
   command: string;
+  resolvedPath?: string;
   version?: string;
   rawVersion?: string;
   message?: string;

--- a/apps/cli/src/commands/setup/checks/harnesses.ts
+++ b/apps/cli/src/commands/setup/checks/harnesses.ts
@@ -2,6 +2,8 @@ import type { CliSetupHarnessId } from "@station/contracts";
 import {
   type ExternalCommandInput,
   type ExternalCommandRunner,
+  type ResolveExecutablePathOptions,
+  resolveExecutablePath,
   runExternalCommand,
 } from "@station/runtime";
 import type { CliEnv } from "../../../env.js";
@@ -15,6 +17,7 @@ export type CheckHarnessesOptions = {
   env?: CliEnv;
   cwd?: string;
   homeDir?: string;
+  access?: (path: string) => Promise<void>;
   configuredHarnesses?: readonly string[];
   configuredCommands?: Readonly<Partial<Record<CliSetupHarnessId, string>>>;
 };
@@ -67,6 +70,8 @@ async function checkHarness(
         status: "ok",
         command: candidate,
       };
+      const resolvedPath = await resolveHarnessCommand(candidate, env, options);
+      if (resolvedPath !== undefined) fact.resolvedPath = resolvedPath;
       if (rawVersion.length > 0) fact.rawVersion = rawVersion;
       const version = parseHarnessVersion(rawVersion);
       if (version !== undefined) fact.version = version;
@@ -83,6 +88,17 @@ async function checkHarness(
     command,
     message: `${definition.label} CLI is not available.`,
   };
+}
+
+async function resolveHarnessCommand(
+  command: string,
+  env: CliEnv,
+  options: CheckHarnessesOptions,
+): Promise<string | undefined> {
+  const resolveOptions: ResolveExecutablePathOptions = {};
+  if (env.PATH !== undefined) resolveOptions.pathEnv = env.PATH;
+  if (options.access !== undefined) resolveOptions.access = options.access;
+  return resolveExecutablePath(command, resolveOptions);
 }
 
 function parseHarnessVersion(output: string): string | undefined {

--- a/apps/cli/src/commands/setup/checks/system.ts
+++ b/apps/cli/src/commands/setup/checks/system.ts
@@ -91,8 +91,10 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
     env: CliEnv;
     cwd: string;
     homeDir: string;
+    access?: (path: string) => Promise<void>;
   } = { env, cwd, homeDir };
   if (options.runner !== undefined) commandInput.runner = options.runner;
+  if (options.access !== undefined) commandInput.access = options.access;
   const commandOptions = commandCheckOptions(commandInput);
   const dependencyInput: {
     runner?: ExternalCommandRunner;
@@ -390,6 +392,7 @@ function commandCheckOptions(input: {
   env: CliEnv;
   cwd: string;
   homeDir?: string;
+  access?: (path: string) => Promise<void>;
 }): CheckGitOptions & CheckHarnessesOptions {
   const options: CheckGitOptions & CheckHarnessesOptions = {
     env: input.env,
@@ -397,6 +400,7 @@ function commandCheckOptions(input: {
   };
   if (input.runner !== undefined) options.runner = input.runner;
   if (input.homeDir !== undefined) options.homeDir = input.homeDir;
+  if (input.access !== undefined) options.access = input.access;
   return options;
 }
 

--- a/apps/cli/src/commands/setup/presentation/projectSetupHarnessChecks.ts
+++ b/apps/cli/src/commands/setup/presentation/projectSetupHarnessChecks.ts
@@ -48,6 +48,15 @@ export function projectSetupHarnessChecks(input: {
       value: unavailable.join(","),
     });
   }
+  const selectedDefault = facts.harnesses.find(
+    (harness) => harness.id === selection.defaultHarness,
+  );
+  if (selectedDefault?.resolvedPath !== undefined) {
+    harnessDetails.push({
+      label: setupMessageRef("detail.resolved-executable"),
+      value: selectedDefault.resolvedPath,
+    });
+  }
 
   const harness = projectHarnessCheck({
     plan,

--- a/apps/cli/src/commands/setup/presenters/json.ts
+++ b/apps/cli/src/commands/setup/presenters/json.ts
@@ -646,6 +646,8 @@ function harnessCheck(facts: SetupFacts, harnessSelection: SetupHarnessSelection
   );
   if (selectedDefault !== undefined) {
     details.command = selectedDefault.command;
+    if (selectedDefault.resolvedPath !== undefined)
+      details.resolvedPath = selectedDefault.resolvedPath;
     details.defaultStatus = "available";
   }
   const selectedLabels = harnessSelection.requiredHarnessIds.map(

--- a/apps/cli/src/observerProviders.ts
+++ b/apps/cli/src/observerProviders.ts
@@ -432,6 +432,9 @@ function buildPiHarnessProvider({
   if (registryOptions.piExtensionPath !== undefined) {
     options.extensionPath = registryOptions.piExtensionPath;
   }
+  if (registryOptions.providerHookIngressLauncher !== undefined) {
+    options.hookBin = registryOptions.providerHookIngressLauncher;
+  }
   applyObserverPaths(options, config, false);
   return createPiHarnessProvider(options);
 }

--- a/apps/cli/test/unit/observerProviders.test.ts
+++ b/apps/cli/test/unit/observerProviders.test.ts
@@ -463,6 +463,7 @@ describe("observer providers", () => {
       resume: true,
       configPath,
       extensionPath: piExtensionPath,
+      hookBin: ingressLauncher,
       observerSocketPath: observerPaths.socketPath,
       stateDir: observerPaths.stateDir,
       hookSpoolDir: observerPaths.hookSpoolDir,
@@ -963,7 +964,10 @@ describe("observer providers", () => {
           },
         ],
       },
-      { configPath: "/tmp/station/config.toml" },
+      {
+        configPath: "/tmp/station/config.toml",
+        providerHookIngressLauncher: "/tmp/station/bin/stn-ingress",
+      },
     );
     const provider = registry.harnesses.get("pi");
     const project = firstProject();
@@ -996,6 +1000,7 @@ describe("observer providers", () => {
       args: expect.arrayContaining(["--extension"]),
       env: {
         STATION_CONFIG_PATH: "/tmp/station/config.toml",
+        STATION_INGRESS_BIN: "/tmp/station/bin/stn-ingress",
       },
     });
   });

--- a/apps/cli/test/unit/setup-checks.test.ts
+++ b/apps/cli/test/unit/setup-checks.test.ts
@@ -97,6 +97,23 @@ describe("setup dependency checks", () => {
     ]);
   });
 
+  it("records the executable path that satisfied a bare harness command", async () => {
+    const binDir = "/setup/bin";
+    const facts = await checkSetupHarnesses({
+      env: { PATH: binDir },
+      access: fakeAccess([join(binDir, "pi")]),
+      runner: fakeRunner([], {
+        "pi --version": "pi 1.2.3\n",
+      }),
+    });
+
+    expect(facts.find((fact) => fact.id === "pi")).toMatchObject({
+      status: "ok",
+      command: "pi",
+      resolvedPath: join(binDir, "pi"),
+    });
+  });
+
   it("creates and proves a writable private state directory", async () => {
     const root = await tempRoot(tempRoots);
     const path = join(root, "state");

--- a/apps/cli/test/unit/setup-operation-adapter.test.ts
+++ b/apps/cli/test/unit/setup-operation-adapter.test.ts
@@ -7,6 +7,7 @@ import type { CursorHookInstallResult } from "@station/cursor";
 import type { OpenCodePluginInstallResult } from "@station/opencode";
 import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
 import { describe, expect, it } from "vitest";
+import { setupConfigMutationInput } from "../../src/commands/setup/adapters/config.js";
 import {
   createHarnessTrackingAdapter,
   type SetupHarnessTrackingRunners,
@@ -22,6 +23,41 @@ import type { SetupCommandDeps } from "../../src/commands/setup/types.js";
 const trackedProviders = ["claude", "codex", "cursor", "opencode"] as const;
 
 describe("setup operation adapters", () => {
+  it("uses the resolved executable when setup creates a harness config block", () => {
+    const input = setupConfigMutationInput(
+      {
+        id: "write-config",
+        kind: "write-config",
+        tier: "required",
+        selected: true,
+        change: "create",
+        defaultHarnessId: "pi",
+        harnessIds: ["pi"],
+        trackingHarnessIds: [],
+        installWorktrunkTracking: false,
+      },
+      {
+        homeDir: "/home/test",
+        config: { status: "missing", path: "/home/test/.config/station/config.toml" },
+        worktrunk: { status: "ok", command: "wt", resolvedPath: "/opt/tools/wt" },
+        tmux: { status: "ok", command: "tmux", resolvedPath: "/opt/tools/tmux" },
+        harnesses: [
+          {
+            id: "pi",
+            label: "Pi",
+            status: "ok",
+            command: "pi",
+            resolvedPath: "/opt/tools/pi",
+          },
+        ],
+      } as SetupFacts,
+    );
+
+    expect(input.desired.harnesses).toEqual([
+      { id: "pi", command: "/opt/tools/pi", installHooks: false },
+    ]);
+  });
+
   it("streams genuine external installers through inherited stdio", async () => {
     const calls: ExternalCommandInput[] = [];
     const runner = async (input: ExternalCommandInput): Promise<ExternalCommandResult> => {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -168,7 +168,9 @@ selected in the current guided run, to be runnable. For Claude, Codex, Cursor,
 and OpenCode, preparation also requires `install_hooks = true` and a successful
 read-only probe of the current Station-owned artifacts. Other configured
 non-default harnesses remain visible but do not block global setup. Pi loads its
-Station extension in process and has no equivalent external hook artifact.
+Station extension in process and has no equivalent external hook artifact; Station passes the
+canonical `stn-ingress` launcher through `STATION_INGRESS_BIN` on each Pi launch so event delivery
+is not dependent on the pane or tmux server `PATH`.
 
 Artifact preparation is not runtime delivery proof. In particular, Codex may
 still require review of Station's current hook definition through `/hooks`.
@@ -521,7 +523,7 @@ Advanced development/demo overrides:
 | `STATION_BUN` | Source/development Station host launches | Bun executable path/name for source/development host launches; fallback is `bun`. |
 | `STATION_HOST_ENTRY` | Source/development Station host launches | Non-standard source/development override for the host entry file. Usually leave unset. |
 | `STATION_HOST_HANDOFF` | Native Station TUI build-upgrade launch | Only exact `1` opts a busy same-protocol older Host into negotiated handoff with fixed `processes` fidelity, followed by warm pane reattach. There is no prompt, launcher flag, or config key; absent, empty, `true`, and every other value preserve the existing visible refusal. |
-| `STATION_INGRESS_BIN` | Generated Pi/OpenCode hook transport | Development/testing override for `stn-ingress`; fallback is the PATH name `stn-ingress`. |
+| `STATION_INGRESS_BIN` | Generated Pi/OpenCode hook transport | Station sets this to the canonical absolute `stn-ingress` launcher for Pi launches and generated hook/plugin artifacts; manual extension/plugin runs fall back to the PATH name `stn-ingress`. |
 | `STATION_DASHBOARD_COMMAND` | CLI TUI launcher | Explicit command override for the observer-backed, command-capable, pane-free dashboard renderer. Development/testing only. |
 | `STATION_TUI_COMMAND` / `STATION_TUI_SESSION_NAME` | tmux popup registry | Development popup routing overrides. |
 | `STATION_SHELL_AUTOCLOSE` | Native Station TUI | `1`/`true` or `0`/`false`; auto-close overlay when a `+sh` shell opens. |

--- a/docs/system-dependencies.md
+++ b/docs/system-dependencies.md
@@ -6,7 +6,7 @@ Station integrates with Worktrunk, tmux, Claude Code, Codex, Cursor, Pi, and Ope
 stn setup
 ```
 
-This configures the core local workflow: the required tools, the selected/default agent CLI and its required Station tracking preparation, and a zero-project config. With no config, one runnable CLI is inferred; several runnable CLIs require an explicit guided selection. The first explicit selection becomes the default only for a new config. Add the first project explicitly in Station.
+This configures the core local workflow: the required tools, the selected/default agent CLI and its required Station tracking preparation, and a zero-project config. With no config, one runnable CLI is inferred; several runnable CLIs require an explicit guided selection. When setup creates or appends a selected harness block, it writes the resolved executable path when a bare command was satisfied through the setup process `PATH`, avoiding later Observer or tmux environment drift. The first explicit selection becomes the default only for a new config. Add the first project explicitly in Station.
 
 The compiled `stn` launches its TUI and Observer without Node.js, pnpm, or Bun. A local source checkout expects Node.js 24.2+ (and below 25), pnpm 11, and Bun 1.3.14 for development. Real-provider test lanes remain opt-in.
 `stn setup system --check` reports those versions, but it does not change the active Node or pnpm
@@ -238,7 +238,9 @@ drifted artifacts, probe failure, prepared state, and providers for which the ch
 resolved STATION config path, observer socket, state directory, spool directory,
 auto-start mode, and absolute `stn-ingress` launcher. Both
 `stn hooks doctor worktrunk` and full `stn doctor` validate that same expectation
-without requiring `--hook-bin`. Pi has no external artifact requirement. Codex artifact preparation
+without requiring `--hook-bin`. Pi has no external artifact requirement; Station injects the same
+absolute ingress launcher into Pi's launch environment as `STATION_INGRESS_BIN`, so Pi status events
+do not rely on bare launcher resolution in a pane or tmux server. Codex artifact preparation
 does not prove runtime delivery or hook trust: review may still be required through `/hooks`, and
 setup does not enable Codex's hook feature or bypass trust. To repair an artifact manually, run:
 

--- a/integrations/harness/pi/src/launch.ts
+++ b/integrations/harness/pi/src/launch.ts
@@ -1,6 +1,7 @@
 import { fileURLToPath } from "node:url";
 import type { BuildHarnessLaunchRequest, HarnessLaunchPlan } from "@station/contracts";
 import {
+  type CommonLaunchEnvOptions,
   type CommonProviderDataInput,
   commonProviderData,
   harnessLaunchEnv,
@@ -8,13 +9,12 @@ import {
 } from "@station/harness-shared";
 import { PiHarnessProviderError } from "./errors.js";
 
-export type PiLaunchOptions = {
+export type PiLaunchOptions = Pick<
+  CommonLaunchEnvOptions,
+  "configPath" | "observerSocketPath" | "stateDir" | "hookSpoolDir" | "hookBin"
+> & {
   command?: string;
   extensionPath?: string;
-  configPath?: string;
-  observerSocketPath?: string;
-  stateDir?: string;
-  hookSpoolDir?: string;
 };
 
 export function buildPiLaunchPlan(

--- a/integrations/harness/pi/src/provider.ts
+++ b/integrations/harness/pi/src/provider.ts
@@ -139,6 +139,9 @@ function buildLaunch(
   if (options.hookSpoolDir !== undefined) {
     launchOptions.hookSpoolDir = options.hookSpoolDir;
   }
+  if (options.hookBin !== undefined) {
+    launchOptions.hookBin = options.hookBin;
+  }
   return buildPiLaunchPlan(request, launchOptions);
 }
 

--- a/integrations/harness/pi/test/unit/launch.test.ts
+++ b/integrations/harness/pi/test/unit/launch.test.ts
@@ -15,6 +15,7 @@ describe("buildPiLaunchPlan", () => {
       observerSocketPath: "/tmp/station/run/observer.sock",
       stateDir: "/tmp/station/state",
       hookSpoolDir: "/tmp/station/state/spool/hooks",
+      hookBin: "/tmp/station/bin/stn-ingress",
     });
 
     expect(HarnessLaunchPlanSchema.parse(plan)).toEqual(plan);
@@ -36,6 +37,7 @@ describe("buildPiLaunchPlan", () => {
         STATION_OBSERVER_SOCKET_PATH: "/tmp/station/run/observer.sock",
         STATION_OBSERVER_STATE_DIR: "/tmp/station/state",
         STATION_HOOK_SPOOL_DIR: "/tmp/station/state/spool/hooks",
+        STATION_INGRESS_BIN: "/tmp/station/bin/stn-ingress",
       },
       providerData: {
         interactive: true,

--- a/integrations/harness/pi/test/unit/provider.test.ts
+++ b/integrations/harness/pi/test/unit/provider.test.ts
@@ -127,6 +127,7 @@ describe("PiHarnessProvider", () => {
       command: "pi-test",
       extensionPath: "/tmp/station/piExtension.js",
       configPath: "/tmp/station/config.toml",
+      hookBin: "/tmp/station/bin/stn-ingress",
       now: () => new Date(now),
     });
 
@@ -135,6 +136,7 @@ describe("PiHarnessProvider", () => {
       args: ["--extension", "/tmp/station/piExtension.js"],
       env: {
         STATION_CONFIG_PATH: "/tmp/station/config.toml",
+        STATION_INGRESS_BIN: "/tmp/station/bin/stn-ingress",
       },
     });
 

--- a/packages/harness-shared/src/index.ts
+++ b/packages/harness-shared/src/index.ts
@@ -19,6 +19,7 @@ export {
 export { createHarnessHookAdapter } from "./hookAdapter.js";
 export { createJsonHookConfigEditor, isJsonObject } from "./hooks/jsonConfig.js";
 export {
+  type CommonLaunchEnvOptions,
   type CommonProviderDataInput,
   commonProviderData,
   harnessLaunchEnv,

--- a/packages/harness-shared/src/launch.ts
+++ b/packages/harness-shared/src/launch.ts
@@ -9,6 +9,7 @@ export type CommonLaunchEnvOptions = {
   observerSocketPath?: string | undefined;
   stateDir?: string | undefined;
   hookSpoolDir?: string | undefined;
+  hookBin?: string | undefined;
   env?: Record<string, string | undefined> | undefined;
   carryEnv?: readonly LaunchEnvCarry[] | undefined;
 };
@@ -55,6 +56,10 @@ export function harnessLaunchEnv(
   }
   if (options.stateDir !== undefined) env.STATION_OBSERVER_STATE_DIR = options.stateDir;
   if (options.hookSpoolDir !== undefined) env.STATION_HOOK_SPOOL_DIR = options.hookSpoolDir;
+  if (options.hookBin !== undefined && options.hookBin.length > 0) {
+    // In-process harness extensions inherit pane/server env, so event delivery gets an explicit launcher.
+    env.STATION_INGRESS_BIN = options.hookBin;
+  }
   for (const carry of options.carryEnv ?? []) {
     carryLaunchEnv(env, carry, options.env);
   }

--- a/packages/harness-shared/test/unit/launch.test.ts
+++ b/packages/harness-shared/test/unit/launch.test.ts
@@ -66,6 +66,17 @@ describe("harnessLaunchEnv", () => {
       HOME: "/tmp/cursor-home",
     });
   });
+
+  it("carries a canonical ingress launcher for in-process event delivery", () => {
+    const env = harnessLaunchEnv("pi", request(), {
+      hookBin: "/tmp/station/bin/stn-ingress",
+    });
+
+    expect(env).toMatchObject({
+      STATION_HARNESS_PROVIDER: "pi",
+      STATION_INGRESS_BIN: "/tmp/station/bin/stn-ingress",
+    });
+  });
 });
 
 function request(): BuildHarnessLaunchRequest {


### PR DESCRIPTION
## What this fixes
Station's harness launch/setup flow could report Pi as setup-ready while the in-process Pi extension still depended on a bare `stn-ingress` lookup inside the launched Pi process. In stale or minimal tmux server environments, Pi could run normally but Station would miss status/event delivery. Setup also persisted bare harness commands even when the successful probe resolved through setup's PATH, leaving later Observer or tmux launches sensitive to PATH drift.

## What changed
- Pass the CLI-composed canonical ingress launcher into Pi harness providers and launch Pi with `STATION_INGRESS_BIN`.
- Move the hook-bin-to-launch-env mapping into `@station/harness-shared` so in-process harness integrations can share it.
- Record resolved harness executable paths during setup checks and use them when setup writes new harness config blocks.
- Surface resolved harness executable evidence in setup output and document the Pi ingress behavior.

## Testing
- `git diff --check`
- Not run: focused Vitest coverage because `pnpm` is not available in this shell (`/bin/bash: pnpm: command not found`).