### PR TITLE
fix(persistence): use deferred transactions for pure observer reads

### DIFF
--- a/apps/observer/src/persistence/sqliteAdapter.ts
+++ b/apps/observer/src/persistence/sqliteAdapter.ts
@@ -48,6 +48,9 @@ export function createSqliteObserverPersistence(
   const now = () => toIsoTimestamp(clock.now());
   const transaction = <T>(task: (database: SqlDatabase) => T): Promise<T> =>
     Effect.runPromise(runSqliteTransactionEffect(options.sqlite, task));
+  // Deferred snapshots let queries proceed while another WAL connection reserves the writer.
+  const readTransaction = <T>(task: (database: SqlDatabase) => T): Promise<T> =>
+    Effect.runPromise(runSqliteTransactionEffect(options.sqlite, task, "deferred"));
   const sessionGroupMutation = <T>(
     mutate: (state: sessionGroupStore.SessionGroupPersistenceState) => {
       state: sessionGroupStore.SessionGroupPersistenceState;
@@ -94,12 +97,12 @@ export function createSqliteObserverPersistence(
       ),
 
     getCommand: (commandId) =>
-      transaction((database) => commandStore.getCommand(database, commandId)),
+      readTransaction((database) => commandStore.getCommand(database, commandId)),
 
-    listCommands: () => transaction(commandStore.listCommands),
+    listCommands: () => readTransaction(commandStore.listCommands),
 
     listCommandErrors: (commandId) =>
-      transaction((database) => commandStore.listCommandErrors(database, commandId)),
+      readTransaction((database) => commandStore.listCommandErrors(database, commandId)),
 
     recordEvent: (event, eventOptions = {}) =>
       transaction((database) => {
@@ -211,7 +214,7 @@ export function createSqliteObserverPersistence(
         return { deduped: false, observations };
       }),
 
-    listEvents: (filter = {}) => transaction((database) => listEvents(database, filter)),
+    listEvents: (filter = {}) => readTransaction((database) => listEvents(database, filter)),
 
     recordProviderObservation: (input) =>
       transaction((database) =>
@@ -223,7 +226,7 @@ export function createSqliteObserverPersistence(
       ),
 
     listProviderObservations: (listOptions = {}) =>
-      transaction((database) =>
+      readTransaction((database) =>
         listProviderObservations(database, {
           ...(listOptions.entityKind === undefined ? {} : { entityKind: listOptions.entityKind }),
           ...(listOptions.includeExpired === undefined
@@ -235,7 +238,7 @@ export function createSqliteObserverPersistence(
       ),
 
     listCurrentProviderEntityObservations: (listOptions = {}) =>
-      transaction((database) =>
+      readTransaction((database) =>
         listCurrentProviderEntityObservations(database, {
           ...(listOptions.entityKind === undefined ? {} : { entityKind: listOptions.entityKind }),
           ...(listOptions.includeExpired === undefined
@@ -257,7 +260,7 @@ export function createSqliteObserverPersistence(
       ),
 
     listWorktreeMetadataCurrent: (listOptions = {}) =>
-      transaction((database) =>
+      readTransaction((database) =>
         worktreeMetadataCurrentStore.listWorktreeMetadataCurrent(database, {
           ...(listOptions.kind === undefined ? {} : { kind: listOptions.kind }),
           ...(listOptions.includeExpired === undefined
@@ -287,10 +290,10 @@ export function createSqliteObserverPersistence(
         });
       }),
 
-    listSessions: () => transaction(correlationStore.listSessions),
+    listSessions: () => readTransaction(correlationStore.listSessions),
 
     listSessionGroups: () =>
-      transaction((database) =>
+      readTransaction((database) =>
         sessionGroupStore.listSessionGroups(sessionGroupSqlite.readSessionGroupState(database)),
       ),
 
@@ -343,15 +346,15 @@ export function createSqliteObserverPersistence(
       ),
 
     listWorktreeDisplayTitles: () =>
-      transaction(worktreeDisplayTitleStore.listWorktreeDisplayTitles),
+      readTransaction(worktreeDisplayTitleStore.listWorktreeDisplayTitles),
 
     getSessionHarnessExecution: (input) =>
-      transaction((database) =>
+      readTransaction((database) =>
         sessionHarnessExecutionStore.getSessionHarnessExecution(database, input),
       ),
 
     listSessionHarnessExecutions: () =>
-      transaction(sessionHarnessExecutionStore.listSessionHarnessExecutions),
+      readTransaction(sessionHarnessExecutionStore.listSessionHarnessExecutions),
 
     repairSessionHarnessDerivedState: (input) =>
       transaction((database) => {
@@ -391,7 +394,7 @@ export function createSqliteObserverPersistence(
       }),
 
     findRememberedHarnessProviderForWorktree: (input) =>
-      transaction((database) =>
+      readTransaction((database) =>
         correlationStore.findRememberedHarnessProviderForWorktree(database, input),
       ),
 
@@ -481,12 +484,12 @@ export function createSqliteObserverPersistence(
       ),
 
     getSessionRecoveryHandle: (handleId) =>
-      transaction((database) =>
+      readTransaction((database) =>
         sessionRecoveryHandleStore.getSessionRecoveryHandle(database, handleId),
       ),
 
     listSessionRecoveryHandles: (listOptions = {}) =>
-      transaction((database) =>
+      readTransaction((database) =>
         sessionRecoveryHandleStore.listSessionRecoveryHandles(database, listOptions),
       ),
 
@@ -501,7 +504,7 @@ export function createSqliteObserverPersistence(
       }),
 
     listSessionTurnReadiness: () =>
-      transaction((database) => sessionTurnReadinessStore.listSessionTurnReadiness(database)),
+      readTransaction((database) => sessionTurnReadinessStore.listSessionTurnReadiness(database)),
 
     deleteSessionTurnReadiness: (input) =>
       transaction((database) =>

--- a/apps/observer/src/sqlite.ts
+++ b/apps/observer/src/sqlite.ts
@@ -93,10 +93,11 @@ export function openObserverSqlite(options: OpenObserverSqliteOptions = {}): Obs
 export function runSqliteTransactionEffect<T>(
   sqlite: ObserverSqliteHandle,
   task: (database: SqlDatabase) => T,
+  mode: "deferred" | "immediate" = "immediate",
 ): Effect.Effect<T, RuntimeSafeError> {
   return Effect.try({
     try: () => {
-      sqlite.database.exec("BEGIN IMMEDIATE");
+      sqlite.database.exec(mode === "deferred" ? "BEGIN" : "BEGIN IMMEDIATE");
       try {
         const value = task(sqlite.database);
         sqlite.database.exec("COMMIT");

--- a/apps/observer/test/integration/sqlite-persistence-ports.test.ts
+++ b/apps/observer/test/integration/sqlite-persistence-ports.test.ts
@@ -128,6 +128,67 @@ describe("SQLite-only Observer persistence behavior", () => {
     }
   });
 
+  it("serves pure reads while another connection reserves the writer", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "station-pure-read-contention-"));
+    const path = join(directory, "observer.sqlite");
+    const sqlite = openObserverSqlite({ path, clock: { now: () => new Date(now) } });
+    const persistence = createSqliteObserverPersistence({
+      sqlite,
+      clock: { now: () => new Date(now) },
+    });
+    await persistence.recordCommandAccepted({
+      commandId: "cmd_pure_read",
+      command: { type: "observer.reconcile", payload: { reason: "pure-read" } },
+      createdAt: now,
+    });
+    const writer = openSqlDatabase(path);
+    try {
+      writer.exec("BEGIN IMMEDIATE");
+      await expect(persistence.getCommand("cmd_pure_read")).resolves.toEqual(
+        expect.objectContaining({ id: "cmd_pure_read", status: "accepted" }),
+      );
+      await expect(persistence.listCommands()).resolves.toEqual([
+        expect.objectContaining({ id: "cmd_pure_read", status: "accepted" }),
+      ]);
+      const emptyReads = [
+        () => persistence.listCommandErrors("cmd_pure_read"),
+        () => persistence.listEvents(),
+        () => persistence.listProviderObservations(),
+        () => persistence.listCurrentProviderEntityObservations(),
+        () => persistence.listWorktreeMetadataCurrent(),
+        () => persistence.listSessions(),
+        () => persistence.listSessionGroups(),
+        () => persistence.listWorktreeDisplayTitles(),
+        () => persistence.listSessionHarnessExecutions(),
+        () => persistence.listSessionRecoveryHandles(),
+        () => persistence.listSessionTurnReadiness(),
+      ];
+      for (const read of emptyReads) await expect(read()).resolves.toEqual([]);
+      await expect(
+        persistence.getSessionHarnessExecution({ provider: "codex", sessionId: "ses_missing" }),
+      ).resolves.toBeUndefined();
+      await expect(
+        persistence.findRememberedHarnessProviderForWorktree({
+          projectId: "web",
+          worktreeId: "wt_missing",
+          worktreePath: "/tmp/station/web/missing",
+        }),
+      ).resolves.toBeUndefined();
+      await expect(
+        persistence.getSessionRecoveryHandle("recovery_missing"),
+      ).resolves.toBeUndefined();
+      expect(persistence.health()).toMatchObject({ status: "healthy" });
+      await expect(persistence.recordEvent({ type: "observer.started", at: now })).rejects.toThrow(
+        "PERSISTENCE_TRANSACTION_FAILED",
+      );
+      writer.exec("ROLLBACK");
+    } finally {
+      writer.close();
+      sqlite.close();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it("migrates historical session lifecycle without treating legacy NULL as open", async () => {
     const directory = await mkdtemp(join(tmpdir(), "station-session-lifecycle-"));
     const path = join(directory, "observer.sqlite");

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -763,10 +763,11 @@ independent of SQLite row translation.
 
 `createSqliteObserverPersistence` is the named `ADAPTER` that implements the
 bundle and `PersistenceHealthSource`. SQL, `Sqlite*Row` representations, parsing
-and translation, `BEGIN IMMEDIATE` transaction boundaries, driver differences,
-schema health, and migrations remain at the SQLite edge. Runtime composition
-opens and closes the concrete SQLite handle around that adapter; application
-core never receives it.
+and translation, transaction boundaries, driver differences, schema health, and
+migrations remain at the SQLite edge. Mutations use `BEGIN IMMEDIATE`; pure reads
+use deferred snapshots so concurrent readers do not claim the writer reservation.
+Runtime composition opens and closes the concrete SQLite handle around that adapter;
+application core never receives it.
 
 The typechecked `createInMemoryObserverPersistence` test fixture implements
 exactly the eight-port bundle over private process-local state, with synchronous


### PR DESCRIPTION
## What this fixes

Observer persistence routed read-only SQLite operations through `BEGIN IMMEDIATE`, so a harmless concurrent writer reservation made queries fail and marked persistence unavailable. This extracts the independent read-contention fix identified in #595 without bringing along #594's durable-command recovery system.

## What changed

- use deferred SQLite snapshots for all 16 pure persistence queries
- retain `BEGIN IMMEDIATE` as the default for every mutation
- include Session Group queries, which the earlier stacked draft accidentally left writer-reserving
- document the read/write transaction boundary
- prove reads remain healthy under a competing writer while a mutation still cannot take that reservation

## Testing

- `pnpm build` — 24/24 packages
- `pnpm typecheck` — 46/46 tasks
- `pnpm lint` — Biome and Observer architecture clean
- SQLite persistence contract — 61/61 tests
- `pnpm test:sqlite:bun:pr` — Node/Bun compatibility and boot-claim races passed
- `env -u STATION_OPENCODE_PLUGIN_BODY_PATH pnpm test:e2e:setup:sqlite` — real SQLite restart smoke passed

## Safety and scope

No migration, schema version, command recovery, startup replay, provider behavior, or UI behavior changes. The existing #590-#594 drafts remain untouched as lab evidence.