### PR TITLE
fix(protocol): negotiate Observer lifecycle schema during upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Station gives every agent an isolated Git worktree, keeps its terminal session a
 ## Install
 
 Station is experimental pre-alpha software. Install the current public version,
-`v0.0.0-pre-alpha.5.10`, with one command:
+`v0.0.0-pre-alpha.5.11`, with one command:
 
 ```sh
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.10/install.sh | sh
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.11/install.sh | sh
 ```
 
 Then complete and verify first-run setup:
@@ -125,11 +125,11 @@ Paste this prompt into a coding agent running on the machine where you want
 Station installed:
 
 ```text
-Install experimental Station v0.0.0-pre-alpha.5.10 and validate setup on this machine.
+Install experimental Station v0.0.0-pre-alpha.5.11 and validate setup on this machine.
 
 Safety and scope:
 - Do not clone the repository or build from source. Use only
-  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.10/install.sh`.
+  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.11/install.sh`.
 - Install to `~/.local/bin` unless I approve another location. Do not edit any
   shell startup file. If the installer reports a PATH mismatch, do not assume
   an export persists across agent tool calls or reaches my Terminal. Use the
@@ -209,7 +209,7 @@ or real-agent lanes.
 
 ## Release status
 
-Station `v0.0.0-pre-alpha.5.10` is an experimental pre-alpha. User-facing commands,
+Station `v0.0.0-pre-alpha.5.11` is an experimental pre-alpha. User-facing commands,
 configuration, state, and release packaging may change without compatibility.
 The old `v0.7.1-rc.*` releases were internal previews, not predecessors in the
 public version line. Report feedback and bugs through

--- a/apps/cli/test/integration/codex-hooks-command.test.ts
+++ b/apps/cli/test/integration/codex-hooks-command.test.ts
@@ -680,7 +680,7 @@ function artifactOwner(launcher: string, runtimeKind: "compiled" | "source", dig
     schemaVersion: 1 as const,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.10",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.11",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/integration/installer-binary-update.test.ts
+++ b/apps/cli/test/integration/installer-binary-update.test.ts
@@ -24,7 +24,7 @@ import type { NativeBinaryRelease } from "../../src/update/githubRelease.js";
 import { createInstallerBinaryUpdateChannel } from "../../src/update/installerBinaryUpdate.js";
 
 const CURRENT_TAG = "v0.7.1-rc.8";
-const TARGET_TAG = "v0.0.0-pre-alpha.5.10";
+const TARGET_TAG = "v0.0.0-pre-alpha.5.11";
 const RECEIPT = "station-installer-binary-v1\n";
 const tempRoots: string[] = [];
 

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -117,7 +117,7 @@ describe("CLI manual-smoke commands", () => {
       "--version",
     ]);
 
-    expect(direct).toEqual({ code: 0, output: "0.0.0-pre-alpha.5.10", outputFormat: "text" });
+    expect(direct).toEqual({ code: 0, output: "0.0.0-pre-alpha.5.11", outputFormat: "text" });
     expect(withMissingConfig).toEqual(direct);
   });
 

--- a/apps/cli/test/integration/popup-command.test.ts
+++ b/apps/cli/test/integration/popup-command.test.ts
@@ -15,7 +15,7 @@ import { createTempState, writeConfigToml } from "../../../../tests/support/temp
 const now = "2026-05-20T12:00:00.000Z";
 const buildIdentity = "a".repeat(64);
 const observerBuildVersion = `0.0.0-local+station.${buildIdentity}`;
-const higherObserverBuildVersion = `0.0.0-pre-alpha.5.10+station.${buildIdentity}`;
+const higherObserverBuildVersion = `0.0.0-pre-alpha.5.11+station.${buildIdentity}`;
 const tuiObserverBuildMismatchError = {
   tag: "TuiCommandError",
   code: "TUI_OBSERVER_BUILD_MISMATCH",

--- a/apps/cli/test/integration/provider-hook-ownership.test.ts
+++ b/apps/cli/test/integration/provider-hook-ownership.test.ts
@@ -165,7 +165,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.10",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.11",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -165,7 +165,7 @@ describe("CLI setup command", () => {
       schemaVersion: 1 as const,
       launcher: join(root, "source", "bin", "stn-ingress"),
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.5.10",
+      version: "0.0.0-pre-alpha.5.11",
       buildIdentity: "a".repeat(64),
     };
     const current = {

--- a/apps/cli/test/integration/tui-command.test.ts
+++ b/apps/cli/test/integration/tui-command.test.ts
@@ -19,7 +19,7 @@ import { resolveStationWorkspaceDir } from "../../src/stationWorkspace.js";
 const now = "2026-05-20T12:00:00.000Z";
 const buildIdentity = "a".repeat(64);
 const observerBuildVersion = `0.0.0-local+station.${buildIdentity}`;
-const higherObserverBuildVersion = `0.0.0-pre-alpha.5.10+station.${buildIdentity}`;
+const higherObserverBuildVersion = `0.0.0-pre-alpha.5.11+station.${buildIdentity}`;
 const nestedTuiDisabledError = {
   tag: "TuiCommandError",
   code: "NESTED_TUI_DISABLED",

--- a/apps/cli/test/integration/worktrunk-hooks-command.test.ts
+++ b/apps/cli/test/integration/worktrunk-hooks-command.test.ts
@@ -352,7 +352,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.10",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.11",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/unit/installer-binary-update.test.ts
+++ b/apps/cli/test/unit/installer-binary-update.test.ts
@@ -30,7 +30,7 @@ import {
 
 const CURRENT_TAG = "v0.7.1-rc.8";
 const CURRENT_VERSION = CURRENT_TAG.slice(1);
-const TARGET_TAG = "v0.0.0-pre-alpha.5.10";
+const TARGET_TAG = "v0.0.0-pre-alpha.5.11";
 const TARGET_VERSION = TARGET_TAG.slice(1);
 const TARGETS = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"] as const;
 const RECEIPT = "station-installer-binary-v1\n";

--- a/apps/cli/test/unit/observer-process/activation-surfacing.test.ts
+++ b/apps/cli/test/unit/observer-process/activation-surfacing.test.ts
@@ -17,7 +17,7 @@ import { createTempState } from "../../../../../tests/support/temp-projects";
 
 const now = "2026-05-20T12:00:00.000Z";
 const sourceBuildVersion = `0.0.0-pre-alpha.4+station.${"e".repeat(64)}`;
-const compiledBuildVersion = `0.0.0-pre-alpha.5.10+station.${"d".repeat(64)}`;
+const compiledBuildVersion = `0.0.0-pre-alpha.5.11+station.${"d".repeat(64)}`;
 
 const bootReason = "FATAL: socket owned by foreign build dbf7f368";
 

--- a/apps/cli/test/unit/observer-process/setup-observer-activation.test.ts
+++ b/apps/cli/test/unit/observer-process/setup-observer-activation.test.ts
@@ -15,7 +15,7 @@ vi.mock("../../../src/observerProcess.js", async (importActual) => {
 });
 
 const now = "2026-05-20T12:00:00.000Z";
-const compiledBuildVersion = `0.0.0-pre-alpha.5.10+station.${"d".repeat(64)}`;
+const compiledBuildVersion = `0.0.0-pre-alpha.5.11+station.${"d".repeat(64)}`;
 
 restartObserverSpy.mockImplementation(async () => ({
   status: "running",

--- a/apps/cli/test/unit/setup-json-presenter.test.ts
+++ b/apps/cli/test/unit/setup-json-presenter.test.ts
@@ -269,7 +269,7 @@ describe("setup plan projection", () => {
       schemaVersion: 1 as const,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.5.10",
+      version: "0.0.0-pre-alpha.5.11",
       buildIdentity: "a".repeat(64),
     };
     const current = {

--- a/apps/observer/test/unit/observerHandoff.test.ts
+++ b/apps/observer/test/unit/observerHandoff.test.ts
@@ -90,7 +90,7 @@ describe("classifyObserverIncumbent", () => {
   });
 
   it("orders the public pre-alpha after the internal preview version line", () => {
-    const publicPreAlpha = observerBuildVersion("0.0.0-pre-alpha.5.10", higherBuildIdentity);
+    const publicPreAlpha = observerBuildVersion("0.0.0-pre-alpha.5.11", higherBuildIdentity);
     const internalPreview = observerBuildVersion("0.7.1-rc.8", lowerBuildIdentity);
 
     expect(decisionFor(publicPreAlpha, internalPreview)).toEqual({

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ can use it or help improve it.
 
 > [!IMPORTANT]
 > Station is experimental pre-alpha software. The current public version is
-> `v0.0.0-pre-alpha.5.10`. Native binaries support macOS 13+ and glibc 2.39+ Linux
+> `v0.0.0-pre-alpha.5.11`. Native binaries support macOS 13+ and glibc 2.39+ Linux
 > on arm64 and x64.
 
 ## Start Here
@@ -26,7 +26,7 @@ Choose the path that matches what you want to do:
 Install the current release:
 
 ```sh
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.10/install.sh | sh
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.11/install.sh | sh
 ```
 
 Then complete and verify setup:

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -10,7 +10,7 @@ only with explicit `stn update --drive-package-manager`; it does not install a
 tap, formula, or cask.
 
 The public installation path for experimental pre-alpha
-`v0.0.0-pre-alpha.5.10` is the exact-tag native installer documented in
+`v0.0.0-pre-alpha.5.11` is the exact-tag native installer documented in
 [Install Station](install.md). Do not use the historical tap for public
 onboarding, and do not update it as part of pre-alpha publication.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,7 +1,7 @@
 # Install Station
 
 Station is experimental pre-alpha software. The current public version is
-`v0.0.0-pre-alpha.5.10`.
+`v0.0.0-pre-alpha.5.11`.
 
 ## Binary Requirements
 
@@ -33,11 +33,11 @@ If you prefer an agent-led install, paste this prompt into a coding agent on the
 target machine:
 
 ```text
