### PR TITLE
feat(groups): move existing sessions between groups

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -505,12 +505,24 @@ and `identity` → `quickSession` → `menu` for Groups, skipping optional Group
 runtime composition. Omitted actions have no rendered target and are invalid semantic cells. Group
 identity toggles collapse; Group quick session launches through the same pointer/focused activation
 contract and the Group menu remains a focus-preserving no-op until its workflow slice lands. Up/Down leaves any header segment immediately, and Left/Right on a
-session row or empty-project action is inert. Remove, rename, and fork row choosers retain a separate
+session row or empty-project action is inert. Remove, rename, move-to-Group, and fork row choosers retain a separate
 visible, selectable canonical-session traversal; slots and Enter resolve through that same chooser
 policy. Next-needs-me uses its own canonical-session policy. `N` continues to open the session flow
 without changing dashboard focus, while uppercase `G` creates a Quick Group for the focused row's
 owning Project (or the first canonical Project when nothing valid is focused). Lowercase `g` remains
 a visible-session slot. Gaps and optimistic create rows remain non-focusable.
+
+Uppercase `M` opens the shared session chooser, then a Move to Group sheet. Native right-click on a
+session opens the same destination step directly. The sheet shows canonical current membership as
+context while its independent cursor selects Ungrouped, same-Project root Groups, or Create new
+Group; externally nested membership is read-only. Slots, arrows plus Enter, pointer rows, `U`, and
+`N` converge on one dashboard-core reassignment operation. Moving to a Group submits one
+`sessionGroup.updateMembership` command with the current membership expectation and destination
+version; ungrouping removes through that same contract, and selecting the current destination is a
+no-op. The sheet stays visible and inert during submission. Success follows the session to its
+canonical destination; ordinary failure retains the picker, while membership/version conflicts
+close and focus canonical truth. Create new Group persists the Group first and never rolls it back
+if the subsequent move fails. Wide footers advertise `M — move to group`; compact footers may omit it.
 
 Focused compact controls use the canonical theme's stronger bounded
 `interaction.compactFocus` fill. A project header's primary segment covers the rendered

