### PR TITLE
fix(protocol): preserve Observer crossover across schema upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Station gives every agent an isolated Git worktree, keeps its terminal session a
 ## Install
 
 Station is experimental pre-alpha software. Install the current public version,
-`v0.0.0-pre-alpha.5.9`, with one command:
+`v0.0.0-pre-alpha.5.10`, with one command:
 
 ```sh
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.9/install.sh | sh
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.10/install.sh | sh
 ```
 
 Then complete and verify first-run setup:
@@ -125,11 +125,11 @@ Paste this prompt into a coding agent running on the machine where you want
 Station installed:
 
 ```text
-Install experimental Station v0.0.0-pre-alpha.5.9 and validate setup on this machine.
+Install experimental Station v0.0.0-pre-alpha.5.10 and validate setup on this machine.
 
 Safety and scope:
 - Do not clone the repository or build from source. Use only
-  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.9/install.sh`.
+  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.10/install.sh`.
 - Install to `~/.local/bin` unless I approve another location. Do not edit any
   shell startup file. If the installer reports a PATH mismatch, do not assume
   an export persists across agent tool calls or reaches my Terminal. Use the
@@ -209,7 +209,7 @@ or real-agent lanes.
 
 ## Release status
 
-Station `v0.0.0-pre-alpha.5.9` is an experimental pre-alpha. User-facing commands,
+Station `v0.0.0-pre-alpha.5.10` is an experimental pre-alpha. User-facing commands,
 configuration, state, and release packaging may change without compatibility.
 The old `v0.7.1-rc.*` releases were internal previews, not predecessors in the
 public version line. Report feedback and bugs through

--- a/apps/cli/src/observerProcess.ts
+++ b/apps/cli/src/observerProcess.ts
@@ -58,10 +58,12 @@ export async function getObserverStatus(
   const client =
     deps.clientFactory?.(paths.socketPath, {
       timeoutMs: observerStatusHealthTimeoutMs(options.timeoutMs),
+      acceptPreviousLifecycleSchema: true,
     }) ??
     createObserverClient({
       socketPath: paths.socketPath,
       timeoutMs: observerStatusHealthTimeoutMs(options.timeoutMs),
+      acceptPreviousLifecycleSchema: true,
     });
   try {
     return {
@@ -215,11 +217,13 @@ async function stopRunningObserver(
     deps.clientFactory?.(status.paths.socketPath, {
       expectedObserverIdentity,
       timeoutMs: requestTimeoutMs,
+      acceptPreviousLifecycleSchema: true,
     }) ??
     createObserverClient({
       socketPath: status.paths.socketPath,
       timeoutMs: requestTimeoutMs,
       expectedObserverIdentity,
+      acceptPreviousLifecycleSchema: true,
     });
   const receipt = await client.stop();
   const convergenceTimeoutMs = remainingStopTimeoutMs(deadlineMs);

--- a/apps/cli/src/observerProcess/types.ts
+++ b/apps/cli/src/observerProcess/types.ts
@@ -25,7 +25,10 @@ export type ObserverProcessDeps = {
   buildVersion?: string;
   clientFactory?: (
     socketPath: string,
-    options?: Pick<CreateObserverClientOptions, "expectedObserverIdentity" | "timeoutMs">,
+    options?: Pick<
+      CreateObserverClientOptions,
+      "acceptPreviousLifecycleSchema" | "expectedObserverIdentity" | "timeoutMs"
+    >,
   ) => ReturnType<typeof createObserverClient>;
   spawnObserver?: (input: SpawnObserverInput) => ChildProcessLike | Promise<ChildProcessLike>;
   clock?: RuntimeClock;

--- a/apps/cli/test/integration/codex-hooks-command.test.ts
+++ b/apps/cli/test/integration/codex-hooks-command.test.ts
@@ -680,7 +680,7 @@ function artifactOwner(launcher: string, runtimeKind: "compiled" | "source", dig
     schemaVersion: 1 as const,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.9",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.10",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/integration/installer-binary-update.test.ts
+++ b/apps/cli/test/integration/installer-binary-update.test.ts
@@ -24,7 +24,7 @@ import type { NativeBinaryRelease } from "../../src/update/githubRelease.js";
 import { createInstallerBinaryUpdateChannel } from "../../src/update/installerBinaryUpdate.js";
 
 const CURRENT_TAG = "v0.7.1-rc.8";
-const TARGET_TAG = "v0.0.0-pre-alpha.5.9";
+const TARGET_TAG = "v0.0.0-pre-alpha.5.10";
 const RECEIPT = "station-installer-binary-v1\n";
 const tempRoots: string[] = [];
 

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -117,7 +117,7 @@ describe("CLI manual-smoke commands", () => {
       "--version",
     ]);
 
-    expect(direct).toEqual({ code: 0, output: "0.0.0-pre-alpha.5.9", outputFormat: "text" });
+    expect(direct).toEqual({ code: 0, output: "0.0.0-pre-alpha.5.10", outputFormat: "text" });
     expect(withMissingConfig).toEqual(direct);
   });
 

--- a/apps/cli/test/integration/popup-command.test.ts
+++ b/apps/cli/test/integration/popup-command.test.ts
@@ -15,7 +15,7 @@ import { createTempState, writeConfigToml } from "../../../../tests/support/temp
 const now = "2026-05-20T12:00:00.000Z";
 const buildIdentity = "a".repeat(64);
 const observerBuildVersion = `0.0.0-local+station.${buildIdentity}`;
-const higherObserverBuildVersion = `0.0.0-pre-alpha.5.9+station.${buildIdentity}`;
+const higherObserverBuildVersion = `0.0.0-pre-alpha.5.10+station.${buildIdentity}`;
 const tuiObserverBuildMismatchError = {
   tag: "TuiCommandError",
   code: "TUI_OBSERVER_BUILD_MISMATCH",

--- a/apps/cli/test/integration/provider-hook-ownership.test.ts
+++ b/apps/cli/test/integration/provider-hook-ownership.test.ts
@@ -165,7 +165,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.9",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.10",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -165,7 +165,7 @@ describe("CLI setup command", () => {
       schemaVersion: 1 as const,
       launcher: join(root, "source", "bin", "stn-ingress"),
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.5.9",
+      version: "0.0.0-pre-alpha.5.10",
       buildIdentity: "a".repeat(64),
     };
     const current = {

--- a/apps/cli/test/integration/tui-command.test.ts
+++ b/apps/cli/test/integration/tui-command.test.ts
@@ -19,7 +19,7 @@ import { resolveStationWorkspaceDir } from "../../src/stationWorkspace.js";
 const now = "2026-05-20T12:00:00.000Z";
 const buildIdentity = "a".repeat(64);
 const observerBuildVersion = `0.0.0-local+station.${buildIdentity}`;
-const higherObserverBuildVersion = `0.0.0-pre-alpha.5.9+station.${buildIdentity}`;
+const higherObserverBuildVersion = `0.0.0-pre-alpha.5.10+station.${buildIdentity}`;
 const nestedTuiDisabledError = {
   tag: "TuiCommandError",
   code: "NESTED_TUI_DISABLED",

--- a/apps/cli/test/integration/worktrunk-hooks-command.test.ts
+++ b/apps/cli/test/integration/worktrunk-hooks-command.test.ts
@@ -352,7 +352,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.9",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.10",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/unit/installer-binary-update.test.ts
+++ b/apps/cli/test/unit/installer-binary-update.test.ts
@@ -30,7 +30,7 @@ import {
 
 const CURRENT_TAG = "v0.7.1-rc.8";
 const CURRENT_VERSION = CURRENT_TAG.slice(1);
-const TARGET_TAG = "v0.0.0-pre-alpha.5.9";
+const TARGET_TAG = "v0.0.0-pre-alpha.5.10";
 const TARGET_VERSION = TARGET_TAG.slice(1);
 const TARGETS = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"] as const;
 const RECEIPT = "station-installer-binary-v1\n";

--- a/apps/cli/test/unit/observer-process/activation-surfacing.test.ts
+++ b/apps/cli/test/unit/observer-process/activation-surfacing.test.ts
@@ -17,7 +17,7 @@ import { createTempState } from "../../../../../tests/support/temp-projects";
 
 const now = "2026-05-20T12:00:00.000Z";
 const sourceBuildVersion = `0.0.0-pre-alpha.4+station.${"e".repeat(64)}`;
-const compiledBuildVersion = `0.0.0-pre-alpha.5.9+station.${"d".repeat(64)}`;
+const compiledBuildVersion = `0.0.0-pre-alpha.5.10+station.${"d".repeat(64)}`;
 
 const bootReason = "FATAL: socket owned by foreign build dbf7f368";
 

--- a/apps/cli/test/unit/observer-process/setup-observer-activation.test.ts
+++ b/apps/cli/test/unit/observer-process/setup-observer-activation.test.ts
@@ -15,7 +15,7 @@ vi.mock("../../../src/observerProcess.js", async (importActual) => {
 });
 
 const now = "2026-05-20T12:00:00.000Z";
-const compiledBuildVersion = `0.0.0-pre-alpha.5.9+station.${"d".repeat(64)}`;
+const compiledBuildVersion = `0.0.0-pre-alpha.5.10+station.${"d".repeat(64)}`;
 
 restartObserverSpy.mockImplementation(async () => ({
   status: "running",

--- a/apps/cli/test/unit/setup-json-presenter.test.ts
+++ b/apps/cli/test/unit/setup-json-presenter.test.ts
@@ -269,7 +269,7 @@ describe("setup plan projection", () => {
       schemaVersion: 1 as const,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.5.9",
+      version: "0.0.0-pre-alpha.5.10",
       buildIdentity: "a".repeat(64),
     };
     const current = {

--- a/apps/observer/src/runtime/server.ts
+++ b/apps/observer/src/runtime/server.ts
@@ -87,12 +87,14 @@ export function createObserverLifecycleClient(options: {
       createObserverClient({
         socketPath,
         timeoutMs: requestTimeout(request.timeoutMs),
+        acceptPreviousLifecycleSchema: true,
       }).health(),
     stop: (socketPath, request) =>
       createObserverClient({
         socketPath,
         timeoutMs: requestTimeout(request.timeoutMs),
         expectedObserverIdentity: request.expectedObserver,
+        acceptPreviousLifecycleSchema: true,
       }).stop(),
     socketListening: async (socketPath, request) => {
       const probe = await probeObserverSocket(socketPath, {

--- a/apps/observer/test/unit/observerHandoff.test.ts
+++ b/apps/observer/test/unit/observerHandoff.test.ts
@@ -90,7 +90,7 @@ describe("classifyObserverIncumbent", () => {
   });
 
   it("orders the public pre-alpha after the internal preview version line", () => {
-    const publicPreAlpha = observerBuildVersion("0.0.0-pre-alpha.5.9", higherBuildIdentity);
+    const publicPreAlpha = observerBuildVersion("0.0.0-pre-alpha.5.10", higherBuildIdentity);
     const internalPreview = observerBuildVersion("0.7.1-rc.8", lowerBuildIdentity);
 
     expect(decisionFor(publicPreAlpha, internalPreview)).toEqual({

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ can use it or help improve it.
 
 > [!IMPORTANT]
 > Station is experimental pre-alpha software. The current public version is
-> `v0.0.0-pre-alpha.5.9`. Native binaries support macOS 13+ and glibc 2.39+ Linux
+> `v0.0.0-pre-alpha.5.10`. Native binaries support macOS 13+ and glibc 2.39+ Linux
 > on arm64 and x64.
 
 ## Start Here
@@ -26,7 +26,7 @@ Choose the path that matches what you want to do:
 Install the current release:
 
 ```sh
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.9/install.sh | sh
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.10/install.sh | sh
 ```
 
 Then complete and verify setup:

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -10,7 +10,7 @@ only with explicit `stn update --drive-package-manager`; it does not install a
 tap, formula, or cask.
 
 The public installation path for experimental pre-alpha
-`v0.0.0-pre-alpha.5.9` is the exact-tag native installer documented in
+`v0.0.0-pre-alpha.5.10` is the exact-tag native installer documented in
 [Install Station](install.md). Do not use the historical tap for public
 onboarding, and do not update it as part of pre-alpha publication.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,7 +1,7 @@
 # Install Station
 
 Station is experimental pre-alpha software. The current public version is
-`v0.0.0-pre-alpha.5.9`.
+`v0.0.0-pre-alpha.5.10`.
 
 ## Binary Requirements
 
@@ -33,11 +33,11 @@ If you prefer an agent-led install, paste this prompt into a coding agent on the
 target machine:
 
 ```text