-Install experimental Station v0.0.0-pre-alpha.5.10 and validate setup on this machine.
+Install experimental Station v0.0.0-pre-alpha.5.11 and validate setup on this machine.
 
 Safety and scope:
 - Do not clone the repository or build from source. Use only
-  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.10/install.sh`.
+  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.11/install.sh`.
 - Install to `~/.local/bin` unless I approve another location. Do not edit any
   shell startup file. If the installer reports a PATH mismatch, do not assume
   an export persists across agent tool calls or reaches my Terminal. Use the
@@ -71,10 +71,10 @@ choices.
 From any directory, run:
 
 ```bash
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.10/install.sh | sh
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.11/install.sh | sh
 ```
 
-The released `install.sh` is stamped with `v0.0.0-pre-alpha.5.10`. With no
+The released `install.sh` is stamped with `v0.0.0-pre-alpha.5.11`. With no
 arguments it downloads only that tag's matching native archive and
 `SHA256SUMS` over unauthenticated HTTPS. The old `v0.7.1-rc.*` releases were
 internal previews, not predecessors in the public version line.
@@ -138,7 +138,7 @@ it separately.
 Pass an absolute or home-relative path through the exact installer:
 
 ```bash
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.10/install.sh | \
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.11/install.sh | \
   sh -s -- --install-dir "$HOME/bin"
 ```
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,6 +1,6 @@
 # Limitations and Workarounds
 
