### PR TITLE
fix(persistence): recover durable commands without blocking readers

### DIFF
--- a/apps/observer/src/commands/queue.ts
+++ b/apps/observer/src/commands/queue.ts
@@ -4,6 +4,7 @@ import type {
   CommandDispatchOptions,
   CommandId,
   CommandReceipt,
+  SafeError,
   StationCommand,
   StationEvent,
   TerminalClosePayload,
@@ -47,11 +48,30 @@ type CommandExecutionContext = Omit<
 
 export type CommandHandler = (context: CommandHandlerContext) => Promise<void>;
 
+export type CommandRecoveryContext = {
+  commandId: CommandId;
+  trace: TraceContext;
+  command: StationCommand;
+  error: SafeError;
+  trigger: "replay" | "startup";
+};
+
+/** Repairs durable terminal state without invoking the original mutation handler. */
+export type CommandRecoveryHandler = (
+  context: CommandRecoveryContext,
+) => Promise<"ignored" | "pending" | "recovered">;
+
 export type CommandQueue = {
   dispatch(command: StationCommand, options?: CommandDispatchOptions): Promise<CommandReceipt>;
+  /** Resumes accepted work and repairs evidence-backed states before startup readiness. */
+  recoverDurableCommands(): Promise<void>;
   drain(): Promise<void>;
   shutdown(): Promise<void>;
   registerHandler(commandType: StationCommand["type"], handler: CommandHandler): void;
+  registerRecoveryHandler(
+    commandType: StationCommand["type"],
+    handler: CommandRecoveryHandler,
+  ): void;
 };
 
 export type CreateCommandQueueOptions = {
@@ -79,9 +99,11 @@ export function createCommandQueue(options: CreateCommandQueueOptions): CommandQ
   const handlers = new Map<StationCommand["type"], CommandHandler>(
     Object.entries(options.handlers ?? {}) as [StationCommand["type"], CommandHandler][],
   );
+  const recoveryHandlers = new Map<StationCommand["type"], CommandRecoveryHandler>();
   // Commands serialize by the narrowest stable identity we can infer; unrelated scopes run in parallel.
   const scopeChains = new Map<string, Promise<void>>();
   const operationAdmissionChains = new Map<CommandId, Promise<void>>();
+  const attemptedRecoveryCommandIds = new Set<CommandId>();
   const executingCommandIds = new Set<CommandId>();
   const pending = new Set<Promise<void>>();
   const controllers = new Set<AbortController>();
@@ -92,7 +114,7 @@ export function createCommandQueue(options: CreateCommandQueueOptions): CommandQ
     context: CommandExecutionContext,
     controller = new AbortController(),
   ): void => {
-    if (shuttingDown || executingCommandIds.has(context.commandId)) return;
+    if (shuttingDown) return;
     const scope = commandScope(context.command);
     const previous = scopeChains.get(scope) ?? Promise.resolve();
     const execution = previous.then(() =>
@@ -119,6 +141,141 @@ export function createCommandQueue(options: CreateCommandQueueOptions): CommandQ
     });
   };
 
+  const repairSucceededEvent = async (current: PersistedCommand): Promise<void> => {
+    const succeededEvents = await options.persistence.listEvents({
+      commandId: current.id,
+      type: "command.succeeded",
+    });
+    if (succeededEvents.length > 0) return;
+    const trace = traceFromRecordedCommand(current);
+    const succeededEvent: StationEvent = {
+      type: "command.succeeded",
+      commandId: current.id,
+      traceId: trace.traceId,
+      spanId: trace.spanId,
+    };
+    await options.persistence.recordEvent(succeededEvent, {
+      commandId: current.id,
+      traceId: trace.traceId,
+      spanId: trace.spanId,
+      createdAt: current.finishedAt ?? nowIso(clock),
+    });
+    options.eventBus?.publish(succeededEvent);
+  };
+
+  const recoverRecordedOperation = async (
+    recorded: PersistedCommand,
+    trigger: CommandRecoveryContext["trigger"] = "replay",
+  ): Promise<void> => {
+    let current = (await options.persistence.getCommand(recorded.id)) ?? recorded;
+    if (current.status === "started" && current.command.type === "worktree.remove") {
+      const worktreeId = current.command.payload.worktreeId;
+      const events = await options.persistence.listEvents({ commandId: current.id });
+      const confirmedRemoval = events.some(
+        ({ event }) => event.type === "worktree.removed" && event.worktreeId === worktreeId,
+      );
+      if (confirmedRemoval) {
+        current = await options.persistence.markCommandSucceeded(current.id, nowIso(clock));
+      }
+    }
+    if (current.status === "succeeded") {
+      await repairSucceededEvent(current);
+      return;
+    }
+    if (current.status === "failed") {
+      const failedEvents = await options.persistence.listEvents({
+        commandId: current.id,
+        type: "command.failed",
+      });
+      if (failedEvents.length === 0 && current.error !== undefined) {
+        const trace = traceFromRecordedCommand(current);
+        const failedEvent: StationEvent = {
+          type: "command.failed",
+          commandId: current.id,
+          error: current.error,
+          traceId: trace.traceId,
+          spanId: trace.spanId,
+        };
+        await options.persistence.recordEvent(failedEvent, {
+          commandId: current.id,
+          traceId: trace.traceId,
+          spanId: trace.spanId,
+          createdAt: current.finishedAt ?? nowIso(clock),
+        });
+        options.eventBus?.publish(failedEvent);
+      }
+      const recoveryHandler = recoveryHandlers.get(current.command.type);
+      if (
+        recoveryHandler !== undefined &&
+        current.error !== undefined &&
+        !attemptedRecoveryCommandIds.has(current.id)
+      ) {
+        // A durable failure receives one repair sequence per queue lifetime; restart permits another.
+        attemptedRecoveryCommandIds.add(current.id);
+        const trace = traceFromRecordedCommand(current);
+        try {
+          const recovery = await recoveryHandler({
+            commandId: current.id,
+            trace,
+            command: current.command,
+            error: current.error,
+            trigger,
+          });
+          if (recovery === "ignored") {
+            attemptedRecoveryCommandIds.delete(current.id);
+          } else if (recovery === "recovered") {
+            current = await options.persistence.markCommandSucceeded(current.id, nowIso(clock));
+            attemptedRecoveryCommandIds.delete(current.id);
+            await repairSucceededEvent(current);
+          }
+        } catch (error) {
+          await options.logger
+            ?.error("Command terminal-state recovery failed.", {
+              commandId: current.id,
+              commandType: current.command.type,
+              traceId: trace.traceId,
+              error,
+            })
+            .catch(() => undefined);
+        }
+      }
+      return;
+    }
+    if (current.status !== "accepted" || executingCommandIds.has(current.id)) {
+      return;
+    }
+    const trace = traceFromRecordedCommand(current);
+    const acceptedEvents = await options.persistence.listEvents({
+      commandId: current.id,
+      type: "command.accepted",
+    });
+    if (acceptedEvents.length === 0) {
+      const acceptedEvent: StationEvent = {
+        type: "command.accepted",
+        commandId: current.id,
+        command: current.command,
+        traceId: trace.traceId,
+        spanId: trace.spanId,
+      };
+      await options.persistence.recordEvent(acceptedEvent, {
+        commandId: current.id,
+        traceId: trace.traceId,
+        spanId: trace.spanId,
+        createdAt: current.createdAt,
+      });
+      options.eventBus?.publish(acceptedEvent);
+    }
+    current = (await options.persistence.getCommand(current.id)) ?? current;
+    if (current.status !== "accepted") {
+      // Re-enter repair when another durable owner advances the command during acceptance repair.
+      await recoverRecordedOperation(current, trigger);
+      return;
+    }
+    if (!executingCommandIds.has(current.id)) {
+      scheduleExecution({ commandId: current.id, trace, command: current.command });
+    }
+  };
+
   const queue: CommandQueue = {
     dispatch: async (inputCommand, dispatchOptions) => {
       const command = StationCommandSchema.parse(inputCommand);
@@ -143,7 +300,9 @@ export function createCommandQueue(options: CreateCommandQueueOptions): CommandQ
         if (dispatchOptions?.operationId !== undefined) {
           const replay = await recordedOperation(options.persistence, commandId, command);
           if (replay !== undefined) {
-            if (replay.receipt.accepted) await resumeAcceptedOperation(replay.recorded);
+            if (replay.receipt.accepted) {
+              await recoverRecordedOperation(replay.recorded);
+            }
             return replay.receipt;
           }
         }
@@ -167,7 +326,9 @@ export function createCommandQueue(options: CreateCommandQueueOptions): CommandQ
           if (dispatchOptions?.operationId !== undefined) {
             const replay = await recordedOperation(options.persistence, commandId, command);
             if (replay !== undefined) {
-              if (replay.receipt.accepted) await resumeAcceptedOperation(replay.recorded);
+              if (replay.receipt.accepted) {
+                await recoverRecordedOperation(replay.recorded);
+              }
               return replay.receipt;
             }
           }
@@ -187,11 +348,53 @@ export function createCommandQueue(options: CreateCommandQueueOptions): CommandQ
         });
         options.eventBus?.publish(acceptedEvent);
         scheduleExecution({ commandId, trace, command });
-        return acceptedReceipt(commandId, trace);
+
+        const receipt: CommandReceipt = {
+          commandId,
+          traceId: trace.traceId,
+          spanId: trace.spanId,
+          accepted: true,
+          status: "accepted",
+        };
+        return CommandReceiptSchema.parse(receipt);
       };
       return dispatchOptions?.operationId === undefined
         ? admit()
         : withOperationAdmission(operationAdmissionChains, commandId, admit);
+    },
+
+    recoverDurableCommands: async () => {
+      const recoverable = await options.persistence.listCommandRecoveryCandidates({
+        failedCommandTypes: [...recoveryHandlers.keys()],
+      });
+      const recover = async (command: PersistedCommand): Promise<void> => {
+        try {
+          await withOperationAdmission(operationAdmissionChains, command.id, () =>
+            recoverRecordedOperation(command, "startup"),
+          );
+        } catch (error) {
+          await options.logger
+            ?.error("Command startup recovery failed.", {
+              commandId: command.id,
+              commandType: command.command.type,
+              error,
+            })
+            .catch(() => undefined);
+        }
+      };
+      const accepted = recoverable.filter((command) => command.status === "accepted");
+      const terminal = recoverable.filter((command) => command.status !== "accepted");
+      await Promise.all([
+        ...terminal.map(recover),
+        (async () => {
+          // Preserve durable admission order before scope chains begin executing accepted work.
+          for (const command of accepted) {
+            if (shuttingDown) break;
+            await recover(command);
+          }
+        })(),
+      ]);
+      await queue.drain();
     },
 
     drain: async () => {
@@ -211,38 +414,11 @@ export function createCommandQueue(options: CreateCommandQueueOptions): CommandQ
     registerHandler: (commandType, handler) => {
       handlers.set(commandType, handler);
     },
-  };
 
-  async function resumeAcceptedOperation(recorded: PersistedCommand): Promise<void> {
-    if (recorded.status !== "accepted" || executingCommandIds.has(recorded.id) || shuttingDown) {
-      return;
-    }
-    const trace = traceFromRecordedCommand(recorded);
-    const acceptedEvents = await options.persistence.listEvents({
-      commandId: recorded.id,
-      type: "command.accepted",
-    });
-    if (acceptedEvents.length === 0) {
-      const acceptedEvent: StationEvent = {
-        type: "command.accepted",
-        commandId: recorded.id,
-        command: recorded.command,
-        traceId: trace.traceId,
-        spanId: trace.spanId,
-      };
-      await options.persistence.recordEvent(acceptedEvent, {
-        commandId: recorded.id,
-        traceId: trace.traceId,
-        spanId: trace.spanId,
-        createdAt: recorded.createdAt,
-      });
-      options.eventBus?.publish(acceptedEvent);
-    }
-    const current = await options.persistence.getCommand(recorded.id);
-    if (current?.status === "accepted") {
-      scheduleExecution({ commandId: current.id, trace, command: current.command });
-    }
-  }
+    registerRecoveryHandler: (commandType, handler) => {
+      recoveryHandlers.set(commandType, handler);
+    },
+  };
 
   return queue;
 }