-Install experimental Station v0.0.0-pre-alpha.5.9 and validate setup on this machine.
+Install experimental Station v0.0.0-pre-alpha.5.10 and validate setup on this machine.
 
 Safety and scope:
 - Do not clone the repository or build from source. Use only
-  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.9/install.sh`.
+  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.10/install.sh`.
 - Install to `~/.local/bin` unless I approve another location. Do not edit any
   shell startup file. If the installer reports a PATH mismatch, do not assume
   an export persists across agent tool calls or reaches my Terminal. Use the
@@ -71,10 +71,10 @@ choices.
 From any directory, run:
 
 ```bash
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.9/install.sh | sh
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.10/install.sh | sh
 ```
 
-The released `install.sh` is stamped with `v0.0.0-pre-alpha.5.9`. With no
+The released `install.sh` is stamped with `v0.0.0-pre-alpha.5.10`. With no
 arguments it downloads only that tag's matching native archive and
 `SHA256SUMS` over unauthenticated HTTPS. The old `v0.7.1-rc.*` releases were
 internal previews, not predecessors in the public version line.
@@ -138,7 +138,7 @@ it separately.
 Pass an absolute or home-relative path through the exact installer:
 
 ```bash
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.9/install.sh | \
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.10/install.sh | \
   sh -s -- --install-dir "$HOME/bin"
 ```
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,6 +1,6 @@
 # Limitations and Workarounds
 