-Station `v0.0.0-pre-alpha.5.10` is experimental pre-alpha software. This page
+Station `v0.0.0-pre-alpha.5.11` is experimental pre-alpha software. This page
 lists user-visible constraints and the available operational workaround for
 each one.
 

--- a/integrations/harness/claude/test/unit/hooks.test.ts
+++ b/integrations/harness/claude/test/unit/hooks.test.ts
@@ -354,7 +354,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.10",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.11",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/cursor/test/unit/hooks.test.ts
+++ b/integrations/harness/cursor/test/unit/hooks.test.ts
@@ -419,7 +419,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.10",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.11",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/opencode/test/unit/pluginInstall.test.ts
+++ b/integrations/harness/opencode/test/unit/pluginInstall.test.ts
@@ -643,7 +643,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.10",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.11",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/opencode/test/unit/provider.test.ts
+++ b/integrations/harness/opencode/test/unit/provider.test.ts
@@ -301,7 +301,7 @@ describe("OpenCodeHarnessProvider", () => {
       schemaVersion: 1 as const,
       launcher: join(root, "requester", "bin", "stn-ingress"),
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.5.10",
+      version: "0.0.0-pre-alpha.5.11",
       buildIdentity: "a".repeat(64),
     };
 

--- a/integrations/worktree/worktrunk/test/unit/hooks.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/hooks.test.ts
@@ -266,7 +266,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.10",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.11",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "station",
-  "version": "0.0.0-pre-alpha.5.10",
+  "version": "0.0.0-pre-alpha.5.11",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -101,7 +101,7 @@ describe("contract schemas", () => {
       schemaVersion: 1,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source",
-      version: "0.0.0-pre-alpha.5.10",
+      version: "0.0.0-pre-alpha.5.11",
       buildIdentity: "a".repeat(64),
     } as const;
     const current = {

--- a/packages/contracts/test/schema/diagnostics-schema.test.ts
+++ b/packages/contracts/test/schema/diagnostics-schema.test.ts
@@ -211,7 +211,7 @@ describe("diagnostics schemas", () => {
         schemaVersion: 1,
         launcher: "/checkout/station/bin/stn-ingress",
         runtimeKind: "source",
-        version: "0.0.0-pre-alpha.5.10",
+        version: "0.0.0-pre-alpha.5.11",
         buildIdentity: "a".repeat(64),
       },
     };

--- a/packages/harness-shared/test/unit/provider.test.ts
+++ b/packages/harness-shared/test/unit/provider.test.ts
@@ -145,7 +145,7 @@ describe("createTerminalBoundHarnessProvider", () => {
       schemaVersion: 1 as const,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.5.10",
+      version: "0.0.0-pre-alpha.5.11",
       buildIdentity: "a".repeat(64),
     };
 

--- a/packages/protocol/src/client.ts
+++ b/packages/protocol/src/client.ts
@@ -12,7 +12,7 @@ import type {
   StationEvent,
 } from "@station/contracts";
 import { STATION_SCHEMA_VERSION, StationEventSchema } from "@station/contracts";
-import { Effect, runRuntimeBoundaryWithTimeout } from "@station/runtime";
+import { Effect, isSafeError, runRuntimeBoundaryWithTimeout } from "@station/runtime";
 import { z } from "zod";
 import {
   JsonRpcVersionSchema,
@@ -64,7 +64,7 @@ export type CreateObserverClientOptions = {
   expectedBuildVersion?: string;
   /** Exact process identity required before an ownership-changing operation. */
   expectedObserverIdentity?: ExpectedObserverIdentity;
-  /** Accepts the immediately previous schema for health and stop during an upgrade crossover. */
+  /** Negotiates the immediately previous schema for health and stop during an upgrade crossover. */
   acceptPreviousLifecycleSchema?: boolean;
 };
 
@@ -74,6 +74,7 @@ type OpenSubscription = {
 };
 
 const defaultRequestId = () => `req_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+const PREVIOUS_LIFECYCLE_SCHEMA_VERSION = "0.10.0";
 const ProtocolSchemaVersionProbeSchema = z
   .object({
     schemaVersion: z.union([z.string(), z.number()]).optional(),
@@ -87,15 +88,15 @@ const ProtocolEventEnvelopeMessageSchema = z
   .strict();
 const PreviousLifecycleSuccessResponseSchema = z
   .object({
-    schemaVersion: z.literal("0.10.0"),
+    schemaVersion: z.literal(PREVIOUS_LIFECYCLE_SCHEMA_VERSION),
     jsonrpc: JsonRpcVersionSchema,
     id: z.string().min(1),
-    result: z.object({ schemaVersion: z.literal("0.10.0") }).passthrough(),
+    result: z.object({ schemaVersion: z.literal(PREVIOUS_LIFECYCLE_SCHEMA_VERSION) }).passthrough(),
   })
   .strict();
 const PreviousLifecycleErrorResponseSchema = z
   .object({
-    schemaVersion: z.literal("0.10.0"),
+    schemaVersion: z.literal(PREVIOUS_LIFECYCLE_SCHEMA_VERSION),
     jsonrpc: JsonRpcVersionSchema,
     id: z.string().min(1),
     error: z.unknown(),
@@ -163,27 +164,44 @@ async function requestProtocolMethod<TMethod extends ProtocolMethod>(
     (method === "observer.health" || method === "observer.stop");
   const result = await runRuntimeBoundaryWithTimeout(
     protocolClientBoundary(method, requestTimeoutMs(options)),
-    ({ signal }) =>
-      openRequestConnection(options, signal, async (connection) => {
-        const iterator = connection.messages()[Symbol.asyncIterator]();
-        if (expectedObserver !== undefined) {
-          await assertExpectedObserver(
+    async ({ signal }) => {
+      const request = (usePreviousLifecycleSchema: boolean) =>
+        openRequestConnection(options, signal, async (connection) => {
+          const iterator = connection.messages()[Symbol.asyncIterator]();
+          if (expectedObserver !== undefined) {
+            await assertExpectedObserver(
+              connection,
+              iterator,
+              `${id}_health`,
+              expectedObserver,
+              acceptPreviousLifecycleSchema,
+              usePreviousLifecycleSchema,
+            );
+          }
+          return readResponseForRequest(
             connection,
             iterator,
-            `${id}_health`,
-            expectedObserver,
+            id,
+            method,
+            params,
             acceptPreviousLifecycleSchema,
+            usePreviousLifecycleSchema,
           );
+        });
+
+      try {
+        return await request(false);
+      } catch (error) {
+        if (
+          !acceptPreviousLifecycleSchema ||
+          !isSafeError(error) ||
+          error.code !== "PROTOCOL_SCHEMA_MISMATCH"
+        ) {
+          throw error;
         }
-        return readResponseForRequest(
-          connection,
-          iterator,
-          id,
-          method,
-          params,
-          acceptPreviousLifecycleSchema,
-        );
-      }),
+        return request(true);
+      }
+    },
   );
 
   return unwrapBoundaryResult(result);
@@ -229,8 +247,14 @@ async function readResponseForRequest<TMethod extends ProtocolMethod>(
   method: TMethod,
   params?: unknown,
   acceptPreviousLifecycleSchema = false,
+  usePreviousLifecycleSchema = false,
 ): Promise<ProtocolResult<TMethod>> {
-  connection.send(protocolRequest(id, method, params));
+  const request = protocolRequest(id, method, params);
+  connection.send(
+    usePreviousLifecycleSchema
+      ? { ...request, schemaVersion: PREVIOUS_LIFECYCLE_SCHEMA_VERSION }
+      : request,
+  );
 
   for (;;) {
     const next = await iterator.next();
@@ -251,6 +275,7 @@ async function assertExpectedObserver(
   id: string,
   expectedObserver: ExpectedObserver,
   acceptPreviousLifecycleSchema: boolean,
+  usePreviousLifecycleSchema: boolean,
 ): Promise<void> {
   const health = await readResponseForRequest(
     connection,
@@ -259,6 +284,7 @@ async function assertExpectedObserver(
     "observer.health",
     undefined,
     acceptPreviousLifecycleSchema,
+    usePreviousLifecycleSchema,
   );
   assertObserverIdentity(expectedObserver, health);
 }

--- a/packages/protocol/test/integration/client-server.test.ts
+++ b/packages/protocol/test/integration/client-server.test.ts
@@ -14,6 +14,7 @@ import {
   startProtocolServer,
 } from "@station/protocol";
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 import { createTempSocketPath } from "../../../../tests/support/sockets";
 import { createFakeObserverApi, emptySnapshot, ids, protocolTestNow } from "../support/fixtures.js";
 
@@ -248,7 +249,7 @@ describe("protocol client/server", () => {
     }
   });
 
-  it("translates the previous lifecycle schema for an identity-pinned stop", async () => {
+  it("retries the previous lifecycle schema for an identity-pinned stop", async () => {
     const { socketPath } = await createTempSocketPath();
     const expectedObserverIdentity = {
       pid: 42,
@@ -256,11 +257,38 @@ describe("protocol client/server", () => {
       version: "0.0.0-pre-alpha.5.2",
       socketPath,
     };
+    const previousLifecycleRequestSchema = z
+      .object({
+        schemaVersion: z.literal("0.10.0"),
+        jsonrpc: z.literal("2.0"),
+        id: z.string().min(1),
+        method: z.enum(["observer.health", "observer.stop"]),
+      })
+      .strict();
+    let connectionCount = 0;
     const server = await listenUnixSocket({
       socketPath,
       onConnection: async (connection) => {
+        connectionCount += 1;
         const iterator = connection.messages()[Symbol.asyncIterator]();
-        const healthRequest = ProtocolRequestSchema.parse((await iterator.next()).value);
+        const firstRequest = (await iterator.next()).value;
+        if (connectionCount === 1) {
+          const currentRequest = ProtocolRequestSchema.parse(firstRequest);
+          connection.send({
+            schemaVersion: "0.10.0",
+            jsonrpc: "2.0",
+            id: currentRequest.id,
+            error: {
+              tag: "ProtocolError",
+              code: "PROTOCOL_SCHEMA_MISMATCH",
+              message: "Observer protocol schema mismatch.",
+            },
+          });
+          return;
+        }
+
+        const healthRequest = previousLifecycleRequestSchema.parse(firstRequest);
+        expect(healthRequest.method).toBe("observer.health");
         connection.send({
           schemaVersion: "0.10.0",
           jsonrpc: "2.0",
@@ -272,7 +300,8 @@ describe("protocol client/server", () => {
           },
         });
 
-        const stopRequest = ProtocolRequestSchema.parse((await iterator.next()).value);
+        const stopRequest = previousLifecycleRequestSchema.parse((await iterator.next()).value);
+        expect(stopRequest.method).toBe("observer.stop");
         connection.send({
           schemaVersion: "0.10.0",
           jsonrpc: "2.0",
@@ -294,6 +323,7 @@ describe("protocol client/server", () => {
         stopped: true,
         at: protocolTestNow,
       });
+      expect(connectionCount).toBe(2);
     } finally {
       await server.close();
     }

--- a/packages/runtime/src/buildInfo.ts
+++ b/packages/runtime/src/buildInfo.ts
@@ -28,7 +28,7 @@ export type StationBuildInfo = {
 export function stationBuildInfo(): StationBuildInfo {
   return {
     version:
-      typeof STATION_BUILD_VERSION === "undefined" ? "0.0.0-pre-alpha.5.10" : STATION_BUILD_VERSION,
+      typeof STATION_BUILD_VERSION === "undefined" ? "0.0.0-pre-alpha.5.11" : STATION_BUILD_VERSION,
     compiled: isCompiledBinary(),
     buildIdentity:
       typeof STATION_BUILD_IDENTITY === "undefined"

--- a/packages/runtime/test/unit/buildInfo.test.ts
+++ b/packages/runtime/test/unit/buildInfo.test.ts
@@ -34,14 +34,14 @@ describe("station build info", () => {
     expect(isCompiledBinary()).toBe(false);
     expect(verifyBuildIdentity).not.toHaveBeenCalled();
     expect(stationBuildInfo()).toEqual({
-      version: "0.0.0-pre-alpha.5.10",
+      version: "0.0.0-pre-alpha.5.11",
       compiled: false,
       buildIdentity,
     });
-    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.5.10+station.${buildIdentity}`);
-    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.5.10+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.5.11+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.5.11+station.${buildIdentity}`);
     expect(stationBuildInfo()).toEqual({
-      version: "0.0.0-pre-alpha.5.10",
+      version: "0.0.0-pre-alpha.5.11",
       compiled: false,
       buildIdentity,
     });

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -79,9 +79,9 @@ describe("release readiness docs", () => {
         "let your agent install and validate station",
       );
       expect(prompt).toContain(
-        "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.10/install.sh",
+        "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.11/install.sh",
       );
-      expect(prompt).toContain("v0.0.0-pre-alpha.5.10");
+      expect(prompt).toContain("v0.0.0-pre-alpha.5.11");
       expect(prompt).toContain("stn setup check --json");
       expect(prompt).toContain("stn doctor");
       expect(prompt).toContain("summary.requiredOk: true");
@@ -236,9 +236,9 @@ describe("release readiness docs", () => {
       ].map(read),
     );
     const packageJson = await readPackageManifest();
-    const exactVersion = "v0.0.0-pre-alpha.5.10";
+    const exactVersion = "v0.0.0-pre-alpha.5.11";
     const exactInstallerUrl =
-      "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.10/install.sh";
+      "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.11/install.sh";
 
     for (const [path, document] of [
       ["README.md", readme],
@@ -372,7 +372,7 @@ describe("release readiness docs", () => {
       expect(promote).toContain(target);
     }
 
-    expect(packageJson.version).toBe("0.0.0-pre-alpha.5.10");
+    expect(packageJson.version).toBe("0.0.0-pre-alpha.5.11");
     expect(packageJson.scripts["smoke:install"]).toBe(
       "node scripts/test-runners/run-install-smoke.mjs",
     );


### PR DESCRIPTION
## What this fixes

Station's update crossover must communicate with the running predecessor after installing the candidate. The pre-alpha.5.10 candidate could validate schema 0.10 response envelopes, but still sent schema 0.11 lifecycle requests first; the published pre-alpha.5.2 Observer rejected those requests before identity verification and stop could complete.

## What changed

- Try the current lifecycle schema first for Observer health and stop.
- On a typed schema-mismatch refusal, reconnect within the same timeout budget and retry only those lifecycle requests with schema 0.10.
- Validate the prior response envelope, verify the exact incumbent process identity, and keep the guarded stop on the same fallback connection.
- Keep all non-lifecycle protocol operations strict on schema 0.11.
- Prepare release metadata and public documentation for pre-alpha.5.11.

## Testing

- `pnpm smoke:release`
- `pnpm test:diagnostics:policy` (54 tests)
- `pnpm lint`
- Protocol client/server integration test (19 tests)
- CLI/Observer lifecycle unit tests (58 tests)
- `pnpm --filter @station/protocol build`

## Safety and scope

The fallback activates only for health and stop, only after a typed protocol schema refusal, and only for the immediately previous 0.10 schema. The stop remains process-identity pinned.