@@ -258,7 +434,9 @@ async function recordedOperation(
   command: StationCommand,
 ): Promise<{ recorded: PersistedCommand; receipt: CommandReceipt } | undefined> {
   const recorded = await persistence.getCommand(commandId);
-  if (recorded === undefined) return undefined;
+  if (recorded === undefined) {
+    return undefined;
+  }
   if (!isDeepStrictEqual(recorded.command, command)) {
     return {
       recorded,
@@ -305,18 +483,10 @@ async function withOperationAdmission<T>(
     return await task();
   } finally {
     release();
-    if (chains.get(commandId) === current) chains.delete(commandId);
+    if (chains.get(commandId) === current) {
+      chains.delete(commandId);
+    }
   }
-}
-
-function acceptedReceipt(commandId: CommandId, trace: TraceContext): CommandReceipt {
-  return CommandReceiptSchema.parse({
-    commandId,
-    traceId: trace.traceId,
-    spanId: trace.spanId,
-    accepted: true,
-    status: "accepted",
-  });
 }
 
 function receiptFromRecordedOperation(recorded: PersistedCommand): CommandReceipt {
@@ -391,30 +561,34 @@ async function executeCommand(
       trace: context.trace,
     },
     async ({ signal }) => {
-      // Combine runtime timeout and queue shutdown into the signal handlers receive.
-      const linked = linkAbortSignals(signal, runtime?.signal);
-      try {
-        // Check before and after handler work because provider calls may notice abort cooperatively.
-        throwIfAborted(linked.signal);
-        if (handler === undefined) {
-          throw missingCommandHandlerError();
-        }
-        handlerExecution = handler({
-          ...context,
-          signal: linked.signal,
-          beginCommit: () => {
+      handlerExecution = (async () => {
+        // Combine runtime timeout and queue shutdown into the signal handlers receive.
+        const linked = linkAbortSignals(signal, runtime?.signal);
+        try {
+          // Check before and after handler work because provider calls may notice abort cooperatively.
+          throwIfAborted(linked.signal);
+          if (handler === undefined) {
+            throw missingCommandHandlerError();
+          }
+          await handler({
+            ...context,
+            signal: linked.signal,
+            beginCommit: () => {
+              throwIfAborted(linked.signal);
+              commitStarted = true;
+            },
+            markExternalMutationCommitted: () => {
+              externalMutationCommitted = true;
+            },
+          });
+          if (!commitStarted && !externalMutationCommitted) {
             throwIfAborted(linked.signal);
-            commitStarted = true;
-          },
-          markExternalMutationCommitted: () => {
-            externalMutationCommitted = true;
-          },
-        });
-        await handlerExecution;
-        if (!commitStarted && !externalMutationCommitted) throwIfAborted(linked.signal);
-      } finally {
-        linked.cleanup();
-      }
+          }
+        } finally {
+          linked.cleanup();
+        }
+      })();
+      await handlerExecution;
     },
   );
 

--- a/apps/observer/src/commands/router.ts
+++ b/apps/observer/src/commands/router.ts
@@ -44,7 +44,10 @@ import { createTerminalCloseHandler, createTerminalFocusHandler } from "./termin
 import { createTerminalIntentRunner, type TerminalIntentRunner } from "./terminalIntentRunner.js";
 import { createWorktreeCreateHandler } from "./worktree/create.js";
 import { createWorktreeForkHandler } from "./worktree/fork.js";
-import { createWorktreeRemoveHandler } from "./worktree/remove.js";
+import {
+  createWorktreeRemoveHandler,
+  createWorktreeRemoveRecoveryHandler,
+} from "./worktree/remove.js";
 
 export type RegisterObserverCommandHandlersOptions = {
   queue: CommandQueue;
@@ -266,6 +269,16 @@ export function registerObserverCommandHandlers(
   for (const commandType of commandTypes) {
     options.queue.registerHandler(commandType, handlers[commandType]);
   }
+  options.queue.registerRecoveryHandler(
+    "worktree.remove",
+    createWorktreeRemoveRecoveryHandler({
+      core: options.core,
+      persistence: options.persistence,
+      eventBus: options.eventBus,
+      clock: options.clock,
+      logger: options.logger,
+    }),
+  );
 
   void options.logger?.info("Observer command handlers registered.", {
     commandTypes,

--- a/apps/observer/src/commands/worktree/remove.ts
+++ b/apps/observer/src/commands/worktree/remove.ts
@@ -26,7 +26,7 @@ import {
   resolveWorktreeRowOrThrow,
   stopHarnessForWorktree,
 } from "../cleanup/index.js";
-import type { CommandHandler } from "../queue.js";
+import type { CommandHandler, CommandRecoveryHandler } from "../queue.js";
 import { reconcileAndPublish } from "../reconcile.js";
 import { findProjectOrThrow, runProviderMutation, throwIfAborted } from "../session/shared.js";
 import type { TerminalIntentRunner } from "../terminalIntentRunner.js";
@@ -49,6 +49,7 @@ export type CreateWorktreeRemoveHandlerOptions = {
  * Revalidates selected checkout and Git registration identity before coordinating removal.
  * Provider-confirmed removal cannot be overwritten by later cancellation or event-journal
  * degradation; it retries atomic session/title retirement once before publishing removal evidence.
+ * A durable retirement failure authorizes only recovery replay of that idempotent completion path.
  */
 export function createWorktreeRemoveHandler(
   options: CreateWorktreeRemoveHandlerOptions,
@@ -276,6 +277,103 @@ function scheduleRemovalReconcile(input: {
       })
       .catch(() => undefined);
   });
+}
+
+/** Recovers only provider-confirmed removal retirement; it never invokes external cleanup. */
+export function createWorktreeRemoveRecoveryHandler(
+  options: Pick<
+    CreateWorktreeRemoveHandlerOptions,
+    "core" | "persistence" | "eventBus" | "clock" | "logger"
+  >,
+): CommandRecoveryHandler {
+  return async (context) => {
+    if (
+      context.command.type !== "worktree.remove" ||
+      context.error.code !== "WORKTREE_REMOVE_RETIREMENT_FAILED" ||
+      context.error.projectId === undefined ||
+      (context.command.payload.projectId !== undefined &&
+        context.error.projectId !== context.command.payload.projectId) ||
+      context.error.worktreeId !== context.command.payload.worktreeId
+    ) {
+      return "ignored";
+    }
+
+    let retirementError: unknown;
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        await options.persistence.retireRemovedWorktreeSessionState({
+          projectId: context.error.projectId,
+          worktreeId: context.command.payload.worktreeId,
+          endedAt: nowIso(options.clock),
+        });
+        retirementError = undefined;
+        break;
+      } catch (error) {
+        retirementError = error;
+      }
+    }
+    if (retirementError !== undefined) {
+      await options.logger
+        ?.error("Confirmed worktree removal retirement recovery failed.", {
+          commandId: context.commandId,
+          traceId: context.trace.traceId,
+          projectId: context.command.payload.projectId,
+          worktreeId: context.command.payload.worktreeId,
+          error: retirementError,
+        })
+        .catch(() => undefined);
+      return "pending";
+    }
+
+    let removalEventError: unknown;
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        await publishRemovedSessionIfAbsent({
+          previousSessionId: context.error.sessionId,
+          nextSessionIds: new Set(),
+          persistence: options.persistence,
+          eventBus: options.eventBus,
+          context,
+          clock: options.clock,
+        });
+        await publishWorktreeRemoved({
+          worktreeId: context.command.payload.worktreeId,
+          persistence: options.persistence,
+          eventBus: options.eventBus,
+          context,
+          clock: options.clock,
+        });
+        removalEventError = undefined;
+        break;
+      } catch (error) {
+        removalEventError = error;
+      }
+    }
+    if (removalEventError !== undefined) {
+      await options.logger
+        ?.error("Recovered worktree removal event publication failed.", {
+          commandId: context.commandId,
+          traceId: context.trace.traceId,
+          projectId: context.command.payload.projectId,
+          worktreeId: context.command.payload.worktreeId,
+          error: removalEventError,
+        })
+        .catch(() => undefined);
+    }
+    if (context.trigger === "replay") {
+      scheduleRemovalReconcile({
+        core: options.core,
+        eventBus: options.eventBus,
+        clock: options.clock,
+        logger: options.logger,
+        commandId: context.commandId,
+        trace: context.trace,
+        projectId: context.error.projectId,
+        worktreeId: context.command.payload.worktreeId,
+      });
+    }
+    return "recovered";
+  };
 }
 
 function worktreeRemovalRefusalDiagnostic(

--- a/apps/observer/src/migrations/018_command_recovery_lookup.ts
+++ b/apps/observer/src/migrations/018_command_recovery_lookup.ts
@@ -1,0 +1,13 @@
+import type { ObserverSqliteMigration } from "./migration.js";
+
+export const commandRecoveryLookupMigration: ObserverSqliteMigration = {
+  version: 18,
+  name: "command_recovery_lookup",
+  sql: `
+    CREATE INDEX IF NOT EXISTS idx_events_command_type
+      ON events (command_id, type);
+
+    CREATE INDEX IF NOT EXISTS idx_command_errors_command
+      ON command_errors (command_id);
+  `,
+};

--- a/apps/observer/src/migrations/index.ts
+++ b/apps/observer/src/migrations/index.ts
@@ -15,6 +15,7 @@ import { nativeBindingIngressClaimsMigration } from "./014_native_binding_ingres
 import { dropRecoveryBreadcrumbsMigration } from "./015_drop_recovery_breadcrumbs.js";
 import { worktreeDisplayTitlesMigration } from "./016_worktree_display_titles.js";
 import { sessionGroupsMigration } from "./017_session_groups.js";
+import { commandRecoveryLookupMigration } from "./018_command_recovery_lookup.js";
 
 /** @knipignore Retains the historical migration type import surface. */
 export type { ObserverSqliteMigration } from "./migration.js";
@@ -37,6 +38,7 @@ export const migrations = [
   dropRecoveryBreadcrumbsMigration,
   worktreeDisplayTitlesMigration,
   sessionGroupsMigration,
+  commandRecoveryLookupMigration,
 ] as const;
 
 export const latestSchemaVersion = migrations[migrations.length - 1]?.version ?? 0;

--- a/apps/observer/src/persistence/commands.ts
+++ b/apps/observer/src/persistence/commands.ts
@@ -11,8 +11,10 @@ import { stringifyJson } from "./json.js";
 import {
   commandErrorFromRow,
   commandFromRow,
+  eventFromRow,
   type SqliteCommandErrorRow,
   type SqliteCommandRow,
+  type SqliteEventRow,
 } from "./rows.js";
 import type { PersistedCommand, PersistedCommandError } from "./types.js";
 
@@ -130,6 +132,81 @@ export function listCommands(database: SqlDatabase): PersistedCommand[] {
     }
   }
   return commands;
+}
+
+export function listCommandRecoveryCandidates(
+  database: SqlDatabase,
+  input: { failedCommandTypes: StationCommand["type"][] },
+): PersistedCommand[] {
+  const invalidSucceededEventCommandIds = invalidSucceededEventCommands(database);
+  const conditions = [
+    `(status = 'accepted')`,
+    `(status = 'succeeded' AND NOT EXISTS (
+      SELECT 1 FROM events WHERE events.command_id = commands.id AND events.type = 'command.succeeded'
+    ))`,
+    `(status = 'started' AND type = 'worktree.remove')`,
+  ];
+  if (input.failedCommandTypes.length > 0) {
+    conditions.push(
+      `(status = 'failed' AND type IN (${input.failedCommandTypes.map(() => "?").join(", ")}))`,
+    );
+  }
+  const rows = database
+    .prepare(`SELECT * FROM commands WHERE ${conditions.join(" OR ")} ORDER BY created_at, id`)
+    .all(...input.failedCommandTypes) as SqliteCommandRow[];
+  if (invalidSucceededEventCommandIds.length > 0) {
+    const invalid = new Set(invalidSucceededEventCommandIds);
+    rows.push(
+      ...(
+        database
+          .prepare("SELECT * FROM commands WHERE status = 'succeeded'")
+          .all() as SqliteCommandRow[]
+      ).filter((row) => invalid.has(row.id)),
+    );
+    rows.sort(
+      (left, right) =>
+        (left.created_at < right.created_at ? -1 : left.created_at > right.created_at ? 1 : 0) ||
+        (left.id < right.id ? -1 : left.id > right.id ? 1 : 0),
+    );
+  }
+  const commands: PersistedCommand[] = [];
+  for (const row of rows) {
+    try {
+      commands.push(
+        commandWithDiagnostics(commandFromRow(row), commandErrorRows(database, row.id)),
+      );
+    } catch {
+      // Recovery is best effort across legacy rows; invalid payloads remain available to diagnostics.
+    }
+  }
+  return commands;
+}
+
+function invalidSucceededEventCommands(database: SqlDatabase): string[] {
+  const recordedRows = database
+    .prepare(
+      `SELECT DISTINCT command_id FROM events
+       WHERE type = 'command.succeeded' AND command_id IS NOT NULL`,
+    )
+    .all() as { command_id: string }[];
+  // SQLite rejects only invalid JSON syntax; the shared event schema still owns validity.
+  const rows = database
+    .prepare(
+      `SELECT * FROM events
+       WHERE type = 'command.succeeded' AND json_valid(payload_json)`,
+    )
+    .all() as SqliteEventRow[];
+  const recorded = new Set(recordedRows.map(({ command_id }) => command_id));
+  const valid = new Set<string>();
+  for (const row of rows) {
+    try {
+      const event = eventFromRow(row);
+      if (event.event.type === "command.succeeded") valid.add(event.event.commandId);
+    } catch {
+      // Indexed row metadata is only coarse evidence; the shared schema owns payload validity.
+    }
+  }
+  return [...recorded].filter((commandId) => !valid.has(commandId));
 }
 
 export function listCommandErrors(

--- a/apps/observer/src/persistence/ports.ts
+++ b/apps/observer/src/persistence/ports.ts
@@ -66,6 +66,10 @@ export interface CommandJournal {
   }): Promise<PersistedCommand>;
   getCommand(commandId: CommandId): Promise<PersistedCommand | undefined>;
   listCommands(): Promise<PersistedCommand[]>;
+  /** Selects coarse durable recovery candidates; queue policy still validates their evidence. */
+  listCommandRecoveryCandidates(input: {
+    failedCommandTypes: StationCommand["type"][];
+  }): Promise<PersistedCommand[]>;
   listCommandErrors(commandId?: CommandId): Promise<PersistedCommandError[]>;
 }
 

--- a/apps/observer/src/persistence/rows.ts
+++ b/apps/observer/src/persistence/rows.ts
@@ -5,6 +5,7 @@ import {
   SessionGroupViewSchema,
   StationCommandSchema,
   StationEventSchema,
+  stationEventCommandId,
 } from "@station/contracts";
 import { parseJson } from "./json.js";
 import { parseProviderObservation } from "./observationParser.js";
@@ -137,6 +138,13 @@ export function commandErrorFromRow(row: SqliteCommandErrorRow): PersistedComman
 
 export function eventFromRow(row: SqliteEventRow): PersistedEvent {
   const event = StationEventSchema.parse(parseJson(row.payload_json));
+  const payloadCommandId = stationEventCommandId(event);
+  if (
+    row.type !== event.type ||
+    (payloadCommandId !== undefined && row.command_id !== payloadCommandId)
+  ) {
+    throw new Error("Event row metadata does not match its payload.");
+  }
   const persistedEvent: PersistedEvent = {
     id: row.id,
     type: event.type,

--- a/apps/observer/src/persistence/sqliteAdapter.ts
+++ b/apps/observer/src/persistence/sqliteAdapter.ts
@@ -63,6 +63,8 @@ export function createSqliteObserverPersistence(
       }
       return mutation.result;
     });
