### PR TITLE
fix(protocol): replay command dispatch after lost responses

### DIFF
--- a/apps/observer/src/commands/queue.ts
+++ b/apps/observer/src/commands/queue.ts
@@ -1,5 +1,7 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
 import type {
+  CommandDispatchOptions,
   CommandId,
   CommandReceipt,
   StationCommand,
@@ -17,7 +19,12 @@ import {
   systemClock,
 } from "@station/runtime";
 import { createErrorEnvelope, toSafeError } from "../diagnostics/errors.js";
-import type { CommandJournal, EventJournal, ObserverIdFactory } from "../persistence/index.js";
+import type {
+  CommandJournal,
+  EventJournal,
+  ObserverIdFactory,
+  PersistedCommand,
+} from "../persistence/index.js";
 import type { StationLogger } from "../stationLogger.js";
 import { nowIso } from "../utils/time.js";
 import { commandCancellationError, linkAbortSignals, throwIfAborted } from "./cancellation.js";
@@ -41,7 +48,7 @@ type CommandExecutionContext = Omit<
 export type CommandHandler = (context: CommandHandlerContext) => Promise<void>;
 
 export type CommandQueue = {
-  dispatch(command: StationCommand): Promise<CommandReceipt>;
+  dispatch(command: StationCommand, options?: CommandDispatchOptions): Promise<CommandReceipt>;
   drain(): Promise<void>;
   shutdown(): Promise<void>;
   registerHandler(commandType: StationCommand["type"], handler: CommandHandler): void;
@@ -74,13 +81,46 @@ export function createCommandQueue(options: CreateCommandQueueOptions): CommandQ
   );
   // Commands serialize by the narrowest stable identity we can infer; unrelated scopes run in parallel.
   const scopeChains = new Map<string, Promise<void>>();
+  const operationAdmissionChains = new Map<CommandId, Promise<void>>();
+  const executingCommandIds = new Set<CommandId>();
   const pending = new Set<Promise<void>>();
   const controllers = new Set<AbortController>();
   const commandTimeoutMs = options.commandTimeoutMs ?? 30_000;
   let shuttingDown = false;
 
+  const scheduleExecution = (
+    context: CommandExecutionContext,
+    controller = new AbortController(),
+  ): void => {
+    if (shuttingDown || executingCommandIds.has(context.commandId)) return;
+    const scope = commandScope(context.command);
+    const previous = scopeChains.get(scope) ?? Promise.resolve();
+    const execution = previous.then(() =>
+      executeCommand(options.persistence, handlers, clock, idFactory, context, {
+        ...(options.eventBus === undefined ? {} : { eventBus: options.eventBus }),
+        ...(options.logger === undefined ? {} : { logger: options.logger }),
+        signal: controller.signal,
+        commandTimeoutMs,
+      }),
+    );
+    // Keep the per-scope chain non-throwing; failures are persisted and later commands still run.
+    const settled = execution.catch(() => undefined);
+    scopeChains.set(scope, settled);
+    executingCommandIds.add(context.commandId);
+    controllers.add(controller);
+    pending.add(settled);
+    settled.finally(() => {
+      executingCommandIds.delete(context.commandId);
+      controllers.delete(controller);
+      pending.delete(settled);
+      if (scopeChains.get(scope) === settled) {
+        scopeChains.delete(scope);
+      }
+    });
+  };
+
   const queue: CommandQueue = {
-    dispatch: async (inputCommand) => {
+    dispatch: async (inputCommand, dispatchOptions) => {
       const command = StationCommandSchema.parse(inputCommand);
       if (shuttingDown) {
         const receipt: CommandReceipt = {
@@ -95,79 +135,63 @@ export function createCommandQueue(options: CreateCommandQueueOptions): CommandQ
         };
         return CommandReceiptSchema.parse(receipt);
       }
-      const commandId = idFactory.commandId();
-      const trace = createTraceContext({ operation: `command.${command.type}` });
-      const controller = new AbortController();
-      const acceptedEvent: StationEvent = {
-        type: "command.accepted",
-        commandId,
-        command,
-        traceId: trace.traceId,
-        spanId: trace.spanId,
-      };
-      await options.persistence.recordCommandAccepted({
-        commandId,
-        command,
-        createdAt: nowIso(clock),
-        traceId: trace.traceId,
-        spanId: trace.spanId,
-      });
-      await options.persistence.recordEvent(acceptedEvent, {
-        commandId,
-        traceId: trace.traceId,
-        spanId: trace.spanId,
-        createdAt: nowIso(clock),
-      });
-      await options.logger?.info("Command accepted.", {
-        commandId,
-        commandType: command.type,
-        traceId: trace.traceId,
-        spanId: trace.spanId,
-      });
-      options.eventBus?.publish(acceptedEvent);
-
-      const scope = commandScope(command);
-      const previous = scopeChains.get(scope) ?? Promise.resolve();
-      const execution = previous.then(() =>
-        executeCommand(
-          options.persistence,
-          handlers,
-          clock,
-          idFactory,
-          {
-            commandId,
-            trace,
-            command,
-          },
-          {
-            ...(options.eventBus === undefined ? {} : { eventBus: options.eventBus }),
-            ...(options.logger === undefined ? {} : { logger: options.logger }),
-            signal: controller.signal,
-            commandTimeoutMs,
-          },
-        ),
-      );
-      // Keep the per-scope chain non-throwing; failures are persisted and later commands still run.
-      const settled = execution.catch(() => undefined);
-      scopeChains.set(scope, settled);
-      controllers.add(controller);
-      pending.add(settled);
-      settled.finally(() => {
-        controllers.delete(controller);
-        pending.delete(settled);
-        if (scopeChains.get(scope) === settled) {
-          scopeChains.delete(scope);
+      const commandId =
+        dispatchOptions?.operationId === undefined
+          ? idFactory.commandId()
+          : commandIdForOperation(dispatchOptions.operationId);
+      const admit = async (): Promise<CommandReceipt> => {
+        if (dispatchOptions?.operationId !== undefined) {
+          const replay = await recordedOperation(options.persistence, commandId, command);
+          if (replay !== undefined) {
+            if (replay.receipt.accepted) await resumeAcceptedOperation(replay.recorded);
+            return replay.receipt;
+          }
         }
-      });
-
-      const receipt: CommandReceipt = {
-        commandId,
-        traceId: trace.traceId,
-        spanId: trace.spanId,
-        accepted: true,
-        status: "accepted",
+        const trace = createTraceContext({ operation: `command.${command.type}` });
+        const acceptedEvent: StationEvent = {
+          type: "command.accepted",
+          commandId,
+          command,
+          traceId: trace.traceId,
+          spanId: trace.spanId,
+        };
+        try {
+          await options.persistence.recordCommandAccepted({
+            commandId,
+            command,
+            createdAt: nowIso(clock),
+            traceId: trace.traceId,
+            spanId: trace.spanId,
+          });
+        } catch (error) {
+          if (dispatchOptions?.operationId !== undefined) {
+            const replay = await recordedOperation(options.persistence, commandId, command);
+            if (replay !== undefined) {
+              if (replay.receipt.accepted) await resumeAcceptedOperation(replay.recorded);
+              return replay.receipt;
+            }
+          }
+          throw error;
+        }
+        await options.persistence.recordEvent(acceptedEvent, {
+          commandId,
+          traceId: trace.traceId,
+          spanId: trace.spanId,
+          createdAt: nowIso(clock),
+        });
+        await options.logger?.info("Command accepted.", {
+          commandId,
+          commandType: command.type,
+          traceId: trace.traceId,
+          spanId: trace.spanId,
+        });
+        options.eventBus?.publish(acceptedEvent);
+        scheduleExecution({ commandId, trace, command });
+        return acceptedReceipt(commandId, trace);
       };
-      return CommandReceiptSchema.parse(receipt);
+      return dispatchOptions?.operationId === undefined
+        ? admit()
+        : withOperationAdmission(operationAdmissionChains, commandId, admit);
     },
 
     drain: async () => {
@@ -189,7 +213,121 @@ export function createCommandQueue(options: CreateCommandQueueOptions): CommandQ
     },
   };
 
+  async function resumeAcceptedOperation(recorded: PersistedCommand): Promise<void> {
+    if (recorded.status !== "accepted" || executingCommandIds.has(recorded.id) || shuttingDown) {
+      return;
+    }
+    const trace = traceFromRecordedCommand(recorded);
+    const acceptedEvents = await options.persistence.listEvents({
+      commandId: recorded.id,
+      type: "command.accepted",
+    });
+    if (acceptedEvents.length === 0) {
+      const acceptedEvent: StationEvent = {
+        type: "command.accepted",
+        commandId: recorded.id,
+        command: recorded.command,
+        traceId: trace.traceId,
+        spanId: trace.spanId,
+      };
+      await options.persistence.recordEvent(acceptedEvent, {
+        commandId: recorded.id,
+        traceId: trace.traceId,
+        spanId: trace.spanId,
+        createdAt: recorded.createdAt,
+      });
+      options.eventBus?.publish(acceptedEvent);
+    }
+    const current = await options.persistence.getCommand(recorded.id);
+    if (current?.status === "accepted") {
+      scheduleExecution({ commandId: current.id, trace, command: current.command });
+    }
+  }
+
   return queue;
+}
+
+function commandIdForOperation(operationId: string): CommandId {
+  const digest = createHash("sha256").update(operationId).digest("hex");
+  return `cmd_op_${digest}`;
+}
+
+async function recordedOperation(
+  persistence: CommandJournal,
+  commandId: CommandId,
+  command: StationCommand,
+): Promise<{ recorded: PersistedCommand; receipt: CommandReceipt } | undefined> {
+  const recorded = await persistence.getCommand(commandId);
+  if (recorded === undefined) return undefined;
+  if (!isDeepStrictEqual(recorded.command, command)) {
+    return {
+      recorded,
+      receipt: CommandReceiptSchema.parse({
+        commandId,
+        accepted: false,
+        status: "rejected",
+        error: {
+          tag: "CommandValidationError",
+          code: "COMMAND_OPERATION_CONFLICT",
+          message: "This command operation identity was already used for different input.",
+          hint: "Retry only the original command or dispatch a new operation.",
+          commandId,
+        },
+      }),
+    };
+  }
+  return { recorded, receipt: receiptFromRecordedOperation(recorded) };
+}
+
+function traceFromRecordedCommand(recorded: PersistedCommand): TraceContext {
+  const fallback = createTraceContext({ operation: `command.${recorded.command.type}` });
+  return {
+    traceId: recorded.traceId ?? fallback.traceId,
+    spanId: recorded.spanId ?? fallback.spanId,
+    operation: `command.${recorded.command.type}`,
+  };
+}
+
+async function withOperationAdmission<T>(
+  chains: Map<CommandId, Promise<void>>,
+  commandId: CommandId,
+  task: () => Promise<T>,
+): Promise<T> {
+  const previous = chains.get(commandId) ?? Promise.resolve();
+  let release: () => void = () => undefined;
+  const turn = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const current = previous.then(() => turn);
+  chains.set(commandId, current);
+  await previous;
+  try {
+    return await task();
+  } finally {
+    release();
+    if (chains.get(commandId) === current) chains.delete(commandId);
+  }
+}
+
+function acceptedReceipt(commandId: CommandId, trace: TraceContext): CommandReceipt {
+  return CommandReceiptSchema.parse({
+    commandId,
+    traceId: trace.traceId,
+    spanId: trace.spanId,
+    accepted: true,
+    status: "accepted",
+  });
+}
+
+function receiptFromRecordedOperation(recorded: PersistedCommand): CommandReceipt {
+  const receipt: CommandReceipt = {
+    commandId: recorded.id,
+    accepted: true,
+    status: "accepted",
+  };
+  if (recorded.traceId !== undefined) receipt.traceId = recorded.traceId;
+  if (recorded.spanId !== undefined) receipt.spanId = recorded.spanId;
+  return CommandReceiptSchema.parse(receipt);
 }
 
 async function executeCommand(

--- a/apps/observer/src/runtime/api.ts
+++ b/apps/observer/src/runtime/api.ts
@@ -1,5 +1,6 @@
 import { type ConfigDiagnostic, emptyConfig, type StationConfig } from "@station/config";
 import type {
+  CommandDispatchOptions,
   CommandId,
   CommandRecord,
   DiagnosticCollectionOptions,
@@ -287,7 +288,8 @@ export function createObserverApi(options: CreateObserverApiOptions): ObserverAp
     getSessionRecoveryReadiness: async () => sessionRecoveryReadiness(options),
     subscribe: (filter?: EventFilter): AsyncIterable<StationEvent> =>
       options.eventBus.subscribe(filter),
-    dispatch: (command: StationCommand) => options.commandQueue.dispatch(command),
+    dispatch: (command: StationCommand, dispatchOptions?: CommandDispatchOptions) =>
+      options.commandQueue.dispatch(command, dispatchOptions),
     getCommand: (commandId: CommandId) => getCommandById(options, commandId),
     runDoctor: (doctorOptions?: DoctorOptions): Promise<DoctorReport> =>
       runDoctor(buildDiagnosticDeps(options, clock), doctorOptions),

--- a/apps/observer/test/integration/command-queue.test.ts
+++ b/apps/observer/test/integration/command-queue.test.ts
@@ -1,4 +1,4 @@
-import type { StationCommand } from "@station/contracts";
+import type { StationCommand, StationEvent } from "@station/contracts";
 import { describe, expect, it } from "vitest";
 import { createCommandQueue } from "../../src/commands/queue";
 import { createSqliteObserverPersistence } from "../../src/persistence";
@@ -100,6 +100,169 @@ const createApiSessionGroupCommand: StationCommand = {
 };
 
 describe("observer command queue", () => {
+  it("returns the original durable receipt after queue reconstruction", async () => {
+    const { sqlite, persistence, queue } = createPersistenceAndQueue();
+    const handled: string[] = [];
+    const handler = async ({ commandId }: { commandId: string }) => {
+      handled.push(commandId);
+    };
+    queue.registerHandler("observer.reconcile", handler);
+
+    const first = await queue.dispatch(reconcileCommand, { operationId: "req_lost_response" });
+    await queue.drain();
+
+    const reconstructed = createCommandQueue({
+      persistence,
+      clock: { now: () => new Date(now) },
+    });
+    reconstructed.registerHandler("observer.reconcile", handler);
+    const replay = await reconstructed.dispatch(reconcileCommand, {
+      operationId: "req_lost_response",
+    });
+    await reconstructed.drain();
+
+    expect(replay).toEqual(first);
+    expect(handled).toEqual([first.commandId]);
+    expect(await persistence.listCommands()).toHaveLength(1);
+    sqlite.close();
+  });
+
+  it("recovers a stranded accepted operation exactly once", async () => {
+    const { sqlite, persistence } = createPersistenceAndQueue();
+    let injected = false;
+    const faultPersistence = {
+      ...persistence,
+      recordEvent: async (
+        event: StationEvent,
+        options?: Parameters<typeof persistence.recordEvent>[1],
+      ) => {
+        if (!injected && event.type === "command.accepted") {
+          injected = true;
+          throw new Error("injected accepted-event write failure");
+        }
+        return persistence.recordEvent(event, options);
+      },
+    };
+    const interrupted = createCommandQueue({
+      persistence: faultPersistence,
+      clock: { now: () => new Date(now) },
+    });
+    interrupted.registerHandler("observer.reconcile", async () => undefined);
+
+    await expect(
+      interrupted.dispatch(reconcileCommand, { operationId: "req_stranded_accepted" }),
+    ).rejects.toThrow("injected accepted-event write failure");
+    await interrupted.shutdown();
+
+    const handled: string[] = [];
+    const reconstructed = createCommandQueue({
+      persistence,
+      clock: { now: () => new Date(now) },
+    });
+    reconstructed.registerHandler("observer.reconcile", async ({ commandId }) => {
+      handled.push(commandId);
+    });
+    const [first, concurrent] = await Promise.all([
+      reconstructed.dispatch(reconcileCommand, { operationId: "req_stranded_accepted" }),
+      reconstructed.dispatch(reconcileCommand, { operationId: "req_stranded_accepted" }),
+    ]);
+    await reconstructed.drain();
+
+    expect(concurrent).toEqual(first);
+    expect(handled).toEqual([first.commandId]);
+    await expect(persistence.getCommand(first.commandId)).resolves.toMatchObject({
+      status: "succeeded",
+    });
+    expect(
+      (await persistence.listEvents({ commandId: first.commandId })).map((event) => event.type),
+    ).toEqual(["command.accepted", "command.started", "command.succeeded"]);
+    sqlite.close();
+  });
+
+  it("does not replay a started operation through another queue", async () => {
+    const { sqlite, persistence, queue } = createPersistenceAndQueue();
+    let release = () => undefined;
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let markStarted = () => undefined;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    queue.registerHandler("observer.reconcile", async () => {
+      markStarted();
+      await blocked;
+    });
+    const first = await queue.dispatch(reconcileCommand, {
+      operationId: "req_started_not_replayable",
+    });
+    await started;
+
+    let replayHandled = 0;
+    const reconstructed = createCommandQueue({
+      persistence,
+      clock: { now: () => new Date(now) },
+    });
+    reconstructed.registerHandler("observer.reconcile", async () => {
+      replayHandled += 1;
+    });
+    const replay = await reconstructed.dispatch(reconcileCommand, {
+      operationId: "req_started_not_replayable",
+    });
+    await reconstructed.drain();
+
+    expect(replay).toEqual(first);
+    expect(replayHandled).toBe(0);
+    release();
+    await queue.drain();
+    sqlite.close();
+  });
+
+  it("rejects an operation identity reused with different input", async () => {
+    const { sqlite, persistence, queue } = createPersistenceAndQueue();
+    const handled: string[] = [];
+    queue.registerHandler("observer.reconcile", async ({ commandId }) => {
+      handled.push(commandId);
+    });
+    queue.registerHandler("session.rename", async ({ commandId }) => {
+      handled.push(commandId);
+    });
+
+    const first = await queue.dispatch(reconcileCommand, { operationId: "req_conflict" });
+    await queue.drain();
+    const conflict = await queue.dispatch(renameSessionCommand, { operationId: "req_conflict" });
+    await queue.drain();
+
+    expect(conflict).toMatchObject({
+      commandId: first.commandId,
+      accepted: false,
+      status: "rejected",
+      error: { code: "COMMAND_OPERATION_CONFLICT" },
+    });
+    expect(handled).toEqual([first.commandId]);
+    expect(await persistence.listCommands()).toHaveLength(1);
+    sqlite.close();
+  });
+
+  it("admits concurrent exact operation replays only once", async () => {
+    const { sqlite, persistence, queue } = createPersistenceAndQueue();
+    const handled: string[] = [];
+    queue.registerHandler("observer.reconcile", async ({ commandId }) => {
+      handled.push(commandId);
+    });
+
+    const [first, replay] = await Promise.all([
+      queue.dispatch(reconcileCommand, { operationId: "req_concurrent" }),
+      queue.dispatch(reconcileCommand, { operationId: "req_concurrent" }),
+    ]);
+    await queue.drain();
+
+    expect(replay).toEqual(first);
+    expect(handled).toEqual([first.commandId]);
+    expect(await persistence.listCommands()).toHaveLength(1);
+    sqlite.close();
+  });
+
   it("records accepted, started, and succeeded lifecycle events", async () => {
     const { sqlite, persistence, queue } = createPersistenceAndQueue();
     const handled: string[] = [];

--- a/apps/observer/test/integration/protocol-server.test.ts
+++ b/apps/observer/test/integration/protocol-server.test.ts
@@ -374,7 +374,7 @@ describe("observer protocol server", () => {
     await fixture.queue.drain();
 
     await expect(client.getCommand(receipt.commandId)).resolves.toMatchObject({
-      id: "cmd_1",
+      id: receipt.commandId,
       status: "succeeded",
     });
     const groupReceipt = await client.dispatch({
@@ -383,7 +383,7 @@ describe("observer protocol server", () => {
     });
     await fixture.queue.drain();
     await expect(client.getCommand(groupReceipt.commandId)).resolves.toMatchObject({
-      id: "cmd_2",
+      id: groupReceipt.commandId,
       status: "succeeded",
     });
     await expect(client.getSnapshot()).resolves.toMatchObject({

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -783,7 +783,7 @@
           "specifier": "../persistence/index.js",
           "resolvedPath": "apps/observer/src/persistence/index.ts",
           "edgeKind": "type-only",
-          "bindings": ["CommandJournal", "EventJournal", "ObserverIdFactory"]
+          "bindings": ["CommandJournal", "EventJournal", "ObserverIdFactory", "PersistedCommand"]
         },
         {
           "specifier": "../stationLogger.js",
@@ -801,7 +801,13 @@
           "specifier": "node:crypto",
           "resolvedPath": "node:crypto",
           "edgeKind": "runtime",
-          "bindings": ["randomUUID"]
+          "bindings": ["createHash", "randomUUID"]
+        },
+        {
+          "specifier": "node:util",
+          "resolvedPath": "node:util",
+          "edgeKind": "runtime",
+          "bindings": ["isDeepStrictEqual"]
         },
         {
           "specifier": "@station/contracts",
@@ -814,6 +820,7 @@
           "resolvedPath": "packages/contracts/src/index.ts",
           "edgeKind": "type-only",
           "bindings": [
+            "CommandDispatchOptions",
             "CommandId",
             "CommandReceipt",
             "StationCommand",
@@ -10620,6 +10627,7 @@
           "resolvedPath": "packages/contracts/src/index.ts",
           "edgeKind": "type-only",
           "bindings": [
+            "CommandDispatchOptions",
             "CommandId",
             "CommandRecord",
             "DiagnosticCollectionOptions",
@@ -15532,7 +15540,7 @@
       "declaration": "createObserverClient",
       "kind": "function",
       "role": "ADAPTER",
-      "purpose": "Presents Observer operations to clients through validated NDJSON requests.",
+      "purpose": "Presents Observer operations to clients through validated NDJSON requests and replays a lost command-dispatch response once with the same durable operation identity.",
       "dependencies": []
     },
     {
@@ -15540,7 +15548,7 @@
       "declaration": "startProtocolServer",
       "kind": "function",
       "role": "ADAPTER",
-      "purpose": "Exposes Observer operations through validated NDJSON requests on a Unix socket.",
+      "purpose": "Exposes Observer operations through validated NDJSON requests on a Unix socket and routes the command request identity into durable admission replay.",
       "dependencies": [
         {
           "path": "packages/contracts/src/observer.ts",

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -380,6 +380,13 @@ unrelated scopes may run concurrently. Failure is normalized into `SafeError`,
 persisted with trace correlation, and published. A failed command does not
 poison the following command in its scope.
 
+The protocol client retries a lost dispatch response once with the same request
+identity. Command admission derives the same durable command ID and returns the
+recorded receipt for exact replay. A stranded `accepted` record resumes once and
+repairs missing acceptance evidence, while `started` and terminal records never
+reexecute. Reusing an identity with different command input refuses before
+mutation; a fresh request identity always denotes a distinct command.
+
 Recorded `sessionGroup.create`, `sessionGroup.rename`,
 `sessionGroup.updateMembership`, `sessionGroup.reparent`, and `sessionGroup.delete` commands serialize by
 project. Inside the snapshot-writer turn they validate configured-project and
@@ -694,6 +701,7 @@ expires.
 | Socket ownership evidence | Connect success proves listening. Only `ECONNREFUSED`, or Bun's existing-path `ENOENT`, plus strict zero-holder `lsof` evidence proves stale. Permission failures, timeouts, live holders, evidence failure, path replacement, and non-socket collisions are inaccessible and authorize no spawn, unlink, stop, or signal. |
 | Observer build ordering | Health and pidfile `version` carry display SemVer plus reserved `station.<sha256>` build metadata derived from both repository inputs and production package outputs. Exact identified selectors attach. At one display version, the lexicographically greater immutable build identity is the only candidate allowed to replace; the loser and any missing legacy identity refuse, so neither silently delegates to different code. Each source process verifies the published identity once before adopting it and reuses that selector without further Git or hash I/O for its lifetime. Different display versions retain SemVer precedence and the existing exact-string equal-precedence tiebreak, except that the declared public reset orders `0.0.0-pre-alpha.*` after internal `0.7.1-rc.*` previews. Missing, invalid, or stale identities refuse. Replacement requires complete corroborating identity and never uses automatic SIGKILL. |
 | Command ordering | Commands serialize by session, worktree, project, terminal target, or command-specific fallback scope. Different scopes can execute concurrently. |
+| Command admission replay | A protocol request identity deterministically addresses one durable command record. Exact replay returns its original receipt and may resume only a never-started accepted record; changed input for that identity refuses. The client retries only dispatch transport and preserves the identity across attempts. |
 | Managed target release | Station target IDs are deterministic per worktree, so release is compare-and-delete on target plus expected Station session. A delayed old exit or failed-launch cleanup cannot remove a replacement binding; `false` proves absence or supersession, while rejection leaves cleanup uncertain. |
 | Command timeout and cancellation | Handlers receive a signal combining the runtime timeout and queue shutdown. A handler with a non-cancellable durable section calls `beginCommit` after read-only validation and immediately before its first write; cancellation may prevent entry, but the queue drains a begun commit to one completion. Create and fork pass that signal into provider-owned reads and subprocesses; a timeout that cannot prove whether mutation completed returns an outcome-unknown error and schedules nonblocking reconcile repair. A provider-confirmed irreversible removal marks its external mutation committed so later timeout or cancellation drains synchronous classification instead of overwriting accurate success. Other cancellation remains cooperative, and the process shutdown backstop handles ignored signals. |
 | Snapshot writer ordering | Full reconciles, Group mutation commits, and harness-report authorization plus base projection share a non-poisoning promise chain. A Group mutation projects only its command project and never scans providers, repairs other durable state, or publishes a reconcile event. Readiness persistence revalidates the live snapshot after its write. Scheduled reconcile requests coalesce; queued work after a run receives a later flush. |

--- a/packages/contracts/src/observer.ts
+++ b/packages/contracts/src/observer.ts
@@ -52,6 +52,11 @@ export const ObserverProcessIdentitySchema = z
   })
   .strict();
 
+export type CommandDispatchOptions = {
+  /** Stable identity for safe durable command recovery or replaying its recorded receipt. */
+  operationId?: string;
+};
+
 export type ObserverProcessIdentity = z.infer<typeof ObserverProcessIdentitySchema>;
 
 export const ObserverSqliteHealthSummarySchema = z
@@ -222,7 +227,7 @@ export type ObserverApi = {
   getSnapshot(options?: { includeDebug?: boolean }): Promise<StationSnapshot>;
   getSessionRecoveryReadiness(): Promise<SessionRecoveryReadiness>;
   subscribe(filter?: EventFilter): AsyncIterable<StationEvent>;
-  dispatch(command: StationCommand): Promise<CommandReceipt>;
+  dispatch(command: StationCommand, options?: CommandDispatchOptions): Promise<CommandReceipt>;
   getCommand(commandId: CommandId): Promise<CommandRecord | undefined>;
   reconcile(reason?: string): Promise<ReconcileReceipt>;
   ingestProviderHookEvent(event: ProviderHookEvent): Promise<ProviderHookReceipt>;

--- a/packages/protocol/src/client.ts
+++ b/packages/protocol/src/client.ts
@@ -12,7 +12,11 @@ import type {
   StationEvent,
 } from "@station/contracts";
 import { STATION_SCHEMA_VERSION, StationEventSchema } from "@station/contracts";
-import { Effect, runRuntimeBoundaryWithTimeout } from "@station/runtime";
+import {
+  Effect,
+  runRuntimeBoundaryWithRetryAndTimeout,
+  runRuntimeBoundaryWithTimeout,
+} from "@station/runtime";
 import { z } from "zod";
 import {
   type ProtocolMethod,
@@ -86,7 +90,8 @@ const ProtocolEventEnvelopeMessageSchema = z
 /**
  * ADAPTER
  *
- * Presents Observer operations to clients through validated NDJSON requests.
+ * Presents Observer operations to clients through validated NDJSON requests and replays a lost
+ * command-dispatch response once with the same durable operation identity.
  */
 export function createObserverClient(options: CreateObserverClientOptions): ObserverClient {
   const requestId = options.requestId ?? defaultRequestId;
@@ -139,17 +144,22 @@ async function requestProtocolMethod<TMethod extends ProtocolMethod>(
 ): Promise<ProtocolResult<TMethod>> {
   const expectedObserver =
     method === "observer.health" ? undefined : resolveExpectedObserver(options);
-  const result = await runRuntimeBoundaryWithTimeout(
-    protocolClientBoundary(method, requestTimeoutMs(options)),
-    ({ signal }) =>
-      openRequestConnection(options, signal, async (connection) => {
-        const iterator = connection.messages()[Symbol.asyncIterator]();
-        if (expectedObserver !== undefined) {
-          await assertExpectedObserver(connection, iterator, `${id}_health`, expectedObserver);
-        }
-        return readResponseForRequest(connection, iterator, id, method, params);
-      }),
-  );
+  const task = ({ signal }: { signal: AbortSignal }) =>
+    openRequestConnection(options, signal, async (connection) => {
+      const iterator = connection.messages()[Symbol.asyncIterator]();
+      if (expectedObserver !== undefined) {
+        await assertExpectedObserver(connection, iterator, `${id}_health`, expectedObserver);
+      }
+      return readResponseForRequest(connection, iterator, id, method, params);
+    });
+  const boundary = protocolClientBoundary(method, requestTimeoutMs(options));
+  const result =
+    method === "command.dispatch"
+      ? await runRuntimeBoundaryWithRetryAndTimeout(
+          { ...boundary, retry: { retries: 1, delayMs: 10 } },
+          task,
+        )
+      : await runRuntimeBoundaryWithTimeout(boundary, task);
 
   return unwrapBoundaryResult(result);
 }

--- a/packages/protocol/src/server.ts
+++ b/packages/protocol/src/server.ts
@@ -41,7 +41,8 @@ export type ProtocolServerOptions = {
 /**
  * ADAPTER
  *
- * Exposes Observer operations through validated NDJSON requests on a Unix socket.
+ * Exposes Observer operations through validated NDJSON requests on a Unix socket and routes the
+ * command request identity into durable admission replay.
  */
 export async function startProtocolServer(
   options: ProtocolServerOptions,
@@ -159,7 +160,7 @@ async function routeSingleResponseRequest(
       }
       case "command.dispatch": {
         const params = CommandDispatchParamsSchema.parse(request.params);
-        return await api.dispatch(params.command);
+        return await api.dispatch(params.command, { operationId: request.id });
       }
       case "command.get": {
         const params = CommandGetParamsSchema.parse(request.params);

--- a/packages/protocol/test/integration/client-server.test.ts
+++ b/packages/protocol/test/integration/client-server.test.ts
@@ -22,9 +22,11 @@ describe("protocol client/server", () => {
     const { socketPath } = await createTempSocketPath();
     const commands = new Map<string, CommandRecord>();
     const snapshot = emptySnapshot();
+    let dispatchOperationId: string | undefined;
     const api = createFakeObserverApi({
       snapshot,
-      dispatch: async (command) => {
+      dispatch: async (command, options) => {
+        dispatchOperationId = options?.operationId;
         const record: CommandRecord = {
           id: "cmd_1",
           type: command.type,
@@ -65,6 +67,7 @@ describe("protocol client/server", () => {
       accepted: true,
       status: "accepted",
     });
+    expect(dispatchOperationId).toBe("req_4");
     await expect(client.getCommand("cmd_1")).resolves.toMatchObject({
       id: "cmd_1",
       type: "worktree.create",
@@ -572,6 +575,50 @@ describe("protocol client/server", () => {
         tag: "TimeoutError",
         code: "PROTOCOL_REQUEST_TIMEOUT",
       });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("retries a lost dispatch response with the same operation identity", async () => {
+    const { socketPath } = await createTempSocketPath();
+    const requestIds: string[] = [];
+    let connectionCount = 0;
+    const server = await listenUnixSocket({
+      socketPath,
+      onConnection: async (connection) => {
+        connectionCount += 1;
+        const iterator = connection.messages()[Symbol.asyncIterator]();
+        const request = ProtocolRequestSchema.parse((await iterator.next()).value);
+        requestIds.push(request.id);
+        if (connectionCount === 1) {
+          connection.close();
+          return;
+        }
+        connection.send(
+          protocolSuccessResponse(request.id, "command.dispatch", {
+            commandId: "cmd_recovered",
+            accepted: true,
+            status: "accepted",
+          }),
+        );
+      },
+    });
+    const client = createObserverClient({
+      socketPath,
+      timeoutMs: 500,
+      requestId: () => "req_lost_dispatch",
+    });
+
+    try {
+      await expect(
+        client.dispatch({
+          type: "worktree.create",
+          payload: { projectId: "web", branch: "recovered" },
+        }),
+      ).resolves.toMatchObject({ commandId: "cmd_recovered", accepted: true });
+      expect(connectionCount).toBe(2);
+      expect(requestIds).toEqual(["req_lost_dispatch", "req_lost_dispatch"]);
     } finally {
       await server.close();
     }


### PR DESCRIPTION
## What this fixes

A client could lose the response after Observer durably accepted a command and then create a second mutation when retrying. A process interruption between durable acceptance and handler scheduling could also strand an accepted command.

This is stack 4 of 5. Previous: #592. Next: #594. Merge the stack bottom-up; after #592 merges, retarget this PR to `main`. Tracks #595 and closes #599.

## What changed

- Retry only command-dispatch transport once, preserving the same protocol request identity.
- Derive one durable command ID from that operation identity and return the original receipt on exact replay.
- Resume only a never-started accepted record and repair missing acceptance evidence before scheduling it once.
- Never reexecute started, succeeded, or failed records during exact replay.
- Reject reuse of an operation identity with different command input before mutation.

## Testing

- `pnpm build` — 24/24 packages passed.
- `pnpm typecheck` — 46/46 tasks passed.
- `pnpm lint` and architecture checks passed.
- 37 focused queue and protocol client/server tests passed, plus the protocol dispatch/get smoke.

## Safety and scope

Replay identity is transport-owned and input-bound. This PR does not perform a broad startup scan or infer completion from current provider state; those responsibilities remain outside exact lost-response replay.
