### PR TITLE
fix(observer): keep known-target launches off inventory

### DIFF
--- a/apps/observer/src/commands/harnessLaunchPreflight.ts
+++ b/apps/observer/src/commands/harnessLaunchPreflight.ts
@@ -18,7 +18,8 @@ export type HarnessLaunchPreflightOptions = {
 /**
  * USE CASE
  *
- * Freshly verifies the selected harness health and hook delivery immediately before launch mutation.
+ * Freshly verifies selected-harness health and hook delivery immediately before launch mutation.
+ * Health gating awaits fresh cache evidence without waiting for serialized snapshot publication.
  */
 export async function assertHarnessLaunchPreconditionsOrThrow(
   options: HarnessLaunchPreflightOptions,
@@ -31,7 +32,7 @@ export async function assertHarnessLaunchPreconditionsOrThrow(
     throw harnessUnavailableError(provider.id);
   }
 
-  await options.providers.healthCache.refresh(provider.id);
+  await options.providers.healthCache.refreshUntilCached(provider.id);
   if (options.signal !== undefined) {
     throwIfAborted(options.signal);
   }

--- a/apps/observer/src/commands/router.ts
+++ b/apps/observer/src/commands/router.ts
@@ -1,7 +1,12 @@
 import type { ProviderProjectConfig, StationCommand } from "@station/contracts";
 import type { RuntimeClock } from "@station/runtime";
 import { createFeatureFlagEvaluator, type FeatureFlagEvaluator } from "../features/evaluator.js";
-import type { EventJournal, SessionGroupStore, SessionStore } from "../persistence/index.js";
+import type {
+  EventJournal,
+  ObservationStore,
+  SessionGroupStore,
+  SessionStore,
+} from "../persistence/index.js";
 import type { ProviderRegistry } from "../providers/registry.js";
 import type { ObserverCore } from "../reconcile/core.js";
 import type { ObserverEventBus } from "../runtime/eventBus.js";
@@ -47,7 +52,7 @@ export type RegisterObserverCommandHandlersOptions = {
   providers: ProviderRegistry;
   projects: readonly ProviderProjectConfig[];
   getProjects?: (() => readonly ProviderProjectConfig[]) | undefined;
-  persistence: SessionStore & SessionGroupStore & EventJournal;
+  persistence: SessionStore & SessionGroupStore & EventJournal & ObservationStore;
   featureFlags?: FeatureFlagEvaluator | undefined;
   eventBus?: ObserverEventBus | undefined;
   clock?: RuntimeClock | undefined;

--- a/apps/observer/src/commands/session/resumeAgent.ts
+++ b/apps/observer/src/commands/session/resumeAgent.ts
@@ -2,7 +2,7 @@ import type { ProviderProjectConfig, SafeError, WorktreeRow } from "@station/con
 import { worktreeHasLiveAgent } from "@station/contracts";
 import type { RuntimeClock } from "@station/runtime";
 import type { FeatureFlagEvaluator } from "../../features/evaluator.js";
-import type { EventJournal, SessionStore } from "../../persistence/index.js";
+import type { EventJournal, ObservationStore, SessionStore } from "../../persistence/index.js";
 import type { ProviderRegistry } from "../../providers/registry.js";
 import type { ObserverCore } from "../../reconcile/core.js";
 import type { ObserverEventBus } from "../../runtime/eventBus.js";
@@ -12,7 +12,6 @@ import { nowIso } from "../../utils/time.js";
 import { assertCommandType } from "../assertCommand.js";
 import type { HarnessLaunchPreflight } from "../harnessLaunchPreflight.js";
 import type { CommandHandler } from "../queue.js";
-import { reconcileAndPublish } from "../reconcile.js";
 import type { TerminalIntentRunner } from "../terminalIntentRunner.js";
 import {
   buildEnsureAgentWorkspaceIntent,
@@ -21,7 +20,7 @@ import {
   discardSessionSeedBestEffort,
   findProjectOrThrow,
   lookupWorktree,
-  publishSessionCreated,
+  reconcileAndPublishSessionCreated,
   resolveTerminalProviderOrThrow,
   type SessionCommandIdFactory,
   seedSession,
@@ -36,7 +35,7 @@ export type CreateSessionResumeAgentHandlerOptions = {
   terminalIntentRunner: TerminalIntentRunner;
   launchPreflight: HarnessLaunchPreflight;
   core: ObserverCore;
-  persistence: SessionStore & EventJournal;
+  persistence: SessionStore & EventJournal & ObservationStore;
   featureFlags: FeatureFlagEvaluator;
   eventBus?: ObserverEventBus | undefined;
   clock?: RuntimeClock | undefined;
@@ -95,7 +94,8 @@ export function createSessionResumeAgentHandler(
       row === undefined
         ? await lookupWorktree({
             providers: options.providers,
-            projectId: payload.projectId,
+            persistence: options.persistence,
+            project,
             worktreeId: payload.worktreeId,
             runtime,
           })
@@ -167,21 +167,30 @@ export function createSessionResumeAgentHandler(
       throw error;
     }
 
-    const nextSnapshot = await reconcileAndPublish({
+    const convergence = reconcileAndPublishSessionCreated({
       core: options.core,
       eventBus: options.eventBus,
+      persistence: options.persistence,
+      context,
+      sessionId,
       clock: options.clock,
       reason: "command:session.resumeAgent",
-      trace: context.trace,
     });
-    await publishSessionCreated({
-      snapshot: nextSnapshot,
-      sessionId,
-      persistence: options.persistence,
-      eventBus: options.eventBus,
-      context,
-      clock: options.clock,
-    });
+    if (row === undefined) {
+      // A targeted restart lookup must not wait behind the full discovery it bypassed.
+      void convergence.catch((error: unknown) => {
+        void options.logger
+          ?.warn("Deferred session resume convergence failed.", {
+            commandId: context.commandId,
+            traceId: context.trace.traceId,
+            sessionId,
+            error,
+          })
+          .catch(() => undefined);
+      });
+      return;
+    }
+    await convergence;
   };
 }
 

--- a/apps/observer/src/commands/session/shared.ts
+++ b/apps/observer/src/commands/session/shared.ts
@@ -26,12 +26,14 @@ import {
 } from "@station/runtime";
 import type {
   EventJournal,
+  ObservationStore,
   SessionSeedGroupPlacement,
   SessionSeedGroupProvenance,
   SessionSeedResult,
   SessionStore,
 } from "../../persistence/index.js";
 import type { ProviderRegistry } from "../../providers/registry.js";
+import type { ObserverCore } from "../../reconcile/core.js";
 import type { ObserverEventBus } from "../../runtime/eventBus.js";
 import type { StationLogger } from "../../stationLogger.js";
 import { linkAbortSignals, throwIfAborted } from "../cancellation.js";
@@ -47,6 +49,7 @@ import {
   worktreeMissingError,
 } from "../errors.js";
 import type { CommandHandlerContext } from "../queue.js";
+import { reconcileAndPublish } from "../reconcile.js";
 
 export { resolveHarnessProviderOrThrow, resolveTerminalProviderOrThrow } from "../providers.js";
 
@@ -192,17 +195,46 @@ export function validateSnapshotRow(row: WorktreeRow | undefined, projectId: str
 
 export async function lookupWorktree(input: {
   providers: ProviderRegistry;
-  projectId: string;
+  persistence: ObservationStore;
+  project: ProviderProjectConfig;
   worktreeId: string;
   runtime: SessionCommandLookupRuntime;
 }): Promise<WorktreeObservation> {
   if (input.providers.worktree.getWorktree === undefined) {
     throw worktreeMissingError({
-      projectId: input.projectId,
+      projectId: input.project.id,
       worktreeId: input.worktreeId,
       message: "The requested worktree is not visible to the worktree provider.",
     });
   }
+
+  const hint = (
+    await input.persistence.listProviderObservations({
+      entityKind: "worktree",
+      includeExpired: true,
+      latestOnly: true,
+    })
+  ).find(
+    (observation) =>
+      observation.entityKind === "worktree" &&
+      observation.provider === input.providers.worktree.id &&
+      observation.entityKey === input.worktreeId &&
+      observation.payload.id === input.worktreeId &&
+      observation.payload.projectId === input.project.id &&
+      observation.payload.registrationIdentity !== undefined,
+  );
+  const worktreeHint = hint?.entityKind === "worktree" ? hint.payload : undefined;
+  const request = {
+    projectId: input.project.id,
+    worktreeId: input.worktreeId,
+    ...(worktreeHint?.registrationIdentity === undefined
+      ? {}
+      : {
+          path: worktreeHint.path,
+          project: input.project,
+          expectedRegistrationIdentity: worktreeHint.registrationIdentity,
+        }),
+  };
 
   const worktree = await runProviderMutation(
     {
@@ -215,30 +247,33 @@ export async function lookupWorktree(input: {
         provider: input.providers.worktree.id,
       },
     },
-    () =>
-      input.providers.worktree.getWorktree?.({
-        projectId: input.projectId,
-        worktreeId: input.worktreeId,
-      }) as Promise<WorktreeObservation | null>,
+    () => input.providers.worktree.getWorktree?.(request) as Promise<WorktreeObservation | null>,
   );
   if (worktree === null) {
     throw worktreeMissingError({
-      projectId: input.projectId,
+      projectId: input.project.id,
       worktreeId: input.worktreeId,
       message: "The requested worktree is not visible to the worktree provider.",
     });
   }
-  if (worktree.projectId !== input.projectId) {
+  if (worktree.id !== input.worktreeId) {
+    throw worktreeMissingError({
+      projectId: input.project.id,
+      worktreeId: input.worktreeId,
+      message: "The worktree provider returned a different worktree than requested.",
+    });
+  }
+  if (worktree.projectId !== input.project.id) {
     throw commandValidationError({
       code: "WORKTREE_PROJECT_MISMATCH",
       message: "The requested worktree belongs to a different configured project.",
-      projectId: input.projectId,
+      projectId: input.project.id,
       worktreeId: input.worktreeId,
     });
   }
   if (worktree.state !== "exists") {
     throw worktreeMissingError({
-      projectId: input.projectId,
+      projectId: input.project.id,
       worktreeId: input.worktreeId,
       message: "The requested worktree no longer has a working directory.",
     });
@@ -566,6 +601,32 @@ export async function publishSessionCreated(input: {
   });
   input.eventBus?.publish(event);
   return session;
+}
+
+export async function reconcileAndPublishSessionCreated(input: {
+  core: ObserverCore;
+  eventBus?: ObserverEventBus | undefined;
+  persistence: EventJournal;
+  context: CommandHandlerContext;
+  sessionId: SessionId;
+  reason: string;
+  clock?: RuntimeClock | undefined;
+}): Promise<void> {
+  const snapshot = await reconcileAndPublish({
+    core: input.core,
+    eventBus: input.eventBus,
+    clock: input.clock,
+    reason: input.reason,
+    trace: input.context.trace,
+  });
+  await publishSessionCreated({
+    snapshot,
+    sessionId: input.sessionId,
+    persistence: input.persistence,
+    eventBus: input.eventBus,
+    context: input.context,
+    clock: input.clock,
+  });
 }
 
 function safeError(input: SafeError): SafeError {

--- a/apps/observer/src/commands/session/startAgent.ts
+++ b/apps/observer/src/commands/session/startAgent.ts
@@ -1,6 +1,6 @@
 import type { ProviderProjectConfig } from "@station/contracts";
 import type { RuntimeClock } from "@station/runtime";
-import type { EventJournal, SessionStore } from "../../persistence/index.js";
+import type { EventJournal, ObservationStore, SessionStore } from "../../persistence/index.js";
 import type { ProviderRegistry } from "../../providers/registry.js";
 import type { ObserverCore } from "../../reconcile/core.js";
 import type { ObserverEventBus } from "../../runtime/eventBus.js";
@@ -9,7 +9,6 @@ import { nowIso } from "../../utils/time.js";
 import { assertCommandType } from "../assertCommand.js";
 import type { HarnessLaunchPreflight } from "../harnessLaunchPreflight.js";
 import type { CommandHandler } from "../queue.js";
-import { reconcileAndPublish } from "../reconcile.js";
 import type { TerminalIntentRunner } from "../terminalIntentRunner.js";
 import {
   assertNoCurrentAgent,
@@ -18,7 +17,7 @@ import {
   discardSessionSeedBestEffort,
   findProjectOrThrow,
   lookupWorktree,
-  publishSessionCreated,
+  reconcileAndPublishSessionCreated,
   rememberedHarnessProviderForWorktree,
   resolveHarnessProviderOrThrow,
   resolveTerminalProviderOrThrow,
@@ -35,7 +34,7 @@ export type CreateSessionStartAgentHandlerOptions = {
   terminalIntentRunner: TerminalIntentRunner;
   launchPreflight: HarnessLaunchPreflight;
   core: ObserverCore;
-  persistence: SessionStore & EventJournal;
+  persistence: SessionStore & EventJournal & ObservationStore;
   eventBus?: ObserverEventBus | undefined;
   clock?: RuntimeClock | undefined;
   idFactory?: Partial<SessionCommandIdFactory> | undefined;
@@ -80,7 +79,8 @@ export function createSessionStartAgentHandler(
       row === undefined
         ? await lookupWorktree({
             providers: options.providers,
-            projectId: payload.projectId,
+            persistence: options.persistence,
+            project,
             worktreeId: payload.worktreeId,
             runtime,
           })
@@ -148,20 +148,29 @@ export function createSessionStartAgentHandler(
       throw error;
     }
 
-    const nextSnapshot = await reconcileAndPublish({
+    const convergence = reconcileAndPublishSessionCreated({
       core: options.core,
       eventBus: options.eventBus,
+      persistence: options.persistence,
+      context,
+      sessionId,
       clock: options.clock,
       reason: "command:session.startAgent",
-      trace: context.trace,
     });
-    await publishSessionCreated({
-      snapshot: nextSnapshot,
-      sessionId,
-      persistence: options.persistence,
-      eventBus: options.eventBus,
-      context,
-      clock: options.clock,
-    });
+    if (row === undefined) {
+      // A targeted restart lookup must not wait behind the full discovery it bypassed.
+      void convergence.catch((error: unknown) => {
+        void options.logger
+          ?.warn("Deferred session start convergence failed.", {
+            commandId: context.commandId,
+            traceId: context.trace.traceId,
+            sessionId,
+            error,
+          })
+          .catch(() => undefined);
+      });
+      return;
+    }
+    await convergence;
   };
 }

--- a/apps/observer/src/providers/healthCache.ts
+++ b/apps/observer/src/providers/healthCache.ts
@@ -26,11 +26,16 @@ type CacheEntry = {
   refreshedAtMs: number;
 };
 
+type InFlightProbe = {
+  cacheReady: Promise<void>;
+  complete: Promise<void>;
+};
+
 /**
  * Out-of-band provider health cache: reconcile reads synchronously and never
- * awaits a health probe during reconcile. Explicit launch preflights await the
- * selected provider's refresh while retaining the same single-flight operation.
- * Each unique probe notifies completion listeners before its in-flight slot clears,
+ * awaits a health probe during reconcile. Explicit launch preflights await fresh
+ * cached evidence without waiting for its serialized snapshot publication. Each
+ * unique probe still notifies completion listeners before its in-flight slot clears,
  * including boot, stale, eager, and launch refreshes.
  * `stn doctor` keeps probing providers live, bypassing this cache.
  */
@@ -40,7 +45,7 @@ export class ProviderHealthCache {
   readonly #timeoutMs: number;
   readonly #clock: RuntimeClock;
   readonly #entries = new Map<string, CacheEntry>();
-  readonly #inFlight = new Map<string, Promise<void>>();
+  readonly #inFlight = new Map<string, InFlightProbe>();
   readonly #probeCompletedListeners = new Set<ProviderHealthProbeCompletedListener>();
 
   constructor(options: ProviderHealthCacheOptions) {
@@ -61,17 +66,35 @@ export class ProviderHealthCache {
 
   /** Probe one provider now, ignoring TTL. Never rejects; joins an in-flight probe. */
   refresh(providerId: string): Promise<void> {
+    return this.#getOrStartProbe(providerId)?.complete ?? Promise.resolve();
+  }
+
+  /**
+   * Probe one provider and resolve when fresh evidence is readable from the cache.
+   * Completion publication remains part of the same in-flight probe.
+   */
+  refreshUntilCached(providerId: string): Promise<void> {
+    return this.#getOrStartProbe(providerId)?.cacheReady ?? Promise.resolve();
+  }
+
+  #getOrStartProbe(providerId: string): InFlightProbe | undefined {
     const inFlight = this.#inFlight.get(providerId);
     if (inFlight !== undefined) {
       return inFlight;
     }
     const target = this.#targets.get(providerId);
     if (target === undefined) {
-      return Promise.resolve();
+      return undefined;
     }
-    const probe = this.#probe(target).finally(() => {
+    let markCacheReady: () => void = () => undefined;
+    const cacheReady = new Promise<void>((resolve) => {
+      markCacheReady = resolve;
+    });
+    const complete = this.#probe(target, markCacheReady).finally(() => {
+      markCacheReady();
       this.#inFlight.delete(providerId);
     });
+    const probe = { cacheReady, complete };
     this.#inFlight.set(providerId, probe);
     return probe;
   }
@@ -87,7 +110,7 @@ export class ProviderHealthCache {
     await Promise.all(Array.from(this.#targets.keys(), (providerId) => this.refresh(providerId)));
   }
 
-  async #probe(target: ProviderHealthProbeTarget): Promise<void> {
+  async #probe(target: ProviderHealthProbeTarget, markCacheReady: () => void): Promise<void> {
     const result = await runRuntimeBoundaryWithTimeout(
       {
         operation: `provider.${target.providerId}.health`,
@@ -124,6 +147,7 @@ export class ProviderHealthCache {
           capabilities: target.capabilities(),
         };
     this.#entries.set(target.providerId, { health, refreshedAtMs: this.#nowMs() });
+    markCacheReady();
     const notifications = Array.from(this.#probeCompletedListeners, (listener) =>
       Promise.resolve().then(() => listener(health)),
     );

--- a/apps/observer/src/runtime/api.ts
+++ b/apps/observer/src/runtime/api.ts
@@ -82,6 +82,7 @@ import { logReconcileSchedulerProfile } from "./reconcileProfiling.js";
 import {
   type CreateReconcileSchedulerOptions,
   createReconcileScheduler,
+  type ReconcileScheduler,
 } from "./reconcileScheduler.js";
 import { createSpoolDrainer, type SpoolDrainDeps } from "./spoolDrain.js";
 
@@ -277,6 +278,7 @@ export function createObserverApi(options: CreateObserverApiOptions): ObserverAp
       buildStop(
         options,
         harnessIngressQueue,
+        reconcileScheduler,
         metadataRefresh,
         stopProviderHealthPublication,
         clock,
@@ -299,9 +301,8 @@ export function createObserverApi(options: CreateObserverApiOptions): ObserverAp
     reportHarnessEvent: async (report: HarnessEventReport): Promise<HarnessEventReportReceipt> =>
       harnessIngressQueue.enqueue(report),
     prepareExternalLaunch: (params) =>
-      prepareExternalLaunchSafe(options, worktreeMutations, reconciling, reconcileDeps, params),
-    reportExternalExit: (params) =>
-      reportExternalExitSafe(options, reconciling, reconcileDeps, params),
+      prepareExternalLaunchSafe(options, worktreeMutations, reconcileScheduler, params),
+    reportExternalExit: (params) => reportExternalExitSafe(options, reconcileScheduler, params),
   };
 
   return api;
@@ -328,22 +329,14 @@ function sessionRecoveryReadiness(options: CreateObserverApiOptions): SessionRec
   return readiness;
 }
 
-function reconcileAfterExternalLaunch(
-  deps: ReconcileExecutorDeps,
-  guard: { reconciling: boolean },
-  reason: string,
-  logger?: StationLogger,
-): void {
-  void runReconcile(deps, guard, reason).catch(async (error) => {
-    await logger?.error("Post-external-launch reconcile failed.", { reason, error });
-  });
+function reconcileAfterExternalLaunch(scheduler: ReconcileScheduler, reason: string): void {
+  scheduler.request(reason);
 }
 
 async function prepareExternalLaunchSafe(
   options: CreateObserverApiOptions,
   worktreeMutations: WorktreeMutationCoordinator,
-  reconciling: { reconciling: boolean },
-  reconcileDeps: ReconcileExecutorDeps,
+  reconcileScheduler: ReconcileScheduler,
   params: Parameters<ObserverApi["prepareExternalLaunch"]>[0],
 ): ReturnType<ObserverApi["prepareExternalLaunch"]> {
   const deps = assertProvidersAvailable(options, worktreeMutations);
@@ -373,31 +366,20 @@ async function prepareExternalLaunchSafe(
   }
   const { outcome, reconcile } = result;
   if (reconcile) {
-    reconcileAfterExternalLaunch(
-      reconcileDeps,
-      reconciling,
-      "agent.prepareExternalLaunch",
-      options.logger,
-    );
+    reconcileAfterExternalLaunch(reconcileScheduler, "agent.prepareExternalLaunch");
   }
   return outcome;
 }
 
 async function reportExternalExitSafe(
   options: CreateObserverApiOptions,
-  reconciling: { reconciling: boolean },
-  reconcileDeps: ReconcileExecutorDeps,
+  reconcileScheduler: ReconcileScheduler,
   params: Parameters<ObserverApi["reportExternalExit"]>[0],
 ): ReturnType<ObserverApi["reportExternalExit"]> {
   const providers = assertProviderRegistryAvailable(options);
   const { outcome, reconcile } = await reportExternalExit({ providers }, params);
   if (reconcile) {
-    reconcileAfterExternalLaunch(
-      reconcileDeps,
-      reconciling,
-      "agent.reportExternalExit",
-      options.logger,
-    );
+    reconcileAfterExternalLaunch(reconcileScheduler, "agent.reportExternalExit");
   }
   return outcome;
 }
@@ -582,12 +564,14 @@ async function buildHealth(
 async function buildStop(
   options: CreateObserverApiOptions,
   harnessIngressQueue: HarnessIngressQueue,
+  reconcileScheduler: ReconcileScheduler,
   metadataRefresh: WorktreeMetadataRefreshService | undefined,
   stopProviderHealthPublication: () => Promise<void>,
   clock: RuntimeClock,
 ): Promise<ObserverStopReceipt> {
   await options.onShutdownStarted?.();
   const providerHealthStopped = stopProviderHealthPublication();
+  await reconcileScheduler.shutdown();
   await harnessIngressQueue.shutdown();
   await metadataRefresh?.shutdown();
   await providerHealthStopped;

--- a/apps/observer/src/runtime/reconcileScheduler.ts
+++ b/apps/observer/src/runtime/reconcileScheduler.ts
@@ -2,6 +2,8 @@ import { Effect } from "@station/runtime";
 
 export type ReconcileScheduler = {
   request(reason: string): void;
+  /** Refuses queued work and waits for an active reconcile before shutdown continues. */
+  shutdown(): Promise<void>;
 };
 
 export type CreateReconcileSchedulerOptions = {
@@ -30,12 +32,17 @@ export function createReconcileScheduler(
   const debounceMs = options.debounceMs ?? defaultDebounceMs;
   const backlogDebounceMs = options.backlogDebounceMs ?? defaultBacklogDebounceMs;
   let running = false;
+  let stopped = false;
   let timerScheduled = false;
+  let activeFlush: Promise<void> | undefined;
   let firstQueuedAt: number | undefined;
   const queuedReasons: string[] = [];
 
   return {
     request: (reason) => {
+      if (stopped) {
+        return;
+      }
       if (queuedReasons.length === 0) {
         firstQueuedAt = Date.now();
       }
@@ -45,19 +52,33 @@ export function createReconcileScheduler(
       }
       scheduleFlush(debounceMs);
     },
+    shutdown: async () => {
+      stopped = true;
+      queuedReasons.length = 0;
+      firstQueuedAt = undefined;
+      timerScheduled = false;
+      await activeFlush;
+    },
   };
 
   function scheduleFlush(delayMs: number): void {
     timerScheduled = true;
-    void sleep(delayMs).then(
-      () => {
-        timerScheduled = false;
-        void flush().catch((error: unknown) => reportError(error));
-      },
-      () => {
-        timerScheduled = false;
-      },
-    );
+    const start = () => {
+      timerScheduled = false;
+      if (stopped) {
+        return;
+      }
+      const flight = flush().catch((error: unknown) => reportError(error));
+      activeFlush = flight;
+      void flight.finally(() => {
+        if (activeFlush === flight) {
+          activeFlush = undefined;
+        }
+      });
+    };
+    void sleep(delayMs).then(start, () => {
+      timerScheduled = false;
+    });
   }
 
   async function flush(): Promise<void> {
@@ -87,7 +108,7 @@ export function createReconcileScheduler(
         durationMs: Math.max(0, Date.now() - startedAt),
         queuedAfter,
       });
-      if (queuedReasons.length > 0 && !timerScheduled) {
+      if (!stopped && queuedReasons.length > 0 && !timerScheduled) {
         scheduleFlush(backlogDebounceMs);
       }
     }

--- a/apps/observer/test/integration/external-launch-reconcile.test.ts
+++ b/apps/observer/test/integration/external-launch-reconcile.test.ts
@@ -3,10 +3,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 import type {
+  AgentPrepareExternalLaunchResult,
   BuildHarnessLaunchRequest,
   HarnessHooksStatus,
   HarnessLaunchPlan,
   HarnessRunObservation,
+  ProviderProjectConfig,
+  WorktreeObservation,
 } from "@station/contracts";
 import { StationTerminalProvider } from "@station/terminal";
 import {
@@ -101,6 +104,90 @@ describe("observer external-launch reconcile", () => {
       }),
     ]);
 
+    fixture.sqlite.close();
+  });
+
+  it("does not await health publication queued behind an in-flight reconcile", async () => {
+    const stateDir = await mkdtemp(join(tmpdir(), "station-observer-ext-"));
+    const worktree = createFakeWorktree({
+      id: "wt_web_feature",
+      projectId: "web",
+      branch: "feature",
+      path: "/tmp/station/web/feature",
+      now,
+    });
+    const worktreeProvider = new BlockingListWorktreeProvider({
+      now,
+      worktrees: [worktree],
+    });
+    const fixture = createFixture(providerIngressSpoolDir(stateDir), {
+      worktree: worktreeProvider,
+    });
+    await fixture.api.reconcile("seed");
+
+    const blocked = worktreeProvider.blockNextList();
+    const reconcile = fixture.api.reconcile("blocked-worktree-list");
+    await blocked.started;
+    const listCallsBeforeLaunch = worktreeProvider.listCalls;
+    let timeout: NodeJS.Timeout | undefined;
+    let result: AgentPrepareExternalLaunchResult;
+    try {
+      result = await Promise.race([
+        fixture.api.prepareExternalLaunch({
+          projectId: "web",
+          worktreeId: "wt_web_feature",
+        }),
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error("External launch waited for the in-flight reconcile.")),
+            250,
+          );
+        }),
+      ]);
+    } finally {
+      if (timeout !== undefined) clearTimeout(timeout);
+      blocked.release();
+    }
+
+    expect(result.kind).toBe("prepared");
+    expect(worktreeProvider.listCalls).toBe(listCallsBeforeLaunch);
+    expect(await fixture.station.listTargets()).toHaveLength(1);
+    await reconcile;
+    await waitForStableCount(() => worktreeProvider.listCalls);
+    await fixture.api.reconcile("flush-post-launch-reconcile");
+    fixture.sqlite.close();
+  });
+
+  it("coalesces a burst of launch-triggered maintenance scans", async () => {
+    const stateDir = await mkdtemp(join(tmpdir(), "station-observer-ext-"));
+    const worktrees = Array.from({ length: 4 }, (_, index) =>
+      createFakeWorktree({
+        id: `wt_web_feature_${index}`,
+        projectId: "web",
+        branch: `feature-${index}`,
+        path: `/tmp/station/web/feature-${index}`,
+        now,
+      }),
+    );
+    const worktreeProvider = new BlockingListWorktreeProvider({ now, worktrees });
+    const fixture = createFixture(providerIngressSpoolDir(stateDir), {
+      worktree: worktreeProvider,
+    });
+    await fixture.api.reconcile("seed-launch-burst");
+    const listCallsBeforeLaunch = worktreeProvider.listCalls;
+
+    await Promise.all(
+      worktrees.map((worktree) =>
+        fixture.api.prepareExternalLaunch({ projectId: "web", worktreeId: worktree.id }),
+      ),
+    );
+    await waitForStableCount(() => worktreeProvider.listCalls);
+    await fixture.api.reconcile("launch-burst-barrier");
+
+    const postLaunchScans = worktreeProvider.listCalls - listCallsBeforeLaunch - 1;
+    expect(postLaunchScans).toBe(1);
+    expect(await fixture.station.listTargets()).toHaveLength(4);
+    expect(await fixture.persistence.listSessions()).toHaveLength(4);
     fixture.sqlite.close();
   });
 
@@ -272,8 +359,9 @@ function createFixture(
   spoolDir: string,
   options: {
     harness?: FakeHarnessProvider;
-    logger?: StationLogger;
     config?: StationConfig;
+    worktree?: FakeWorktreeProvider;
+    logger?: StationLogger;
   } = {},
 ) {
   const clock = { now: () => new Date(now) };
@@ -284,20 +372,22 @@ function createFixture(
   const station = new StationTerminalProvider({ clock });
   const harness = options.harness ?? new FakeHarnessProvider({ now });
   const providers = new ProviderRegistry({
-    worktree: new FakeWorktreeProvider({
-      now,
-      worktrees: [
-        createFakeWorktree({
-          id: "wt_web_feature",
-          projectId: "web",
-          branch: "feature",
-          path: "/tmp/station/web/feature",
-          remote: { host: "github.com", owner: "example", repo: "web" },
-          headSha: "2222222222222222222222222222222222222222",
-          now,
-        }),
-      ],
-    }),
+    worktree:
+      options.worktree ??
+      new FakeWorktreeProvider({
+        now,
+        worktrees: [
+          createFakeWorktree({
+            id: "wt_web_feature",
+            projectId: "web",
+            branch: "feature",
+            path: "/tmp/station/web/feature",
+            remote: { host: "github.com", owner: "example", repo: "web" },
+            headSha: "2222222222222222222222222222222222222222",
+            now,
+          }),
+        ],
+      }),
     terminal: new FakeTerminalProvider({ now }),
     managedTerminal: station,
     harnesses: [harness],
@@ -317,7 +407,43 @@ function createFixture(
     clock,
     ...(options.logger === undefined ? {} : { logger: options.logger }),
   });
-  return { api, harness, persistence, sqlite };
+  return { api, harness, persistence, sqlite, station };
+}
+
+class BlockingListWorktreeProvider extends FakeWorktreeProvider {
+  listCalls = 0;
+  #blocked:
+    | {
+        started: Promise<void>;
+        markStarted: () => void;
+        wait: Promise<void>;
+        release: () => void;
+      }
+    | undefined;
+
+  blockNextList(): { started: Promise<void>; release: () => void } {
+    let markStarted = () => undefined;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    let release = () => undefined;
+    const wait = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.#blocked = { started, markStarted, wait, release };
+    return { started, release };
+  }
+
+  override async listWorktrees(project: ProviderProjectConfig): Promise<WorktreeObservation[]> {
+    this.listCalls += 1;
+    const blocked = this.#blocked;
+    if (blocked !== undefined) {
+      this.#blocked = undefined;
+      blocked.markStarted();
+      await blocked.wait;
+    }
+    return super.listWorktrees(project);
+  }
 }
 
 class MissingHooksHarness extends FakeHarnessProvider {
@@ -366,4 +492,20 @@ async function waitFor(predicate: () => boolean | Promise<boolean>): Promise<voi
     await new Promise((resolve) => setTimeout(resolve, 5));
   }
   throw new Error("Timed out waiting for predicate.");
+}
+
+async function waitForStableCount(read: () => number): Promise<void> {
+  let previous = read();
+  let stableSince = Date.now();
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const current = read();
+    if (current !== previous) {
+      previous = current;
+      stableSince = Date.now();
+    } else if (Date.now() - stableSince >= 150) {
+      return;
+    }
+  }
+  throw new Error("Timed out waiting for reconcile call count to stabilize.");
 }

--- a/apps/observer/test/integration/session-commands.test.ts
+++ b/apps/observer/test/integration/session-commands.test.ts
@@ -1,15 +1,18 @@
 import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 import type {
   BuildHarnessLaunchRequest,
+  GetWorktreeRequest,
   HarnessLaunchPlan,
   HarnessProvider,
   ManagedTerminalLaunchProcessResult,
   ManagedTerminalLifecycle,
   ProviderHealth,
+  ProviderProjectConfig,
   SafeError,
   TerminalIntent,
   TerminalIntentReceipt,
   TerminalLaunchProcessRequest,
+  WorktreeObservation,
 } from "@station/contracts";
 import { createCursorHarnessProvider } from "@station/cursor";
 import { createPiHarnessProvider } from "@station/pi";
@@ -1310,6 +1313,108 @@ describe("session command vertical slice", () => {
     fixture.sqlite.close();
   });
 
+  it("uses a durable worktree observation only as a validated restart lookup hint", async () => {
+    const worktree = createFakeWorktree({
+      id: "wt_web_restart_hint",
+      projectId: "web",
+      branch: "restart-hint",
+      now,
+    });
+    const requests: GetWorktreeRequest[] = [];
+    class RestartHintProvider extends FakeWorktreeProvider {
+      readonly listStarted: Promise<void>;
+      #markListStarted: (() => void) | undefined;
+      #releaseList: (() => void) | undefined;
+      readonly #listRelease: Promise<void>;
+
+      constructor() {
+        super({ now, worktrees: [worktree] });
+        this.listStarted = new Promise((resolve) => {
+          this.#markListStarted = resolve;
+        });
+        this.#listRelease = new Promise((resolve) => {
+          this.#releaseList = resolve;
+        });
+      }
+
+      releaseList(): void {
+        this.#releaseList?.();
+      }
+
+      override async listWorktrees(project: ProviderProjectConfig): Promise<WorktreeObservation[]> {
+        this.#markListStarted?.();
+        await this.#listRelease;
+        return super.listWorktrees(project);
+      }
+
+      override async getWorktree(request: GetWorktreeRequest): Promise<WorktreeObservation | null> {
+        requests.push(request);
+        return request.path === worktree.path &&
+          request.expectedRegistrationIdentity === worktree.registrationIdentity
+          ? worktree
+          : null;
+      }
+    }
+    const terminalIntentRunner = new CapturingTerminalIntentRunner();
+    const worktreeProvider = new RestartHintProvider();
+    const fixture = createFixture({
+      worktree: worktreeProvider,
+      terminalIntentRunner,
+      sessionIds: ["ses_restart_hint"],
+    });
+    await fixture.persistence.recordProviderObservation({
+      provider: "fake-worktree",
+      providerType: "worktree",
+      entityKind: "worktree",
+      entityKey: worktree.id,
+      payload: worktree,
+      observedAt: now,
+    });
+    expect(fixture.core.getSnapshot().rows).toEqual([]);
+    const startupReconcile = fixture.core.reconcile("observer.startup");
+    await worktreeProvider.listStarted;
+
+    const receipt = await fixture.queue.dispatch({
+      type: "session.startAgent",
+      payload: { projectId: "web", worktreeId: worktree.id },
+    });
+    const commandCompletion = fixture.queue.drain().then(() => true);
+    let timeout: NodeJS.Timeout | undefined;
+    const completedWhileDiscoveryBlocked = await Promise.race([
+      commandCompletion,
+      new Promise<false>((resolve) => {
+        timeout = setTimeout(resolve, 250, false);
+      }),
+    ]);
+    if (timeout !== undefined) clearTimeout(timeout);
+    expect(completedWhileDiscoveryBlocked).toBe(true);
+
+    await expect(fixture.persistence.getCommand(receipt.commandId)).resolves.toMatchObject({
+      status: "succeeded",
+    });
+    expect(requests).toEqual([
+      expect.objectContaining({
+        worktreeId: worktree.id,
+        projectId: "web",
+        path: worktree.path,
+        expectedRegistrationIdentity: worktree.registrationIdentity,
+      }),
+    ]);
+    expect(terminalIntentRunner.intents).toHaveLength(1);
+    await expect(fixture.persistence.listSessions()).resolves.toEqual([
+      expect.objectContaining({ id: "ses_restart_hint", worktreeId: worktree.id }),
+    ]);
+    const reconciledEvents = fixture.eventBus
+      .subscribe({ type: "observer.reconciled" })
+      [Symbol.asyncIterator]();
+    worktreeProvider.releaseList();
+    await startupReconcile;
+    await commandCompletion;
+    await reconciledEvents.next();
+    await reconciledEvents.return?.();
+    fixture.sqlite.close();
+  });
+
   it("submits session.startAgent launch work through the terminal intent runner seam", async () => {
     const terminalIntentRunner = new CapturingTerminalIntentRunner();
     const terminal = new FakeTerminalProvider({
@@ -2392,6 +2497,7 @@ function createFixture(
     sessionIds?: string[];
     sessionGroupIds?: string[];
     featureFlags?: { sessionResumeAgent?: boolean };
+    commandTimeoutMs?: number;
   } = {},
 ) {
   const clock = { now: () => new Date(now) };
@@ -2439,6 +2545,7 @@ function createFixture(
       sessionId: () => sessionIds.shift() ?? "ses_fallback",
       sessionGroupId: () => sessionGroupIds.shift() ?? "grp_fallback",
     },
+    commandTimeoutMs: options.commandTimeoutMs,
   });
   return { sqlite, persistence, eventBus, queue, providers, core };
 }

--- a/apps/observer/test/unit/providerHealthCache.test.ts
+++ b/apps/observer/test/unit/providerHealthCache.test.ts
@@ -89,6 +89,37 @@ describe("provider health cache", () => {
     expect(listener).toHaveBeenCalledWith(healthyResult("fake"));
   });
 
+  it("lets launch waiters use fresh cache evidence while ordinary refresh awaits publication", async () => {
+    let releaseListener = () => undefined;
+    const listenerBlocked = new Promise<void>((resolve) => {
+      releaseListener = resolve;
+    });
+    let markListenerStarted = () => undefined;
+    const listenerStarted = new Promise<void>((resolve) => {
+      markListenerStarted = resolve;
+    });
+    const cache = new ProviderHealthCache({
+      targets: [target("fake", async () => healthyResult("fake"))],
+    });
+    cache.onProbeCompleted(async () => {
+      markListenerStarted();
+      await listenerBlocked;
+    });
+
+    let refreshCompleted = false;
+    const refresh = cache.refresh("fake").then(() => {
+      refreshCompleted = true;
+    });
+    await cache.refreshUntilCached("fake");
+
+    expect(cache.read("fake")?.status).toBe("healthy");
+    expect(refreshCompleted).toBe(false);
+    await listenerStarted;
+    releaseListener();
+    await refresh;
+    expect(refreshCompleted).toBe(true);
+  });
+
   it("keeps refresh non-rejecting when a completion listener fails", async () => {
     const cache = new ProviderHealthCache({
       targets: [target("fake", async () => healthyResult("fake"))],

--- a/apps/observer/test/unit/reconcileScheduler.test.ts
+++ b/apps/observer/test/unit/reconcileScheduler.test.ts
@@ -109,6 +109,47 @@ describe("reconcile scheduler", () => {
     ]);
   });
 
+  it("drops queued work on shutdown", async () => {
+    const reasons: string[] = [];
+    const scheduler = createReconcileScheduler({
+      debounceMs: 20,
+      reconcile: async (reason) => {
+        reasons.push(reason);
+      },
+    });
+
+    scheduler.request("agent.prepareExternalLaunch");
+    await scheduler.shutdown();
+    await sleep(30);
+
+    expect(reasons).toEqual([]);
+  });
+
+  it("waits for an active reconcile on shutdown", async () => {
+    const reconcile = deferred<void>();
+    const started = deferred<void>();
+    const scheduler = createReconcileScheduler({
+      debounceMs: 0,
+      reconcile: async () => {
+        started.resolve();
+        await reconcile.promise;
+      },
+    });
+
+    scheduler.request("agent.prepareExternalLaunch");
+    await started.promise;
+    let stopped = false;
+    const shutdown = scheduler.shutdown().then(() => {
+      stopped = true;
+    });
+    await drainMicrotasks();
+    expect(stopped).toBe(false);
+
+    reconcile.resolve();
+    await shutdown;
+    expect(stopped).toBe(true);
+  });
+
   it("waits for a backlog quiet period before follow-up reconcile", async () => {
     const reasons: string[] = [];
     const firstReconcile = deferred<void>();

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -537,7 +537,7 @@
           "name": "assertHarnessLaunchPreconditionsOrThrow",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Freshly verifies the selected harness health and hook delivery immediately before launch mutation."
+          "purpose": "Freshly verifies selected-harness health and hook delivery immediately before launch mutation. Health gating awaits fresh cache evidence without waiting for serialized snapshot publication."
         },
         {
           "name": "HarnessLaunchPreflight",
@@ -1096,7 +1096,7 @@
           "specifier": "../persistence/index.js",
           "resolvedPath": "apps/observer/src/persistence/index.ts",
           "edgeKind": "type-only",
-          "bindings": ["EventJournal", "SessionGroupStore", "SessionStore"]
+          "bindings": ["EventJournal", "ObservationStore", "SessionGroupStore", "SessionStore"]
         },
         {
           "specifier": "../providers/registry.js",
@@ -1769,12 +1769,6 @@
           "bindings": ["CommandHandler"]
         },
         {
-          "specifier": "../reconcile.js",
-          "resolvedPath": "apps/observer/src/commands/reconcile.ts",
-          "edgeKind": "runtime",
-          "bindings": ["reconcileAndPublish"]
-        },
-        {
           "specifier": "./shared.js",
           "resolvedPath": "apps/observer/src/commands/session/shared.ts",
           "edgeKind": "runtime",
@@ -1785,7 +1779,7 @@
             "discardSessionSeedBestEffort",
             "findProjectOrThrow",
             "lookupWorktree",
-            "publishSessionCreated",
+            "reconcileAndPublishSessionCreated",
             "resolveTerminalProviderOrThrow",
             "seedSession",
             "throwIfAborted",
@@ -1815,7 +1809,7 @@
           "specifier": "../../persistence/index.js",
           "resolvedPath": "apps/observer/src/persistence/index.ts",
           "edgeKind": "type-only",
-          "bindings": ["EventJournal", "SessionStore"]
+          "bindings": ["EventJournal", "ObservationStore", "SessionStore"]
         },
         {
           "specifier": "../../providers/registry.js",
@@ -1926,6 +1920,12 @@
         },
         {
           "name": "publishSessionCreated",
+          "kind": "function",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "reconcileAndPublishSessionCreated",
           "kind": "function",
           "role": null,
           "purpose": null
@@ -2048,11 +2048,18 @@
           "bindings": ["CommandHandlerContext"]
         },
         {
+          "specifier": "../reconcile.js",
+          "resolvedPath": "apps/observer/src/commands/reconcile.ts",
+          "edgeKind": "runtime",
+          "bindings": ["reconcileAndPublish"]
+        },
+        {
           "specifier": "../../persistence/index.js",
           "resolvedPath": "apps/observer/src/persistence/index.ts",
           "edgeKind": "type-only",
           "bindings": [
             "EventJournal",
+            "ObservationStore",
             "SessionSeedGroupPlacement",
             "SessionSeedGroupProvenance",
             "SessionSeedResult",
@@ -2064,6 +2071,12 @@
           "resolvedPath": "apps/observer/src/providers/registry.ts",
           "edgeKind": "type-only",
           "bindings": ["ProviderRegistry"]
+        },
+        {
+          "specifier": "../../reconcile/core.js",
+          "resolvedPath": "apps/observer/src/reconcile/core.ts",
+          "edgeKind": "type-only",
+          "bindings": ["ObserverCore"]
         },
         {
           "specifier": "../../runtime/eventBus.js",
@@ -2161,12 +2174,6 @@
           "bindings": ["CommandHandler"]
         },
         {
-          "specifier": "../reconcile.js",
-          "resolvedPath": "apps/observer/src/commands/reconcile.ts",
-          "edgeKind": "runtime",
-          "bindings": ["reconcileAndPublish"]
-        },
-        {
           "specifier": "./shared.js",
           "resolvedPath": "apps/observer/src/commands/session/shared.ts",
           "edgeKind": "runtime",
@@ -2177,7 +2184,7 @@
             "discardSessionSeedBestEffort",
             "findProjectOrThrow",
             "lookupWorktree",
-            "publishSessionCreated",
+            "reconcileAndPublishSessionCreated",
             "rememberedHarnessProviderForWorktree",
             "resolveHarnessProviderOrThrow",
             "resolveTerminalProviderOrThrow",
@@ -2203,7 +2210,7 @@
           "specifier": "../../persistence/index.js",
           "resolvedPath": "apps/observer/src/persistence/index.ts",
           "edgeKind": "type-only",
-          "bindings": ["EventJournal", "SessionStore"]
+          "bindings": ["EventJournal", "ObservationStore", "SessionStore"]
         },
         {
           "specifier": "../../providers/registry.js",
@@ -10449,7 +10456,7 @@
           "specifier": "./reconcileScheduler.js",
           "resolvedPath": "apps/observer/src/runtime/reconcileScheduler.ts",
           "edgeKind": "type-only",
-          "bindings": ["CreateReconcileSchedulerOptions"]
+          "bindings": ["CreateReconcileSchedulerOptions", "ReconcileScheduler"]
         },
         {
           "specifier": "./spoolDrain.js",
@@ -13557,7 +13564,7 @@
       "declaration": "assertHarnessLaunchPreconditionsOrThrow",
       "kind": "function",
       "role": "USE CASE",
-      "purpose": "Freshly verifies the selected harness health and hook delivery immediately before launch mutation.",
+      "purpose": "Freshly verifies selected-harness health and hook delivery immediately before launch mutation. Health gating awaits fresh cache evidence without waiting for serialized snapshot publication.",
       "dependencies": []
     },
     {
@@ -14415,13 +14422,6 @@
           "kind": "function",
           "role": "USE CASE",
           "edgeKind": "runtime"
-        },
-        {
-          "path": "apps/observer/src/stationLogger.ts",
-          "declaration": "StationLogger",
-          "kind": "interface",
-          "role": "DRIVEN PORT",
-          "edgeKind": "type-only"
         },
         {
           "path": "packages/contracts/src/observer.ts",

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -343,8 +343,8 @@ defined startup failure path and shutdown owner.
 ### Shutdown
 
 The API stop path first aborts and awaits duplicate inspection, then stops
-provider-health publication, drains harness ingress, marks metadata refresh
-terminal, aborts active local and repository reads, shuts down ref invalidation,
+provider-health publication, refuses queued reconciles and awaits an active scheduler flush,
+drains harness ingress, marks metadata refresh terminal, aborts active local and repository reads, shuts down ref invalidation,
 and waits for the refresh flight before process shutdown. Ref-watcher shutdown
 invalidates callbacks first, clears debounce timers, attempts every close despite
 individual failures, and makes later replacement and callbacks no-ops. During
@@ -389,6 +389,11 @@ reconcile repair.
 Changed Group events derive from the mutation result and are persisted and published in
 canonical order before command success; validated no-ops emit no Group event. This path
 does not read providers or publish `observer.reconciled`.
+
+`session.startAgent` and `session.resumeAgent` use current targeted provider evidence when
+the selected worktree is absent from the snapshot. A persisted path and registration
+identity may seed that lookup, but only the provider's fresh validation authorizes launch;
+full-inventory convergence runs afterward without holding foreground completion.
 
 `worktree.remove` carries the selected worktree ID, canonical path, branch, and
 opaque Git registration identity. Its use case refreshes provider evidence and
@@ -598,7 +603,7 @@ focus returns before any health or hook probe.
 `prepareExternalLaunch` and `reportExternalExit` are latency-sensitive
 handshakes rather than recorded commands. Their use cases depend on the
 composition-supplied `ManagedTerminalLifecycle`, carry provider-owned target IDs
-opaquely, and request reconcile after relevant lifecycle changes. Returning an
+opaquely, and request coalesced background reconcile after relevant lifecycle changes. Returning an
 attachable managed target or an existing live session precedes launch preflight.
 Target discovery includes Station Host reconstruction, so negotiated handoff and
 orphan-bridge adoption retain their existing PTY instead of entering provider
@@ -694,7 +699,7 @@ expires.
 | Spool drain | One configured drain runs at a time and processes stable filename order through direct durable ingress. Stable spool IDs survive legacy records without hook IDs; completion is idempotent after primary dedupe, and failed records remain on disk with attempt/error evidence. |
 | Hook auto-start throttle | `hook-autostart.lock` limits provider-hook spawn attempts only. It is never Observer ownership; each child still enters the socket-relative SQLite boot claim. |
 | Event delivery | Each subscriber currently has an unbounded in-memory queue. There is no replay or publisher backpressure; slow-subscriber growth is therefore a known operating characteristic. |
-| Background refresh | Each unique provider probe publishes its completed result through the serialized snapshot writer before its in-flight slot clears. Joined refresh callers do not duplicate publication; shutdown unsubscribes first and drains commits already in progress. Probe and metadata-refresh failures remain best-effort and do not block the primary reconcile result. Duplicate cleanup is one-shot after startup reconcile, single-flight, claim-authorized, and shutdown-cancellable rather than periodic. |
+| Background refresh | Each unique provider probe publishes its completed result through the serialized snapshot writer before its in-flight slot clears. Joined refresh callers do not duplicate publication; launch preflight may proceed once fresh evidence reaches the cache without waiting behind that serialized publication. Shutdown unsubscribes first and drains commits already in progress. Probe and metadata-refresh failures remain best-effort and do not block the primary reconcile result. Duplicate cleanup is one-shot after startup reconcile, single-flight, claim-authorized, and shutdown-cancellable rather than periodic. |
 
 Retry belongs at an adapter or runtime boundary whose owner can state why the
 operation is safe to repeat. Do not retry a mutation without an idempotency key,


### PR DESCRIPTION
## What this fixes

Starting, resuming, or externally launching an agent could wait behind a full worktree inventory scan even when Station already knew the selected worktree. Fresh launch health could also become readable in cache while the caller remained blocked behind serialized snapshot publication.

This is stack 2 of 5. Previous: #590. Next: #592. Merge the stack bottom-up; after #590 merges, retarget this PR to `main`. Tracks #595 and closes #597.

## What changed

- Use current targeted provider evidence when start or resume cannot find the selected worktree in the snapshot.
- Treat persisted path and registration data only as lookup hints that the provider must revalidate.
- Complete targeted start and resume before the deferred full-inventory convergence scan.
- Let launch preflight proceed as soon as fresh health evidence is cached while retaining serialized publication.
- Route external-launch maintenance through the coalescing reconcile scheduler and drain active scheduler work during shutdown.

## Testing

- `pnpm build` — 24/24 packages passed.
- `pnpm typecheck` — 46/46 tasks passed.
- `pnpm lint`, architecture checks, and the timer-boundary diagnostic passed.
- 49 focused integration tests and 17 focused unit tests passed.

## User-visible behavior

Known-target start and resume no longer wait for unrelated worktree discovery. Bursts of external launch maintenance coalesce into one background scan. This PR does not add the still-experimental generalized post-session batching from WTL-0070.