+  const readTransaction = <T>(task: (database: SqlDatabase) => T): Promise<T> =>
+    Effect.runPromise(runSqliteTransactionEffect(options.sqlite, task, "deferred"));
 
   return {
     health: () => options.sqlite.health(),
@@ -94,12 +96,15 @@ export function createSqliteObserverPersistence(
       ),
 
     getCommand: (commandId) =>
-      transaction((database) => commandStore.getCommand(database, commandId)),
+      readTransaction((database) => commandStore.getCommand(database, commandId)),
 
-    listCommands: () => transaction(commandStore.listCommands),
+    listCommands: () => readTransaction(commandStore.listCommands),
+
+    listCommandRecoveryCandidates: (input) =>
+      readTransaction((database) => commandStore.listCommandRecoveryCandidates(database, input)),
 
     listCommandErrors: (commandId) =>
-      transaction((database) => commandStore.listCommandErrors(database, commandId)),
+      readTransaction((database) => commandStore.listCommandErrors(database, commandId)),
 
     recordEvent: (event, eventOptions = {}) =>
       transaction((database) => {
@@ -211,7 +216,7 @@ export function createSqliteObserverPersistence(
         return { deduped: false, observations };
       }),
 
-    listEvents: (filter = {}) => transaction((database) => listEvents(database, filter)),
+    listEvents: (filter = {}) => readTransaction((database) => listEvents(database, filter)),
 
     recordProviderObservation: (input) =>
       transaction((database) =>
@@ -223,7 +228,7 @@ export function createSqliteObserverPersistence(
       ),
 
     listProviderObservations: (listOptions = {}) =>
-      transaction((database) =>
+      readTransaction((database) =>
         listProviderObservations(database, {
           ...(listOptions.entityKind === undefined ? {} : { entityKind: listOptions.entityKind }),
           ...(listOptions.includeExpired === undefined
@@ -235,7 +240,7 @@ export function createSqliteObserverPersistence(
       ),
 
     listCurrentProviderEntityObservations: (listOptions = {}) =>
-      transaction((database) =>
+      readTransaction((database) =>
         listCurrentProviderEntityObservations(database, {
           ...(listOptions.entityKind === undefined ? {} : { entityKind: listOptions.entityKind }),
           ...(listOptions.includeExpired === undefined
@@ -257,7 +262,7 @@ export function createSqliteObserverPersistence(
       ),
 
     listWorktreeMetadataCurrent: (listOptions = {}) =>
-      transaction((database) =>
+      readTransaction((database) =>
         worktreeMetadataCurrentStore.listWorktreeMetadataCurrent(database, {
           ...(listOptions.kind === undefined ? {} : { kind: listOptions.kind }),
           ...(listOptions.includeExpired === undefined
@@ -287,7 +292,7 @@ export function createSqliteObserverPersistence(
         });
       }),
 
-    listSessions: () => transaction(correlationStore.listSessions),
+    listSessions: () => readTransaction(correlationStore.listSessions),
 
     listSessionGroups: () =>
       transaction((database) =>
@@ -343,15 +348,15 @@ export function createSqliteObserverPersistence(
       ),
 
     listWorktreeDisplayTitles: () =>
-      transaction(worktreeDisplayTitleStore.listWorktreeDisplayTitles),
+      readTransaction(worktreeDisplayTitleStore.listWorktreeDisplayTitles),
 
     getSessionHarnessExecution: (input) =>
-      transaction((database) =>
+      readTransaction((database) =>
         sessionHarnessExecutionStore.getSessionHarnessExecution(database, input),
       ),
 
     listSessionHarnessExecutions: () =>
-      transaction(sessionHarnessExecutionStore.listSessionHarnessExecutions),
+      readTransaction(sessionHarnessExecutionStore.listSessionHarnessExecutions),
 
     repairSessionHarnessDerivedState: (input) =>
       transaction((database) => {
@@ -391,7 +396,7 @@ export function createSqliteObserverPersistence(
       }),
 
     findRememberedHarnessProviderForWorktree: (input) =>
-      transaction((database) =>
+      readTransaction((database) =>
         correlationStore.findRememberedHarnessProviderForWorktree(database, input),
       ),
 
@@ -481,12 +486,12 @@ export function createSqliteObserverPersistence(
       ),
 
     getSessionRecoveryHandle: (handleId) =>
-      transaction((database) =>
+      readTransaction((database) =>
         sessionRecoveryHandleStore.getSessionRecoveryHandle(database, handleId),
       ),
 
     listSessionRecoveryHandles: (listOptions = {}) =>
-      transaction((database) =>
+      readTransaction((database) =>
         sessionRecoveryHandleStore.listSessionRecoveryHandles(database, listOptions),
       ),
 
@@ -501,7 +506,7 @@ export function createSqliteObserverPersistence(
       }),
 
     listSessionTurnReadiness: () =>
-      transaction((database) => sessionTurnReadinessStore.listSessionTurnReadiness(database)),
+      readTransaction((database) => sessionTurnReadinessStore.listSessionTurnReadiness(database)),
 
     deleteSessionTurnReadiness: (input) =>
       transaction((database) =>

--- a/apps/observer/src/runtime/main.ts
+++ b/apps/observer/src/runtime/main.ts
@@ -316,9 +316,14 @@ async function runClaimedObserverRuntime(input: {
   });
   let stopping: Promise<void> | undefined;
   let stopReceipt: Promise<ObserverStopReceipt> | undefined;
+  let commandShutdown: Promise<void> | undefined;
   let observerApi: ObserverApi;
   let shutdownExitCode = 0;
   let displaced = false;
+  const shutdownCommandQueue = (): Promise<void> => {
+    commandShutdown ??= commandQueue.shutdown();
+    return commandShutdown;
+  };
   const stopObserver = async (exitCode = 0) => {
     shutdownExitCode = Math.max(shutdownExitCode, exitCode);
     stopping ??= runShutdownWithBackstop(
@@ -336,7 +341,7 @@ async function runClaimedObserverRuntime(input: {
           shutdownError = error;
         }
         try {
-          await commandQueue.shutdown();
+          await shutdownCommandQueue();
         } catch (error) {
           shutdownError ??= error;
         }
@@ -435,7 +440,13 @@ async function runClaimedObserverRuntime(input: {
     ...observerApi,
     health: () => startupGate.runHealth(observerApi.health),
     stop: async () => {
-      startupGate.requestStop();
+      if (startupGate.requestStop()) {
+        void shutdownCommandQueue().catch((error) =>
+          logger
+            .error("Pre-ready command shutdown failed.", { socketPath, error })
+            .catch(() => undefined),
+        );
+      }
       const shutdown = stopObserver();
       void shutdown.catch((error) =>
         logger.error("Observer shutdown failed.", { socketPath, error }).catch(() => undefined),
@@ -498,6 +509,7 @@ async function runClaimedObserverRuntime(input: {
         void api.stop();
       },
     });
+    await commandQueue.recoverDurableCommands();
     const startupCommit = startupGate.settleReady(() => claim.release());
     shouldReconcile = startupCommit.status === "ready";
     if (startupCommit.status === "ready" && startupCommit.claimRelease.status === "failed") {
@@ -706,7 +718,8 @@ function resolvePath(input: string, homeDir: string): string {
 }
 
 type ObserverStartupGate = {
-  requestStop(): void;
+  /** Returns whether startup work still needs cancellation. */
+  requestStop(): boolean;
   assertReadyForOperation(): void;
   settleReady(releaseClaim: () => ObserverBootClaimReleaseResult): ObserverStartupCommit;
   settleFailed(): void;
@@ -735,9 +748,11 @@ export function createObserverStartupGate(): ObserverStartupGate {
 
   return {
     requestStop: () => {
-      if (state === "stopping" || state === "failed") return;
+      if (state === "stopping" || state === "failed") return false;
+      const wasStarting = state === "starting";
       if (state === "ready") ready = pending();
       state = "stopping";
+      return wasStarting;
     },
     assertReadyForOperation: () => {
       if (state === "ready") return;

--- a/apps/observer/src/sqlite.ts
+++ b/apps/observer/src/sqlite.ts
@@ -93,10 +93,11 @@ export function openObserverSqlite(options: OpenObserverSqliteOptions = {}): Obs
 export function runSqliteTransactionEffect<T>(
   sqlite: ObserverSqliteHandle,
   task: (database: SqlDatabase) => T,
+  mode: "deferred" | "immediate" = "immediate",
 ): Effect.Effect<T, RuntimeSafeError> {
   return Effect.try({
     try: () => {
-      sqlite.database.exec("BEGIN IMMEDIATE");
+      sqlite.database.exec(mode === "deferred" ? "BEGIN" : "BEGIN IMMEDIATE");
       try {
         const value = task(sqlite.database);
         sqlite.database.exec("COMMIT");

--- a/apps/observer/test/integration/cleanup-commands.test.ts
+++ b/apps/observer/test/integration/cleanup-commands.test.ts
@@ -819,6 +819,138 @@ describe("cleanup command handlers", () => {
     fixture.sqlite.close();
   });
 
+  it("repairs a durable confirmed-removal retirement failure without repeating cleanup", async () => {
+    const fixture = createFixture({
+      state: "working",
+      worktreeRetirementFailures: 2,
+    });
+    await fixture.core.reconcile("pre-durable-retirement-repair");
+    const selected = fixture.core.getSnapshot().rows[0];
+    if (selected?.registrationIdentity === undefined) {
+      throw new Error("Expected a verified removal selection.");
+    }
+    const command = {
+      type: "worktree.remove" as const,
+      payload: {
+        worktreeId: selected.id,
+        projectId: selected.projectId,
+        expectedPath: selected.path,
+        expectedBranch: selected.branch,
+        expectedRegistrationIdentity: selected.registrationIdentity,
+        force: true,
+      },
+    };
+    const operationId = "cleanup-durable-retirement-repair";
+
+    const original = await fixture.queue.dispatch(command, { operationId });
+    await fixture.queue.drain();
+    await expect(fixture.persistence.getCommand(original.commandId)).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "WORKTREE_REMOVE_RETIREMENT_FAILED" },
+    });
+    expect(fixture.worktreeRetirementAttempts()).toBe(2);
+    const cleanupBefore = {
+      removed: fixture.worktree.snapshot().removed,
+      stopped: fixture.harness.snapshot().stopped,
+      closed: fixture.terminal.snapshot().closed,
+    };
+
+    const [first, concurrent] = await Promise.all([
+      fixture.queue.dispatch(command, { operationId }),
+      fixture.queue.dispatch(command, { operationId }),
+    ]);
+    await fixture.queue.drain();
+
+    expect(concurrent).toEqual(first);
+    expect(fixture.worktreeRetirementAttempts()).toBe(3);
+    expect({
+      removed: fixture.worktree.snapshot().removed,
+      stopped: fixture.harness.snapshot().stopped,
+      closed: fixture.terminal.snapshot().closed,
+    }).toEqual(cleanupBefore);
+    await expect(fixture.persistence.getCommand(original.commandId)).resolves.toMatchObject({
+      status: "succeeded",
+    });
+    await expect(
+      fixture.persistence.listEvents({ commandId: original.commandId }),
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "command.failed" }),
+        expect.objectContaining({ type: "session.removed" }),
+        expect.objectContaining({ type: "worktree.removed" }),
+        expect.objectContaining({ type: "command.succeeded" }),
+      ]),
+    );
+    await expect(fixture.persistence.listSessions()).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "ses_web_cleanup", lifecycle: "ended" }),
+      ]),
+    );
+    await expect(fixture.persistence.listWorktreeDisplayTitles()).resolves.toEqual([]);
+    await vi.waitFor(() => expect(fixture.core.getSnapshot().rows).toEqual([]));
+    fixture.sqlite.close();
+  });
+
+  it("attempts persistent durable retirement recovery once per queue lifetime", async () => {
+    const fixture = createFixture({
+      state: "working",
+      worktreeRetirementFailures: "persistent",
+    });
+    await fixture.core.reconcile("pre-persistent-durable-retirement-repair");
+    const selected = fixture.core.getSnapshot().rows[0];
+    if (selected?.registrationIdentity === undefined) {
+      throw new Error("Expected a verified removal selection.");
+    }
+    const command = {
+      type: "worktree.remove" as const,
+      payload: {
+        worktreeId: selected.id,
+        projectId: selected.projectId,
+        expectedPath: selected.path,
+        expectedBranch: selected.branch,
+        expectedRegistrationIdentity: selected.registrationIdentity,
+        force: true,
+      },
+    };
+    const operationId = "cleanup-persistent-durable-retirement-repair";
+
+    const original = await fixture.queue.dispatch(command, { operationId });
+    await fixture.queue.drain();
+    const cleanupBefore = {
+      removed: fixture.worktree.snapshot().removed,
+      stopped: fixture.harness.snapshot().stopped,
+      closed: fixture.terminal.snapshot().closed,
+    };
+    await Promise.all([
+      fixture.queue.dispatch(command, { operationId }),
+      fixture.queue.dispatch(command, { operationId }),
+    ]);
+    await fixture.queue.drain();
+
+    expect(fixture.worktreeRetirementAttempts()).toBe(4);
+    expect({
+      removed: fixture.worktree.snapshot().removed,
+      stopped: fixture.harness.snapshot().stopped,
+      closed: fixture.terminal.snapshot().closed,
+    }).toEqual(cleanupBefore);
+    await expect(fixture.persistence.getCommand(original.commandId)).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "WORKTREE_REMOVE_RETIREMENT_FAILED" },
+    });
+    expect(
+      (await fixture.persistence.listEvents({ commandId: original.commandId })).filter((event) =>
+        event.type.endsWith(".removed"),
+      ),
+    ).toEqual([]);
+    await expect(fixture.persistence.listSessions()).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "ses_web_cleanup", lifecycle: "open" }),
+      ]),
+    );
+    await expect(fixture.persistence.listWorktreeDisplayTitles()).resolves.toHaveLength(1);
+    fixture.sqlite.close();
+  });
+
   it("does not commit cancellation handling when the provider declines removal", async () => {
     const fixture = createFixture({
       state: "none",
@@ -830,8 +962,8 @@ describe("cleanup command handlers", () => {
       throw new Error("Expected a verified removal selection.");
     }
 
-    const receipt = await fixture.queue.dispatch({
-      type: "worktree.remove",
+    const command = {
+      type: "worktree.remove" as const,
       payload: {
         worktreeId: selected.id,
         projectId: selected.projectId,
@@ -840,7 +972,11 @@ describe("cleanup command handlers", () => {
         expectedRegistrationIdentity: selected.registrationIdentity,
         force: true,
       },
-    });
+    };
+    const operationId = "cleanup-provider-declined-removal";
+    const receipt = await fixture.queue.dispatch(command, { operationId });
+    await fixture.queue.drain();
+    await fixture.queue.dispatch(command, { operationId });
     await fixture.queue.drain();
 
     await expect(fixture.persistence.getCommand(receipt.commandId)).resolves.toMatchObject({

--- a/apps/observer/test/integration/command-queue.test.ts
+++ b/apps/observer/test/integration/command-queue.test.ts
@@ -1,4 +1,5 @@
-import type { StationCommand, StationEvent } from "@station/contracts";
+import { createHash } from "node:crypto";
+import type { ErrorEnvelope, SafeError, StationCommand, StationEvent } from "@station/contracts";
 import { describe, expect, it } from "vitest";
 import { createCommandQueue } from "../../src/commands/queue";
 import { createSqliteObserverPersistence } from "../../src/persistence";
@@ -99,8 +100,24 @@ const createApiSessionGroupCommand: StationCommand = {
   },
 };
 
+const removeWorktreeCommand: StationCommand = {
+  type: "worktree.remove",
+  payload: {
+    projectId: "web",
+    worktreeId: "wt_feature_auth",
+    expectedPath: "/tmp/station/web/feature-auth",
+    expectedBranch: "feature/auth",
+    expectedRegistrationIdentity: "git-registration:feature-auth",
+    force: true,
+  },
+};
+
+function commandIdForOperation(operationId: string) {
+  return `cmd_op_${createHash("sha256").update(operationId).digest("hex")}`;
+}
+
 describe("observer command queue", () => {
-  it("returns the original durable receipt after queue reconstruction", async () => {
+  it("returns the original durable receipt when an operation is replayed after queue reconstruction", async () => {
     const { sqlite, persistence, queue } = createPersistenceAndQueue();
     const handled: string[] = [];
     const handler = async ({ commandId }: { commandId: string }) => {
@@ -108,7 +125,9 @@ describe("observer command queue", () => {
     };
     queue.registerHandler("observer.reconcile", handler);
 
-    const first = await queue.dispatch(reconcileCommand, { operationId: "req_lost_response" });
+    const first = await queue.dispatch(reconcileCommand, {
+      operationId: "req_lost_response",
+    });
     await queue.drain();
 
     const reconstructed = createCommandQueue({
@@ -127,7 +146,7 @@ describe("observer command queue", () => {
     sqlite.close();
   });
 
-  it("recovers a stranded accepted operation exactly once", async () => {
+  it("recovers a stranded accepted operation exactly once after queue reconstruction", async () => {
     const { sqlite, persistence } = createPersistenceAndQueue();
     let injected = false;
     const faultPersistence = {
@@ -153,6 +172,9 @@ describe("observer command queue", () => {
       interrupted.dispatch(reconcileCommand, { operationId: "req_stranded_accepted" }),
     ).rejects.toThrow("injected accepted-event write failure");
     await interrupted.shutdown();
+    await expect(persistence.listCommands()).resolves.toEqual([
+      expect.objectContaining({ status: "accepted" }),
+    ]);
 
     const handled: string[] = [];
     const reconstructed = createCommandQueue({
@@ -173,9 +195,12 @@ describe("observer command queue", () => {
     await expect(persistence.getCommand(first.commandId)).resolves.toMatchObject({
       status: "succeeded",
     });
-    expect(
-      (await persistence.listEvents({ commandId: first.commandId })).map((event) => event.type),
-    ).toEqual(["command.accepted", "command.started", "command.succeeded"]);
+    await expect(persistence.listEvents({ commandId: first.commandId })).resolves.toEqual([
+      expect.objectContaining({ type: "command.accepted" }),
+      expect.objectContaining({ type: "command.started" }),
+      expect.objectContaining({ type: "command.succeeded" }),
+    ]);
+    await reconstructed.shutdown();
     sqlite.close();
   });
 
@@ -197,6 +222,9 @@ describe("observer command queue", () => {
       operationId: "req_started_not_replayable",
     });
     await started;
+    await expect(persistence.getCommand(first.commandId)).resolves.toMatchObject({
+      status: "started",
+    });
 
     let replayHandled = 0;
     const reconstructed = createCommandQueue({
@@ -215,10 +243,580 @@ describe("observer command queue", () => {
     expect(replayHandled).toBe(0);
     release();
     await queue.drain();
+    await reconstructed.shutdown();
+    await queue.shutdown();
     sqlite.close();
   });
 
-  it("rejects an operation identity reused with different input", async () => {
+  it("terminalizes a started removal only from matching command-correlated evidence", async () => {
+    const { sqlite, persistence } = createPersistenceAndQueue();
+    const operationId = "req_started_remove_with_evidence";
+    const commandId = commandIdForOperation(operationId);
+    await persistence.recordCommandAccepted({ commandId, command: removeWorktreeCommand });
+    await persistence.markCommandStarted(commandId);
+    await persistence.recordEvent(
+      { type: "worktree.removed", worktreeId: "wt_unrelated" },
+      { commandId },
+    );
+    let replayHandled = 0;
+    const reconstructed = createCommandQueue({
+      persistence,
+      clock: { now: () => new Date(now) },
+    });
+    reconstructed.registerHandler("worktree.remove", async () => {
+      replayHandled += 1;
+    });
+
+    await reconstructed.dispatch(removeWorktreeCommand, { operationId });
+    await expect(persistence.getCommand(commandId)).resolves.toMatchObject({ status: "started" });
+    await persistence.recordEvent(
+      { type: "worktree.removed", worktreeId: "wt_feature_auth" },
+      { commandId },
+    );
+
+    const [first, concurrent] = await Promise.all([
+      reconstructed.dispatch(removeWorktreeCommand, { operationId }),
+      reconstructed.dispatch(removeWorktreeCommand, { operationId }),
+    ]);
+    await reconstructed.drain();
+
+    expect(concurrent).toEqual(first);
+    expect(replayHandled).toBe(0);
+    await expect(persistence.getCommand(commandId)).resolves.toMatchObject({
+      status: "succeeded",
+    });
+    expect(
+      (await persistence.listEvents({ commandId })).filter(
+        (event) => event.type === "command.succeeded",
+      ),
+    ).toHaveLength(1);
+    await reconstructed.shutdown();
+    sqlite.close();
+  });
+
+  it("repairs a missing success event for a terminal operation replay", async () => {
+    const { sqlite, persistence } = createPersistenceAndQueue();
+    const operationId = "req_succeeded_missing_event";
+    const commandId = commandIdForOperation(operationId);
+    await persistence.recordCommandAccepted({ commandId, command: reconcileCommand });
+    await persistence.markCommandStarted(commandId);
+    await persistence.markCommandSucceeded(commandId);
+    const reconstructed = createCommandQueue({
+      persistence,
+      clock: { now: () => new Date(now) },
+    });
+
+    await reconstructed.dispatch(reconcileCommand, { operationId });
+    await reconstructed.dispatch(reconcileCommand, { operationId });
+
+    expect(
+      (await persistence.listEvents({ commandId })).filter(
+        (event) => event.type === "command.succeeded",
+      ),
+    ).toHaveLength(1);
+    await reconstructed.shutdown();
+    sqlite.close();
+  });
+
+  it("repairs a missing failure event for a terminal operation replay without replaying its handler", async () => {
+    const { sqlite, persistence } = createPersistenceAndQueue();
+    const operationId = "req_failed_missing_event";
+    let injected = false;
+    const faultPersistence = {
+      ...persistence,
+      recordEvent: async (
+        event: StationEvent,
+        options?: Parameters<typeof persistence.recordEvent>[1],
+      ) => {
+        if (!injected && event.type === "command.failed") {
+          injected = true;
+          throw new Error("injected failed-event write failure");
+        }
+        return persistence.recordEvent(event, options);
+      },
+    };
+    const interrupted = createCommandQueue({
+      persistence: faultPersistence,
+      clock: { now: () => new Date(now) },
+      idFactory: { errorId: () => "err_failed_missing_event" },
+    });
+    interrupted.registerHandler("observer.reconcile", async () => {
+      throw {
+        tag: "CommandExecutionError",
+        code: "EXPECTED_FAILURE",
+        message: "Expected queue failure.",
+      };
+    });
+
+    const first = await interrupted.dispatch(reconcileCommand, { operationId });
+    await interrupted.drain();
+    await interrupted.shutdown();
+    const failed = await persistence.getCommand(first.commandId);
+    expect(failed).toMatchObject({ status: "failed", error: { code: "EXPECTED_FAILURE" } });
+    await expect(
+      persistence.listEvents({ commandId: first.commandId, type: "command.failed" }),
+    ).resolves.toHaveLength(0);
+
+    let replayHandled = 0;
+    const published: StationEvent[] = [];
+    const reconstructed = createCommandQueue({
+      persistence,
+      clock: { now: () => new Date(now) },
+      eventBus: { publish: (event) => published.push(event) },
+    });
+    reconstructed.registerHandler("observer.reconcile", async () => {
+      replayHandled += 1;
+    });
+    const [replay, concurrent] = await Promise.all([
+      reconstructed.dispatch(reconcileCommand, { operationId }),
+      reconstructed.dispatch(reconcileCommand, { operationId }),
+    ]);
+
+    expect(concurrent).toEqual(replay);
+    expect(replayHandled).toBe(0);
+    await expect(
+      persistence.listEvents({ commandId: first.commandId, type: "command.failed" }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        event: expect.objectContaining({
+          type: "command.failed",
+          commandId: first.commandId,
+          error: failed?.error,
+        }),
+      }),
+    ]);
+    expect(published).toEqual([
+      expect.objectContaining({ type: "command.failed", error: failed?.error }),
+    ]);
+    await reconstructed.shutdown();
+    sqlite.close();
+  });
+
+  it("runs one recovery-only handler for concurrent exact replay of a durable failure", async () => {
+    const { sqlite, persistence } = createPersistenceAndQueue();
+    const operationId = "req_failed_recovery_only";
+    const commandId = commandIdForOperation(operationId);
+    const safeError: SafeError = {
+      tag: "PersistenceError",
+      code: "REPAIRABLE_FAILURE",
+      message: "Repairable terminal failure.",
+    };
+    const envelope: ErrorEnvelope = {
+      id: "err_repairable",
+      tag: safeError.tag,
+      code: safeError.code,
+      message: safeError.message,
+      severity: "error",
+      commandId,
+      redacted: true,
+      createdAt: now,
+    };
+    await persistence.recordCommandAccepted({ commandId, command: reconcileCommand });
+    await persistence.markCommandStarted(commandId);
+    await persistence.markCommandFailed({ commandId, safeError, envelope });
+    await persistence.recordEvent(
+      { type: "command.failed", commandId, error: safeError },
+      { commandId },
+    );
+    let ordinaryHandlerCalls = 0;
+    let recoveryHandlerCalls = 0;
+    const reconstructed = createCommandQueue({
+      persistence,
+      clock: { now: () => new Date(now) },
+    });
+    reconstructed.registerHandler("observer.reconcile", async () => {
+      ordinaryHandlerCalls += 1;
+    });
+    reconstructed.registerRecoveryHandler("observer.reconcile", async () => {
+      recoveryHandlerCalls += 1;
+      return "recovered";
+    });
+
+    await Promise.all([
+      reconstructed.dispatch(reconcileCommand, { operationId }),
+      reconstructed.dispatch(reconcileCommand, { operationId }),
+    ]);
+
+    expect(ordinaryHandlerCalls).toBe(0);
+    expect(recoveryHandlerCalls).toBe(1);
+    await expect(persistence.getCommand(commandId)).resolves.toMatchObject({ status: "succeeded" });
+    expect((await persistence.listEvents({ commandId })).map((event) => event.type)).toEqual([
+      "command.failed",
+      "command.succeeded",
+    ]);
+    await reconstructed.shutdown();
+    sqlite.close();
+  });
+
+  it("recovers registered durable failures without replay and isolates a failed repair", async () => {
+    const { sqlite, persistence } = createPersistenceAndQueue();
+    const recoverOperationId = "req_startup_recover";
+    const failingOperationId = "req_startup_recovery_failure";
+    const unrelatedOperationId = "req_startup_unrelated_failure";
+    const recoverCommandId = commandIdForOperation(recoverOperationId);
+    const failingCommandId = commandIdForOperation(failingOperationId);
+    const unrelatedCommandId = commandIdForOperation(unrelatedOperationId);
+    for (const [commandId, command, code] of [
+      [recoverCommandId, reconcileCommand, "RECOVER_ME"],
+      [failingCommandId, reconcileCommand, "RECOVERY_THROWS"],
+      [unrelatedCommandId, renameSessionCommand, "UNREGISTERED_TYPE"],
+    ] as const) {
+      await persistence.recordCommandAccepted({ commandId, command, createdAt: now });
+      await persistence.markCommandStarted(commandId, now);
+      const error: SafeError = {
+        tag: "CommandExecutionError",
+        code,
+        message: code,
+      };
+      await persistence.markCommandFailed({
+        commandId,
+        safeError: error,
+        envelope: {
+          id: `err_${code}`,
+          tag: error.tag,
+          code: error.code,
+          message: error.message,
+          severity: "error",
+          commandId,
+          redacted: true,
+          createdAt: now,
+        },
+        finishedAt: now,
+      });
+      await persistence.recordEvent({ type: "command.failed", commandId, error }, { commandId });
+    }
+
+    let ordinaryHandlerCalls = 0;
+    let recoveryHandlerCalls = 0;
+    const reconstructed = createCommandQueue({
+      persistence,
+      clock: { now: () => new Date(now) },
+    });
+    reconstructed.registerHandler("observer.reconcile", async () => {
+      ordinaryHandlerCalls += 1;
+    });
+    reconstructed.registerRecoveryHandler("observer.reconcile", async ({ error }) => {
+      recoveryHandlerCalls += 1;
+      if (error.code === "RECOVERY_THROWS") throw new Error("injected recovery failure");
+      return "recovered";
+    });
+
+    await reconstructed.recoverDurableCommands();
+
+    expect(ordinaryHandlerCalls).toBe(0);
+    expect(recoveryHandlerCalls).toBe(2);
+    await expect(persistence.getCommand(recoverCommandId)).resolves.toMatchObject({
+      status: "succeeded",
+    });
+    await expect(persistence.getCommand(failingCommandId)).resolves.toMatchObject({
+      status: "failed",
+    });
+    await expect(persistence.getCommand(unrelatedCommandId)).resolves.toMatchObject({
+      status: "failed",
+    });
+    await expect(
+      persistence.listEvents({ commandId: recoverCommandId, type: "command.succeeded" }),
+    ).resolves.toHaveLength(1);
+    await reconstructed.shutdown();
+    sqlite.close();
+  });
+
+  it("resumes accepted work and repairs evidence-backed records during durable recovery", async () => {
+    const { sqlite, persistence } = createPersistenceAndQueue();
+    const startedOperationId = "req_startup_started_remove_with_evidence";
+    const succeededOperationId = "req_startup_succeeded_missing_event";
+    const ambiguousOperationId = "req_startup_started_remove_without_evidence";
+    const acceptedOperationId = "req_startup_accepted_control";
+    const startedCommandId = commandIdForOperation(startedOperationId);
+    const succeededCommandId = commandIdForOperation(succeededOperationId);
+    const ambiguousCommandId = commandIdForOperation(ambiguousOperationId);
+    const acceptedCommandId = commandIdForOperation(acceptedOperationId);
+    await persistence.recordCommandAccepted({
+      commandId: startedCommandId,
+      command: removeWorktreeCommand,
+      createdAt: now,
+    });
+    await persistence.markCommandStarted(startedCommandId, now);
+    await persistence.recordEvent(
+      { type: "worktree.removed", worktreeId: removeWorktreeCommand.payload.worktreeId },
+      { commandId: startedCommandId },
+    );
+    await persistence.recordCommandAccepted({
+      commandId: succeededCommandId,
+      command: reconcileCommand,
+      createdAt: now,
+    });
+    await persistence.markCommandStarted(succeededCommandId, now);
+    await persistence.markCommandSucceeded(succeededCommandId, now);
+    await persistence.recordCommandAccepted({
+      commandId: ambiguousCommandId,
+      command: removeWorktreeCommand,
+      createdAt: now,
+    });
+    await persistence.markCommandStarted(ambiguousCommandId, now);
+    await persistence.recordCommandAccepted({
+      commandId: acceptedCommandId,
+      command: reconcileCommand,
+      createdAt: now,
+    });
+
+    let ordinaryHandlerCalls = 0;
+    const reconstructed = createCommandQueue({
+      persistence,
+      clock: { now: () => new Date(now) },
+    });
+    reconstructed.registerHandler("worktree.remove", async () => {
+      ordinaryHandlerCalls += 1;
+    });
+    reconstructed.registerHandler("observer.reconcile", async () => {
+      ordinaryHandlerCalls += 1;
+    });
+
+    await reconstructed.recoverDurableCommands();
+
+    expect(ordinaryHandlerCalls).toBe(1);
+    await expect(persistence.getCommand(startedCommandId)).resolves.toMatchObject({
+      status: "succeeded",
+    });
+    await expect(persistence.getCommand(succeededCommandId)).resolves.toMatchObject({
+      status: "succeeded",
+    });
+    await expect(persistence.getCommand(ambiguousCommandId)).resolves.toMatchObject({
+      status: "started",
+    });
+    await expect(persistence.getCommand(acceptedCommandId)).resolves.toMatchObject({
+      status: "succeeded",
+    });
+    await expect(
+      persistence.listEvents({ commandId: startedCommandId, type: "command.succeeded" }),
+    ).resolves.toHaveLength(1);
+    await expect(
+      persistence.listEvents({ commandId: succeededCommandId, type: "command.succeeded" }),
+    ).resolves.toHaveLength(1);
+    await expect(
+      persistence.listEvents({ commandId: acceptedCommandId, type: "command.accepted" }),
+    ).resolves.toHaveLength(1);
+    await expect(
+      persistence.listEvents({ commandId: acceptedCommandId, type: "command.succeeded" }),
+    ).resolves.toHaveLength(1);
+    await reconstructed.shutdown();
+    sqlite.close();
+  });
+
+  it("re-reads accepted recovery state before scheduling it", async () => {
+    const { sqlite, persistence } = createPersistenceAndQueue();
+    const commandId = "cmd_stale_accepted_recovery";
+    await persistence.recordCommandAccepted({
+      commandId,
+      command: reconcileCommand,
+      createdAt: now,
+    });
+    let statusReadReached = () => undefined;
+    const statusRead = new Promise<void>((resolve) => {
+      statusReadReached = resolve;
+    });
+    let releaseStatusRead = () => undefined;
+    const release = new Promise<void>((resolve) => {
+      releaseStatusRead = resolve;
+    });
+    let candidatesSelected = false;
+    let blocked = false;
+    const racePersistence = {
+      ...persistence,
+      listCommandRecoveryCandidates: async (
+        input: Parameters<typeof persistence.listCommandRecoveryCandidates>[0],
+      ) => {
+        const candidates = await persistence.listCommandRecoveryCandidates(input);
+        candidatesSelected = true;
+        return candidates;
+      },
+      getCommand: async (selectedCommandId: Parameters<typeof persistence.getCommand>[0]) => {
+        if (candidatesSelected && !blocked) {
+          blocked = true;
+          statusReadReached();
+          await release;
+        }
+        return persistence.getCommand(selectedCommandId);
+      },
+    };
+    let handlerCalls = 0;
+    const reconstructed = createCommandQueue({ persistence: racePersistence });
+    reconstructed.registerHandler("observer.reconcile", async () => {
+      handlerCalls += 1;
+    });
+
+    const recovery = reconstructed.recoverDurableCommands();
+    await statusRead;
+    await persistence.markCommandSucceeded(commandId, now);
+    releaseStatusRead();
+    await recovery;
+
+    expect(handlerCalls).toBe(0);
+    expect((await persistence.listEvents({ commandId })).map(({ event }) => event.type)).toEqual([
+      "command.succeeded",
+    ]);
+    await reconstructed.shutdown();
+    sqlite.close();
+  });
+
+  it("repairs terminal state advanced during acceptance recovery", async () => {
+    const { sqlite, persistence } = createPersistenceAndQueue();
+    const commandId = "cmd_advanced_during_acceptance_recovery";
+    await persistence.recordCommandAccepted({
+      commandId,
+      command: reconcileCommand,
+      createdAt: now,
+    });
+    let finalReadReached = () => undefined;
+    const finalRead = new Promise<void>((resolve) => {
+      finalReadReached = resolve;
+    });
+    let releaseFinalRead = () => undefined;
+    const release = new Promise<void>((resolve) => {
+      releaseFinalRead = resolve;
+    });
+    let getCalls = 0;
+    const racePersistence = {
+      ...persistence,
+      getCommand: async (selectedCommandId: Parameters<typeof persistence.getCommand>[0]) => {
+        getCalls += 1;
+        if (getCalls === 2) {
+          finalReadReached();
+          await release;
+        }
+        return persistence.getCommand(selectedCommandId);
+      },
+    };
+    let handlerCalls = 0;
+    const reconstructed = createCommandQueue({ persistence: racePersistence });
+    reconstructed.registerHandler("observer.reconcile", async () => {
+      handlerCalls += 1;
+    });
+
+    const recovery = reconstructed.recoverDurableCommands();
+    await finalRead;
+    await persistence.markCommandSucceeded(commandId, now);
+    releaseFinalRead();
+    await recovery;
+
+    expect(handlerCalls).toBe(0);
+    expect((await persistence.listEvents({ commandId })).map(({ event }) => event.type)).toEqual([
+      "command.accepted",
+      "command.succeeded",
+    ]);
+    await reconstructed.shutdown();
+    sqlite.close();
+  });
+
+  it("stops admitting accepted recovery work after queue shutdown", async () => {
+    const { sqlite, persistence } = createPersistenceAndQueue();
+    const commandIds = [
+      "cmd_recovery_stop_1",
+      "cmd_recovery_stop_2",
+      "cmd_recovery_stop_3",
+    ] as const;
+    for (const commandId of commandIds) {
+      await persistence.recordCommandAccepted({
+        commandId,
+        command: renameSessionCommand,
+        createdAt: now,
+      });
+    }
+    let handlerStarted = () => undefined;
+    const started = new Promise<void>((resolveStarted) => {
+      handlerStarted = resolveStarted;
+    });
+    let handlerCalls = 0;
+    const reconstructed = createCommandQueue({
+      persistence,
+      clock: { now: () => new Date(now) },
+    });
+    reconstructed.registerHandler("session.rename", async ({ signal }) => {
+      handlerCalls += 1;
+      handlerStarted();
+      await new Promise<void>((_resolve, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+      });
+    });
+
+    const recovery = reconstructed.recoverDurableCommands();
+    await started;
+    await Promise.all([reconstructed.shutdown(), recovery]);
+
+    expect(handlerCalls).toBe(1);
+    await expect(persistence.getCommand(commandIds[0])).resolves.toMatchObject({
+      status: "failed",
+      error: expect.objectContaining({ code: "COMMAND_CANCELLED" }),
+    });
+    for (const commandId of commandIds.slice(1)) {
+      await expect(persistence.getCommand(commandId)).resolves.toMatchObject({
+        status: "accepted",
+      });
+    }
+    const resumed: string[] = [];
+    const replacement = createCommandQueue({
+      persistence,
+      clock: { now: () => new Date(now) },
+    });
+    replacement.registerHandler("session.rename", async ({ commandId }) => {
+      resumed.push(commandId);
+    });
+
+    await replacement.recoverDurableCommands();
+
+    expect(resumed).toEqual(commandIds.slice(1));
+    for (const commandId of commandIds.slice(1)) {
+      await expect(persistence.getCommand(commandId)).resolves.toMatchObject({
+        status: "succeeded",
+      });
+      await expect(
+        persistence.listEvents({ commandId, type: "command.accepted" }),
+      ).resolves.toHaveLength(1);
+    }
+    await replacement.shutdown();
+    sqlite.close();
+  });
+
+  it("continues accepted recovery in scope after a handler failure", async () => {
+    const { sqlite, persistence } = createPersistenceAndQueue();
+    const commandIds = ["cmd_recovery_failure_1", "cmd_recovery_failure_2"] as const;
+    for (const [index, commandId] of commandIds.entries()) {
+      await persistence.recordCommandAccepted({
+        commandId,
+        command: {
+          type: "session.rename",
+          payload: { sessionId: "ses_recovery_failure", title: `Recovery ${index}` },
+        },
+        createdAt: now,
+      });
+    }
+    const handlerCalls: string[] = [];
+    const reconstructed = createCommandQueue({
+      persistence,
+      clock: { now: () => new Date(now) },
+    });
+    reconstructed.registerHandler("session.rename", async ({ commandId }) => {
+      handlerCalls.push(commandId);
+      if (commandId === commandIds[0]) throw new Error("injected recovery failure");
+    });
+
+    await expect(reconstructed.recoverDurableCommands()).resolves.toBeUndefined();
+
+    expect(handlerCalls).toEqual(commandIds);
+    await expect(persistence.getCommand(commandIds[0])).resolves.toMatchObject({
+      status: "failed",
+      error: expect.objectContaining({ code: "COMMAND_EXECUTION_FAILED" }),
+    });
+    await expect(persistence.getCommand(commandIds[1])).resolves.toMatchObject({
+      status: "succeeded",
+    });
+    for (const commandId of commandIds) {
+      await expect(persistence.listEvents({ commandId })).resolves.toHaveLength(3);
+    }
+    sqlite.close();
+  });
+
+  it("rejects an operation identity replayed with different command input", async () => {
     const { sqlite, persistence, queue } = createPersistenceAndQueue();
     const handled: string[] = [];
     queue.registerHandler("observer.reconcile", async ({ commandId }) => {
@@ -228,16 +826,23 @@ describe("observer command queue", () => {
       handled.push(commandId);
     });
 
-    const first = await queue.dispatch(reconcileCommand, { operationId: "req_conflict" });
+    const first = await queue.dispatch(reconcileCommand, {
+      operationId: "req_conflicting_replay",
+    });
     await queue.drain();
-    const conflict = await queue.dispatch(renameSessionCommand, { operationId: "req_conflict" });
+    const conflict = await queue.dispatch(renameSessionCommand, {
+      operationId: "req_conflicting_replay",
+    });
     await queue.drain();
 
     expect(conflict).toMatchObject({
       commandId: first.commandId,
       accepted: false,
       status: "rejected",
-      error: { code: "COMMAND_OPERATION_CONFLICT" },
+      error: {
+        tag: "CommandValidationError",
+        code: "COMMAND_OPERATION_CONFLICT",
+      },
     });
     expect(handled).toEqual([first.commandId]);
     expect(await persistence.listCommands()).toHaveLength(1);
@@ -252,14 +857,62 @@ describe("observer command queue", () => {
     });
 
     const [first, replay] = await Promise.all([
-      queue.dispatch(reconcileCommand, { operationId: "req_concurrent" }),
-      queue.dispatch(reconcileCommand, { operationId: "req_concurrent" }),
+      queue.dispatch(reconcileCommand, { operationId: "req_concurrent_replay" }),
+      queue.dispatch(reconcileCommand, { operationId: "req_concurrent_replay" }),
     ]);
     await queue.drain();
 
     expect(replay).toEqual(first);
     expect(handled).toEqual([first.commandId]);
     expect(await persistence.listCommands()).toHaveLength(1);
+    sqlite.close();
+  });
+
+  it("admits startup recovery and an exact operation replay only once", async () => {
+    const { sqlite, persistence } = createPersistenceAndQueue();
+    const operationId = "req_startup_recovery_replay";
+    const commandId = commandIdForOperation(operationId);
+    await persistence.recordCommandAccepted({ commandId, command: reconcileCommand });
+    let recoveryEntered = () => undefined;
+    const entered = new Promise<void>((resolveEntered) => {
+      recoveryEntered = resolveEntered;
+    });
+    let releaseRecovery = () => undefined;
+    const release = new Promise<void>((resolveRelease) => {
+      releaseRecovery = resolveRelease;
+    });
+    let blocked = false;
+    const blockedPersistence = {
+      ...persistence,
+      listEvents: async (filter?: Parameters<typeof persistence.listEvents>[0]) => {
+        if (!blocked) {
+          blocked = true;
+          recoveryEntered();
+          await release;
+        }
+        return persistence.listEvents(filter);
+      },
+    };
+    const handled: string[] = [];
+    const reconstructed = createCommandQueue({ persistence: blockedPersistence });
+    reconstructed.registerHandler("observer.reconcile", async ({ commandId: handledId }) => {
+      handled.push(handledId);
+    });
+
+    const recovery = reconstructed.recoverDurableCommands();
+    await entered;
+    const replay = reconstructed.dispatch(reconcileCommand, { operationId });
+    releaseRecovery();
+    const [, receipt] = await Promise.all([recovery, replay]);
+
+    expect(receipt.commandId).toBe(commandId);
+    expect(handled).toEqual([commandId]);
+    expect((await persistence.listEvents({ commandId })).map(({ event }) => event.type)).toEqual([
+      "command.accepted",
+      "command.started",
+      "command.succeeded",
+    ]);
+    await reconstructed.shutdown();
     sqlite.close();
   });
 
@@ -648,7 +1301,6 @@ describe("observer command queue", () => {
     ).toEqual(["command.accepted", "command.started", "command.failed"]);
     sqlite.close();
   });
-
   it("shutdown interrupts an in-flight command and drains after failure is recorded", async () => {
     const { sqlite, persistence, queue } = createPersistenceAndQueue({ commandTimeoutMs: 1000 });
     let started = () => {};

--- a/apps/observer/test/integration/persistence.test.ts
+++ b/apps/observer/test/integration/persistence.test.ts
@@ -490,6 +490,57 @@ describe("observer persistence", () => {
     sqlite.close();
   });
 
+  it("selects succeeded commands whose indexed success evidence fails strict parsing", async () => {
+    const sqlite = openObserverSqlite({ clock: { now: () => new Date(now) } });
+    const persistence = createSqliteObserverPersistence({
+      sqlite,
+      clock: { now: () => new Date(now) },
+      idFactory: ids(),
+    });
+    const commandIds = ["cmd_bad_json", "cmd_bad_identity", "cmd_extra_field"] as const;
+    for (const commandId of commandIds) {
+      await persistence.recordCommandAccepted({ commandId, command, createdAt: now });
+      await persistence.markCommandStarted(commandId, now);
+      await persistence.markCommandSucceeded(commandId, now);
+    }
+    const insertEvent = sqlite.database.prepare(`
+      INSERT INTO events (id, type, source, command_id, trace_id, span_id, payload_json, created_at)
+      VALUES (?, 'command.succeeded', 'observer', ?, NULL, NULL, ?, ?)
+    `);
+    insertEvent.run("evt_bad_json", commandIds[0], "{", now);
+    insertEvent.run(
+      "evt_bad_identity",
+      commandIds[1],
+      JSON.stringify({ type: "command.succeeded", commandId: "cmd_other" }),
+      now,
+    );
+    insertEvent.run(
+      "evt_extra_field",
+      commandIds[2] ?? "",
+      JSON.stringify({ type: "command.succeeded", commandId: commandIds[2], legacy: true }),
+      now,
+    );
+
+    expect(
+      (await persistence.listCommandRecoveryCandidates({ failedCommandTypes: [] })).map(
+        ({ id }) => id,
+      ),
+    ).toEqual([...commandIds].sort());
+    await expect(persistence.listEvents({ type: "command.succeeded" })).resolves.toEqual([]);
+    insertEvent.run(
+      "evt_repaired_json",
+      commandIds[0] ?? "",
+      JSON.stringify({ type: "command.succeeded", commandId: commandIds[0] }),
+      now,
+    );
+    expect(
+      (await persistence.listCommandRecoveryCandidates({ failedCommandTypes: [] })).map(
+        ({ id }) => id,
+      ),
+    ).toEqual(commandIds.slice(1).sort());
+    sqlite.close();
+  });
+
   it("drops retired provider hook event rows rather than upgrading them", async () => {
     const sqlite = openObserverSqlite({ clock: { now: () => new Date(now) } });
     const persistence = createSqliteObserverPersistence({

--- a/apps/observer/test/integration/protocol-server.test.ts
+++ b/apps/observer/test/integration/protocol-server.test.ts
@@ -1,7 +1,8 @@
-import { access, chmod, mkdtemp, rm } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
+import type { CreateWorktreeRequest } from "@station/contracts";
 import { componentLogPath } from "@station/observability";
 import { createObserverClient } from "@station/protocol";
 import {
@@ -201,6 +202,96 @@ describe("observer protocol server", () => {
       await runtime.catch(() => undefined);
     }
   });
+
+  it("cancels accepted mutation recovery when stopped before readiness", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-pre-ready-stop-"));
+    const stateDir = join(root, "state");
+    const projectRoot = join(root, "project");
+    const configPath = join(root, "config.toml");
+    const socketPath = join(root, "observer.sock");
+    await mkdir(stateDir, { recursive: true });
+    await mkdir(projectRoot, { recursive: true });
+    await writeFile(configPath, preReadyStopConfig(projectRoot), "utf8");
+    const commandId = "cmd_pre_ready_stop";
+    const seeded = openObserverSqlite({ path: join(stateDir, "observer.sqlite") });
+    const seededPersistence = createSqliteObserverPersistence({ sqlite: seeded });
+    await seededPersistence.recordCommandAccepted({
+      commandId,
+      command: {
+        type: "worktree.create",
+        payload: { projectId: "web", branch: "pre-ready-stop" },
+      },
+      createdAt: now,
+    });
+    seeded.close();
+    let providerStarted = () => undefined;
+    const providerStart = new Promise<void>((resolveStart) => {
+      providerStarted = resolveStart;
+    });
+    let releaseProvider = () => undefined;
+    const providerRelease = new Promise<void>((resolveRelease) => {
+      releaseProvider = resolveRelease;
+    });
+    class BlockingCreateProvider extends FakeWorktreeProvider {
+      override async createWorktree(request: CreateWorktreeRequest) {
+        providerStarted();
+        await releaseOrAbort(providerRelease, request.signal);
+        return super.createWorktree(request);
+      }
+    }
+    const forcedExit = vi.fn();
+    const processExit = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    const runtime = runObserverMain(
+      [
+        "--config",
+        configPath,
+        "--socket",
+        socketPath,
+        "--state-dir",
+        stateDir,
+        "--startup-timeout-ms",
+        "2000",
+      ],
+      {
+        buildVersion: observerBuildVersion,
+        exit: forcedExit,
+        providerRegistryFactory: () =>
+          new ProviderRegistry({
+            worktree: new BlockingCreateProvider({ id: "worktrunk", now }),
+            terminal: new FakeTerminalProvider({ now }),
+            harnesses: [new FakeHarnessProvider({ now })],
+          }),
+      },
+    );
+    const client = createObserverClient({ socketPath, requestId: ids("pre-ready-stop") });
+    try {
+      await providerStart;
+      const stopped = Promise.all([client.stop(), runtime]);
+      await expect(
+        Promise.race([
+          stopped.then(() => true),
+          new Promise<false>((resolveTimeout) => setTimeout(() => resolveTimeout(false), 500)),
+        ]),
+      ).resolves.toBe(true);
+      releaseProvider();
+      await stopped;
+      const inspected = openObserverSqlite({ path: join(stateDir, "observer.sqlite") });
+      const inspectedPersistence = createSqliteObserverPersistence({ sqlite: inspected });
+      await expect(inspectedPersistence.getCommand(commandId)).resolves.toMatchObject({
+        status: "failed",
+        error: expect.objectContaining({ code: "COMMAND_CANCELLED" }),
+      });
+      inspected.close();
+      expect(forcedExit).not.toHaveBeenCalled();
+    } finally {
+      releaseProvider();
+      await client.stop().catch(() => undefined);
+      await runtime.catch(() => undefined);
+      await new Promise((resolveDelay) => setTimeout(resolveDelay, 2100));
+      processExit.mockRestore();
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 5000);
 
   it("keeps production duplicate inspection report-only without blocking health", async () => {
     const { dir, socketPath } = await createTempSocketPath();
@@ -408,6 +499,42 @@ describe("observer protocol server", () => {
     await server.close();
     fixture.sqlite.close();
   });
+
+  it("replays one protocol command identity without a second durable execution", async () => {
+    const { socketPath } = await createTempSocketPath();
+    const fixture = createObserverFixture(socketPath);
+    const server = await startObserverServer({
+      socketPath,
+      api: fixture.api,
+      clock: fixture.clock,
+    });
+    const client = createObserverClient({
+      socketPath,
+      requestId: () => "req_replayed_command",
+    });
+    const command = {
+      type: "observer.reconcile" as const,
+      payload: { reason: "replayed-command" },
+    };
+
+    try {
+      const first = await client.dispatch(command);
+      await fixture.queue.drain();
+      const replay = await client.dispatch(command);
+      await fixture.queue.drain();
+
+      expect(replay).toEqual(first);
+      expect(await fixture.persistence.listCommands()).toHaveLength(1);
+      expect(
+        (await fixture.persistence.listEvents({ commandId: first.commandId })).map(
+          (event) => event.type,
+        ),
+      ).toEqual(["command.accepted", "command.started", "command.succeeded"]);
+    } finally {
+      await server.close();
+      fixture.sqlite.close();
+    }
+  });
 });
 
 function createObserverFixture(socketPath: string) {
@@ -464,7 +591,7 @@ function createObserverFixture(socketPath: string) {
     eventBus,
     clock,
   });
-  return { api, queue, sqlite, clock };
+  return { api, queue, sqlite, persistence, clock };
 }
 
 const config: StationConfig = {
@@ -509,4 +636,42 @@ function observerIds() {
 function ids(prefix: string): () => string {
   let id = 0;
   return () => `${prefix}_${++id}`;
+}
+
+function preReadyStopConfig(projectRoot: string): string {
+  return [
+    "schema_version = 1",
+    "",
+    "[defaults]",
+    'worktree_provider = "worktrunk"',
+    'terminal = "fake-terminal"',
+    'harness = "fake-harness"',
+    'layout = "agent-shell"',
+    "",
+    "[[projects]]",
+    'id = "web"',
+    'label = "web"',
+    `root = ${JSON.stringify(projectRoot)}`,
+    'default_branch = "main"',
+    "",
+    "[projects.worktrunk]",
+    "enabled = true",
+    'base = "main"',
+    "",
+  ].join("\n");
+}
+
+async function releaseOrAbort(release: Promise<void>, signal?: AbortSignal): Promise<void> {
+  await new Promise<void>((resolveRelease, reject) => {
+    const onAbort = () => reject(signal?.reason);
+    if (signal?.aborted === true) {
+      onAbort();
+      return;
+    }
+    signal?.addEventListener("abort", onAbort, { once: true });
+    void release.then(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolveRelease();
+    });
+  });
 }

--- a/apps/observer/test/integration/sqlite-persistence-ports.test.ts
+++ b/apps/observer/test/integration/sqlite-persistence-ports.test.ts
@@ -46,7 +46,7 @@ describe("SQLite-only Observer persistence behavior", () => {
 
     const upgraded = openObserverSqlite({ path, clock: { now: () => new Date(now) } });
     try {
-      expect(upgraded.health().schemaVersion).toBe(17);
+      expect(upgraded.health().schemaVersion).toBe(18);
       const persistence = createSqliteObserverPersistence({ sqlite: upgraded });
       await persistence.createSessionGroup({
         id: "group_durable",
@@ -125,6 +125,68 @@ describe("SQLite-only Observer persistence behavior", () => {
       ]);
     } finally {
       sqlite.close();
+    }
+  });
+
+  it("serves pure reads while another connection reserves the writer", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "station-command-recovery-read-"));
+    const path = join(directory, "observer.sqlite");
+    const sqlite = openObserverSqlite({ path, clock: { now: () => new Date(now) } });
+    const persistence = createSqliteObserverPersistence({
+      sqlite,
+      clock: { now: () => new Date(now) },
+    });
+    await persistence.recordCommandAccepted({
+      commandId: "cmd_recovery_read",
+      command: { type: "observer.reconcile", payload: { reason: "recovery-read" } },
+      createdAt: now,
+    });
+    const writer = openSqlDatabase(path);
+    try {
+      writer.exec("BEGIN IMMEDIATE");
+      await expect(persistence.getCommand("cmd_recovery_read")).resolves.toEqual(
+        expect.objectContaining({ id: "cmd_recovery_read", status: "accepted" }),
+      );
+      await expect(persistence.listCommands()).resolves.toEqual([
+        expect.objectContaining({ id: "cmd_recovery_read", status: "accepted" }),
+      ]);
+      await expect(
+        persistence.listCommandRecoveryCandidates({ failedCommandTypes: [] }),
+      ).resolves.toEqual([
+        expect.objectContaining({ id: "cmd_recovery_read", status: "accepted" }),
+      ]);
+      const emptyReads = [
+        () => persistence.listCommandErrors("cmd_recovery_read"),
+        () => persistence.listEvents(),
+        () => persistence.listProviderObservations(),
+        () => persistence.listCurrentProviderEntityObservations(),
+        () => persistence.listWorktreeMetadataCurrent(),
+        () => persistence.listSessions(),
+        () => persistence.listWorktreeDisplayTitles(),
+        () => persistence.listSessionHarnessExecutions(),
+        () => persistence.listSessionRecoveryHandles(),
+        () => persistence.listSessionTurnReadiness(),
+      ];
+      for (const read of emptyReads) await expect(read()).resolves.toEqual([]);
+      await expect(
+        persistence.getSessionHarnessExecution({ provider: "codex", sessionId: "ses_missing" }),
+      ).resolves.toBeUndefined();
+      await expect(
+        persistence.findRememberedHarnessProviderForWorktree({
+          projectId: "web",
+          worktreeId: "wt_missing",
+          worktreePath: "/tmp/station/web/missing",
+        }),
+      ).resolves.toBeUndefined();
+      await expect(
+        persistence.getSessionRecoveryHandle("recovery_missing"),
+      ).resolves.toBeUndefined();
+      expect(persistence.health()).toMatchObject({ status: "healthy" });
+      writer.exec("ROLLBACK");
+    } finally {
+      writer.close();
+      sqlite.close();
+      await rm(directory, { recursive: true, force: true });
     }
   });
 
@@ -477,6 +539,7 @@ describe("SQLite-only Observer persistence behavior", () => {
         [15, "drop_recovery_breadcrumbs"],
         [16, "worktree_display_titles"],
         [17, "session_groups"],
+        [18, "command_recovery_lookup"],
       ]);
       await expect(persistence.listSessions()).resolves.toEqual([
         expect.objectContaining({

--- a/apps/observer/test/support/inMemoryObserverPersistence.ts
+++ b/apps/observer/test/support/inMemoryObserverPersistence.ts
@@ -216,6 +216,29 @@ export function createInMemoryObserverPersistence(
           .map((command) => commandWithDiagnostics(draft, command)),
       ),
 
+    listCommandRecoveryCandidates: ({ failedCommandTypes }) =>
+      transaction((draft) => {
+        const failedTypes = new Set(failedCommandTypes);
+        const completedCommandIds = new Set(
+          [...draft.events.values()]
+            .filter((event) => event.type === "command.succeeded")
+            .map((event) => event.commandId),
+        );
+        return [...draft.commands.values()]
+          .filter(
+            (command) =>
+              command.status === "accepted" ||
+              (command.status === "succeeded" && !completedCommandIds.has(command.id)) ||
+              (command.status === "started" && command.command.type === "worktree.remove") ||
+              (command.status === "failed" && failedTypes.has(command.command.type)),
+          )
+          .sort(
+            (left, right) =>
+              compareAsc(left.createdAt, right.createdAt) || compareAsc(left.id, right.id),
+          )
+          .map((command) => commandWithDiagnostics(draft, command));
+      }),
+
     listCommandErrors: (commandId) =>
       transaction((draft) =>
         sortedCommandErrors(draft).filter(

--- a/apps/observer/test/support/observerPersistenceContract.ts
+++ b/apps/observer/test/support/observerPersistenceContract.ts
@@ -193,6 +193,85 @@ export function observerPersistenceContract(
         });
       });
 
+      it("selects unresolved command recovery candidates without deciding their evidence", async () => {
+        await withPersistence(createFixture, async ({ persistence }) => {
+          const removeCommand: StationCommand = {
+            type: "worktree.remove",
+            payload: {
+              worktreeId: "wt_recovery",
+              expectedPath: "/tmp/station/recovery",
+              expectedBranch: "recovery",
+              expectedRegistrationIdentity: "registration:recovery",
+              force: true,
+            },
+          };
+          await persistence.recordCommandAccepted({
+            commandId: "cmd_complete",
+            command,
+            createdAt: now,
+          });
+          await persistence.markCommandStarted("cmd_complete", now);
+          await persistence.markCommandSucceeded("cmd_complete", now);
+          await persistence.recordEvent(
+            { type: "command.succeeded", commandId: "cmd_complete" },
+            { commandId: "cmd_complete", createdAt: now },
+          );
+          await persistence.recordCommandAccepted({
+            commandId: "cmd_missing_success",
+            command,
+            createdAt: now,
+          });
+          await persistence.markCommandStarted("cmd_missing_success", now);
+          await persistence.markCommandSucceeded("cmd_missing_success", now);
+          await persistence.recordCommandAccepted({
+            commandId: "cmd_started_remove",
+            command: removeCommand,
+            createdAt: now,
+          });
+          await persistence.markCommandStarted("cmd_started_remove", now);
+          await persistence.recordCommandAccepted({
+            commandId: "cmd_failed_registered",
+            command,
+            createdAt: now,
+          });
+          await persistence.markCommandStarted("cmd_failed_registered", now);
+          const safeError = contractSafeError("RECOVERY_CANDIDATE");
+          await persistence.markCommandFailed({
+            commandId: "cmd_failed_registered",
+            safeError,
+            envelope: contractEnvelope({
+              id: "err_recovery_candidate",
+              commandId: "cmd_failed_registered",
+              createdAt: now,
+            }),
+            finishedAt: now,
+          });
+          await persistence.recordCommandAccepted({
+            commandId: "cmd_accepted",
+            command,
+            createdAt: now,
+          });
+
+          await expect(
+            persistence.listCommandRecoveryCandidates({
+              failedCommandTypes: ["observer.reconcile"],
+            }),
+          ).resolves.toEqual([
+            expect.objectContaining({ id: "cmd_accepted" }),
+            expect.objectContaining({ id: "cmd_failed_registered" }),
+            expect.objectContaining({ id: "cmd_missing_success" }),
+            expect.objectContaining({ id: "cmd_started_remove" }),
+          ]);
+          await expect(
+            persistence.listCommandRecoveryCandidates({ failedCommandTypes: [] }),
+          ).resolves.toEqual([
+            expect.objectContaining({ id: "cmd_accepted" }),
+            expect.objectContaining({ id: "cmd_missing_success" }),
+            expect.objectContaining({ id: "cmd_started_remove" }),
+          ]);
+        });
+      });
+
       it("rejects duplicate and invalid commands without changing prior state", async () => {
         await withPersistence(createFixture, async ({ persistence }) => {
           await persistence.recordCommandAccepted({

--- a/apps/observer/test/support/testObserver.ts
+++ b/apps/observer/test/support/testObserver.ts
@@ -20,9 +20,11 @@ export function fakeObserverCommandQueue(): CommandQueue {
     dispatch: async () => {
       throw new Error("dispatch is not used by this test.");
     },
+    recoverDurableCommands: async () => undefined,
     drain: async () => undefined,
     shutdown: async () => undefined,
     registerHandler: () => undefined,
+    registerRecoveryHandler: () => undefined,
   };
 }
 

--- a/apps/observer/test/unit/observerStartupGate.test.ts
+++ b/apps/observer/test/unit/observerStartupGate.test.ts
@@ -11,7 +11,7 @@ describe("observer startup gate", () => {
     gate.settleReady(() => ({ status: "released" }));
     expect(() => gate.assertReadyForOperation()).not.toThrow();
 
-    gate.requestStop();
+    expect(gate.requestStop()).toBe(false);
     expect(() => gate.assertReadyForOperation()).toThrow(
       expect.objectContaining({ code: "OBSERVER_STOPPING" }),
     );
@@ -24,7 +24,8 @@ describe("observer startup gate", () => {
       shutdownReleased = true;
     });
 
-    gate.requestStop();
+    expect(gate.requestStop()).toBe(true);
+    expect(gate.requestStop()).toBe(false);
     await Promise.resolve();
     expect(shutdownReleased).toBe(false);
 

--- a/apps/observer/test/unit/persistence-rows.test.ts
+++ b/apps/observer/test/unit/persistence-rows.test.ts
@@ -1,7 +1,9 @@
 import { createFakeTerminalTarget, createFakeWorktree } from "@station/testing";
 import { describe, expect, it } from "vitest";
 import {
+  eventFromRow,
   providerObservationFromRow,
+  type SqliteEventRow,
   type SqliteProviderObservationRow,
 } from "../../src/persistence/rows";
 
@@ -66,6 +68,27 @@ describe("persistence row conversion", () => {
     if (observation.entityKind === "terminal_target") {
       expect(observation.payload.providerData).toBeUndefined();
     }
+  });
+
+  it("rejects event rows whose indexed metadata contradicts the strict payload", () => {
+    const row: SqliteEventRow = {
+      id: "evt_1",
+      type: "command.succeeded",
+      source: "observer",
+      command_id: "cmd_1",
+      trace_id: null,
+      span_id: null,
+      payload_json: JSON.stringify({ type: "command.succeeded", commandId: "cmd_1" }),
+      created_at: now,
+    };
+
+    expect(eventFromRow(row)).toMatchObject({ type: "command.succeeded", commandId: "cmd_1" });
+    expect(() => eventFromRow({ ...row, type: "command.failed" })).toThrow(
+      "metadata does not match",
+    );
+    expect(() => eventFromRow({ ...row, command_id: "cmd_other" })).toThrow(
+      "metadata does not match",
+    );
   });
 });
 

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -754,6 +754,18 @@
           "purpose": null
         },
         {
+          "name": "CommandRecoveryContext",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "CommandRecoveryHandler",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
           "name": "createCommandQueue",
           "kind": "function",
           "role": null,
@@ -823,6 +835,7 @@
             "CommandDispatchOptions",
             "CommandId",
             "CommandReceipt",
+            "SafeError",
             "StationCommand",
             "StationEvent",
             "TerminalClosePayload",
@@ -1093,7 +1106,7 @@
           "specifier": "./worktree/remove.js",
           "resolvedPath": "apps/observer/src/commands/worktree/remove.ts",
           "edgeKind": "runtime",
-          "bindings": ["createWorktreeRemoveHandler"]
+          "bindings": ["createWorktreeRemoveHandler", "createWorktreeRemoveRecoveryHandler"]
         },
         {
           "specifier": "../features/evaluator.js",
@@ -2976,11 +2989,17 @@
           "name": "createWorktreeRemoveHandler",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Revalidates selected checkout and Git registration identity before coordinating removal. Provider-confirmed removal cannot be overwritten by later cancellation or event-journal degradation; it retries atomic session/title retirement once before publishing removal evidence."
+          "purpose": "Revalidates selected checkout and Git registration identity before coordinating removal. Provider-confirmed removal cannot be overwritten by later cancellation or event-journal degradation; it retries atomic session/title retirement once before publishing removal evidence. A durable retirement failure authorizes only recovery replay of that idempotent completion path."
         },
         {
           "name": "CreateWorktreeRemoveHandlerOptions",
           "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "createWorktreeRemoveRecoveryHandler",
+          "kind": "function",
           "role": null,
           "purpose": null
         }
@@ -3012,7 +3031,7 @@
           "specifier": "../queue.js",
           "resolvedPath": "apps/observer/src/commands/queue.ts",
           "edgeKind": "type-only",
-          "bindings": ["CommandHandler"]
+          "bindings": ["CommandHandler", "CommandRecoveryHandler"]
         },
         {
           "specifier": "../reconcile.js",
@@ -4269,6 +4288,18 @@
         },
         {
           "name": "CommandQueue",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "CommandRecoveryContext",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "CommandRecoveryHandler",
           "kind": "type",
           "role": null,
           "purpose": null
@@ -6848,6 +6879,25 @@
       ]
     },
     {
+      "path": "apps/observer/src/migrations/018_command_recovery_lookup.ts",
+      "exports": [
+        {
+          "name": "commandRecoveryLookupMigration",
+          "kind": "const",
+          "role": null,
+          "purpose": null
+        }
+      ],
+      "imports": [
+        {
+          "specifier": "./migration.js",
+          "resolvedPath": "apps/observer/src/migrations/migration.ts",
+          "edgeKind": "type-only",
+          "bindings": ["ObserverSqliteMigration"]
+        }
+      ]
+    },
+    {
       "path": "apps/observer/src/migrations/index.ts",
       "exports": [
         {
@@ -6973,6 +7023,12 @@
           "bindings": ["sessionGroupsMigration"]
         },
         {
+          "specifier": "./018_command_recovery_lookup.js",
+          "resolvedPath": "apps/observer/src/migrations/018_command_recovery_lookup.ts",
+          "edgeKind": "runtime",
+          "bindings": ["commandRecoveryLookupMigration"]
+        },
+        {
           "specifier": "./migration.js",
           "resolvedPath": "apps/observer/src/migrations/migration.ts",
           "edgeKind": "type-only",
@@ -7003,6 +7059,12 @@
         },
         {
           "name": "listCommandErrors",
+          "kind": "function",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "listCommandRecoveryCandidates",
           "kind": "function",
           "role": null,
           "purpose": null
@@ -7049,13 +7111,13 @@
           "specifier": "./rows.js",
           "resolvedPath": "apps/observer/src/persistence/rows.ts",
           "edgeKind": "runtime",
-          "bindings": ["commandErrorFromRow", "commandFromRow"]
+          "bindings": ["commandErrorFromRow", "commandFromRow", "eventFromRow"]
         },
         {
           "specifier": "./rows.js",
           "resolvedPath": "apps/observer/src/persistence/rows.ts",
           "edgeKind": "type-only",
-          "bindings": ["SqliteCommandErrorRow", "SqliteCommandRow"]
+          "bindings": ["SqliteCommandErrorRow", "SqliteCommandRow", "SqliteEventRow"]
         },
         {
           "specifier": "./types.js",
@@ -8207,7 +8269,8 @@
             "SafeErrorSchema",
             "SessionGroupViewSchema",
             "StationCommandSchema",
-            "StationEventSchema"
+            "StationEventSchema",
+            "stationEventCommandId"
           ]
         },
         {
@@ -13947,7 +14010,7 @@
       "declaration": "createWorktreeRemoveHandler",
       "kind": "function",
       "role": "USE CASE",
-      "purpose": "Revalidates selected checkout and Git registration identity before coordinating removal. Provider-confirmed removal cannot be overwritten by later cancellation or event-journal degradation; it retries atomic session/title retirement once before publishing removal evidence.",
+      "purpose": "Revalidates selected checkout and Git registration identity before coordinating removal. Provider-confirmed removal cannot be overwritten by later cancellation or event-journal degradation; it retries atomic session/title retirement once before publishing removal evidence. A durable retirement failure authorizes only recovery replay of that idempotent completion path.",
       "dependencies": [
         {
           "path": "apps/observer/src/stationLogger.ts",

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -187,7 +187,7 @@ ownership even where current ownership is still a deviation.
 | Recorded mutations | Driving | `StationCommand`, `dispatch`, command handlers | CLI, Station client, protocol client | Commands persist acceptance and completion; the production handler map is compile-time exhaustive over the command union. |
 | Provider hook delivery | Driving | provider hook ingress | `stn-ingress`, protocol method, offline spool, provider hook adapters | Raw input is validated once and provider vocabulary is normalized at the adapter boundary. |
 | Harness status delivery | Driving | harness event report ingress | harness hooks, provider hook adapters, protocol clients | Reports are deduplicated, queued, projected, persisted, and followed by reconcile. |
-| Worktree operations | Driven | `WorktreeProvider` | Worktrunk and test adapters | Strong purpose-owned port; targeted lookups and removals revalidate current Git identity, managed-root containment, and unforced dirty state before returning evidence or mutating. Mutation requests carry cooperative cancellation into adapter-owned reads and subprocesses. |
+| Worktree operations | Driven | `WorktreeProvider` | Worktrunk and test adapters | Strong purpose-owned port; mutation requests carry cooperative cancellation into adapter-owned reads and subprocesses, while cancelled removals use fresh Git evidence to distinguish preserved targets from completed deletion. |
 | Terminal operations | Driven | `TerminalProvider` | tmux, Station terminal, and test adapters | General topology and operations are provider-owned. |
 | Managed terminal lifecycle | Driven | `ManagedTerminalLifecycle` | Station terminal adapter, optionally backed by Station Host | Explicit injected role returning only an opaque target identity and declaring whether launched processes persist beyond the caller; Host backing may add spawn/list/close/attachment lifecycle, while Station retains native presentation and host-backed targets remain externally non-focusable. |
 | Harness operations | Driven | `HarnessProvider`, `SessionRecoveryArtifactLocator` | Claude, Codex, Cursor, OpenCode, Pi, scripted, and test adapters | Strong purpose-owned ports with provider-local parsing, compatibility admission, and exact recovery-artifact location; unsupported artifact providers make migration ineligible. |
@@ -245,7 +245,7 @@ No single layer owns all truth.
 | State | Authority and lifetime |
 | --- | --- |
 | Loaded config | Authoritative for managed projects, defaults, provider choices, feature policy, and configured hooks. Durable in TOML; loaded into process memory at startup and updated through explicit config operations. |
-| Provider observations | Each provider is authoritative only for external facts it can prove. Live reads and normalized ingress observations may be persisted with retention, but cached evidence does not outrank a newer provider read. A persisted worktree observation may supply a targeted lookup's path and registration hint only when the provider revalidates current native evidence before returning it. |
+| Provider observations | Each provider is authoritative only for external facts it can prove. Live reads and normalized ingress observations may be persisted with retention, but cached evidence does not outrank a newer provider read. A persisted worktree observation may supply a restart lookup's path and registration hint only when the provider revalidates current targeted evidence before returning it. |
 | Provider-owned identity | Worktree, target, harness-run, native execution, and external endpoint identity stays owned by the provider that minted it. Application code may carry opaque IDs but must not reconstruct their format. |
 | Observer-minted state | Command, event, error, report, session, Session Group, correlation, readiness, and recovery identities are legitimate internal facts minted by the observer. The observer does not invent external facts. |
 | Observer SQLite | Durable observer memory for commands, events, ingress dedupe, observations, correlations, sessions, project-local Session Groups, canonical worktree display titles, native-execution bindings, metadata caches, recovery handles, and readiness. Group membership is exclusive per session, while Group deletion changes only organizational rows. Display-title authority is keyed by `(projectId, worktreeId)` and survives transient provider observation gaps; it is not branch or provider identity. |
@@ -344,7 +344,8 @@ defined startup failure path and shutdown owner.
 
 The API stop path first aborts and awaits duplicate inspection, then stops
 provider-health publication, refuses queued reconciles and awaits an active scheduler flush,
-drains harness ingress, marks metadata refresh terminal, aborts active local and repository reads, shuts down ref invalidation,
+drains harness ingress, marks metadata refresh
+terminal, aborts active local and repository reads, shuts down ref invalidation,
 and waits for the refresh flight before process shutdown. Ref-watcher shutdown
 invalidates callbacks first, clears debounce timers, attempts every close despite
 individual failures, and makes later replacement and callbacks no-ops. During
@@ -356,6 +357,11 @@ new commands, aborts running handlers cooperatively, and waits for their
 per-scope chains; configured event hooks and the protocol server then close
 before SQLite. A bounded process backstop prevents a handler that ignores
 cancellation from keeping a stopped Observer alive indefinitely.
+Before readiness, stop begins command-queue cancellation immediately so accepted
+recovery cannot hold startup settlement; ready-state shutdown retains the ordinary
+API-first ordering. Recovery stops admitting accepted rows once shutdown begins,
+leaving never-started records durable for a later owner while started cooperative
+handlers record cancellation.
 
 The exact socket, pidfile, listener-abandonment, displacement, and explicit CLI
 stop/restart ordering is part of the canonical
@@ -367,8 +373,8 @@ architecture-level ownership specification.
 ### Command Execution
 
 ```text
-client -> transport validation -> ObserverApi.dispatch
-       -> validate command -> persist accepted -> publish accepted
+client -> transport validation + replay identity -> ObserverApi.dispatch
+       -> validate command -> resolve or persist durable admission -> publish accepted
        -> serialize by command scope -> persist/publish started
        -> handler -> policies and driven ports -> reconcile when required
        -> persist/publish succeeded or failed -> command query/completion wait
@@ -380,13 +386,6 @@ unrelated scopes may run concurrently. Failure is normalized into `SafeError`,
 persisted with trace correlation, and published. A failed command does not
 poison the following command in its scope.
 
-The protocol client retries a lost dispatch response once with the same request
-identity. Command admission derives the same durable command ID and returns the
-recorded receipt for exact replay. A stranded `accepted` record resumes once and
-repairs missing acceptance evidence, while `started` and terminal records never
-reexecute. Reusing an identity with different command input refuses before
-mutation; a fresh request identity always denotes a distinct command.
-
 Recorded `sessionGroup.create`, `sessionGroup.rename`,
 `sessionGroup.updateMembership`, `sessionGroup.reparent`, and `sessionGroup.delete` commands serialize by
 project. Inside the snapshot-writer turn they validate configured-project and
@@ -397,25 +396,57 @@ Changed Group events derive from the mutation result and are persisted and publi
 canonical order before command success; validated no-ops emit no Group event. This path
 does not read providers or publish `observer.reconciled`.
 
-`session.startAgent` and `session.resumeAgent` use current targeted provider evidence when
-the selected worktree is absent from the snapshot. A persisted path and registration
-identity may seed that lookup, but only the provider's fresh validation authorizes launch;
-full-inventory convergence runs afterward without holding foreground completion.
+The protocol client retries a lost dispatch response once with the same request
+identity. Command admission derives the same durable command ID after process or
+queue reconstruction and returns the recorded receipt. An exact replay schedules
+a stranded `accepted` record once, repairing its missing acceptance event when
+needed. `started` records never execute again because work may already have
+crossed an external mutation boundary. A started removal becomes succeeded only
+when its own durable `worktree.removed` event names the selected worktree and
+proves provider-confirmed completion; current provider state, session state, or a
+session event alone is not provenance. Replay also repairs a missing success event
+for an already-succeeded record and reconstructs a missing failure event from an
+already-failed record's persisted public `SafeError`; neither repair reexecutes a handler.
+One recovery-only handler may repair a known terminal failure at most once per queue
+lifetime. The current handler accepts only a provider-confirmed removal whose exact
+command/error identities say durable session retirement failed; it repeats no external
+cleanup, retries only the idempotent retirement transaction, then publishes removal and
+success evidence. A persistent repair failure remains failed and evidence-free until a
+later process can attempt recovery again. After binding and watching its socket, the owning
+Observer runs one durable-command recovery pass before readiness; it repairs missing terminal
+events and evidence-backed started removals, runs registered failed-command recovery without
+invoking original mutation handlers, and resumes accepted commands through their ordinary
+scope-serialized handlers. Recovery drains resumed work before readiness; ambiguous started
+commands remain untouched, and per-command failure is logged without blocking peers. Startup repairs fold snapshot
+convergence into the normal single startup reconcile; client-triggered replay retains its
+non-blocking deferred reconcile. `CommandJournal` selects unresolved coarse candidates with
+indexed lifecycle-event evidence; it parses indexed success rows through the shared strict schema
+so corrupt row metadata or payloads cannot suppress repair. The queue still parses each command
+candidate and owns final evidence ranking.
+Reusing that identity with different command input refuses before mutation; a
+fresh identity remains a distinct command and is never inferred from branch or
+path coincidence.
 
 `worktree.remove` carries the selected worktree ID, canonical path, branch, and
 opaque Git registration identity. Its use case refreshes provider evidence and
 uniquely re-resolves that identity before terminal or worktree cleanup, refusing
 primary, default-branch, stale, missing, or ambiguous targets. The worktree
-adapter rechecks the expected registration identity, path, branch, managed-root
-containment, and unforced dirty state immediately before mutation so an external
-checkout replacement cannot reuse the selected path and branch as removal
-identity. Targeted reads treat supplied paths and registration identities as hints
-and return only current Git-validated observations. Adapter race refusals retain
-provider-neutral, trace-correlated diagnostic evidence. After provider-confirmed
-removal, the command retries atomic session/title retirement once, publishes
-removal evidence, and schedules full-inventory repair without holding command
-completion behind it. Cancellation after that irreversible confirmation cannot
-replace the authoritative removal result.
+adapter rechecks the expected registration identity, path, and branch immediately
+before mutation so an external checkout replacement cannot reuse the selected
+path and branch as removal identity. Adapter race refusals retain provider-neutral,
+trace-correlated diagnostic evidence. After provider-confirmed removal, the
+command retries the atomic session/title retirement transaction once, publishes
+removal evidence, and starts reconcile repair without holding completion behind the inventory scan. Repair
+failure or cancellation after confirmation cannot replace the removal result.
+If both synchronous retirement attempts fail, the failed command itself preserves
+provider confirmation and exact project/worktree/session repair identity. Exact replay
+can later retire only that durable state and complete evidence; it never calls Worktrunk,
+the harness, or the terminal again.
+Before confirmation, the command's cooperative signal reaches provider-owned Git
+and Worktrunk subprocesses so cancellation can still prevent deletion. Removal
+events are idempotent per command and retry once after a partial journal failure;
+persistent event degradation is logged and left to snapshot reconcile without
+changing the provider-confirmed command result.
 
 ### Session Recovery Cutover
 
@@ -701,9 +732,9 @@ expires.
 | Socket ownership evidence | Connect success proves listening. Only `ECONNREFUSED`, or Bun's existing-path `ENOENT`, plus strict zero-holder `lsof` evidence proves stale. Permission failures, timeouts, live holders, evidence failure, path replacement, and non-socket collisions are inaccessible and authorize no spawn, unlink, stop, or signal. |
 | Observer build ordering | Health and pidfile `version` carry display SemVer plus reserved `station.<sha256>` build metadata derived from both repository inputs and production package outputs. Exact identified selectors attach. At one display version, the lexicographically greater immutable build identity is the only candidate allowed to replace; the loser and any missing legacy identity refuse, so neither silently delegates to different code. Each source process verifies the published identity once before adopting it and reuses that selector without further Git or hash I/O for its lifetime. Different display versions retain SemVer precedence and the existing exact-string equal-precedence tiebreak, except that the declared public reset orders `0.0.0-pre-alpha.*` after internal `0.7.1-rc.*` previews. Missing, invalid, or stale identities refuse. Replacement requires complete corroborating identity and never uses automatic SIGKILL. |
 | Command ordering | Commands serialize by session, worktree, project, terminal target, or command-specific fallback scope. Different scopes can execute concurrently. |
-| Command admission replay | A protocol request identity deterministically addresses one durable command record. Exact replay returns its original receipt and may resume only a never-started accepted record; changed input for that identity refuses. The client retries only dispatch transport and preserves the identity across attempts. |
 | Managed target release | Station target IDs are deterministic per worktree, so release is compare-and-delete on target plus expected Station session. A delayed old exit or failed-launch cleanup cannot remove a replacement binding; `false` proves absence or supersession, while rejection leaves cleanup uncertain. |
-| Command timeout and cancellation | Handlers receive a signal combining the runtime timeout and queue shutdown. A handler with a non-cancellable durable section calls `beginCommit` after read-only validation and immediately before its first write; cancellation may prevent entry, but the queue drains a begun commit to one completion. Create and fork pass that signal into provider-owned reads and subprocesses; a timeout that cannot prove whether mutation completed returns an outcome-unknown error and schedules nonblocking reconcile repair. A provider-confirmed irreversible removal marks its external mutation committed so later timeout or cancellation drains synchronous classification instead of overwriting accurate success. Other cancellation remains cooperative, and the process shutdown backstop handles ignored signals. |
+| Command admission replay | A protocol request identity deterministically addresses one durable command record. Exact replay returns its original receipt without another event or handler run; changed input for that identity refuses. The client retries only the dispatch transport once and preserves the identity across attempts. |
+| Command timeout and cancellation | Handlers receive a signal combining the runtime timeout and queue shutdown. A handler with a non-cancellable durable section calls `beginCommit` after read-only validation and immediately before its first write; cancellation may prevent entry, but the queue drains a begun commit to one completion. Create and fork timeouts report an outcome-unknown error because an external tool may already have mutated, then start non-blocking reconcile repair without delaying the response behind inventory discovery. A provider-confirmed irreversible removal marks its external mutation committed so a later timeout or cancellation drains synchronous classification instead of overwriting accurate success; its pre-confirmation Git and Worktrunk subprocesses remain cancellable. Other cancellation remains cooperative, and the process shutdown backstop handles ignored signals. |
 | Snapshot writer ordering | Full reconciles, Group mutation commits, and harness-report authorization plus base projection share a non-poisoning promise chain. A Group mutation projects only its command project and never scans providers, repairs other durable state, or publishes a reconcile event. Readiness persistence revalidates the live snapshot after its write. Scheduled reconcile requests coalesce; queued work after a run receives a later flush. |
 | Persisted harness compatibility | A harness adapter may use a provider-local strict schema to reject recognizable observations accepted by an earlier build. Unparseable legacy data remains admitted. Reconcile excludes only provider-rejected observations, then atomically replaces the affected session's derived native binding and readiness from the remaining admitted history; a succeeded acknowledgement remains authoritative. |
 | Provider reads | Reads are timeboxed, retried at the runtime boundary, and concurrency-limited. Failures become provider health and reconcile errors. |
@@ -782,10 +813,11 @@ independent of SQLite row translation.
 
 `createSqliteObserverPersistence` is the named `ADAPTER` that implements the
 bundle and `PersistenceHealthSource`. SQL, `Sqlite*Row` representations, parsing
-and translation, `BEGIN IMMEDIATE` transaction boundaries, driver differences,
-schema health, and migrations remain at the SQLite edge. Runtime composition
-opens and closes the concrete SQLite handle around that adapter; application
-core never receives it.
+and translation, transaction boundaries, driver differences, schema health, and
+migrations remain at the SQLite edge. Mutations use `BEGIN IMMEDIATE`; pure reads
+use deferred snapshots so concurrent readers do not claim the writer reservation.
+Runtime composition opens and closes the concrete SQLite handle around that adapter;
+application core never receives it.
 
 The typechecked `createInMemoryObserverPersistence` test fixture implements
 exactly the eight-port bundle over private process-local state, with synchronous

--- a/tests/e2e/observer-sqlite-smoke.test.ts
+++ b/tests/e2e/observer-sqlite-smoke.test.ts
@@ -130,7 +130,7 @@ describe("production Observer SQLite smoke", () => {
         path: databasePath,
         open: true,
         status: "healthy",
-        schemaVersion: 17,
+        schemaVersion: 18,
       });
       expect((await stat(databasePath)).size).toBeGreaterThan(0);
 
@@ -172,7 +172,7 @@ describe("production Observer SQLite smoke", () => {
         path: databasePath,
         open: true,
         status: "healthy",
-        schemaVersion: 17,
+        schemaVersion: 18,
       });
     } finally {
       await client.stop().catch(() => undefined);


### PR DESCRIPTION
## What this fixes

Observer restart could leave accepted commands stranded or terminal command records missing their durable lifecycle events. Recovery selection also degraded with journal size, while pure SQLite reads unnecessarily joined writer-reserving transactions.

This is stack 5 of 5. Previous: #593. Merge the stack bottom-up; after #593 merges, retarget this PR to `main`. Tracks #595 and closes #600.

## What changed

- Recover accepted commands before readiness through their ordinary scope-serialized handlers.
- Repair missing success and failure events without reexecuting terminal commands.
- Complete started removals only from matching command-correlated removal evidence.
- Add a recovery-only handler for provider-confirmed removal retirement; it never repeats external cleanup.
- Add indexed recovery candidate selection in schema migration 18.
- Use deferred SQLite transactions for pure reads so readers remain available during writer reservation.
- Stop admitting recovery work when shutdown begins and preserve unstarted rows for a later owner.

## Testing

- `pnpm build` — 24/24 packages passed.
- `pnpm typecheck` — 46/46 tasks passed.
- `pnpm lint` and Observer architecture checks passed.
- Full fast lane passed: 2,586 unit, 81 contract, 155 diagnostics, and 5 scripted-agent tests.
- Full integration lane passed: 719 tests.
- Real Observer SQLite restart smoke passed.

## Safety and scope

Ambiguous started commands remain untouched. Recovery uses strict command-correlated evidence, isolates per-command failures, and does not treat current provider absence as proof that a historical mutation succeeded.