--- a/packages/dashboard-core/src/entrypoints/selectors.ts
+++ b/packages/dashboard-core/src/entrypoints/selectors.ts
@@ -134,10 +134,13 @@ export type { FleetSummary } from "../selectors/fleetSummary.js";
 export { selectFleetSummary } from "../selectors/fleetSummary.js";
 export type {
   KeyedChoice,
+  MoveToGroupSessionContext,
   NewSessionGroupOption,
   NewSessionHarnessOption,
 } from "../selectors/selectors.js";
 export {
+  selectMoveToGroupChoices,
+  selectMoveToGroupSessionContext,
   selectNewSessionGroupChoices,
   selectNewSessionHarnessChoices,
   selectNewSessionProjectChoices,

--- a/packages/dashboard-core/src/entrypoints/state.ts
+++ b/packages/dashboard-core/src/entrypoints/state.ts
@@ -45,6 +45,7 @@ export {
 } from "../state/keymap.js";
 export type { TuiKey } from "../state/keys.js";
 export { addPendingProjectDefaultHarness } from "../state/localRows.js";
+export { resolveMoveSessionToGroupOperation } from "../state/operations/sessionGroups.js";
 export { createInitialTuiState } from "../state/screen.js";
 export { tuiScreenBehavior } from "../state/screenBehavior.js";
 export {
@@ -54,8 +55,17 @@ export {
   applyAddProjectSubmitted,
 } from "../state/screens/addProjectScreen.js";
 export { openNewSession } from "../state/screens/dashboard.js";
-
 export type { ForkSessionActionId } from "../state/screens/fork.js";
+export {
+  MOVE_TO_GROUP_CREATE_CHOICE_ID,
+  MOVE_TO_GROUP_LIST_ID,
+  MOVE_TO_GROUP_UNGROUPED_CHOICE_ID,
+  moveToGroupExistingChoiceId,
+  openMoveToGroupCreate,
+  openMoveToGroupForRow,
+  selectMoveToGroupDestination,
+  submitMoveToGroupCreate,
+} from "../state/screens/moveToGroup.js";
 
 export { openProjectDefaultAgentPicker } from "../state/screens/projectDefaultAgent.js";
 export {
@@ -91,7 +101,6 @@ export {
   NEW_SESSION_UNGROUPED_CHOICE_ID,
   newSessionExistingGroupChoiceId,
 } from "../state/selection/specs/newSession.js";
-
 export type { TuiSelectionState } from "../state/selection/types.js";
 
 export {

--- a/packages/dashboard-core/src/selectors/selectors.ts
+++ b/packages/dashboard-core/src/selectors/selectors.ts
@@ -1,4 +1,10 @@
-import type { ProjectId, ProviderHealth, ProviderId, SessionGroupId } from "@station/contracts";
+import type {
+  ProjectId,
+  ProviderHealth,
+  ProviderId,
+  SessionGroupId,
+  SessionId,
+} from "@station/contracts";
 import { pendingProjectDefaultHarnesses } from "../state/localRows.js";
 import type { DashboardSnapshotView, DashboardViewState } from "../state/types.js";
 
@@ -63,6 +69,11 @@ export type NewSessionHarnessOption = {
 };
 
 export type NewSessionGroupOption = DashboardSnapshotView["sessionGroups"][number];
+export type MoveToGroupSessionContext = {
+  session: DashboardSnapshotView["sessions"][number];
+  project: DashboardSnapshotView["projects"][number];
+  currentGroup?: NewSessionGroupOption;
+};
 
 export function keyChoices<T>(values: readonly T[]): Array<KeyedChoice<T>> {
   return values.slice(0, SELECTION_KEYS.length).map((value, index) => {
@@ -131,6 +142,29 @@ export function selectNewSessionRootGroup(
     (group) =>
       group.id === groupId && group.projectId === projectId && group.parentGroupId === undefined,
   );
+}
+
+/** Resolves the latest canonical session, Project, and exclusive Group membership. */
+export function selectMoveToGroupSessionContext(
+  snapshot: DashboardSnapshotView,
+  sessionId: SessionId,
+): MoveToGroupSessionContext | undefined {
+  const session = snapshot.sessions.find((candidate) => candidate.id === sessionId);
+  if (session === undefined) return undefined;
+  const project = snapshot.projects.find((candidate) => candidate.id === session.projectId);
+  if (project === undefined) return undefined;
+  const currentGroup = snapshot.sessionGroups.find((group) => group.sessionIds.includes(sessionId));
+  const context: MoveToGroupSessionContext = { session, project };
+  if (currentGroup !== undefined) context.currentGroup = currentGroup;
+  return context;
+}
+
+export function selectMoveToGroupChoices(
+  snapshot: DashboardSnapshotView,
+  sessionId: SessionId,
+): Array<KeyedChoice<NewSessionGroupOption>> {
+  const context = selectMoveToGroupSessionContext(snapshot, sessionId);
+  return context === undefined ? [] : selectNewSessionGroupChoices(snapshot, context.project.id);
 }
 
 export function selectNewSessionHarnessOptions(

--- a/packages/dashboard-core/src/state/actions.ts
+++ b/packages/dashboard-core/src/state/actions.ts
@@ -16,6 +16,12 @@ import {
   handleForkSessionAction,
   openForkDetailsForRow,
 } from "./screens/fork.js";
+import {
+  openMoveToGroupCreate,
+  openMoveToGroupForRow,
+  selectMoveToGroupDestination,
+  submitMoveToGroupCreate,
+} from "./screens/moveToGroup.js";
 import { handleNewSessionAction } from "./screens/newSession.js";
 import {
   applyDashboardPersistentFilter,
@@ -109,6 +115,9 @@ export type TuiSemanticAction =
   | { type: "removeWorktree.activate"; actionId: RemoveWorktreeActionId }
   | { type: "forkSession.activate"; actionId: ForkSessionActionId }
   | { type: "renameSession.submit" }
+  | { type: "moveToGroup.select"; destinationGroupId: SessionGroupId | null }
+  | { type: "moveToGroup.create.open" }
+  | { type: "moveToGroup.create.submit" }
   | { type: "projectMenu.activate"; actionId: ProjectMenuInputActionId }
   | { type: "createGroup.activate"; actionId: CreateGroupActionId }
   | {
@@ -126,6 +135,7 @@ export type DashboardStateAction =
   | { type: "addProject.selectRow"; index: number }
   | { type: "screen.clickAway" }
   | { type: "renameSession.openEdit"; rowId: SessionId; returnTo: "dashboard" }
+  | { type: "moveToGroup.open"; rowId: SessionId }
   | { type: "removeWorktree.openConfirm"; rowId: SessionId }
   | { type: "projectDefaultAgent.open"; projectId: ProjectId }
   | { type: "projectSettings.open"; projectId: ProjectId }
@@ -180,6 +190,12 @@ export function handleTuiAction(
       return handleForkSessionAction(state, action.actionId);
     case "renameSession.submit":
       return submitRenameSession(state);
+    case "moveToGroup.select":
+      return selectMoveToGroupDestination(state, action.destinationGroupId);
+    case "moveToGroup.create.open":
+      return stateTransition(openMoveToGroupCreate(state));
+    case "moveToGroup.create.submit":
+      return submitMoveToGroupCreate(state);
     case "projectMenu.activate":
       return handleProjectMenuAction(state, action.actionId);
     case "createGroup.activate":
@@ -214,6 +230,7 @@ function handleDashboardStateAction(
       return stateTransition(selectAddProjectRow(state, action.index));
     case "screen.clickAway":
     case "renameSession.openEdit":
+    case "moveToGroup.open":
     case "removeWorktree.openConfirm":
     case "projectDefaultAgent.open":
     case "projectSettings.open":
@@ -230,6 +247,7 @@ function handleDashboardScreenAction(
     DashboardStateAction,
     | { type: "screen.clickAway" }
     | { type: "renameSession.openEdit" }
+    | { type: "moveToGroup.open" }
     | { type: "removeWorktree.openConfirm" }
     | { type: "projectDefaultAgent.open" }
     | { type: "projectSettings.open" }
@@ -245,6 +263,8 @@ function handleDashboardScreenAction(
       return stateTransition(
         openRenameEditForRow(state, action.rowId, { returnTo: action.returnTo }),
       );
+    case "moveToGroup.open":
+      return stateTransition(openMoveToGroupForRow(state, action.rowId));
     case "removeWorktree.openConfirm":
       return stateTransition(openRemoveWorktreeConfirmForRow(state, action.rowId));
     case "projectDefaultAgent.open":

--- a/packages/dashboard-core/src/state/commandBuilders.ts
+++ b/packages/dashboard-core/src/state/commandBuilders.ts
@@ -66,6 +66,14 @@ export type UpdateSessionGroupMembershipCommandInput = {
   groupId: SessionGroupId;
   expectedVersion: number;
   sessionId: SessionId;
+  expectedGroupId?: SessionGroupId | null;
+};
+
+export type MoveSessionToGroupCommandInput = {
+  projectId: ProjectView["id"];
+  sessionId: SessionId;
+  currentGroup: { id: SessionGroupId; version: number } | undefined;
+  destinationGroup: { id: SessionGroupId; version: number } | undefined;
 };
 
 export function buildStartAgentCommand(
@@ -255,7 +263,33 @@ export function buildUpdateSessionGroupMembershipCommand(
       projectId: input.projectId,
       groupId: input.groupId,
       expectedVersion: input.expectedVersion,
-      add: [{ sessionId: input.sessionId, expectedGroupId: null }],
+      add: [{ sessionId: input.sessionId, expectedGroupId: input.expectedGroupId ?? null }],
+    },
+  };
+}
+
+/** Builds the single optimistic-concurrency command for Group reassignment or ungrouping. */
+export function buildMoveSessionToGroupCommand(
+  input: MoveSessionToGroupCommandInput,
+): Extract<StationCommand, { type: "sessionGroup.updateMembership" }> | undefined {
+  if (input.currentGroup?.id === input.destinationGroup?.id) return undefined;
+  if (input.destinationGroup !== undefined) {
+    return buildUpdateSessionGroupMembershipCommand({
+      projectId: input.projectId,
+      groupId: input.destinationGroup.id,
+      expectedVersion: input.destinationGroup.version,
+      sessionId: input.sessionId,
+      expectedGroupId: input.currentGroup?.id ?? null,
+    });
+  }
+  if (input.currentGroup === undefined) return undefined;
+  return {
+    type: "sessionGroup.updateMembership",
+    payload: {
+      projectId: input.projectId,
+      groupId: input.currentGroup.id,
+      expectedVersion: input.currentGroup.version,
+      remove: [{ sessionId: input.sessionId, expectedGroupId: input.currentGroup.id }],
     },
   };
 }

--- a/packages/dashboard-core/src/state/dashboardFocus.ts
+++ b/packages/dashboard-core/src/state/dashboardFocus.ts
@@ -47,7 +47,8 @@ export function focusDashboardSession(state: DashboardState, sessionId: SessionI
   if (state.snapshot === undefined) {
     return clearDashboardFocus(state);
   }
-  const tree = dashboardTree(state);
+  const revealed = revealSessionAncestry(state, sessionId);
+  const tree = dashboardTree(revealed);
   const cursor = treeGridCursorForRow({
     projection: tree,
     rowId: dashboardRowIds.session(sessionId),
@@ -55,8 +56,27 @@ export function focusDashboardSession(state: DashboardState, sessionId: SessionI
     policy: dashboardPolicy,
   });
   return cursor === undefined
-    ? clearDashboardFocus(state)
-    : focusResolvedDashboardCursor(state, tree, cursor);
+    ? clearDashboardFocus(revealed)
+    : focusResolvedDashboardCursor(revealed, tree, cursor);
+}
+
+function revealSessionAncestry(state: DashboardState, sessionId: SessionId): DashboardState {
+  const snapshot = state.snapshot;
+  const session = snapshot?.sessions.find((candidate) => candidate.id === sessionId);
+  if (snapshot === undefined || session === undefined) return state;
+  const collapsedProjectIds = new Set(state.collapsedProjectIds);
+  const collapsedGroupIds = new Set(state.collapsedGroupIds);
+  collapsedProjectIds.delete(session.projectId);
+  let group = snapshot.sessionGroups.find((candidate) => candidate.sessionIds.includes(sessionId));
+  while (group !== undefined) {
+    collapsedGroupIds.delete(group.id);
+    const parentId = group.parentGroupId;
+    group =
+      parentId === undefined
+        ? undefined
+        : snapshot.sessionGroups.find((candidate) => candidate.id === parentId);
+  }
+  return { ...state, screen: { name: "dashboard" }, collapsedProjectIds, collapsedGroupIds };
 }
 
 /** Reveals and focuses one canonical Group header cell. */
@@ -333,7 +353,8 @@ function navigationPolicy(state: DashboardState): DashboardPolicy {
   const screen = state.screen;
   return (screen.name === "removeWorktree" ||
     screen.name === "renameSession" ||
-    screen.name === "fork") &&
+    screen.name === "fork" ||
+    screen.name === "moveToGroup") &&
     screen.step === "chooseSlot"
     ? chooserPolicy
     : dashboardPolicy;

--- a/packages/dashboard-core/src/state/keymap.ts
+++ b/packages/dashboard-core/src/state/keymap.ts
@@ -17,6 +17,9 @@ export type TuiInputMode =
   | "removeUnavailable"
   | "renameChooseSlot"
   | "renameEdit"
+  | "moveToGroupChooseSlot"
+  | "moveToGroupDestination"
+  | "moveToGroupCreate"
   | "forkChooseSlot"
   | "forkDetails"
   | "newSessionReview"
@@ -60,6 +63,9 @@ export function deriveTuiInputMode(state: DashboardStateView): TuiInputMode {
       return screen.step === "unavailable" ? "removeUnavailable" : "removeConfirm";
     case "renameSession":
       return screen.step === "chooseSlot" ? "renameChooseSlot" : "renameEdit";
+    case "moveToGroup":
+      if (screen.step === "chooseSlot") return "moveToGroupChooseSlot";
+      return screen.step === "chooseDestination" ? "moveToGroupDestination" : "moveToGroupCreate";
     case "fork":
       return screen.step === "chooseSlot" ? "forkChooseSlot" : "forkDetails";
     case "newSession":
@@ -230,6 +236,13 @@ export const TUI_DASHBOARD_BINDINGS = [
     action: "tui.rename.open",
     outcome: "handled",
     help: { keys: "R", label: "rename" },
+  },
+  {
+    id: "tui.dashboard.moveToGroup",
+    pattern: { kind: "char", char: "M" },
+    action: "tui.moveToGroup.open",
+    outcome: "handled",
+    help: { keys: "M", label: "move to group", footerOrder: 25 },
   },
   {
     id: "tui.dashboard.fork",

--- a/packages/dashboard-core/src/state/operations/localOperationRunner.ts
+++ b/packages/dashboard-core/src/state/operations/localOperationRunner.ts
@@ -15,7 +15,11 @@ import { runQuickSessionInGroupOperation } from "./groupQuickSession.js";
 import { projectCommandOperations } from "./projectCommands.js";
 import { runRemoveWorktreeOperation } from "./removeWorktree.js";
 import { runRenameSessionOperation } from "./renameSession.js";
-import { runCreateSessionGroupOperation } from "./sessionGroups.js";
+import {
+  runCreateSessionGroupForMoveOperation,
+  runCreateSessionGroupOperation,
+  runMoveSessionToGroupOperation,
+} from "./sessionGroups.js";
 import type { DashboardCapabilityOperation, TuiOperation } from "./types.js";
 
 type OperationHandlers = {
@@ -168,6 +172,28 @@ export function createTuiLocalOperationRunner(input: {
           store: store(),
           service: input.service,
           capabilities: capabilityOperations,
+          operation,
+          clientLabel: input.clientLabel,
+          scope: input.scope,
+        }),
+      );
+    },
+    moveSessionToGroup: (operation) => {
+      input.scope.run(() =>
+        runMoveSessionToGroupOperation({
+          store: store(),
+          service: input.service,
+          operation,
+          clientLabel: input.clientLabel,
+          scope: input.scope,
+        }),
+      );
+    },
+    createSessionGroupForMove: (operation) => {
+      input.scope.run(() =>
+        runCreateSessionGroupForMoveOperation({
+          store: store(),
+          service: input.service,
           operation,
           clientLabel: input.clientLabel,
           scope: input.scope,

--- a/packages/dashboard-core/src/state/operations/sessionGroups.ts
+++ b/packages/dashboard-core/src/state/operations/sessionGroups.ts
@@ -1,10 +1,13 @@
-import type { SafeError } from "@station/contracts";
+import type { SafeError, SessionGroupId, SessionId } from "@station/contracts";
 import type { StoreApi } from "zustand/vanilla";
 import { dashboardRowIds, selectDashboardTree } from "../../selectors/dashboardTree.js";
+import { selectMoveToGroupSessionContext } from "../../selectors/selectors.js";
 import { safeErrorToToast, toSafeError } from "../../services/errors/errors.js";
 import type { ObserverService } from "../../services/types.js";
+import { buildMoveSessionToGroupCommand } from "../commandBuilders.js";
 import {
   focusDashboardGroup,
+  focusDashboardSession,
   focusResolvedDashboardCursor,
   reconcileDashboardFocus,
 } from "../dashboardFocus.js";
@@ -15,7 +18,172 @@ import type { DashboardState } from "../types.js";
 import type { DashboardCapabilityOperationRunner } from "./capabilityOperation.js";
 import { executeDashboardCommandError } from "./commandExecutionError.js";
 import { runQuickSessionInGroupOperation } from "./groupQuickSession.js";
-import type { CreateSessionGroupOperation } from "./types.js";
+import type {
+  CreateSessionGroupForMoveOperation,
+  CreateSessionGroupOperation,
+  MoveSessionToGroupOperation,
+} from "./types.js";
+
+export type MoveSessionToGroupResolution =
+  | { kind: "submit"; operation: MoveSessionToGroupOperation }
+  | { kind: "noop" }
+  | { kind: "failure"; error: SafeError };
+
+/** Resolves one canonical reassignment operation for every current and future Group surface. */
+export function resolveMoveSessionToGroupOperation(
+  state: DashboardState,
+  sessionId: SessionId,
+  destinationGroupId: SessionGroupId | null,
+): MoveSessionToGroupResolution {
+  const snapshot = state.snapshot;
+  const context =
+    snapshot === undefined ? undefined : selectMoveToGroupSessionContext(snapshot, sessionId);
+  if (snapshot === undefined || context === undefined) {
+    return { kind: "failure", error: staleMoveError("The session is no longer available.") };
+  }
+  const destination =
+    destinationGroupId === null
+      ? undefined
+      : snapshot.sessionGroups.find(
+          (group) =>
+            group.id === destinationGroupId &&
+            group.projectId === context.project.id &&
+            group.parentGroupId === undefined,
+        );
+  if (destinationGroupId !== null && destination === undefined) {
+    return {
+      kind: "failure",
+      error: staleMoveError("The destination Group is no longer available."),
+    };
+  }
+  const command = buildMoveSessionToGroupCommand({
+    projectId: context.project.id,
+    sessionId,
+    currentGroup: context.currentGroup,
+    destinationGroup: destination,
+  });
+  if (command === undefined) return { kind: "noop" };
+  return {
+    kind: "submit",
+    operation: {
+      type: "moveSessionToGroup",
+      sessionId,
+      projectId: context.project.id,
+      expectedCurrentGroupId: context.currentGroup?.id ?? null,
+      destinationGroupId,
+      command,
+    },
+  };
+}
+
+export async function runMoveSessionToGroupOperation(input: {
+  store: StoreApi<DashboardState>;
+  service: ObserverService;
+  operation: MoveSessionToGroupOperation;
+  clientLabel: string;
+  scope: DashboardRuntimeEffectScope;
+}): Promise<void> {
+  const stale = validatePreparedMove(input.store.getState(), input.operation);
+  if (stale !== undefined) {
+    input.scope.commit(() => closeMoveOnConflict(input.store, input.operation.sessionId, stale));
+    return;
+  }
+  let failure: SafeError | undefined;
+  try {
+    failure = await executeDashboardCommandError({
+      service: input.service,
+      command: input.operation.command,
+      clientLabel: input.clientLabel,
+    });
+  } catch (error: unknown) {
+    failure = toSafeError(error, { clientLabel: input.clientLabel });
+  }
+  if (!input.scope.isOpen()) return;
+  if (failure === undefined) {
+    input.scope.commit(() => {
+      const state = input.store.getState();
+      input.store.setState(focusDashboardSession(state, input.operation.sessionId));
+    });
+    return;
+  }
+  input.scope.commit(() => {
+    if (isMembershipConflict(failure)) {
+      closeMoveOnConflict(input.store, input.operation.sessionId, failure);
+    } else {
+      retainMoveFailure(input.store, input.operation, failure);
+    }
+  });
+}
+
+export async function runCreateSessionGroupForMoveOperation(input: {
+  store: StoreApi<DashboardState>;
+  service: ObserverService;
+  operation: CreateSessionGroupForMoveOperation;
+  clientLabel: string;
+  scope: DashboardRuntimeEffectScope;
+}): Promise<void> {
+  let createFailure: SafeError | undefined;
+  try {
+    createFailure = await executeDashboardCommandError({
+      service: input.service,
+      command: input.operation.command,
+      clientLabel: input.clientLabel,
+    });
+  } catch (error: unknown) {
+    createFailure = toSafeError(error, { clientLabel: input.clientLabel });
+  }
+  if (!input.scope.isOpen()) return;
+  if (createFailure !== undefined) {
+    input.scope.commit(() => retainMoveCreateFailure(input.store, input.operation, createFailure));
+    return;
+  }
+  const created = resolveCreatedGroup(input.store.getState(), input.operation);
+  if (created.kind === "failure") {
+    input.scope.commit(() =>
+      closeMoveOnConflict(input.store, input.operation.sessionId, created.error),
+    );
+    return;
+  }
+  const resolution = resolveMoveSessionToGroupOperation(
+    input.store.getState(),
+    input.operation.sessionId,
+    created.group.id,
+  );
+  if (resolution.kind !== "submit") {
+    const error =
+      resolution.kind === "failure"
+        ? resolution.error
+        : convergenceError("The created Group could not receive the session.");
+    input.scope.commit(() => closeMoveOnConflict(input.store, input.operation.sessionId, error));
+    return;
+  }
+  input.scope.commit(() => {
+    const state = input.store.getState();
+    if (
+      state.screen.name === "moveToGroup" &&
+      state.screen.step === "createGroup" &&
+      state.screen.sessionId === input.operation.sessionId
+    ) {
+      input.store.setState({
+        ...state,
+        screen: {
+          name: "moveToGroup",
+          step: "chooseDestination",
+          sessionId: state.screen.sessionId,
+          sessionTitle: state.screen.sessionTitle,
+          submitting: true,
+        },
+      });
+    }
+  });
+  await runMoveSessionToGroupOperation({
+    store: input.store,
+    service: input.service,
+    operation: resolution.operation,
+    clientLabel: input.clientLabel,
+    scope: input.scope,
+  });
+}
 
 /**
  * Runs durable Group creation before ordinary Quick Session execution, expected membership, and
@@ -85,7 +253,7 @@ export async function runCreateSessionGroupOperation(input: {
 
 function resolveCreatedGroup(
   state: DashboardState,
-  operation: CreateSessionGroupOperation,
+  operation: CreateSessionGroupOperation | CreateSessionGroupForMoveOperation,
 ):
   | { kind: "success"; group: NonNullable<DashboardState["snapshot"]>["sessionGroups"][number] }
   | { kind: "failure"; error: SafeError } {
@@ -104,6 +272,115 @@ function resolveCreatedGroup(
         kind: "failure",
         error: convergenceError("The created Group could not be identified uniquely."),
       };
+}
+
+function validatePreparedMove(
+  state: DashboardState,
+  operation: MoveSessionToGroupOperation,
+): SafeError | undefined {
+  const snapshot = state.snapshot;
+  const context =
+    snapshot === undefined
+      ? undefined
+      : selectMoveToGroupSessionContext(snapshot, operation.sessionId);
+  if (context === undefined || context.project.id !== operation.projectId) {
+    return staleMoveError("The session is no longer available.");
+  }
+  if ((context.currentGroup?.id ?? null) !== operation.expectedCurrentGroupId) {
+    return assignmentConflictError();
+  }
+  const target = snapshot?.sessionGroups.find(
+    (group) => group.id === operation.command.payload.groupId,
+  );
+  if (
+    target === undefined ||
+    target.projectId !== operation.projectId ||
+    target.version !== operation.command.payload.expectedVersion
+  ) {
+    return versionConflictError();
+  }
+  if (operation.destinationGroupId !== null) {
+    const destination = snapshot?.sessionGroups.find(
+      (group) => group.id === operation.destinationGroupId,
+    );
+    if (destination?.parentGroupId !== undefined) {
+      return staleMoveError("The destination Group is no longer at the Project root.");
+    }
+  }
+  return undefined;
+}
+
+function retainMoveFailure(
+  store: StoreApi<DashboardState>,
+  operation: MoveSessionToGroupOperation,
+  error: SafeError,
+): void {
+  const state = store.getState();
+  const screen = state.screen;
+  const next =
+    screen.name === "moveToGroup" &&
+    screen.step === "chooseDestination" &&
+    screen.sessionId === operation.sessionId
+      ? { ...state, screen: { ...screen, submitting: false } }
+      : state;
+  store.setState(addTuiToast(next, safeErrorToToast(error)));
+}
+
+function retainMoveCreateFailure(
+  store: StoreApi<DashboardState>,
+  operation: CreateSessionGroupForMoveOperation,
+  error: SafeError,
+): void {
+  const state = store.getState();
+  const screen = state.screen;
+  const next =
+    screen.name === "moveToGroup" &&
+    screen.step === "createGroup" &&
+    screen.sessionId === operation.sessionId
+      ? { ...state, screen: { ...screen, submitting: false } }
+      : state;
+  store.setState(addTuiToast(next, safeErrorToToast(error)));
+}
+
+function closeMoveOnConflict(
+  store: StoreApi<DashboardState>,
+  sessionId: SessionId,
+  error: SafeError,
+): void {
+  const focused = focusDashboardSession(
+    { ...store.getState(), screen: { name: "dashboard" } },
+    sessionId,
+  );
+  store.setState(addTuiToast(focused, safeErrorToToast(error)));
+}
+
+function isMembershipConflict(error: SafeError): boolean {
+  return (
+    error.code === "SESSION_GROUP_VERSION_CONFLICT" ||
+    error.code === "SESSION_GROUP_ASSIGNMENT_CONFLICT"
+  );
+}
+
+function staleMoveError(message: string): SafeError {
+  return {
+    tag: "CommandConflictError",
+    code: "SESSION_GROUP_ASSIGNMENT_CONFLICT",
+    message,
+    hint: "Review the session's current Group before trying again.",
+  };
+}
+
+function assignmentConflictError(): SafeError {
+  return staleMoveError("The session's Group changed before the move could start.");
+}
+
+function versionConflictError(): SafeError {
+  return {
+    tag: "CommandConflictError",
+    code: "SESSION_GROUP_VERSION_CONFLICT",
+    message: "The destination Group changed before the move could start.",
+    hint: "Review the current Group state before trying again.",
+  };
 }
 
 function retainCreateGroupFailure(

--- a/packages/dashboard-core/src/state/operations/types.ts
+++ b/packages/dashboard-core/src/state/operations/types.ts
@@ -113,6 +113,24 @@ export type CreateQuickSessionInGroupOperation = {
   fallbackCell: "identity" | "quickSession";
 };
 
+export type MoveSessionToGroupOperation = {
+  type: "moveSessionToGroup";
+  sessionId: SessionId;
+  projectId: ProjectView["id"];
+  expectedCurrentGroupId: SessionGroupId | null;
+  destinationGroupId: SessionGroupId | null;
+  command: Extract<StationCommand, { type: "sessionGroup.updateMembership" }>;
+};
+
+export type CreateSessionGroupForMoveOperation = {
+  type: "createSessionGroupForMove";
+  sessionId: SessionId;
+  projectId: ProjectView["id"];
+  name: string;
+  previousGroupIds: readonly SessionGroupId[];
+  command: Extract<StationCommand, { type: "sessionGroup.create" }>;
+};
+
 export type DashboardCapabilityOperation =
   | ActivateSessionOperation
   | CreateManagedSessionOperation
@@ -132,4 +150,6 @@ export type TuiOperation =
   | SetProjectDefaultHarnessOperation
   | RemoveProjectOperation
   | CreateSessionGroupOperation
-  | CreateQuickSessionInGroupOperation;
+  | CreateQuickSessionInGroupOperation
+  | MoveSessionToGroupOperation
+  | CreateSessionGroupForMoveOperation;

--- a/packages/dashboard-core/src/state/screen.ts
+++ b/packages/dashboard-core/src/state/screen.ts
@@ -1,5 +1,6 @@
 import type { StationSnapshot } from "@station/contracts";
 import { reconcileNewSessionFlow } from "../flows/newSession.js";
+import { selectMoveToGroupSessionContext } from "../selectors/selectors.js";
 import { reconcileDashboardFocus } from "./dashboardFocus.js";
 import { createEmptyTuiLocalRows, pruneLocalRowsForSnapshot } from "./localRows.js";
 import { seedNewSessionPickerCursor } from "./selection/specs/newSession.js";
@@ -39,13 +40,19 @@ export function createInitialTuiState(options: CreateInitialTuiStateOptions = {}
 
 export function replaceSnapshot(state: DashboardState, snapshot: StationSnapshot): DashboardState {
   const projectSurface = reconcileProjectSurface(state, snapshot);
-  const screen =
+  const flowScreen =
     projectSurface.name === "newSession"
       ? {
           name: "newSession" as const,
           flow: reconcileNewSessionFlow(projectSurface.flow, snapshot),
         }
       : projectSurface;
+  const screen =
+    flowScreen.name === "moveToGroup" &&
+    flowScreen.step !== "chooseSlot" &&
+    selectMoveToGroupSessionContext(snapshot, flowScreen.sessionId) === undefined
+      ? { name: "dashboard" as const }
+      : flowScreen;
   const next: DashboardState = {
     ...state,
     screen,

--- a/packages/dashboard-core/src/state/screenBehavior.ts
+++ b/packages/dashboard-core/src/state/screenBehavior.ts
@@ -2,6 +2,7 @@ import { addProjectScreenBehavior } from "./screens/addProjectScreen.js";
 import { dashboardScreenBehavior } from "./screens/dashboard.js";
 import { forkScreenBehavior } from "./screens/fork.js";
 import { helpScreenBehavior } from "./screens/help.js";
+import { moveToGroupScreenBehavior } from "./screens/moveToGroup.js";
 import { newSessionScreenBehavior } from "./screens/newSession.js";
 import { persistentFilterScreenBehavior } from "./screens/persistentFilter.js";
 import { projectCollapseScreenBehavior } from "./screens/projectCollapse.js";
@@ -46,6 +47,8 @@ export function tuiScreenBehavior(screen: DashboardScreenView): TuiScreenBehavio
       return removeWorktreeScreenBehavior(screen);
     case "renameSession":
       return renameSessionScreenBehavior(screen);
+    case "moveToGroup":
+      return moveToGroupScreenBehavior(screen);
     case "fork":
       return forkScreenBehavior(screen);
     case "addProject":

--- a/packages/dashboard-core/src/state/screens/dashboard.ts
+++ b/packages/dashboard-core/src/state/screens/dashboard.ts
@@ -104,6 +104,13 @@ function handleDashboardAction(
           screen: { name: "renameSession", step: "chooseSlot" },
         },
       };
+    case "tui.moveToGroup.open":
+      return {
+        state: {
+          ...state,
+          screen: { name: "moveToGroup", step: "chooseSlot" },
+        },
+      };
     case "tui.fork.open":
       return {
         state: {

--- a/packages/dashboard-core/src/state/screens/moveToGroup.ts
+++ b/packages/dashboard-core/src/state/screens/moveToGroup.ts
@@ -1,0 +1,207 @@
+import type { SessionGroupId, SessionId } from "@station/contracts";
+import {
+  createEditableTextInputState,
+  editableTextInputIntentForInput,
+  transitionEditableTextInput,
+} from "../../components/EditableTextInput/editing.js";
+import {
+  selectDashboardSessionRow,
+  sessionRowDisplayTitle,
+} from "../../selectors/dashboardSessionRows.js";
+import { selectMoveToGroupSessionContext } from "../../selectors/selectors.js";
+import { buildCreateSessionGroupCommand } from "../commandBuilders.js";
+import type { TuiKey } from "../keys.js";
+import { isReturnKey } from "../keys.js";
+import { resolveMoveSessionToGroupOperation } from "../operations/sessionGroups.js";
+import { addTuiToast } from "../toasts.js";
+import type { TuiTransition } from "../transition.js";
+import type { DashboardScreenView, DashboardState } from "../types.js";
+import { handleDashboardRowChoiceKey } from "./rowChoose.js";
+
+type MoveToGroupScreen = Extract<DashboardState["screen"], { name: "moveToGroup" }>;
+type MoveToGroupScreenView = Extract<DashboardScreenView, { name: "moveToGroup" }>;
+
+const chooseSlotBehavior = { dashboardHoverEnabled: true };
+const sheetBehavior = { dashboardHoverEnabled: false, clickAway: cancelMoveToGroup };
+
+export const MOVE_TO_GROUP_LIST_ID = "moveToGroupDestination";
+export const MOVE_TO_GROUP_UNGROUPED_CHOICE_ID = "moveToGroup:ungrouped";
+export const MOVE_TO_GROUP_CREATE_CHOICE_ID = "moveToGroup:create";
+
+export function moveToGroupExistingChoiceId(groupId: SessionGroupId): string {
+  return `moveToGroup:existing:${groupId}`;
+}
+
+export function moveToGroupScreenBehavior(screen: MoveToGroupScreenView) {
+  return screen.step === "chooseSlot" ? chooseSlotBehavior : sheetBehavior;
+}
+
+export function handleMoveToGroupKey(state: DashboardState, key: TuiKey): TuiTransition {
+  if (state.screen.name !== "moveToGroup") return { state };
+  if (state.screen.step === "chooseSlot") {
+    if (key.escape === true) return { state: cancelMoveToGroup(state) };
+    return handleDashboardRowChoiceKey(state, key, (current, rowId) => ({
+      state: openMoveToGroupForRow(current, rowId),
+    }));
+  }
+  if (state.screen.submitting) return { state };
+  if (state.screen.step === "chooseDestination") {
+    if (key.escape === true) return { state: cancelMoveToGroup(state) };
+    if (key.input === "U") return selectMoveToGroupDestination(state, null);
+    if (key.input === "N") return { state: openMoveToGroupCreate(state) };
+    return { state };
+  }
+  if (key.escape === true) return { state: backToMoveToGroupDestinations(state) };
+  if (isReturnKey(key)) return submitMoveToGroupCreate(state);
+  const intent = editableTextInputIntentForInput({ input: key.input, key });
+  if (intent.type !== "edit") return { state };
+  return {
+    state: {
+      ...state,
+      screen: {
+        ...state.screen,
+        draftName: transitionEditableTextInput(state.screen.draftName, intent.action),
+      },
+    },
+  };
+}
+
+/** Opens the destination sheet for a current canonical dashboard session. */
+export function openMoveToGroupForRow(state: DashboardState, rowId: SessionId): DashboardState {
+  if (
+    state.screen.name !== "dashboard" &&
+    !(state.screen.name === "moveToGroup" && state.screen.step === "chooseSlot")
+  ) {
+    return state;
+  }
+  const snapshot = state.snapshot;
+  if (snapshot === undefined) return state;
+  const row = selectDashboardSessionRow(snapshot, rowId);
+  if (row === undefined) return state;
+  const screen: Extract<MoveToGroupScreen, { step: "chooseDestination" }> = {
+    name: "moveToGroup",
+    step: "chooseDestination",
+    sessionId: row.session.id,
+    sessionTitle: sessionRowDisplayTitle(row, state.localRows),
+    submitting: false,
+  };
+  const next = { ...state, screen };
+  const context = selectMoveToGroupSessionContext(snapshot, row.session.id);
+  const selectedId =
+    context?.currentGroup?.parentGroupId === undefined && context?.currentGroup !== undefined
+      ? moveToGroupExistingChoiceId(context.currentGroup.id)
+      : MOVE_TO_GROUP_UNGROUPED_CHOICE_ID;
+  const selection = new Map(next.selection);
+  selection.set(MOVE_TO_GROUP_LIST_ID, selectedId);
+  return { ...next, selection };
+}
+
+export function selectMoveToGroupDestination(
+  state: DashboardState,
+  destinationGroupId: SessionGroupId | null,
+): TuiTransition {
+  if (
+    state.screen.name !== "moveToGroup" ||
+    state.screen.step !== "chooseDestination" ||
+    state.screen.submitting
+  ) {
+    return { state };
+  }
+  const resolution = resolveMoveSessionToGroupOperation(
+    state,
+    state.screen.sessionId,
+    destinationGroupId,
+  );
+  if (resolution.kind === "noop") {
+    return { state: { ...state, screen: { name: "dashboard" } } };
+  }
+  if (resolution.kind === "failure") {
+    return { state: addTuiToast(state, { kind: "error", message: resolution.error.message }) };
+  }
+  return {
+    state: { ...state, screen: { ...state.screen, submitting: true } },
+    operations: [resolution.operation],
+  };
+}
+
+export function openMoveToGroupCreate(state: DashboardState): DashboardState {
+  if (
+    state.screen.name !== "moveToGroup" ||
+    state.screen.step !== "chooseDestination" ||
+    state.screen.submitting
+  ) {
+    return state;
+  }
+  return {
+    ...state,
+    screen: {
+      name: "moveToGroup",
+      step: "createGroup",
+      sessionId: state.screen.sessionId,
+      sessionTitle: state.screen.sessionTitle,
+      draftName: createEditableTextInputState(),
+      submitting: false,
+    },
+  };
+}
+
+export function submitMoveToGroupCreate(state: DashboardState): TuiTransition {
+  if (
+    state.screen.name !== "moveToGroup" ||
+    state.screen.step !== "createGroup" ||
+    state.screen.submitting ||
+    state.snapshot === undefined
+  ) {
+    return { state };
+  }
+  const name = state.screen.draftName.value.trim();
+  if (name.length === 0) return { state };
+  const context = selectMoveToGroupSessionContext(state.snapshot, state.screen.sessionId);
+  if (context === undefined) return staleSessionTransition(state);
+  return {
+    state: { ...state, screen: { ...state.screen, submitting: true } },
+    operations: [
+      {
+        type: "createSessionGroupForMove",
+        sessionId: context.session.id,
+        projectId: context.project.id,
+        name,
+        previousGroupIds: state.snapshot.sessionGroups.map((group) => group.id),
+        command: buildCreateSessionGroupCommand({ projectId: context.project.id, name }),
+      },
+    ],
+  };
+}
+
+function backToMoveToGroupDestinations(state: DashboardState): DashboardState {
+  if (state.screen.name !== "moveToGroup" || state.screen.step !== "createGroup") return state;
+  return {
+    ...state,
+    screen: {
+      name: "moveToGroup",
+      step: "chooseDestination",
+      sessionId: state.screen.sessionId,
+      sessionTitle: state.screen.sessionTitle,
+      submitting: false,
+    },
+  };
+}
+
+function cancelMoveToGroup(state: DashboardState): DashboardState {
+  if (
+    state.screen.name !== "moveToGroup" ||
+    (state.screen.step !== "chooseSlot" && state.screen.submitting)
+  ) {
+    return state;
+  }
+  return { ...state, screen: { name: "dashboard" } };
+}
+
+function staleSessionTransition(state: DashboardState): TuiTransition {
+  return {
+    state: addTuiToast(
+      { ...state, screen: { name: "dashboard" } },
+      { kind: "error", message: "The session is no longer available." },
+    ),
+  };
+}

--- a/packages/dashboard-core/src/state/selection/registry.ts
+++ b/packages/dashboard-core/src/state/selection/registry.ts
@@ -9,6 +9,7 @@ import {
 import { projectCollapseListSpec, projectSettingsPickerListSpec } from "./specs/projectChoosers.js";
 import { projectDefaultAgentListSpec } from "./specs/projectDefaultAgent.js";
 import { projectSettingsAgentListSpec } from "./specs/projectSettingsAgent.js";
+import { moveToGroupDestinationListSpec } from "./specs/sessionGroups.js";
 import type { RegisteredListSpec } from "./types.js";
 
 /**
@@ -26,6 +27,7 @@ export const LIST_REGISTRY: Partial<Record<TuiInputMode, RegisteredListSpec>> = 
   projectCollapse: projectCollapseListSpec,
   projectSettingsPicker: projectSettingsPickerListSpec,
   projectSettings: projectSettingsAgentListSpec,
+  moveToGroupDestination: moveToGroupDestinationListSpec,
 };
 
 export function listSpecForState(state: DashboardState): RegisteredListSpec | undefined {

--- a/packages/dashboard-core/src/state/selection/specs/sessionGroups.ts
+++ b/packages/dashboard-core/src/state/selection/specs/sessionGroups.ts
@@ -1,0 +1,64 @@
+import { selectMoveToGroupChoices } from "../../../selectors/selectors.js";
+import {
+  MOVE_TO_GROUP_CREATE_CHOICE_ID,
+  MOVE_TO_GROUP_LIST_ID,
+  MOVE_TO_GROUP_UNGROUPED_CHOICE_ID,
+  moveToGroupExistingChoiceId,
+  openMoveToGroupCreate,
+  selectMoveToGroupDestination,
+} from "../../screens/moveToGroup.js";
+import { defineList, type ListRow } from "../types.js";
+
+export const moveToGroupDestinationListSpec = defineList({
+  listId: MOVE_TO_GROUP_LIST_ID,
+  cursor: true,
+  active: (state) =>
+    state.screen.name === "moveToGroup" &&
+    state.screen.step === "chooseDestination" &&
+    !state.screen.submitting,
+  rows: (state): readonly ListRow<string>[] => {
+    if (
+      state.screen.name !== "moveToGroup" ||
+      state.screen.step !== "chooseDestination" ||
+      state.snapshot === undefined
+    ) {
+      return [];
+    }
+    return [
+      { selectable: true, id: MOVE_TO_GROUP_UNGROUPED_CHOICE_ID },
+      ...selectMoveToGroupChoices(state.snapshot, state.screen.sessionId).map((choice) => ({
+        selectable: true as const,
+        id: moveToGroupExistingChoiceId(choice.value.id),
+      })),
+      { selectable: true, id: MOVE_TO_GROUP_CREATE_CHOICE_ID },
+    ];
+  },
+  slots: (state) => {
+    if (
+      state.screen.name !== "moveToGroup" ||
+      state.screen.step !== "chooseDestination" ||
+      state.snapshot === undefined
+    ) {
+      return [];
+    }
+    return selectMoveToGroupChoices(state.snapshot, state.screen.sessionId).map((choice) => ({
+      key: choice.key,
+      value: moveToGroupExistingChoiceId(choice.value.id),
+    }));
+  },
+  commit: (state, id) => {
+    if (
+      state.screen.name !== "moveToGroup" ||
+      state.screen.step !== "chooseDestination" ||
+      state.snapshot === undefined
+    ) {
+      return { state };
+    }
+    if (id === MOVE_TO_GROUP_UNGROUPED_CHOICE_ID) return selectMoveToGroupDestination(state, null);
+    if (id === MOVE_TO_GROUP_CREATE_CHOICE_ID) return { state: openMoveToGroupCreate(state) };
+    const group = selectMoveToGroupChoices(state.snapshot, state.screen.sessionId).find(
+      (choice) => moveToGroupExistingChoiceId(choice.value.id) === id,
+    )?.value;
+    return group === undefined ? { state } : selectMoveToGroupDestination(state, group.id);
+  },
+});

--- a/packages/dashboard-core/src/state/transition.ts
+++ b/packages/dashboard-core/src/state/transition.ts
@@ -4,6 +4,7 @@ import { handleAddProjectKey } from "./screens/addProjectScreen.js";
 import { handleDashboardKey } from "./screens/dashboard.js";
 import { handleForkKey } from "./screens/fork.js";
 import { handleHelpKey } from "./screens/help.js";
+import { handleMoveToGroupKey } from "./screens/moveToGroup.js";
 import { handleNewSessionKey } from "./screens/newSession.js";
 import { handleDashboardPersistentFilterKey } from "./screens/persistentFilter.js";
 import { handleProjectCollapseKey } from "./screens/projectCollapse.js";
@@ -81,6 +82,8 @@ export function handleTuiKey(
       return handleRemoveWorktreeKey(state, key);
     case "renameSession":
       return handleRenameSessionKey(state, key);
+    case "moveToGroup":
+      return handleMoveToGroupKey(state, key);
     case "fork":
       return handleForkKey(state, key);
     case "newSession":

--- a/packages/dashboard-core/src/state/types.ts
+++ b/packages/dashboard-core/src/state/types.ts
@@ -179,6 +179,22 @@ export type TuiScreen =
       returnTo?: "dashboard";
       validationError?: string;
     }
+  | { name: "moveToGroup"; step: "chooseSlot" }
+  | {
+      name: "moveToGroup";
+      step: "chooseDestination";
+      sessionId: SessionId;
+      sessionTitle: string;
+      submitting: boolean;
+    }
+  | {
+      name: "moveToGroup";
+      step: "createGroup";
+      sessionId: SessionId;
+      sessionTitle: string;
+      draftName: EditableTextInputState;
+      submitting: boolean;
+    }
   | { name: "fork"; step: "chooseSlot" }
   | {
       name: "fork";

--- a/packages/dashboard-core/test/unit/components/dashboardFooter.test.ts
+++ b/packages/dashboard-core/test/unit/components/dashboardFooter.test.ts
@@ -56,7 +56,7 @@ describe("dashboard footer model", () => {
   it("preserves the ready dashboard footer", () => {
     expect(footer()).toEqual({
       kind: "dashboard",
-      text: "↵ activate  N new  A add  ⇥ next-needs-me  / filter  X delete  ? help  Q/esc:close",
+      text: "↵ activate  N new  M move to group  A add  ⇥ next-needs-me  / filter  X delete  ? help  Q/esc:close",
     });
   });
 

--- a/packages/dashboard-core/test/unit/state/keymap.test.ts
+++ b/packages/dashboard-core/test/unit/state/keymap.test.ts
@@ -23,6 +23,7 @@ describe("dashboard key bindings", () => {
     expect(matchDashboardBinding({ input: "\r", return: true })?.action).toBe("tui.focus.activate");
     expect(matchDashboardBinding({ input: "N" })?.action).toBe("tui.newSession.open");
     expect(matchDashboardBinding({ input: "G" })?.action).toBe("tui.quickGroup.create");
+    expect(matchDashboardBinding({ input: "M" })?.action).toBe("tui.moveToGroup.open");
     expect(matchDashboardBinding({ input: "?" })?.action).toBe("tui.help.open");
   });
 
@@ -61,6 +62,11 @@ describe("dashboard key bindings", () => {
     expect(isSlotKey({ input: "g" })).toBe(true);
     expect(matchDashboardBinding({ input: "g" })?.action).toBe("tui.row.activateSlot");
   });
+
+  it("keeps lowercase m as a session slot", () => {
+    expect(isSlotKey({ input: "m" })).toBe(true);
+    expect(matchDashboardBinding({ input: "m" })?.action).toBe("tui.row.activateSlot");
+  });
 });
 
 describe("dashboard lifecycle keys", () => {
@@ -84,7 +90,7 @@ describe("dashboard footer binding metadata", () => {
 
   it("derives full and compact shortcut membership from binding metadata", () => {
     expect(footerText("full")).toBe(
-      "↵ activate  N new  A add  ⇥ next-needs-me  / filter  X delete  ? help",
+      "↵ activate  N new  M move to group  A add  ⇥ next-needs-me  / filter  X delete  ? help",
     );
     expect(footerText("compact")).toBe(
       "↵ activate  N new  ⇥ next-needs-me  / filter  X delete  ? help",
@@ -107,6 +113,11 @@ describe("dashboard footer binding metadata", () => {
     expect(dashboardBindingHelp("tui.dashboard.quickGroup")).toEqual({
       keys: "G",
       label: "quick group",
+    });
+    expect(dashboardBindingHelp("tui.dashboard.moveToGroup")).toEqual({
+      keys: "M",
+      label: "move to group",
+      footerOrder: 25,
     });
     expect(dashboardBindingHelp("tui.dashboard.nextNeedsMe")).toMatchObject({
       keys: "⇥",

--- a/packages/dashboard-core/test/unit/state/operations/moveSessionGroups.test.ts
+++ b/packages/dashboard-core/test/unit/state/operations/moveSessionGroups.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from "vitest";
+import { createStore } from "zustand/vanilla";
+import { buildCreateSessionGroupCommand } from "../../../../src/state/commandBuilders.js";
+import {
+  resolveMoveSessionToGroupOperation,
+  runCreateSessionGroupForMoveOperation,
+  runMoveSessionToGroupOperation,
+} from "../../../../src/state/operations/sessionGroups.js";
+import type { CreateSessionGroupForMoveOperation } from "../../../../src/state/operations/types.js";
+import { createDashboardRuntimeEffectScope } from "../../../../src/state/runtimeEffectScope.js";
+import { createInitialTuiState, replaceSnapshot } from "../../../../src/state/screen.js";
+import { openMoveToGroupForRow } from "../../../../src/state/screens/moveToGroup.js";
+import type { DashboardState } from "../../../../src/state/types.js";
+import { createGroupedDashboardSnapshot, fixtureNow } from "../../../fixtures/snapshots.js";
+import { FakeTuiObserverService } from "../../../support/fakeObserverService.js";
+
+describe("Move Session to Group operation", () => {
+  it("moves Group to Group once and follows canonical focus", async () => {
+    const setup = moveSetup("ses_wt_web_attention", "group_empty");
+    setup.service.waitForCommandCompletion = async (commandId) => {
+      setup.store.setState(
+        replaceSnapshot(
+          setup.store.getState(),
+          moveMembership(setup.initial, setup.sessionId, "group_empty"),
+        ),
+      );
+      return { status: "succeeded", commandId };
+    };
+
+    await setup.run();
+
+    expect(setup.service.dispatched).toEqual([setup.operation.command]);
+    expect(setup.store.getState()).toMatchObject({
+      screen: { name: "dashboard" },
+      dashboardFocus: { rowId: `session:${setup.sessionId}`, cellId: "identity" },
+    });
+    expect(currentGroupId(setup.store.getState(), setup.sessionId)).toBe("group_empty");
+    await setup.scope.dispose();
+  });
+
+  it("moves an ungrouped session with a null expectation", () => {
+    const initial = createGroupedDashboardSnapshot();
+    const state = openMoveToGroupForRow(
+      createInitialTuiState({ initialSnapshot: initial }),
+      "ses_wt_web_stuck",
+    );
+    const resolution = resolveMoveSessionToGroupOperation(state, "ses_wt_web_stuck", "group_empty");
+    expect(resolution).toMatchObject({
+      kind: "submit",
+      operation: {
+        command: {
+          payload: {
+            add: [{ sessionId: "ses_wt_web_stuck", expectedGroupId: null }],
+          },
+        },
+      },
+    });
+  });
+
+  it("retains the picker for an ordinary failure", async () => {
+    const setup = moveSetup("ses_wt_web_attention", "group_empty");
+    setup.service.nextReceipt = {
+      commandId: "cmd_rejected",
+      accepted: false,
+      status: "rejected",
+      error: {
+        tag: "CommandValidationError",
+        code: "MOVE_REJECTED",
+        message: "Move was rejected.",
+      },
+    };
+
+    await setup.run();
+
+    expect(setup.store.getState().screen).toMatchObject({
+      name: "moveToGroup",
+      step: "chooseDestination",
+      submitting: false,
+    });
+    expect(setup.store.getState().toasts.at(-1)?.toast).toMatchObject({
+      message: "Move was rejected.",
+    });
+    await setup.scope.dispose();
+  });
+
+  it("closes on assignment conflict and focuses the session at canonical truth", async () => {
+    const setup = moveSetup("ses_wt_web_attention", "group_empty");
+    setup.service.waitForCommandCompletion = async (commandId) => {
+      const canonical = moveMembership(setup.initial, setup.sessionId, "group_build");
+      setup.service.setSnapshot(canonical);
+      setup.store.setState(replaceSnapshot(setup.store.getState(), canonical));
+      return {
+        status: "failed",
+        commandId,
+        error: {
+          tag: "CommandConflictError",
+          code: "SESSION_GROUP_ASSIGNMENT_CONFLICT",
+          message: "The session moved elsewhere.",
+        },
+      };
+    };
+
+    await setup.run();
+
+    expect(setup.store.getState()).toMatchObject({
+      screen: { name: "dashboard" },
+      dashboardFocus: { rowId: `session:${setup.sessionId}`, cellId: "identity" },
+      toasts: [
+        expect.objectContaining({
+          toast: expect.objectContaining({
+            message: 'The session\'s Group changed; it is now in "Build".',
+          }),
+        }),
+      ],
+    });
+    expect(setup.store.getState().collapsedGroupIds.has("group_build")).toBe(false);
+    await setup.scope.dispose();
+  });
+});
+
+describe("Create Group for move operation", () => {
+  it("preserves the valid empty Group and picker when the subsequent move fails", async () => {
+    const initial = createGroupedDashboardSnapshot();
+    const screenState = openMoveToGroupForRow(
+      createInitialTuiState({ initialSnapshot: initial }),
+      "ses_wt_web_attention",
+    );
+    const store = createStore<DashboardState>(() => ({
+      ...screenState,
+      screen: {
+        name: "moveToGroup",
+        step: "createGroup",
+        sessionId: "ses_wt_web_attention",
+        sessionTitle: "checkout-copy",
+        draftName: { value: "Fresh", cursor: 5 },
+        submitting: true,
+      },
+    }));
+    const service = new FakeTuiObserverService(initial);
+    const scope = createDashboardRuntimeEffectScope();
+    const operation: CreateSessionGroupForMoveOperation = {
+      type: "createSessionGroupForMove",
+      sessionId: "ses_wt_web_attention",
+      projectId: "web",
+      name: "Fresh",
+      previousGroupIds: initial.sessionGroups.map((group) => group.id),
+      command: buildCreateSessionGroupCommand({ projectId: "web", name: "Fresh" }),
+    };
+    service.waitForCommandCompletion = async (commandId) => {
+      if (service.dispatched.at(-1)?.type === "sessionGroup.create") {
+        store.setState(
+          replaceSnapshot(store.getState(), {
+            ...initial,
+            sessionGroups: [
+              ...initial.sessionGroups,
+              {
+                id: "group_fresh",
+                projectId: "web",
+                name: "Fresh",
+                sessionIds: [],
+                version: 1,
+                createdAt: fixtureNow,
+                updatedAt: fixtureNow,
+              },
+            ],
+          }),
+        );
+        return { status: "succeeded", commandId };
+      }
+      return {
+        status: "failed",
+        commandId,
+        error: { tag: "CommandExecutionError", code: "MOVE_FAILED", message: "Move failed." },
+      };
+    };
+
+    await runCreateSessionGroupForMoveOperation({
+      store,
+      service,
+      operation,
+      clientLabel: "test",
+      scope,
+    });
+
+    expect(service.dispatched.map((command) => command.type)).toEqual([
+      "sessionGroup.create",
+      "sessionGroup.updateMembership",
+    ]);
+    expect(store.getState().snapshot?.sessionGroups).toContainEqual(
+      expect.objectContaining({ id: "group_fresh", sessionIds: [] }),
+    );
+    expect(currentGroupId(store.getState(), operation.sessionId)).toBe("group_active");
+    expect(store.getState().screen).toMatchObject({
+      name: "moveToGroup",
+      step: "chooseDestination",
+      submitting: false,
+    });
+    await scope.dispose();
+  });
+});
+
+function moveSetup(sessionId: string, destinationGroupId: string) {
+  const initial = createGroupedDashboardSnapshot();
+  const open = openMoveToGroupForRow(
+    createInitialTuiState({ initialSnapshot: initial }),
+    sessionId,
+  );
+  const resolution = resolveMoveSessionToGroupOperation(open, sessionId, destinationGroupId);
+  if (resolution.kind !== "submit") throw new Error("move fixture did not resolve");
+  const state = {
+    ...open,
+    screen: { ...open.screen, submitting: true },
+  } as DashboardState;
+  const store = createStore<DashboardState>(() => state);
+  const service = new FakeTuiObserverService(initial);
+  const scope = createDashboardRuntimeEffectScope();
+  return {
+    initial,
+    sessionId,
+    store,
+    service,
+    scope,
+    operation: resolution.operation,
+    run: () =>
+      runMoveSessionToGroupOperation({
+        store,
+        service,
+        operation: resolution.operation,
+        clientLabel: "test",
+        scope,
+      }),
+  };
+}
+
+function moveMembership(
+  snapshot: ReturnType<typeof createGroupedDashboardSnapshot>,
+  sessionId: string,
+  destinationGroupId: string | null,
+) {
+  return {
+    ...snapshot,
+    sessionGroups: snapshot.sessionGroups.map((group) => ({
+      ...group,
+      version:
+        group.id === destinationGroupId || group.sessionIds.includes(sessionId)
+          ? group.version + 1
+          : group.version,
+      sessionIds:
+        group.id === destinationGroupId
+          ? [...group.sessionIds.filter((id) => id !== sessionId), sessionId]
+          : group.sessionIds.filter((id) => id !== sessionId),
+    })),
+  };
+}
+
+function currentGroupId(state: DashboardState, sessionId: string): string | undefined {
+  return state.snapshot?.sessionGroups.find((group) => group.sessionIds.includes(sessionId))?.id;
+}

--- a/packages/dashboard-core/test/unit/state/screens/moveToGroup.test.ts
+++ b/packages/dashboard-core/test/unit/state/screens/moveToGroup.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  selectMoveToGroupChoices,
+  selectMoveToGroupSessionContext,
+} from "../../../../src/selectors/selectors.js";
+import { createInitialTuiState } from "../../../../src/state/screen.js";
+import {
+  openMoveToGroupForRow,
+  selectMoveToGroupDestination,
+} from "../../../../src/state/screens/moveToGroup.js";
+import { handleTuiKey } from "../../../../src/state/transition.js";
+import { createGroupedDashboardSnapshot } from "../../../fixtures/snapshots.js";
+
+describe("Move to Group screen", () => {
+  it("opens from M, then uses the shared canonical session chooser", () => {
+    const state = createInitialTuiState({ initialSnapshot: createGroupedDashboardSnapshot() });
+    const opened = handleTuiKey(state, { input: "M" }).state;
+    expect(opened.screen).toEqual({ name: "moveToGroup", step: "chooseSlot" });
+
+    const chosen = handleTuiKey(opened, { input: "", downArrow: true }).state;
+    expect(chosen.dashboardFocus?.rowId).toBe("session:ses_wt_web_attention");
+    expect(handleTuiKey(chosen, { input: "\r", return: true }).state.screen).toMatchObject({
+      name: "moveToGroup",
+      step: "chooseDestination",
+      sessionId: "ses_wt_web_attention",
+      submitting: false,
+    });
+  });
+
+  it("lists only same-Project root Groups while retaining nested membership as context", () => {
+    const snapshot = createGroupedDashboardSnapshot();
+    const state = openMoveToGroupForRow(
+      createInitialTuiState({ initialSnapshot: snapshot }),
+      "ses_wt_web_working",
+    );
+
+    expect(
+      selectMoveToGroupSessionContext(snapshot, "ses_wt_web_working")?.currentGroup,
+    ).toMatchObject({
+      id: "group_build",
+      parentGroupId: "group_active",
+    });
+    expect(
+      selectMoveToGroupChoices(snapshot, "ses_wt_web_working").map((choice) => choice.value.id),
+    ).toEqual(["group_active", "group_empty"]);
+    expect(state.selection.get("moveToGroupDestination")).toBe("moveToGroup:ungrouped");
+  });
+
+  it("builds Group-to-Group and Group-to-Ungrouped commands with canonical expectations", () => {
+    const snapshot = createGroupedDashboardSnapshot();
+    const grouped = openMoveToGroupForRow(
+      createInitialTuiState({ initialSnapshot: snapshot }),
+      "ses_wt_web_attention",
+    );
+
+    expect(selectMoveToGroupDestination(grouped, "group_empty").operations).toEqual([
+      {
+        type: "moveSessionToGroup",
+        sessionId: "ses_wt_web_attention",
+        projectId: "web",
+        expectedCurrentGroupId: "group_active",
+        destinationGroupId: "group_empty",
+        command: {
+          type: "sessionGroup.updateMembership",
+          payload: {
+            projectId: "web",
+            groupId: "group_empty",
+            expectedVersion: 1,
+            add: [{ sessionId: "ses_wt_web_attention", expectedGroupId: "group_active" }],
+          },
+        },
+      },
+    ]);
+    expect(selectMoveToGroupDestination(grouped, null).operations?.[0]).toMatchObject({
+      command: {
+        payload: {
+          groupId: "group_active",
+          expectedVersion: 1,
+          remove: [{ sessionId: "ses_wt_web_attention", expectedGroupId: "group_active" }],
+        },
+      },
+    });
+  });
+
+  it("closes without a command for the current destination", () => {
+    const state = openMoveToGroupForRow(
+      createInitialTuiState({ initialSnapshot: createGroupedDashboardSnapshot() }),
+      "ses_wt_web_attention",
+    );
+    const transition = selectMoveToGroupDestination(state, "group_active");
+    expect(transition.operations).toBeUndefined();
+    expect(transition.state.screen).toEqual({ name: "dashboard" });
+  });
+
+  it("supports U, N, name entry, submit, Escape, and duplicate-submit suppression", () => {
+    const initial = openMoveToGroupForRow(
+      createInitialTuiState({ initialSnapshot: createGroupedDashboardSnapshot() }),
+      "ses_wt_web_idle",
+    );
+    expect(handleTuiKey(initial, { input: "U" }).operations?.[0]).toMatchObject({
+      type: "moveSessionToGroup",
+      destinationGroupId: null,
+    });
+
+    const create = handleTuiKey(initial, { input: "N" }).state;
+    expect(create.screen).toMatchObject({ name: "moveToGroup", step: "createGroup" });
+    const named = handleTuiKey(create, { input: "Fresh" }).state;
+    const submitted = handleTuiKey(named, { input: "\r", return: true });
+    expect(submitted.operations?.[0]).toMatchObject({
+      type: "createSessionGroupForMove",
+      sessionId: "ses_wt_web_idle",
+      projectId: "web",
+      name: "Fresh",
+    });
+    expect(submitted.state.screen).toMatchObject({ submitting: true });
+    expect(handleTuiKey(submitted.state, { input: "\r", return: true }).operations).toBeUndefined();
+    expect(handleTuiKey(submitted.state, { input: "", escape: true }).state).toBe(submitted.state);
+    expect(handleTuiKey(create, { input: "", escape: true }).state.screen).toMatchObject({
+      step: "chooseDestination",
+    });
+  });
+});

--- a/packages/dashboard-core/test/unit/state/selection/engine.test.ts
+++ b/packages/dashboard-core/test/unit/state/selection/engine.test.ts
@@ -196,6 +196,7 @@ describe("list registry — migrated modes", () => {
       "addProjectChoose",
       "addProjectFilter",
       "addProjectStart",
+      "moveToGroupDestination",
       "newSessionPickAgent",
       "newSessionPickGroup",
       "newSessionPickProject",

--- a/station/src/contextMenu/items.test.ts
+++ b/station/src/contextMenu/items.test.ts
@@ -160,6 +160,11 @@ describe("buildContextMenuItems", () => {
         action: { kind: "renameSession", rowId: STATION_IDLE_SESSION_ID },
       },
       {
+        id: "station.moveToGroup",
+        label: "Move to Group…",
+        action: { kind: "moveToGroup", rowId: STATION_IDLE_SESSION_ID },
+      },
+      {
         id: "station.forkSession",
         label: "Fork Session",
         action: { kind: "forkSession", rowId: STATION_IDLE_SESSION_ID },
@@ -274,6 +279,11 @@ describe("buildContextMenuItems", () => {
         action: { kind: "renameSession", rowId: "ses_wt_station_none" },
       },
       {
+        id: "station.moveToGroup",
+        label: "Move to Group…",
+        action: { kind: "moveToGroup", rowId: "ses_wt_station_none" },
+      },
+      {
         id: "station.forkSession",
         label: "Fork Session",
         action: { kind: "forkSession", rowId: "ses_wt_station_none" },
@@ -319,6 +329,11 @@ describe("buildContextMenuItems", () => {
 
     expect(items).toEqual([
       {
+        id: "station.moveToGroup",
+        label: "Move to Group…",
+        action: { kind: "moveToGroup", rowId: "run_wt_station_idle" },
+      },
+      {
         id: "station.forkSession",
         label: "Fork Session",
         action: { kind: "forkSession", rowId: "run_wt_station_idle" },
@@ -356,10 +371,12 @@ describe("buildContextMenuItems", () => {
 
     expect(stationItems.map((item) => item.label)).toEqual([
       "Rename Session",
+      "Move to Group…",
       "Fork Session",
       "Delete Worktree…",
     ]);
     expect(externalItems.map((item) => item.label)).toEqual([
+      "Move to Group…",
       "Fork Session",
       "Delete Worktree…",
     ]);
@@ -390,6 +407,11 @@ describe("buildContextMenuItems", () => {
         id: "station.renameSession",
         label: "Rename Session",
         action: { kind: "renameSession", rowId: STATION_IDLE_SESSION_ID },
+      },
+      {
+        id: "station.moveToGroup",
+        label: "Move to Group…",
+        action: { kind: "moveToGroup", rowId: STATION_IDLE_SESSION_ID },
       },
       {
         id: "station.forkSession",

--- a/station/src/contextMenu/items.ts
+++ b/station/src/contextMenu/items.ts
@@ -143,6 +143,11 @@ function buildSessionItems(
       action: { kind: "renameSession", rowId: row.id },
     });
   }
+  items.push({
+    id: "station.moveToGroup",
+    label: "Move to Group…",
+    action: { kind: "moveToGroup", rowId: row.id },
+  });
   // Any worktree can be forked (branch off its HEAD, copy its dirty tree).
   items.push({
     id: "station.forkSession",

--- a/station/src/contextMenu/types.ts
+++ b/station/src/contextMenu/types.ts
@@ -22,6 +22,7 @@ export type ContextMenuItemId =
   | "pane.splitBelow"
   | "pane.close"
   | "station.renameSession"
+  | "station.moveToGroup"
   | "station.forkSession"
   | "station.removeWorktree"
   | "project.quickGroup"
@@ -37,6 +38,7 @@ export type ContextMenuItemAction =
   | { kind: "splitPane"; paneId: PaneId; direction: PaneSplitDirection }
   | { kind: "closePane"; paneId: PaneId }
   | { kind: "renameSession"; rowId: string }
+  | { kind: "moveToGroup"; rowId: string }
   | { kind: "forkSession"; rowId: string }
   | { kind: "removeWorktree"; rowId: string }
   | { kind: "quickGroup"; projectId: string }

--- a/station/src/input/runtime/executeOutcome.ts
+++ b/station/src/input/runtime/executeOutcome.ts
@@ -132,6 +132,13 @@ function selectContextMenuItem(effects: StationInputEffects, itemIndex: number |
         effects.store.actions.openOverlay(STATION_OVERLAY_ID);
       }
       return;
+    case "moveToGroup":
+      if (dashboardRuntime !== undefined) {
+        dashboardRuntime.actions.dispatch({ type: "moveToGroup.open", rowId: action.rowId });
+        dismissCurrentAttention(effects);
+        effects.store.actions.openOverlay(STATION_OVERLAY_ID);
+      }
+      return;
     case "removeWorktree":
       if (dashboardRuntime !== undefined) {
         dashboardRuntime.actions.dispatch({ type: "removeWorktree.openConfirm", rowId: action.rowId });

--- a/station/src/input/stationInput.test.ts
+++ b/station/src/input/stationInput.test.ts
@@ -1031,11 +1031,28 @@ describe("createStationInputRuntime STATION context-menu actions", () => {
     });
   });
 
+  it("opens Move to Group directly for a row context-menu session", () => {
+    const { runtime, store, dashboardRuntime, rightClickRow } = contextMenuHarness();
+
+    rightClickRow();
+    runtime.handleSequence("\x1b[B");
+    runtime.handleSequence("\r");
+
+    expect(store.getState().input.contextMenu).toBeNull();
+    expect(dashboardRuntime.state.getState().screen).toMatchObject({
+      name: "moveToGroup",
+      step: "chooseDestination",
+      sessionId: "ses_wt_station_idle",
+      submitting: false,
+    });
+  });
+
   it("opens the fork details sheet from a row context menu", () => {
     const { runtime, store, dashboardRuntime, rightClickRow } = contextMenuHarness();
 
     rightClickRow();
-    // Menu order: Rename, Fork, Delete Session — one down reaches the fork.
+    // Menu order: Rename, Move, Fork, Delete Session — two downs reach the fork.
+    expect(runtime.handleSequence("\x1b[B")).toBe(true);
     expect(runtime.handleSequence("\x1b[B")).toBe(true);
     expect(runtime.handleSequence("\r")).toBe(true);
 
@@ -1052,7 +1069,8 @@ describe("createStationInputRuntime STATION context-menu actions", () => {
     const { runtime, store, dashboardRuntime, rightClickRow } = contextMenuHarness();
 
     rightClickRow();
-    // Menu order: Rename, Fork, Delete Session — two downs reach the delete.
+    // Menu order: Rename, Move, Fork, Delete Session — three downs reach delete.
+    expect(runtime.handleSequence("\x1b[B")).toBe(true);
     expect(runtime.handleSequence("\x1b[B")).toBe(true);
     expect(runtime.handleSequence("\x1b[B")).toBe(true);
     expect(runtime.handleSequence("\r")).toBe(true);
@@ -1074,7 +1092,8 @@ describe("createStationInputRuntime STATION context-menu actions", () => {
     );
 
     rightClickRow("run_wt_station_idle");
-    // Menu order: Fork, Delete Worktree… — one down reaches the informational action.
+    // Menu order: Move, Fork, Delete Worktree… — two downs reach the informational action.
+    runtime.handleSequence("\x1b[B");
     runtime.handleSequence("\x1b[B");
     runtime.handleSequence("\r");
 
@@ -1090,6 +1109,7 @@ describe("createStationInputRuntime STATION context-menu actions", () => {
     const { runtime, dashboardRuntime, rightClickRow } = contextMenuHarness();
 
     rightClickRow();
+    runtime.handleSequence("\x1b[B");
     runtime.handleSequence("\x1b[B");
     runtime.handleSequence("\x1b[B");
     runtime.handleSequence("\r");
@@ -1108,6 +1128,7 @@ describe("createStationInputRuntime STATION context-menu actions", () => {
     const { runtime, dashboardRuntime, rightClickRow } = contextMenuHarness();
 
     rightClickRow();
+    runtime.handleSequence("\x1b[B");
     runtime.handleSequence("\x1b[B");
     runtime.handleSequence("\x1b[B");
     runtime.handleSequence("\r");

--- a/station/src/station/input/stationMouse.test.ts
+++ b/station/src/station/input/stationMouse.test.ts
@@ -759,6 +759,20 @@ describe("routeStationMouse", () => {
     expect(store.state.getState().screen).toMatchObject({ flow: { mode: "pickGroup" } });
   });
 
+  it("routes Move-to-Group destination rows through the registered picker", async () => {
+    const store = makeStore(groupedManyProjectsSnapshot());
+    store.actions.dispatch({ type: "moveToGroup.open", rowId: "ses_wt_group_contracts" });
+
+    routeStationMouse({ kind: "sheetChoice", choiceKey: "2" }, LEFT_DOWN, store);
+    expect(store.state.getState().screen).toMatchObject({
+      name: "moveToGroup",
+      step: "chooseDestination",
+      submitting: true,
+    });
+
+    await store.dispose();
+  });
+
   it("treats right-click as inert at the STATION router layer", () => {
     const store = makeStore();
     const before = store.state.getState().screen;

--- a/station/src/station/input/stationMouse.ts
+++ b/station/src/station/input/stationMouse.ts
@@ -63,6 +63,7 @@ export type StationMouseTarget =
   | { kind: "newSessionAction"; actionId: NewSessionActionId }
   | { kind: "projectMenuAction"; actionId: ProjectMenuInputActionId }
   | { kind: "createGroupAction"; actionId: CreateGroupActionId }
+  | { kind: "moveToGroupCreateSubmit" }
   | { kind: "renameSessionSubmit" }
   | { kind: "forkSessionAction"; actionId: ForkSessionActionId }
   | { kind: "screenBackdrop" }
@@ -217,6 +218,9 @@ export function routeStationMouse(
       return { kind: "handled" };
     case "createGroupAction":
       dispatchStationAction(runtime, { type: "createGroup.activate", actionId: target.actionId });
+      return { kind: "handled" };
+    case "moveToGroupCreateSubmit":
+      dispatchStationAction(runtime, { type: "moveToGroup.create.submit" });
       return { kind: "handled" };
     case "renameSessionSubmit":
       dispatchStationAction(runtime, { type: "renameSession.submit" });

--- a/station/src/station/view/ActiveScreenOverlayView.tsx
+++ b/station/src/station/view/ActiveScreenOverlayView.tsx
@@ -17,6 +17,7 @@ import { RenameSessionSheetView } from "./sheets/RenameSessionSheetView.js";
 import { RemoveSessionSheetView } from "./sheets/RemoveSessionSheetView.js";
 import { ForkSessionSheetView } from "./sheets/ForkSessionSheetView.js";
 import { CreateGroupSheetView } from "./sheets/CreateGroupSheetView.js";
+import { MoveToGroupSheetView } from "./sheets/MoveToGroupSheetView.js";
 import { stationMouseProps, useStationMouse } from "./stationMouseContext.js";
 
 export type ActiveScreenOverlayViewProps = {
@@ -115,6 +116,16 @@ function renderActiveScreenOverlay({
       );
     case "createGroup":
       return <CreateGroupSheetView screen={screen} columns={columns} rows={rows} />;
+    case "moveToGroup":
+      return screen.step === "chooseSlot" ? null : (
+        <MoveToGroupSheetView
+          screen={screen}
+          snapshot={snapshot}
+          selection={selection}
+          columns={columns}
+          rows={rows}
+        />
+      );
     case "widgetSettings":
       return (
         <WidgetSettingsPanelView

--- a/station/src/station/view/HelpOverlayView.tsx
+++ b/station/src/station/view/HelpOverlayView.tsx
@@ -46,7 +46,7 @@ const STATION_HELP_CONTENT = [
   { key: navigation.key, description: `${navigation.description} · wheel scroll` },
   dashboardHelp("tui.dashboard.focusActivate"),
   dashboardHelp("tui.dashboard.nextNeedsMe"),
-  dashboardHelp("tui.dashboard.quickGroup"),
+  dashboardHelpGroup(["tui.dashboard.quickGroup", "tui.dashboard.moveToGroup"]),
   {
     key: dashboardKeys([
       "tui.dashboard.filter",

--- a/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
@@ -68,7 +68,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
                                                                                                                         
                                                                                                                         
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
-↵ activate  N new  A add  ⇥ next-needs-me  / filter  X delete  ? help  Q/esc:close                                      
+↵ activate  N new  M move to group  A add  ⇥ next-needs-me  / filter  X delete  ? help  Q/esc:close                     
 "
 `;
 
@@ -176,7 +176,7 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle        
                                                                                                                         
                                                                                                                         
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
-↵ activate  N new  A add  ⇥ next-needs-me  / filter  X delete  ? help  Q/esc:close                                      
+↵ activate  N new  M move to group  A add  ⇥ next-needs-me  / filter  X delete  ? help  Q/esc:close                     
 "
 `;
 
@@ -284,7 +284,7 @@ FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown  x 1 exited  ○ 0
                                                                                                                         
                                                                                                                         
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
-↵ activate  N new  A add  ⇥ next-needs-me  / filter  X delete  ? help  Q/esc:close                                      
+↵ activate  N new  M move to group  A add  ⇥ next-needs-me  / filter  X delete  ? help  Q/esc:close                     
 "
 `;
 
@@ -472,7 +472,7 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle        
                                                                                                                         
                                                                                                                         
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
-↵ activate  N new  A add  ⇥ next-needs-me  / filter  X delete  ? help  Q/esc:close                                      
+↵ activate  N new  M move to group  A add  ⇥ next-needs-me  / filter  X delete  ? help  Q/esc:close                     
 "
 `;
 
@@ -516,7 +516,7 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle        
                                                                                                                         
                                                                                                                         
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
-↵ activate  N new  A add  ⇥ next-needs-me  / filter  X delete  ? help  Q/esc:close                                      
+↵ activate  N new  M move to group  A add  ⇥ next-needs-me  / filter  X delete  ? help  Q/esc:close                     
 "
 `;
 
@@ -717,7 +717,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  no sessions yet · [ + ad└──────────────────────────────────────────────────────────────────────┘
 
 ──────────────────────────────────────────────────────────────────────────────────────────────────
-↵ activate  N new  A add  ⇥ next-needs-me  / filter  X delete  ? help  Esc:dismiss  Q:close
+↵ activate  N new  ⇥ next  / filter  X delete  ? help  Esc:dismiss  Q:close
 "
 `;
 

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -18,7 +18,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [8] ○ t│  ↑/↓        move cursor · wheel scroll                       │-1 #4 ✓ 
         │  ↵          open focused session                             │        
 ▼ script│  tab        next session needing you                         │qs] [▾] 
- [9] ○ a│  G          quick group                                      │6 #5 x1 
+ [9] ○ a│  G/M        quick group/move to group                        │6 #5 x1 
  [a] ? m│  / ↵ Esc Q  edit/apply/cancel-clear/retain-close filter      │ -1 #10 
         │  Tab S/P/A  build filter conditions · F applies builder      │        
 ▼ empty-│  1-9/a-z    open visible session or toggle condition         │qs] [▾] 
@@ -92,6 +92,62 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 │▸ Quick session (Q) On                                                        │
 │  Create Group (C)    Cancel (Esc)                                            │
 │ Enter/Q toggle · ↑↓ focus · Esc cancel                                       │
+└──────────────────────────────────────────────────────────────────────────────┘
+"
+`;
+
+exports[`modal flow golden frames renders the move to group destination sheet 1`] = `
+"                                                                                
+FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
+─────────────────────────────────────────────────────────────────────────────── 
+       SESSION                     AGENT     STATUS                 DIFF · PR   
+▼ station  12 sessions · 6 Groups · 11 agents                     [sh] [qs] [▾] 
+╭▼ Design refresh 2 sessions──────────────────────────────────────────[qs] [▾]╮ 
+│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│ 
+│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│ 
+╰─────────────────────────────────────────────────────────────────────────────╯ 
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ Move to Group                                                                │
+│ Session    group-contracts                                                   │
+│ Current    Design refresh                                                    │
+│ U Ungrouped                                                                  │
+│✓1 Design refresh                                                             │
+│ 2 Observer hardening                                                         │
+│ 3 Runtime cleanup                                                            │
+│ 4 Post-launch                                                                │
+│ 5 Release train                                                              │
+│ 6 Input parity and minimum-width interaction verification                    │
+│ N Create new Group…                                                          │
+│                                                                              │
+│ ↑↓ move   ↵ select   U ungrouped   N create   Esc cancel                     │
+└──────────────────────────────────────────────────────────────────────────────┘
+"
+`;
+
+exports[`modal flow golden frames renders the move to group create sheet 1`] = `
+"                                                                                
+FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
+─────────────────────────────────────────────────────────────────────────────── 
+       SESSION                     AGENT     STATUS                 DIFF · PR   
+▼ station  12 sessions · 6 Groups · 11 agents                     [sh] [qs] [▾] 
+╭▼ Design refresh 2 sessions──────────────────────────────────────────[qs] [▾]╮ 
+│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│ 
+│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│ 
+╰─────────────────────────────────────────────────────────────────────────────╯ 
+╭▼ Input parity and minimum-width interaction verification 1 session──[qs] [▾]╮ 
+│ [3] ○ input-routing               codex     idle                      +27 -6│ 
+╰─────────────────────────────────────────────────────────────────────────────╯ 
+╭▼ Observer hardening 3 sessions──────────────────────────────────────[qs] [▾]╮ 
+│ [4] ○ diagnostic-index            codex     idle                      +38 -7│ 
+│ [5] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│ 
+│ [6] ⠋ trace-readiness             codex     working           +91 -22 #478 …│ 
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ Create Group                                                                 │
+│ Session    group-contracts                                                   │
+│▸ Group       Release|                                                        │
+│  Create and Move (Enter)                                                     │
+│                                                                              │
+│ Enter create and move · Esc back                                             │
 └──────────────────────────────────────────────────────────────────────────────┘
 "
 `;

--- a/station/src/station/view/modals.golden.test.tsx
+++ b/station/src/station/view/modals.golden.test.tsx
@@ -34,6 +34,7 @@ import {
   openRemoveWorktreeConfirmForRow,
   openProjectDefaultAgentPicker,
   openCreateGroup,
+  openMoveToGroupForRow,
   openProjectMenu,
   openProjectSettings,
  } from "@station/dashboard-core/state";
@@ -114,6 +115,8 @@ const CASES: ModalCase[] = [
       "open visible session",
       "G",
       "quick group",
+      "M",
+      "move to group",
       "edit/apply/cancel-clear/retain-close filter",
       "╭",
       "╰",
@@ -149,6 +152,31 @@ const CASES: ModalCase[] = [
       "Create Group (C)",
       "Cancel (Esc)",
     ],
+  },
+  {
+    name: "move to group destination sheet",
+    keys: [],
+    snapshot: groupedManyProjectsSnapshot,
+    prepare: (state) => openMoveToGroupForRow(state, "ses_wt_group_contracts"),
+    expect: [
+      "Move to Group",
+      "Session    group-contracts",
+      "Current    Design refresh",
+      "U Ungrouped",
+      "1 Design refresh",
+      "N Create new Group…",
+    ],
+  },
+  {
+    name: "move to group create sheet",
+    keys: [],
+    snapshot: groupedManyProjectsSnapshot,
+    prepare: (state) => {
+      const opened = openMoveToGroupForRow(state, "ses_wt_group_contracts");
+      const creating = handleTuiKey(opened, { input: "N" }).state;
+      return handleTuiKey(creating, { input: "Release" }).state;
+    },
+    expect: ["Create Group", "Session    group-contracts", "Group", "Release", "Create and Move"],
   },
   {
     name: "persistent filter header editor",

--- a/station/src/station/view/sheets/MoveToGroupSheetView.test.tsx
+++ b/station/src/station/view/sheets/MoveToGroupSheetView.test.tsx
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { MouseButtons } from "@opentui/core/testing";
+import { testRender } from "@opentui/react/test-utils";
+import type { DashboardScreenView } from "@station/dashboard-core/state";
+import { act } from "react";
+import { nativeStationTheme, StationThemeProvider } from "../../../theme/index.js";
+import { groupedManyProjectsSnapshot } from "../../fixtures/scenarios.js";
+import type { StationMouseTarget } from "../../input/stationMouse.js";
+import { StationHoverProvider, StationMouseProvider } from "../stationMouseContext.js";
+import { MoveToGroupSheetView } from "./MoveToGroupSheetView.js";
+
+type MoveScreen = Exclude<
+  Extract<DashboardScreenView, { name: "moveToGroup" }>,
+  { step: "chooseSlot" }
+>;
+
+const teardowns: Array<() => void> = [];
+afterEach(async () => {
+  await act(async () => {
+    for (const teardown of teardowns.splice(0)) teardown();
+  });
+});
+
+async function render(
+  screen: MoveScreen,
+  selection = new Map<string, string>(),
+  rows = 24,
+) {
+  const targets: StationMouseTarget[] = [];
+  const snapshot = groupedManyProjectsSnapshot();
+  const setup = await testRender(
+    <StationThemeProvider theme={nativeStationTheme}>
+      <StationHoverProvider value>
+        <StationMouseProvider value={(target) => targets.push(target)}>
+          <MoveToGroupSheetView
+            snapshot={snapshot}
+            screen={screen}
+            selection={selection}
+            columns={80}
+            rows={rows}
+          />
+        </StationMouseProvider>
+      </StationHoverProvider>
+    </StationThemeProvider>,
+    { width: 80, height: rows },
+  );
+  teardowns.push(() => setup.renderer.destroy());
+  await setup.renderOnce();
+  return { setup, targets };
+}
+
+describe("MoveToGroupSheetView", () => {
+  it("separates current membership from cursor focus and exposes every destination row", async () => {
+    const { setup, targets } = await render(
+      {
+        name: "moveToGroup",
+        step: "chooseDestination",
+        sessionId: "ses_wt_group_contracts",
+        sessionTitle: "group-contracts",
+        submitting: false,
+      },
+      new Map([["moveToGroupDestination", "moveToGroup:existing:group_observer_hardening"]]),
+    );
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("Current    Design refresh");
+    expect(frame).toContain("✓1 Design refresh");
+    expect(frame).toContain("2 Observer hardening");
+    expect(frame).toContain("N Create new Group…");
+
+    const lines = frame.split("\n");
+    for (const label of ["U Ungrouped", "2 Observer hardening", "N Create new Group…"]) {
+      const row = lines.findIndex((line) => line.includes(label));
+      await setup.mockMouse.click(lines[row]?.indexOf(label) ?? -1, row, MouseButtons.LEFT);
+    }
+    expect(targets.filter((target) => target.kind === "sheetChoice")).toEqual([
+      { kind: "sheetChoice", choiceKey: "U" },
+      { kind: "sheetChoice", choiceKey: "2" },
+      { kind: "sheetChoice", choiceKey: "N" },
+    ]);
+  });
+
+  it("renders create-and-move progress without a duplicate submit target", async () => {
+    const screen: MoveScreen = {
+      name: "moveToGroup",
+      step: "createGroup",
+      sessionId: "ses_wt_group_contracts",
+      sessionTitle: "group-contracts",
+      draftName: { value: "Release", cursor: 7 },
+      submitting: true,
+    };
+    const { setup, targets } = await render(screen);
+    expect(setup.captureCharFrame()).toContain("Creating Group…");
+    expect(setup.captureCharFrame()).toContain("Create and Move");
+    const lines = setup.captureCharFrame().split("\n");
+    const row = lines.findIndex((line) => line.includes("Create and Move"));
+    await setup.mockMouse.click(lines[row]?.indexOf("Create and Move") ?? -1, row, MouseButtons.LEFT);
+    expect(targets.some((target) => target.kind === "moveToGroupCreateSubmit")).toBe(false);
+  });
+
+  it("windows a short destination list around keyboard focus", async () => {
+    const { setup } = await render(
+      {
+        name: "moveToGroup",
+        step: "chooseDestination",
+        sessionId: "ses_wt_group_contracts",
+        sessionTitle: "group-contracts",
+        submitting: false,
+      },
+      new Map([["moveToGroupDestination", "moveToGroup:existing:group_release_train"]]),
+      11,
+    );
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("Release train");
+    expect(frame).toContain("5-6 of 6");
+    expect(frame).toContain("U Ungrouped");
+    expect(frame).toContain("N Create new Group…");
+  });
+});

--- a/station/src/station/view/sheets/MoveToGroupSheetView.tsx
+++ b/station/src/station/view/sheets/MoveToGroupSheetView.tsx
@@ -1,0 +1,159 @@
+import {
+  bottomSheetContentWidth,
+  selectMoveToGroupChoices,
+  selectMoveToGroupSessionContext,
+} from "@station/dashboard-core/selectors";
+import {
+  MOVE_TO_GROUP_CREATE_CHOICE_ID,
+  MOVE_TO_GROUP_LIST_ID,
+  MOVE_TO_GROUP_UNGROUPED_CHOICE_ID,
+  moveToGroupExistingChoiceId,
+} from "@station/dashboard-core/state";
+import type {
+  DashboardScreenView,
+  DashboardSnapshotView,
+  DashboardStateView,
+} from "@station/dashboard-core/state";
+import { EditableTextInputView } from "../EditableTextInputView.js";
+import { BottomSheetFrameView } from "./BottomSheetFrameView.js";
+import {
+  SheetButtonRow,
+  SheetChoiceLine,
+  SheetControlRow,
+  SheetFooter,
+  SheetLabelValue,
+  SheetLine,
+  SheetProgressFooter,
+} from "./parts.js";
+
+type MoveToGroupScreen = Exclude<
+  Extract<DashboardScreenView, { name: "moveToGroup" }>,
+  { step: "chooseSlot" }
+>;
+
+export type MoveToGroupSheetViewProps = {
+  snapshot: DashboardSnapshotView;
+  screen: MoveToGroupScreen;
+  selection: DashboardStateView["selection"];
+  columns: number;
+  rows: number;
+};
+
+export function MoveToGroupSheetView({
+  snapshot,
+  screen,
+  selection,
+  columns,
+  rows,
+}: MoveToGroupSheetViewProps) {
+  const width = bottomSheetContentWidth(columns);
+  if (screen.step === "createGroup") {
+    return (
+      <BottomSheetFrameView columns={columns} rows={rows} title="Create Group" contentRows={6}>
+        <SheetLabelValue width={width} label="Session" labelWidth={10} value={screen.sessionTitle} />
+        <SheetControlRow
+          width={width}
+          label="Group"
+          value={
+            <EditableTextInputView
+              value={screen.draftName.value}
+              cursor={screen.draftName.cursor}
+              placeholder="Group name"
+              active={!screen.submitting}
+            />
+          }
+          valueCells={Math.max(screen.draftName.value.length, "Group name".length) + 1}
+          focused
+          disabled={screen.submitting}
+          mouseTarget={{ kind: "sheetBackdrop" }}
+        />
+        <SheetButtonRow
+          width={width}
+          buttons={[
+            {
+              id: "moveToGroup.create.submit",
+              label: "Create and Move",
+              compactLabel: "Create",
+              shortcut: "Enter",
+              tone: "primary",
+              focused: false,
+              disabled: screen.submitting || screen.draftName.value.trim().length === 0,
+              mouseTarget: { kind: "moveToGroupCreateSubmit" },
+            },
+          ]}
+        />
+        <SheetLine width={width}> </SheetLine>
+        {screen.submitting ? (
+          <SheetProgressFooter width={width}>Creating Group…</SheetProgressFooter>
+        ) : (
+          <SheetFooter width={width}>Enter create and move · Esc back</SheetFooter>
+        )}
+      </BottomSheetFrameView>
+    );
+  }
+
+  const context = selectMoveToGroupSessionContext(snapshot, screen.sessionId);
+  const choices = selectMoveToGroupChoices(snapshot, screen.sessionId);
+  const currentGroupId = context?.currentGroup?.id;
+  const currentLabel =
+    context?.currentGroup === undefined
+      ? "Ungrouped"
+      : context.currentGroup.parentGroupId === undefined
+        ? context.currentGroup.name
+        : `${context.currentGroup.name} (nested, read-only)`;
+  const selectedId = selection.get(MOVE_TO_GROUP_LIST_ID);
+  const listHeight = Math.max(1, Math.min(choices.length, rows - 9));
+  const selectedIndex = Math.max(
+    0,
+    choices.findIndex((choice) => moveToGroupExistingChoiceId(choice.value.id) === selectedId),
+  );
+  const start = Math.max(0, Math.min(selectedIndex, choices.length - listHeight));
+  const visibleChoices = choices.slice(start, start + listHeight);
+  return (
+    <BottomSheetFrameView
+      columns={columns}
+      rows={rows}
+      title="Move to Group"
+      contentRows={visibleChoices.length + 7}
+    >
+      <SheetLabelValue width={width} label="Session" labelWidth={10} value={screen.sessionTitle} />
+      <SheetLabelValue width={width} label="Current" labelWidth={10} value={currentLabel} />
+      <SheetChoiceLine
+        choiceKey="U"
+        label="Ungrouped"
+        detail=""
+        width={width}
+        current={currentGroupId === undefined}
+        selected={selectedId === MOVE_TO_GROUP_UNGROUPED_CHOICE_ID}
+      />
+      {visibleChoices.map((choice) => (
+        <SheetChoiceLine
+          key={choice.value.id}
+          choiceKey={choice.key}
+          label={choice.value.name}
+          detail=""
+          width={width}
+          current={currentGroupId === choice.value.id}
+          selected={selectedId === moveToGroupExistingChoiceId(choice.value.id)}
+        />
+      ))}
+      <SheetChoiceLine
+        choiceKey="N"
+        label="Create new Group…"
+        detail=""
+        width={width}
+        selected={selectedId === MOVE_TO_GROUP_CREATE_CHOICE_ID}
+      />
+      <SheetLine width={width}> </SheetLine>
+      {screen.submitting ? (
+        <SheetProgressFooter width={width}>Moving session…</SheetProgressFooter>
+      ) : (
+        <SheetFooter width={width}>
+          {visibleChoices.length < choices.length
+            ? `↑↓ move   ↵ select   ${start + 1}-${start + visibleChoices.length} of ${choices.length}   U/N   Esc cancel`
+            : "↑↓ move   ↵ select   U ungrouped   N create   Esc cancel"}
+        </SheetFooter>
+      )}
+    </BottomSheetFrameView>
+  );
+}


### PR DESCRIPTION
## What this fixes

Station Groups could be assigned while creating a session, but existing sessions could not be reorganized from the TUI. This adds a complete move flow while keeping `snapshot.sessionGroups` as canonical membership and preserving the dashboard's existing slot-key behavior.

## What changed

- Add an uppercase `M` flow that selects an existing session and then a destination.
- Add a row context-menu action that opens the destination step directly.
- Allow moving to Ungrouped, an existing same-project root Group, or a newly created Group.
- Apply membership changes through the existing optimistic-concurrency command path, with conflict convergence, retryable failures, duplicate-submit suppression, and preservation of a successfully created Group if the subsequent move fails.
- Derive the `M` key, wide footer hint, and Help entry from the centralized dashboard binding registry; the compact footer intentionally omits the new hint.
- Document the keyboard and mouse workflow.

## Testing

- `pnpm build` — 24/24 packages
- `pnpm typecheck` — 46/46 tasks
- `pnpm --dir station typecheck`
- `pnpm lint`
- Dashboard move operations, screen transitions, keymap, footer, selection, and Group membership tests
- Station input, mouse, context-menu, sheet, and golden-frame tests
- Station corpus: 1,587 unaffected tests passed; the reviewed Help-frame delta then passed in the focused modal suite, 60/60
- Previously load-timed-out runtime tests passed when rerun in bounded isolation

## User-visible behavior

Focus a session and press `M`, choose the session, then choose Ungrouped, an existing Group, or Create new Group. Right-clicking a session skips the first chooser. The wide footer and Help overlay advertise `M`; lowercase `m` remains a session slot.

## Safety and scope

Destinations are limited to root Groups in the session's project. No existing test file or protected behavior was removed; existing assertions changed only where the inserted menu item or centralized shortcut formatter changes the rendered UI.