-Station `v0.0.0-pre-alpha.5.9` is experimental pre-alpha software. This page
+Station `v0.0.0-pre-alpha.5.10` is experimental pre-alpha software. This page
 lists user-visible constraints and the available operational workaround for
 each one.
 

--- a/integrations/harness/claude/test/unit/hooks.test.ts
+++ b/integrations/harness/claude/test/unit/hooks.test.ts
@@ -354,7 +354,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.9",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.10",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/cursor/test/unit/hooks.test.ts
+++ b/integrations/harness/cursor/test/unit/hooks.test.ts
@@ -419,7 +419,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.9",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.10",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/opencode/test/unit/pluginInstall.test.ts
+++ b/integrations/harness/opencode/test/unit/pluginInstall.test.ts
@@ -643,7 +643,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.9",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.10",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/opencode/test/unit/provider.test.ts
+++ b/integrations/harness/opencode/test/unit/provider.test.ts
@@ -301,7 +301,7 @@ describe("OpenCodeHarnessProvider", () => {
       schemaVersion: 1 as const,
       launcher: join(root, "requester", "bin", "stn-ingress"),
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.5.9",
+      version: "0.0.0-pre-alpha.5.10",
       buildIdentity: "a".repeat(64),
     };
 

--- a/integrations/worktree/worktrunk/test/unit/hooks.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/hooks.test.ts
@@ -266,7 +266,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.9",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.10",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "station",
-  "version": "0.0.0-pre-alpha.5.9",
+  "version": "0.0.0-pre-alpha.5.10",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -101,7 +101,7 @@ describe("contract schemas", () => {
       schemaVersion: 1,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source",
-      version: "0.0.0-pre-alpha.5.9",
+      version: "0.0.0-pre-alpha.5.10",
       buildIdentity: "a".repeat(64),
     } as const;
     const current = {

--- a/packages/contracts/test/schema/diagnostics-schema.test.ts
+++ b/packages/contracts/test/schema/diagnostics-schema.test.ts
@@ -211,7 +211,7 @@ describe("diagnostics schemas", () => {
         schemaVersion: 1,
         launcher: "/checkout/station/bin/stn-ingress",
         runtimeKind: "source",
-        version: "0.0.0-pre-alpha.5.9",
+        version: "0.0.0-pre-alpha.5.10",
         buildIdentity: "a".repeat(64),
       },
     };

--- a/packages/harness-shared/test/unit/provider.test.ts
+++ b/packages/harness-shared/test/unit/provider.test.ts
@@ -145,7 +145,7 @@ describe("createTerminalBoundHarnessProvider", () => {
       schemaVersion: 1 as const,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.5.9",
+      version: "0.0.0-pre-alpha.5.10",
       buildIdentity: "a".repeat(64),
     };
 

--- a/packages/protocol/src/client.ts
+++ b/packages/protocol/src/client.ts
@@ -15,6 +15,7 @@ import { STATION_SCHEMA_VERSION, StationEventSchema } from "@station/contracts";
 import { Effect, runRuntimeBoundaryWithTimeout } from "@station/runtime";
 import { z } from "zod";
 import {
+  JsonRpcVersionSchema,
   type ProtocolMethod,
   type ProtocolResponse,
   ProtocolResponseSchema,
@@ -63,6 +64,8 @@ export type CreateObserverClientOptions = {
   expectedBuildVersion?: string;
   /** Exact process identity required before an ownership-changing operation. */
   expectedObserverIdentity?: ExpectedObserverIdentity;
+  /** Accepts the immediately previous schema for health and stop during an upgrade crossover. */
+  acceptPreviousLifecycleSchema?: boolean;
 };
 
 type OpenSubscription = {
@@ -80,6 +83,22 @@ const ProtocolEventEnvelopeMessageSchema = z
   .object({
     schemaVersion: z.literal(STATION_SCHEMA_VERSION),
     event: z.unknown(),
+  })
+  .strict();
+const PreviousLifecycleSuccessResponseSchema = z
+  .object({
+    schemaVersion: z.literal("0.10.0"),
+    jsonrpc: JsonRpcVersionSchema,
+    id: z.string().min(1),
+    result: z.object({ schemaVersion: z.literal("0.10.0") }).passthrough(),
+  })
+  .strict();
+const PreviousLifecycleErrorResponseSchema = z
+  .object({
+    schemaVersion: z.literal("0.10.0"),
+    jsonrpc: JsonRpcVersionSchema,
+    id: z.string().min(1),
+    error: z.unknown(),
   })
   .strict();
 
@@ -139,15 +158,31 @@ async function requestProtocolMethod<TMethod extends ProtocolMethod>(
 ): Promise<ProtocolResult<TMethod>> {
   const expectedObserver =
     method === "observer.health" ? undefined : resolveExpectedObserver(options);
+  const acceptPreviousLifecycleSchema =
+    options.acceptPreviousLifecycleSchema === true &&
+    (method === "observer.health" || method === "observer.stop");
   const result = await runRuntimeBoundaryWithTimeout(
     protocolClientBoundary(method, requestTimeoutMs(options)),
     ({ signal }) =>
       openRequestConnection(options, signal, async (connection) => {
         const iterator = connection.messages()[Symbol.asyncIterator]();
         if (expectedObserver !== undefined) {
-          await assertExpectedObserver(connection, iterator, `${id}_health`, expectedObserver);
+          await assertExpectedObserver(
+            connection,
+            iterator,
+            `${id}_health`,
+            expectedObserver,
+            acceptPreviousLifecycleSchema,
+          );
         }
-        return readResponseForRequest(connection, iterator, id, method, params);
+        return readResponseForRequest(
+          connection,
+          iterator,
+          id,
+          method,
+          params,
+          acceptPreviousLifecycleSchema,
+        );
       }),
   );
 
@@ -193,6 +228,7 @@ async function readResponseForRequest<TMethod extends ProtocolMethod>(
   id: string,
   method: TMethod,
   params?: unknown,
+  acceptPreviousLifecycleSchema = false,
 ): Promise<ProtocolResult<TMethod>> {
   connection.send(protocolRequest(id, method, params));
 
@@ -201,7 +237,7 @@ async function readResponseForRequest<TMethod extends ProtocolMethod>(
     if (next.done) {
       throw protocolSocketClosedError();
     }
-    const response = parseProtocolResponseMessage(next.value);
+    const response = parseProtocolResponseMessage(next.value, acceptPreviousLifecycleSchema);
     if (response.id !== id) {
       continue;
     }
@@ -214,8 +250,16 @@ async function assertExpectedObserver(
   iterator: AsyncIterator<unknown>,
   id: string,
   expectedObserver: ExpectedObserver,
+  acceptPreviousLifecycleSchema: boolean,
 ): Promise<void> {
-  const health = await readResponseForRequest(connection, iterator, id, "observer.health");
+  const health = await readResponseForRequest(
+    connection,
+    iterator,
+    id,
+    "observer.health",
+    undefined,
+    acceptPreviousLifecycleSchema,
+  );
   assertObserverIdentity(expectedObserver, health);
 }
 
@@ -467,13 +511,39 @@ async function readSubscriptionEvent(
   });
 }
 
-function parseProtocolResponseMessage(message: unknown): ProtocolResponse {
+function parseProtocolResponseMessage(
+  message: unknown,
+  acceptPreviousLifecycleSchema = false,
+): ProtocolResponse {
   const parsed = ProtocolResponseSchema.safeParse(message);
   if (parsed.success) {
     return parsed.data;
   }
+  if (acceptPreviousLifecycleSchema) {
+    const previous = normalizePreviousLifecycleResponse(message);
+    if (previous !== undefined) return previous;
+  }
   throwProtocolSchemaMismatchIfPresent(message);
   throw parsed.error;
+}
+
+function normalizePreviousLifecycleResponse(message: unknown): ProtocolResponse | undefined {
+  const success = PreviousLifecycleSuccessResponseSchema.safeParse(message);
+  if (success.success) {
+    const normalized = ProtocolResponseSchema.safeParse({
+      ...success.data,
+      schemaVersion: STATION_SCHEMA_VERSION,
+      result: { ...success.data.result, schemaVersion: STATION_SCHEMA_VERSION },
+    });
+    return normalized.success ? normalized.data : undefined;
+  }
+  const failure = PreviousLifecycleErrorResponseSchema.safeParse(message);
+  if (!failure.success) return undefined;
+  const normalized = ProtocolResponseSchema.safeParse({
+    ...failure.data,
+    schemaVersion: STATION_SCHEMA_VERSION,
+  });
+  return normalized.success ? normalized.data : undefined;
 }
 
 function parseProtocolEventEnvelope(message: unknown) {

--- a/packages/protocol/test/integration/client-server.test.ts
+++ b/packages/protocol/test/integration/client-server.test.ts
@@ -248,6 +248,57 @@ describe("protocol client/server", () => {
     }
   });
 
+  it("translates the previous lifecycle schema for an identity-pinned stop", async () => {
+    const { socketPath } = await createTempSocketPath();
+    const expectedObserverIdentity = {
+      pid: 42,
+      startedAt: protocolTestNow,
+      version: "0.0.0-pre-alpha.5.2",
+      socketPath,
+    };
+    const server = await listenUnixSocket({
+      socketPath,
+      onConnection: async (connection) => {
+        const iterator = connection.messages()[Symbol.asyncIterator]();
+        const healthRequest = ProtocolRequestSchema.parse((await iterator.next()).value);
+        connection.send({
+          schemaVersion: "0.10.0",
+          jsonrpc: "2.0",
+          id: healthRequest.id,
+          result: {
+            schemaVersion: "0.10.0",
+            status: "healthy",
+            ...expectedObserverIdentity,
+          },
+        });
+
+        const stopRequest = ProtocolRequestSchema.parse((await iterator.next()).value);
+        connection.send({
+          schemaVersion: "0.10.0",
+          jsonrpc: "2.0",
+          id: stopRequest.id,
+          result: { schemaVersion: "0.10.0", stopped: true, at: protocolTestNow },
+        });
+      },
+    });
+    const client = createObserverClient({
+      socketPath,
+      expectedObserverIdentity,
+      acceptPreviousLifecycleSchema: true,
+      requestId: ids("previous-stop"),
+    });
+
+    try {
+      await expect(client.stop()).resolves.toEqual({
+        schemaVersion: STATION_SCHEMA_VERSION,
+        stopped: true,
+        at: protocolTestNow,
+      });
+    } finally {
+      await server.close();
+    }
+  });
+
   it("checks legacy process health and stops it on one connection", async () => {
     const { socketPath } = await createTempSocketPath();
     const expectedObserverIdentity = {

--- a/packages/runtime/src/buildInfo.ts
+++ b/packages/runtime/src/buildInfo.ts
@@ -28,7 +28,7 @@ export type StationBuildInfo = {
 export function stationBuildInfo(): StationBuildInfo {
   return {
     version:
-      typeof STATION_BUILD_VERSION === "undefined" ? "0.0.0-pre-alpha.5.9" : STATION_BUILD_VERSION,
+      typeof STATION_BUILD_VERSION === "undefined" ? "0.0.0-pre-alpha.5.10" : STATION_BUILD_VERSION,
     compiled: isCompiledBinary(),
     buildIdentity:
       typeof STATION_BUILD_IDENTITY === "undefined"

--- a/packages/runtime/test/unit/buildInfo.test.ts
+++ b/packages/runtime/test/unit/buildInfo.test.ts
@@ -34,14 +34,14 @@ describe("station build info", () => {
     expect(isCompiledBinary()).toBe(false);
     expect(verifyBuildIdentity).not.toHaveBeenCalled();
     expect(stationBuildInfo()).toEqual({
-      version: "0.0.0-pre-alpha.5.9",
+      version: "0.0.0-pre-alpha.5.10",
       compiled: false,
       buildIdentity,
     });
-    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.5.9+station.${buildIdentity}`);
-    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.5.9+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.5.10+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.5.10+station.${buildIdentity}`);
     expect(stationBuildInfo()).toEqual({
-      version: "0.0.0-pre-alpha.5.9",
+      version: "0.0.0-pre-alpha.5.10",
       compiled: false,
       buildIdentity,
     });

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -79,9 +79,9 @@ describe("release readiness docs", () => {
         "let your agent install and validate station",
       );
       expect(prompt).toContain(
-        "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.9/install.sh",
+        "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.10/install.sh",
       );
-      expect(prompt).toContain("v0.0.0-pre-alpha.5.9");
+      expect(prompt).toContain("v0.0.0-pre-alpha.5.10");
       expect(prompt).toContain("stn setup check --json");
       expect(prompt).toContain("stn doctor");
       expect(prompt).toContain("summary.requiredOk: true");
@@ -236,9 +236,9 @@ describe("release readiness docs", () => {
       ].map(read),
     );
     const packageJson = await readPackageManifest();
-    const exactVersion = "v0.0.0-pre-alpha.5.9";
+    const exactVersion = "v0.0.0-pre-alpha.5.10";
     const exactInstallerUrl =
-      "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.9/install.sh";
+      "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.10/install.sh";
 
     for (const [path, document] of [
       ["README.md", readme],
@@ -372,7 +372,7 @@ describe("release readiness docs", () => {
       expect(promote).toContain(target);
     }
 
-    expect(packageJson.version).toBe("0.0.0-pre-alpha.5.9");
+    expect(packageJson.version).toBe("0.0.0-pre-alpha.5.10");
     expect(packageJson.scripts["smoke:install"]).toBe(
       "node scripts/test-runners/run-install-smoke.mjs",
     );


### PR DESCRIPTION
## What this fixes

Station's updater installs the candidate before asking it to replace the running Observer. When upgrading from the published pre-alpha.5.2 release, the candidate CLI rejected the incumbent Observer's immediately previous lifecycle schema, so the restart could not reach the identity-pinned stop and the end-to-end update was refused.

## What changed

- Accept and normalize schema 0.10 responses only for Observer health and stop during lifecycle handoff.
- Preserve the exact process-identity check before the ownership-changing stop request.
- Keep every other protocol request, response, event, and subscription strict on the current schema.
- Prepare the release metadata and public documentation for pre-alpha.5.10.

## Testing

- `pnpm smoke:release`
- `pnpm test:diagnostics:policy` (54 tests)
- `pnpm lint`
- Protocol client/server integration test (19 tests)
- CLI/Observer lifecycle unit tests (58 tests)
- Builds for `@station/protocol`, `@station/cli`, and `@station/observer`

## Safety and scope

Compatibility is deliberately limited to the known 0.10-to-0.11 upgrade crossover and the two lifecycle methods required to identify and stop the incumbent Observer. It does not weaken normal protocol validation.