### PR TITLE
fix(tui): complete Groups durability and input-parity bake

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -272,12 +272,6 @@ Nested project tables:
 | `[projects.env]` | any key | string | Extra env for project launches; local overlays cannot set it. |
 | `[projects.display]` | `group` | string | Optional grouping label. |
 | `[projects.display]` | `sort_order` | int | Optional sort order. |
-
-`[projects.display].group` is a static label for organizing whole projects. It is unrelated to
-dynamic Session Groups, which are Observer-owned state stored in SQLite and projected through
-`StationSnapshot.sessionGroups`. Session Groups are not configured under `[workspace]`, `[tui]`,
-the runtime `config.toml`, or project-local `.station/config.toml`; recorded `sessionGroup.*`
-Observer commands are their mutation boundary.
 | `[projects.worktrunk]` | `enabled` | bool | Defaults to `true` when omitted. |
 | `[projects.worktrunk]` | `base` | string | Overrides `[worktree.worktrunk].base` for this project. |
 | `[projects.worktrunk]` | `managed_root` | string | Per-project authoritative managed root; relative paths resolve against `project.root`. If omitted and global `managed_root` is set, STATION derives a unique project child directory. |
@@ -287,6 +281,13 @@ Observer commands are their mutation boundary.
 | `[projects.recovery_breadcrumbs]` | `path` | string | Optional breadcrumb path. |
 | `[projects.local_config]` | `enabled` | bool | Required inside the table; only `true` reads the project-local file. |
 | `[projects.local_config]` | `path` | string | Required inside the table; `~/` expands against `$HOME`, anything else resolves against `project.root`. |
+
+`[projects.display].group` is a static label for organizing whole projects. It is unrelated to
+dynamic Session Groups, which are Observer-owned state stored in SQLite and projected through
+`StationSnapshot.sessionGroups`. Session Groups are not configured under `[workspace]`, `[tui]`,
+the runtime `config.toml`, or project-local `.station/config.toml`. They change only through
+Observer-owned operations, including recorded `sessionGroup.*` commands and atomic session
+seed/placement; config is never Group state.
 
 `stn project add` refuses both a first add and an idempotent re-add when the
 checkout-style `root` has local `core.bare=true`; the failed mutation leaves the

--- a/docs/dashboard-architecture.md
+++ b/docs/dashboard-architecture.md
@@ -136,10 +136,11 @@ Station renderers
 `selectors/dashboardTree.ts` is the sole dashboard hierarchy adapter. It joins
 canonical sessions to worktree metadata, merges optimistic creates, applies
 filter and collapse state, and projects Project roots, direct Group blocks,
-project-root sessions, inert Group closing-frame rows, and inert gaps. Every
+project-root sessions, inert Group closing-frame rows, and inert inter-project gaps. Every
 expanded Group ends with one cell-less frame row, including an empty Group, so
 the visible ring has truthful viewport height without gaining focus, a slot, or
-an action. `snapshot.sessionGroups` is the exclusive membership authority;
+an action. That closing edge is part of the frame, not a synthetic spacer before
+or after the Group block. `snapshot.sessionGroups` is the exclusive membership authority;
 optional parent links are deliberately flattened. Ordinary optimistic create
 rows remain at the project root. A Quick Group launch may temporarily target
 one pending row at its new Group and suppress the exact matching ungrouped
@@ -151,14 +152,20 @@ canonical replacement. A Group-inheriting Fork targets its optimistic row at the
 a source move, deletion, or canonical replacement prunes that hint without synthesizing membership
 or exposing a duplicate root row. Deliberate New Session retains its sheet and never creates such a
 row.
-The renderer-local `GroupOrderingMode` chooses Groups-first or whole-block
-alphabetical interleaving without changing canonical arrays.
+The renderer-local `GroupOrderingMode` is `"groups-first" | "alphabetical-interleaved"`.
+Groups-first is the default and places alphabetized Group blocks before project-root sessions.
+Alphabetical interleaving compares Group names with root-session display titles while keeping each
+Group header, direct members, and closing edge together as one block. Neither mode changes canonical
+arrays, collapse state, filtering, or the continuous slots assigned only to rendered sessions; no
+public config currently selects the mode.
 The internal `treeGrid.ts` controller knows only immutable nodes, ordered cells,
 visibility, and a supplied eligibility policy; it has no dashboard or terminal
 knowledge and is not a package entrypoint.
 
 Project and Group collapse sets remain renderer-local and survive snapshot
-replacement even when an ID is temporarily absent. Persistent filtering admits
+replacement, Observer restart, and warm popup dismissal/reopen even when an ID is temporarily
+absent. Filtering and ordering never mutate either collapse set; resize and scroll changes retain or
+deterministically reconcile the stable cursor and viewport. Persistent filtering admits
 session rows through one candidate projection while retaining durable Project
 and Group containers; Group-name matches provide member text context, member
 matches retain their Group header, and container match ranges remain semantic

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -390,6 +390,10 @@ project. Inside the snapshot-writer turn they validate configured-project and
 canonical-session identity plus requested parent ancestry, enter a non-cancellable commit
 immediately before calling `SessionGroupStore`, and project only the command project without
 reconcile repair.
+Reparenting accepts only an existing parent in the same project; a missing or cross-project parent,
+self-parenting, and every direct or transitive cycle fail atomically before commit. Deletion ungroups
+only the deleted Group's direct members and reparents its direct children to its parent or the project
+root. Neither operation closes or removes a session, agent, terminal, worktree, or provider resource.
 Changed Group events derive from the mutation result and are persisted and published in
 canonical order before command success; validated no-ops emit no Group event. This path
 does not read providers or publish `observer.reconciled`.
@@ -935,7 +939,7 @@ participate. Nonliteral dynamic module edges fail because their ownership cannot
 be resolved. External literal dynamics such as `bun:sqlite` and `node:sqlite`
 remain recorded external edges rather than source-cycle members.
 
-The current Observer graph contains 147 production modules and no strongly
+The current Observer graph contains 146 production modules and no strongly
 connected component. `migrations/migration.ts` now owns
 `ObserverSqliteMigration`, so numbered migration declarations do not depend on
 their ordered aggregator. `reconcile/reconcileResult.ts` owns

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -397,8 +397,9 @@ reattach; pane borders and neighboring panes must remain unlinked.
 - Treat the active UI as the full terminal canvas. Layout code should account for the terminal viewport, not a decorative parent container.
 - Native Station owns its opaque Station canvas. The standalone dashboard uses opaque terminal-default background intent for its unaccented canvas, panels, prompts, Help surface, and toasts; this behavior is provider-neutral and does not use transparency.
 - Keep header, body, footer, overlays, prompts, and toasts from overlapping at narrow or short terminal sizes.
-- Render canonical Groups as contiguous blocks in the projected row order. An expanded Group uses its header as the top edge, inert side rails around direct members, and one inert closing-frame row; an empty expanded Group therefore has a header and closing edge only. A collapsed Group keeps the bounded identity and any enabled optional actions but omits its members and closing edge. The responsive `[qs]`/`[quick session]` action and `[▾]` are visible by default; runtime composition may independently suppress either action, with no user-facing config key yet. Identity toggles collapse, Quick Session expands the Group and launches into it, and `[▾]` opens the anchored Q/N/S/R Group menu.
-- Group rings use the quiet hairline role by default, bright working color while the header is focused, and dim working color while a direct member has focus. Exact target focus uses compact focus; member focus and hover keep the ordinary dashboard fills. Borders, separators, whitespace, and closing rows are inert, and viewport clipping may show any ordinary edge of the projected block without renderer-owned regrouping.
+- Render canonical Groups as contiguous blocks in the projected row order. An expanded Group uses its header as the top edge, inert side rails around direct members, and one inert closing-frame row; that row is the visible frame edge, not a synthetic blank spacer before or after the block. An empty expanded Group therefore has a header and closing edge only. A collapsed Group keeps the bounded identity and any enabled optional actions but omits its members and closing edge. The responsive `[qs]`/`[quick session]` action and `[▾]` are visible by default; runtime composition may independently suppress either action, with no user-facing config key yet. Identity toggles collapse, Quick Session expands the Group and launches into it, and `[▾]` opens the anchored Q/N/S/R Group menu.
+- Group ordering is the renderer-local union `"groups-first" | "alphabetical-interleaved"`. Groups-first is the default and places alphabetized Group blocks before project-root sessions. Alphabetical interleaving compares Group names with root-session display titles while keeping every Group block intact. Both modes retain canonical arrays, collapse and filter state, and continuous slots assigned only to rendered sessions; no user-facing config key selects the mode.
+- Group rings use the quiet hairline role by default, bright working color while the header is focused, and dim working color while a direct member has focus. Disclosure remains explicit through `▼` and `▶`. A focused dashboard session row carries `▏`, while the exact focused Project or Group header target carries `▸` in addition to compact focus fill. Member focus and hover keep the ordinary dashboard fills. Borders, separators, whitespace, and closing rows are inert, and viewport clipping may show any ordinary edge of the projected block without renderer-owned regrouping.
 - The tmux popup runs the same interactive observer-backed dashboard without
   native Station panes. Its close behavior and footer copy must match popup
   semantics, such as `q/esc:close` when a warm dismissal is expected. `Ctrl-O`
@@ -506,6 +507,9 @@ dispatches `dashboard.cell.activate`, the same activation used by focused Enter.
 filtered, pending, or stale cells remain inert. Wheel events over child rows use
 dashboard scrolling, and active modal surfaces intercept background clicks and scrolling.
 
+These pointer, keyboard, and non-color marker contracts provide practical input usability. This
+milestone does not claim screen-reader or accessibility-tree support.
+
 Dashboard focus follows rendered order through each Project header, its direct Group blocks and
 project-root sessions, or the stable Add Session action rendered when that Project is empty. The cursor is one branded
 `{ rowId, cellId }` identity. Entering a header vertically always selects `identity`; Left/Right then
@@ -516,16 +520,16 @@ identity toggles collapse; Group quick session launches through the same pointer
 contract, and the Group menu control opens its anchored action menu while preserving the cell for
 safe return. Up/Down leaves any header segment immediately, and Left/Right on a
 session row or empty-project action is inert. Remove, rename, move-to-Group, and fork row choosers retain a separate
-visible, selectable canonical-session traversal; slots and Enter resolve through that same chooser
-policy. Next-needs-me uses its own canonical-session policy. `N` continues to open the session flow
+visible, selectable canonical-session traversal with `▸` as its keyboard cursor; slots and Enter
+resolve through that same chooser policy. Next-needs-me uses its own canonical-session policy. `N` continues to open the session flow
 without changing dashboard focus, while uppercase `G` creates a Quick Group for the focused row's
 owning Project (or the first canonical Project when nothing valid is focused). Lowercase `g` remains
 a visible-session slot. Gaps and optimistic create rows remain non-focusable.
 
 Uppercase `M` opens the shared session chooser, then a Move to Group sheet. Native right-click on a
-session opens the same destination step directly. The sheet shows canonical current membership as
-context while its independent cursor selects Ungrouped, same-Project root Groups, or Create new
-Group; externally nested membership is read-only. Slots, arrows plus Enter, pointer rows, `U`, and
+session opens the same destination step directly. The sheet marks canonical current membership with
+`✓`, while its independent `▸` keyboard cursor selects Ungrouped, same-Project root Groups, or Create
+new Group; the two markers may appear on different rows, and externally nested membership is read-only. Slots, arrows plus Enter, pointer rows, `U`, and
 `N` converge on one dashboard-core reassignment operation. Moving to a Group submits one
 `sessionGroup.updateMembership` command with the current membership expectation and destination
 version; ungrouping removes through that same contract, and selecting the current destination is a
@@ -541,7 +545,8 @@ control owns exactly its label cells and separator spaces remain inert. An empty
 pointer target cover only `[ + add session ]`; its explanatory text and surrounding whitespace
 remain inert and unpainted. Wide and compact labels preserve the same control identity. Hover stays
 component-local, temporarily supersedes the focus background, and reveals persistent keyboard focus
-again when the pointer leaves; no focus glyph is added.
+again when the pointer leaves; the persistent `▏` row or `▸` target marker remains the non-color
+focus cue.
 
 Group collapse moves a hidden direct member to that Group's identity; Project collapse remains the
 outer ancestor and moves any hidden descendant to the Project identity. A focused Group identity
@@ -553,6 +558,9 @@ and scrolls it into view. The Default Agent picker retains its header focus bene
 Escape, click-away, unchanged selection, and a successful change return to `menu`; project
 removal while open uses the same deterministic focus fallback. The dashboard footer describes Enter
 as `activate` because it may activate a session row, project-header control, or empty-project action.
+Ordering mode, collapse sets, and the applied filter remain renderer-local across Observer restart,
+snapshot replacement, and warm popup dismissal/reopen. Filtering never mutates collapse; scrolling
+and resize retain or deterministically reconcile focus and viewport position.
 
 Activating a Group's responsive `[qs]`/`[quick session]` action launches an ordinary Quick Session without embedding Group placement in
 the create request. While pending, its targeted local row is rendered inside the expanded Group. On
@@ -565,7 +573,8 @@ Activating a Project's `[▾]` opens a right-edge anchored menu with Quick Group
 default agent, and Project settings… in that order. Up/Down wraps, Enter activates, `G` selects Quick
 Group, and Escape or click-away returns to the same Project `menu` cell. The overlay opens above its
 Project row when it would overflow and clamps in narrow or short terminals without reflowing the
-dashboard. Native right-click exposes the same four actions through the shared core transitions.
+dashboard. The focused action carries `▸`; native right-click exposes the same four actions, marker,
+and shared core transitions.
 
 Activating a Group's `[▾]` opens a right-edge menu with visible Q/N/S/R keyboard shortcuts for
 Quick session, New session…, Group settings…, and Remove Group…. Separators precede Settings and
@@ -574,7 +583,7 @@ click-away share dashboard-core transitions. The menu flips above its Group row 
 clamps at compact sizes. New Session preselects only a current same-Project root Group and fails
 closed for a stale, moved, or nested target. Remove Group… opens the typed Remove section and never
 deletes directly. Native right-click on any Group-header cell exposes the same ordered actions,
-shortcuts, validation, and destinations.
+shortcuts, `▸` focused-action marker, validation, and destinations.
 
 One responsive settings shell contains General, Sessions, and Remove Group; `G`, `S`, and `R`, arrows plus Enter, and
 semantic pointer targets reach every section and control. General shows read-only Project identity and saves one versioned Group rename. Sessions

--- a/integrations/terminal/tmux/test/integration/popup-real.test.ts
+++ b/integrations/terminal/tmux/test/integration/popup-real.test.ts
@@ -2199,17 +2199,13 @@ async function fixtureDiagnostics(fixture: DashboardFixture): Promise<string> {
 }
 
 function isDashboardContent(content: string): boolean {
-  return (
-    content.includes("FLEET") &&
-    content.includes("Station snapshot mock") &&
-    content.includes("? help")
-  );
+  return content.includes("FLEET") && content.includes("station · overview");
 }
 
 function isGroupedManyProjectDashboardContent(content: string): boolean {
   return (
     content.includes("FLEET") &&
-    content.includes("╭▼ Design refresh") &&
+    content.includes("╭ ▼ Design refresh") &&
     content.includes("group-contracts") &&
     content.includes("? help")
   );
@@ -2397,7 +2393,7 @@ function dashboardFrameMatchesGeometry(content: string, dimensions: Dimensions):
     lines[2] === divider &&
     lines[3]?.includes("SESSION") === true &&
     lines[dimensions.rows - 2] === divider &&
-    lines[dimensions.rows - 1]?.startsWith("↵ open") === true &&
+    lines[dimensions.rows - 1]?.startsWith("↵ activate") === true &&
     !lines.includes("─")
   );
 }
@@ -2412,7 +2408,7 @@ function assertDashboardFrameGeometry(
   expect(lines[2], `${label} top divider`).toBe(divider);
   expect(lines[3], `${label} column header`).toContain("SESSION");
   expect(lines[dimensions.rows - 2], `${label} bottom divider`).toBe(divider);
-  expect(lines[dimensions.rows - 1], `${label} footer`).toMatch(/^↵ open/u);
+  expect(lines[dimensions.rows - 1], `${label} footer`).toMatch(/^↵ activate/u);
   expect(
     lines.filter((line) => line === divider),
     `${label} divider rows`,

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "test:e2e:setup:guided:all-shells": "STATION_SETUP_E2E_ALL_SHELLS=true pnpm test:e2e:setup:guided",
     "test:e2e:setup:core": "vitest run --config config/vitest/vitest.setup-e2e.config.ts tests/e2e/setup-core-flow.test.ts",
     "test:e2e:setup:sqlite": "vitest run --config config/vitest/vitest.setup-e2e.config.ts tests/e2e/observer-sqlite-smoke.test.ts",
-    "test:e2e:observer": "vitest run --config config/vitest/vitest.e2e.config.ts tests/e2e/observer-lifecycle.test.ts tests/e2e/session-migration.test.ts",
+    "test:e2e:observer": "vitest run --config config/vitest/vitest.e2e.config.ts tests/e2e/observer-lifecycle.test.ts tests/e2e/session-migration.test.ts tests/e2e/full-session-lifecycle/session-create-scripted.test.ts",
     "test:e2e:host-upgrade": "pnpm --dir station test:host:upgrade",
     "test:e2e": "vitest run --config config/vitest/vitest.e2e.config.ts",
     "test:e2e:real": "vitest run --config config/vitest/vitest.real-e2e.config.ts",

--- a/packages/dashboard-core/src/state/screens/groupMenu.ts
+++ b/packages/dashboard-core/src/state/screens/groupMenu.ts
@@ -6,7 +6,7 @@ import { addTuiToast } from "../toasts.js";
 import type { TuiTransition } from "../transition.js";
 import type { DashboardState, GroupMenuActionId } from "../types.js";
 import { openNewSession } from "./dashboard.js";
-import { openGroupSettings } from "./groupSettings.js";
+import { focusGroupSettingsControl, openGroupSettings } from "./groupSettings.js";
 import { submitQuickSessionInGroup } from "./quickSession.js";
 
 export type GroupMenuInputActionId = GroupMenuActionId | "cancel";
@@ -134,8 +134,10 @@ export function activateSessionGroupMenuAction(
       });
     case "settings":
       return { state: openGroupSettings(dashboardState, input.groupId, "general") };
-    case "remove":
-      return { state: openGroupSettings(dashboardState, input.groupId, "remove") };
+    case "remove": {
+      const settings = openGroupSettings(dashboardState, input.groupId, "remove");
+      return { state: focusGroupSettingsControl(settings, "removeConfirm") };
+    }
   }
 }
 

--- a/packages/dashboard-core/test/unit/state/interactionParity.test.ts
+++ b/packages/dashboard-core/test/unit/state/interactionParity.test.ts
@@ -366,24 +366,60 @@ describe("primary workflow interaction parity", () => {
       { type: "dashboard.cell.activate", rowId, cellId: "menu" },
       context,
     ).state;
-    const pointer = handleTuiAction(
-      menu,
-      { type: "groupMenu.activate", actionId: "quickSession" },
-      context,
-    );
-    const focused = handleTuiKey(menu, { input: "\r", return: true }, context);
-    const shortcut = handleTuiKey(menu, { input: "Q" }, context);
+    const cases = [
+      { actionId: "quickSession", shortcut: "Q", down: 0 },
+      { actionId: "newSession", shortcut: "N", down: 1 },
+      { actionId: "settings", shortcut: "S", down: 2 },
+      { actionId: "remove", shortcut: "R", down: 3 },
+    ] as const;
 
-    for (const transition of [pointer, focused, shortcut]) {
-      expect(transition.state.screen).toEqual({ name: "dashboard" });
-      expect(transition.state.dashboardFocus).toEqual({ rowId, cellId: "menu" });
-      expect(transition.operations).toEqual([
-        expect.objectContaining({
-          type: "quickCreateSessionInGroup",
-          groupId: "group_active",
-          fallbackCell: "menu",
-        }),
-      ]);
+    for (const testCase of cases) {
+      let focusedMenu = menu;
+      for (let index = 0; index < testCase.down; index += 1) {
+        focusedMenu = handleTuiKey(focusedMenu, { input: "", downArrow: true }, context).state;
+      }
+      const transitions = [
+        handleTuiAction(menu, { type: "groupMenu.activate", actionId: testCase.actionId }, context),
+        handleTuiKey(focusedMenu, { input: "\r", return: true }, context),
+        handleTuiKey(menu, { input: testCase.shortcut }, context),
+      ];
+
+      for (const transition of transitions) {
+        expect(transition.state.dashboardFocus).toEqual({ rowId, cellId: "menu" });
+        switch (testCase.actionId) {
+          case "quickSession":
+            expect(transition.state.screen).toEqual({ name: "dashboard" });
+            expect(transition.operations).toEqual([
+              expect.objectContaining({
+                type: "quickCreateSessionInGroup",
+                groupId: "group_active",
+                fallbackCell: "menu",
+              }),
+            ]);
+            break;
+          case "newSession":
+            expect(transition.state.screen).toMatchObject({
+              name: "newSession",
+              flow: {
+                mode: "review",
+                selectedProjectId: "web",
+                groupSelection: { kind: "existing", groupId: "group_active" },
+              },
+            });
+            expect(transition.operations).toBeUndefined();
+            break;
+          case "settings":
+          case "remove":
+            expect(transition.state.screen).toMatchObject({
+              name: "groupSettings",
+              projectId: "web",
+              groupId: "group_active",
+              section: testCase.actionId === "settings" ? "general" : "remove",
+            });
+            expect(transition.operations).toBeUndefined();
+            break;
+        }
+      }
     }
   });
 

--- a/packages/dashboard-core/test/unit/state/interactionParity.test.ts
+++ b/packages/dashboard-core/test/unit/state/interactionParity.test.ts
@@ -415,6 +415,9 @@ describe("primary workflow interaction parity", () => {
               projectId: "web",
               groupId: "group_active",
               section: testCase.actionId === "settings" ? "general" : "remove",
+              ...(testCase.actionId === "remove"
+                ? { focus: "detail", detailFocus: "removeConfirm" }
+                : { focus: "list" }),
             });
             expect(transition.operations).toBeUndefined();
             break;

--- a/packages/dashboard-core/test/unit/state/screens/groupMenu.test.ts
+++ b/packages/dashboard-core/test/unit/state/screens/groupMenu.test.ts
@@ -8,6 +8,8 @@ import {
   handleGroupMenuKey,
   openGroupMenu,
 } from "../../../../src/state/screens/groupMenu.js";
+import { handleTuiKey } from "../../../../src/state/transition.js";
+import type { DashboardState } from "../../../../src/state/types.js";
 import { createGroupedDashboardSnapshot } from "../../../fixtures/snapshots.js";
 
 describe("Group menu", () => {
@@ -106,7 +108,14 @@ describe("Group menu", () => {
         projectId: "web",
         groupId: "group_active",
         section,
+        ...(actionId === "remove"
+          ? { focus: "detail", detailFocus: "removeConfirm" }
+          : { focus: "list" }),
       });
+      if (actionId === "remove") {
+        const typed = handleTuiKey(transition.state, { input: "d" }).state;
+        expect(groupSettingsScreen(typed).removeDraft.value).toBe("d");
+      }
     }
   });
 
@@ -155,6 +164,11 @@ describe("Group menu", () => {
     expect(replaceSnapshot(opened, withoutGroup).screen).toEqual({ name: "dashboard" });
   });
 });
+
+function groupSettingsScreen(state: DashboardState) {
+  if (state.screen.name !== "groupSettings") throw new Error("expected Group Settings");
+  return state.screen;
+}
 
 function baseState() {
   return createInitialTuiState({ initialSnapshot: createGroupedDashboardSnapshot() });

--- a/station/src/contextMenu/ContextMenuSurface.test.tsx
+++ b/station/src/contextMenu/ContextMenuSurface.test.tsx
@@ -33,6 +33,9 @@ describe("ContextMenuSurface", () => {
       expect(frame).toContain("Split Right");
       expect(frame).toContain("Split Below");
       expect(frame).toContain("Close Pane");
+      expect(frame.split("\n").find((line) => line.includes("Close Pane"))).toContain(
+        "|▸Close Pane",
+      );
     } finally {
       setup.renderer.destroy();
     }
@@ -149,12 +152,14 @@ describe("ContextMenuSurface", () => {
     try {
       const frame = setup.captureCharFrame();
       const spans = setup.captureSpans();
-      expect(frame.split("\n")[1]).toMatch(/Quick session\s+Q\|/);
-      expect(frame.split("\n")[2]).toMatch(/New session…\s+N\|/);
-      expect(frame.split("\n")[3]).toContain("+--------------------+");
-      expect(frame.split("\n")[4]).toMatch(/Group settings…\s+S\|/);
-      expect(frame.split("\n")[5]).toContain("+--------------------+");
-      expect(frame.split("\n")[6]).toMatch(/Remove Group…\s+R\|/);
+      const lines = frame.split("\n");
+      expect(lines[1]).toMatch(/\|▸Quick session\s+Q\|/);
+      expect(lines[2]).toMatch(/\| New session…\s+N\|/);
+      expect(lines[3]).toContain("+--------------------+");
+      expect(lines[4]).toMatch(/\| Group settings…\s+S\|/);
+      expect(lines[5]).toContain("+--------------------+");
+      expect(lines[6]).toMatch(/\| Remove Group…\s+R\|/);
+      expect(lines.filter((line) => line.includes("▸"))).toHaveLength(1);
       expect(spanAtFrameCell(spans, 6, 2)?.fg).not.toEqual(spanAtFrameCell(spans, 1, 2)?.fg);
       await setup.mockMouse.click(2, 6, MouseButtons.LEFT);
       expect(calls.at(-1)).toEqual({ kind: "contextMenuItem", itemIndex: 3 });

--- a/station/src/contextMenu/ContextMenuSurface.tsx
+++ b/station/src/contextMenu/ContextMenuSurface.tsx
@@ -112,7 +112,7 @@ function ContextMenuItemRow({
         onMouseDown={onMouseDown}
         onMouseMove={onMouseMove}
       >
-        {`| ${content}|`}
+        {`|${active ? "▸" : " "}${content}|`}
       </text>
     </box>
   );

--- a/station/src/dashboardRenderer/FullscreenDashboard.test.tsx
+++ b/station/src/dashboardRenderer/FullscreenDashboard.test.tsx
@@ -339,7 +339,7 @@ describe("FullscreenDashboard mouse composition", () => {
       return { row, line: lines[row] ?? "" };
     };
 
-    expect(setup.captureCharFrame()).toContain("╭▼ Design refresh 2 sessions");
+    expect(setup.captureCharFrame()).toContain("╭ ▼ Design refresh 2 sessions");
     expect(setup.captureCharFrame()).toContain("│ [1]");
     const member = cellFor(setup.captureCharFrame(), "group-contracts");
     await actOn(async () => {
@@ -367,6 +367,7 @@ describe("FullscreenDashboard mouse composition", () => {
       rowId: groupId,
       cellId: "quickSession",
     });
+    expect(groupLine().line).toContain("▸[quick session]");
     expect([...fixture.runtime.state.getState().collapsedGroupIds]).toEqual([]);
 
     group = groupLine();

--- a/station/src/station/StationOverlay.test.tsx
+++ b/station/src/station/StationOverlay.test.tsx
@@ -152,7 +152,7 @@ describe("StationOverlay", () => {
     const groupId = dashboardRowIds.group("group_design_refresh");
     const header = cellFor(setup.captureCharFrame(), "Design refresh");
 
-    expect(setup.captureCharFrame()).toContain("╭▼ Design refresh 2 sessions");
+    expect(setup.captureCharFrame()).toContain("╭ ▼ Design refresh 2 sessions");
     await setup.mockMouse.click(header.col, header.row, MouseButtons.LEFT);
 
     expect(calls.at(-1)).toEqual({
@@ -160,7 +160,7 @@ describe("StationOverlay", () => {
       target: { kind: "dashboardCell", rowId: groupId, cellId: "identity" },
     });
     expect([...store.state.getState().collapsedGroupIds]).toEqual(["group_design_refresh"]);
-    expect(setup.captureCharFrame()).toContain("▶ Design refresh 2 sessions");
+    expect(setup.captureCharFrame()).toContain("▸▶ Design refresh 2 sessions");
   });
 
   it("lets an inner screen consume popup click-away before the outer overlay", async () => {

--- a/station/src/station/view/DashboardMenuView.tsx
+++ b/station/src/station/view/DashboardMenuView.tsx
@@ -118,7 +118,7 @@ function DashboardMenuItem({
       onMouseOver={() => setHover(true)}
       onMouseOut={() => setHover(false)}
     >
-      {` ${content}`}
+      {`${item.focused ? "▸" : " "}${content}`}
     </text>
   );
 }

--- a/station/src/station/view/GroupHeaderView.tsx
+++ b/station/src/station/view/GroupHeaderView.tsx
@@ -87,15 +87,15 @@ function ExpandedGroupHeader({
   focusedCellId?: DashboardCellId | undefined;
   focus: GroupFrameFocus;
 }) {
-  const actionsWidth =
-    groupHeaderActionLabelsWidth(actions) + Math.max(0, actions.length - 1);
+  const actionsWidth = groupHeaderActionsWidth(actions);
+  const minimumFillWidth = actions.length === 0 ? 1 : 0;
   const identity = groupIdentityLayout(
     payload,
-    Math.max(0, columns - 1 - 1 - actionsWidth - 1),
+    Math.max(0, columns - 1 - 1 - actionsWidth - minimumFillWidth - 1),
   );
   const fillWidth = Math.max(
-    1,
-    columns - 1 - identity.width - actionsWidth - 1,
+    minimumFillWidth,
+    columns - 1 - 1 - identity.width - actionsWidth - 1,
   );
   return (
     <box flexDirection="row" width="100%" height={1} overflow="hidden">
@@ -107,10 +107,13 @@ function ExpandedGroupHeader({
         dimmed={payload.persistentFilterMatch?.matched === false}
         persistentFilterMatch={payload.persistentFilterMatch}
       />
-      <GroupFrameText text={"─".repeat(fillWidth)} focus={focus} />
-      {actions.map((action, index) => (
+      {fillWidth > 0 ? <GroupFrameText text={"─".repeat(fillWidth)} focus={focus} /> : null}
+      {actions.map((action) => (
         <Fragment key={action.cellId}>
-          {index === 0 ? null : <GroupFrameText text=" " focus={focus} />}
+          <GroupFrameText
+            text={focusedCellId === action.cellId ? "▸" : " "}
+            focus={focus}
+          />
           <GroupActionTarget
             label={action.label}
             rowId={rowId}
@@ -140,7 +143,7 @@ function CollapsedGroupHeader({
 }) {
   const identity = groupIdentityLayout(
     payload,
-    Math.max(0, columns - 1 - groupHeaderActionLabelsWidth(actions) - actions.length),
+    Math.max(0, columns - 1 - 1 - groupHeaderActionsWidth(actions)),
   );
   const dimmed = payload.persistentFilterMatch?.matched === false;
   return (
@@ -156,7 +159,10 @@ function CollapsedGroupHeader({
       <box flexGrow={1} height={1} />
       {actions.map((action) => (
         <Fragment key={action.cellId}>
-          <text flexShrink={0}> </text>
+          <CollapsedGroupActionCursor
+            focused={focusedCellId === action.cellId}
+            dimmed={dimmed}
+          />
           <GroupActionTarget
             label={action.label}
             rowId={rowId}
@@ -184,8 +190,9 @@ function groupHeaderActions(
   return actions;
 }
 
-function groupHeaderActionLabelsWidth(actions: readonly GroupHeaderAction[]): number {
-  return actions.reduce((width, action) => width + stringWidth(action.label), 0);
+function groupHeaderActionsWidth(actions: readonly GroupHeaderAction[]): number {
+  // Every action reserves one inert cursor cell so focus cannot change width or pointer geometry.
+  return actions.reduce((width, action) => width + 1 + stringWidth(action.label), 0);
 }
 
 function GroupIdentityTarget({
@@ -214,6 +221,7 @@ function GroupIdentityTarget({
       onMouseOver={() => setHover(true)}
       onMouseOut={() => setHover(false)}
     >
+      {focused ? "▸" : " "}
       {layout.prefix}
       {textMatchSegments(layout.name, persistentFilterMatch?.labelRanges ?? []).map(
         (segment, index) => (
@@ -272,6 +280,25 @@ function GroupActionTarget({
       onMouseOut={() => setHover(false)}
     >
       {label}
+    </text>
+  );
+}
+
+function CollapsedGroupActionCursor({
+  focused,
+  dimmed,
+}: {
+  focused: boolean;
+  dimmed: boolean;
+}) {
+  const theme = useStationTheme();
+  return (
+    <text
+      flexShrink={0}
+      fg={toOpenTuiColor(focused ? theme.status.working : theme.text.muted)}
+      attributes={dimmed ? TextAttributes.DIM : TextAttributes.NONE}
+    >
+      {focused ? "▸" : " "}
     </text>
   );
 }

--- a/station/src/station/view/GroupMenuView.test.tsx
+++ b/station/src/station/view/GroupMenuView.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { testRender } from "@opentui/react/test-utils";
 import { createInitialTuiState, openGroupMenu } from "@station/dashboard-core/state";
+import { act } from "react";
 import { nativeStationTheme, StationThemeProvider } from "../../theme/index.js";
 import { spanAtFrameCell } from "../../terminal/testing/frameProbe.js";
 import { groupedManyProjectsSnapshot } from "../fixtures/scenarios.js";
@@ -30,16 +31,31 @@ describe("GroupMenuView", () => {
       const frame = setup.captureCharFrame();
       const spans = setup.captureSpans();
       const lines = frame.split("\n");
+      const quickSessionRow = lines.findIndex((line) => line.includes("Quick session"));
+      const newSessionRow = lines.findIndex((line) => line.includes("New session…"));
       expect(frame).toContain("Design refresh");
-      expect(lines.find((line) => line.includes("Quick session"))).toMatch(/Quick session\s+Q/);
+      expect(lines[quickSessionRow]).toMatch(/▸Quick session\s+Q/);
       expect(lines.find((line) => line.includes("New session…"))).toMatch(/New session…\s+N/);
       expect(lines.find((line) => line.includes("Group settings…"))).toMatch(
         /Group settings…\s+S/,
       );
       expect(lines.find((line) => line.includes("Remove Group…"))).toMatch(/Remove Group…\s+R/);
+      expect(lines.filter((line) => line.includes("▸"))).toHaveLength(1);
       expect(spanAtFrameCell(spans, 9, 14)?.fg).not.toEqual(
         spanAtFrameCell(spans, 4, 14)?.fg,
       );
+
+      await act(async () => {
+        await setup.mockMouse.moveTo(
+          lines[newSessionRow]?.indexOf("New session…") ?? -1,
+          newSessionRow,
+        );
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+      await setup.flush();
+      const hoveredLines = setup.captureCharFrame().split("\n");
+      expect(hoveredLines[quickSessionRow]).toContain("▸Quick session");
+      expect(hoveredLines[newSessionRow]).not.toContain("▸");
     } finally {
       setup.renderer.destroy();
     }

--- a/station/src/station/view/ProjectHeaderView.tsx
+++ b/station/src/station/view/ProjectHeaderView.tsx
@@ -60,7 +60,7 @@ export function ProjectHeaderView({
         persistentFilterMatch={persistentFilterMatch}
       />
       <box flexGrow={1} height={1} />
-      <ProjectHeaderSeparator dimmed={dimmed} />
+      <ProjectHeaderCursor focused={focusedCellId === "shell"} dimmed={dimmed} />
       <ProjectHeaderAction
         label={shellLabel}
         rowId={rowId}
@@ -68,7 +68,7 @@ export function ProjectHeaderView({
         focused={focusedCellId === "shell"}
         dimmed={dimmed}
       />
-      <ProjectHeaderSeparator dimmed={dimmed} />
+      <ProjectHeaderCursor focused={focusedCellId === "quickSession"} dimmed={dimmed} />
       <ProjectHeaderAction
         label={quickSessionLabel}
         rowId={rowId}
@@ -76,7 +76,7 @@ export function ProjectHeaderView({
         focused={focusedCellId === "quickSession"}
         dimmed={dimmed}
       />
-      <ProjectHeaderSeparator dimmed={dimmed} />
+      <ProjectHeaderCursor focused={focusedCellId === "menu"} dimmed={dimmed} />
       <ProjectHeaderAction
         label={MENU_AFFORDANCE_LABEL}
         rowId={rowId}
@@ -120,11 +120,12 @@ function ProjectHeaderPrimary({
       onMouseOver={() => setHover(true)}
       onMouseOut={() => setHover(false)}
     >
+      {focused ? "▸" : " "}
       <ProjectHeaderLabel
         project={project}
         collapsed={collapsed}
         groupCount={groupCount}
-        width={width}
+        width={Math.max(0, width - 1)}
         dimmed={dimmed}
         persistentFilterMatch={persistentFilterMatch}
       />
@@ -132,7 +133,7 @@ function ProjectHeaderPrimary({
   );
 }
 
-// Each action has its own trailing cell so its click cannot also toggle the project header.
+// Each action's preceding cursor cell stays inert so whitespace cannot activate the action.
 function ProjectHeaderAction({
   label,
   rowId,
@@ -164,15 +165,15 @@ function ProjectHeaderAction({
   );
 }
 
-function ProjectHeaderSeparator({ dimmed }: { dimmed: boolean }) {
+function ProjectHeaderCursor({ focused, dimmed }: { focused: boolean; dimmed: boolean }) {
   const theme = useStationTheme();
   return (
     <text
       flexShrink={0}
-      fg={toOpenTuiColor(theme.text.muted)}
+      fg={toOpenTuiColor(focused ? theme.status.working : theme.text.muted)}
       attributes={dimmed ? TextAttributes.DIM : TextAttributes.NONE}
     >
-      {" "}
+      {focused ? "▸" : " "}
     </text>
   );
 }

--- a/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
@@ -5,23 +5,23 @@ exports[`dashboard golden frames renders many-projects at 80x24 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-overlay                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
+ ▼ scripts  2 sessions · 2 agents                                 [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
                                                                                 
-▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
+ ▼ empty-project  0 sessions                                      [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
@@ -33,23 +33,23 @@ exports[`dashboard golden frames renders many-projects at 120x40 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle     4 projects · 10 sessions · 9 agents 
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
        SESSION                                   AGENT     STATUS                                             DIFF · PR 
-▼ station  5 sessions · 4 agents                                                            [shell] [quick session] [▾] 
+ ▼ station  5 sessions · 4 agents                                                           [shell] [quick session] [▾] 
  [1] ○ cli-help-man                              codex     idle                                            +14 -6 #70 ✓ 
  [2] - docs-cleanup                              codex     no agent                                                     
  [3] ○ pty-buffer                                codex     idle                                                   #73 ✓ 
  [4] + session-resume                            codex     starting                                                     
  [5] ⠋ station-overlay                           codex     working                                       +412 -96 #76 … 
                                                                                                                         
-▼ observer  3 sessions · 3 agents                                                           [shell] [quick session] [▾] 
+ ▼ observer  3 sessions · 3 agents                                                          [shell] [quick session] [▾] 
  [6] x batch-export                              opencode  exited                                                  #8 ✓ 
  [7] ⠋ provider-hooks                            opencode  working                                         +32 -8 #16 … 
  [8] ○ trace-bundle                              opencode  idle                                              +1 -1 #4 ✓ 
                                                                                                                         
-▼ scripts  2 sessions · 2 agents                                                            [shell] [quick session] [▾] 
+ ▼ scripts  2 sessions · 2 agents                                                           [shell] [quick session] [▾] 
  [9] ○ api-cache                                 opencode  idle                                            +14 -6 #5 x1 
  [a] ? metadata-refresh                          opencode  unknown                                            +3 -1 #10 
                                                                                                                         
-▼ empty-project  0 sessions                                                                 [shell] [quick session] [▾] 
+ ▼ empty-project  0 sessions                                                                [shell] [quick session] [▾] 
  no sessions yet · [ + add session ]                                                                                    
                                                                                                                         
                                                                                                                         
@@ -77,14 +77,14 @@ exports[`dashboard golden frames renders many-projects at 60x16 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown   
 ─────────────────────────────────────────────────────────── 
        SESSION                 AGENT     STATUS          PR 
-▼ station  5 sessions · 4 agents              [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents             [sh] [qs] [▾] 
  [1] ○ cli-help-man            codex     idle         #70 ✓ 
  [2] - docs-cleanup            codex     no agent           
  [3] ○ pty-buffer              codex     idle         #73 ✓ 
  [4] + session-resume          codex     starting           
  [5] ⠋ station-overlay         codex     working      #76 … 
                                                             
-▼ observer  3 sessions · 3 agents             [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents            [sh] [qs] [▾] 
  [6] x batch-export            opencode  exited        #8 ✓ 
 ▼ 4 below · showing 6 of 10                                 
 ─────────────────────────────────────────────────────────── 
@@ -97,7 +97,7 @@ exports[`dashboard golden frames renders many-projects at 40x12 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0      
 ─────────────────────────────────────── 
        SESSION             STATUS       
-▼ station  5 sessions · … [sh] [qs] [▾] 
+ ▼ station  5 sessions ·… [sh] [qs] [▾] 
  [1] ○ cli-help-man        idle         
  [2] - docs-cleanup        no agent     
  [3] ○ pty-buffer          idle         
@@ -113,22 +113,22 @@ exports[`dashboard golden frames renders grouped-many-projects at 80x24 1`] = `
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                     AGENT     STATUS                 DIFF · PR   
-▼ station  12 sessions · 6 Groups · 11 agents                     [sh] [qs] [▾] 
-╭▼ Design refresh 2 sessions──────────────────────────────────────────[qs] [▾]╮ 
+ ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾] 
+╭ ▼ Design refresh 2 sessions──────────────────────────────────────── [qs] [▾]╮ 
 │ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│ 
 │ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Input parity and minimum-width interaction verification 1 session──[qs] [▾]╮ 
+╭ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]╮ 
 │ [3] ○ input-routing               codex     idle                      +27 -6│ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Observer hardening 3 sessions──────────────────────────────────────[qs] [▾]╮ 
+╭ ▼ Observer hardening 3 sessions──────────────────────────────────── [qs] [▾]╮ 
 │ [4] ○ diagnostic-index            codex     idle                      +38 -7│ 
 │ [5] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│ 
 │ [6] ⠋ trace-readiness             codex     working           +91 -22 #478 …│ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Post-launch 0 sessions─────────────────────────────────────────────[qs] [▾]╮ 
+╭ ▼ Post-launch 0 sessions─────────────────────────────────────────── [qs] [▾]╮ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Release train 3 sessions───────────────────────────────────────────[qs] [▾]╮ 
+╭ ▼ Release train 3 sessions───────────────────────────────────────── [qs] [▾]╮ 
 │ [7] x asset-proof                 codex     exited                    +19 -2│ 
 ▼ 5 below · showing 7 of 12                                                     
 ─────────────────────────────────────────────────────────────────────────────── 
@@ -141,27 +141,27 @@ exports[`dashboard golden frames renders grouped-many-projects at 120x40 1`] = `
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle                  1 project · 12 sessions · 11 agents 
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
        SESSION                                   AGENT     STATUS                                           DIFF · PR   
-▼ station  12 sessions · 6 Groups · 11 agents                                               [shell] [quick session] [▾] 
-╭▼ Design refresh 2 sessions───────────────────────────────────────────────────────────────────────[quick session] [▾]╮ 
+ ▼ station  12 sessions · 6 Groups · 11 agents                                              [shell] [quick session] [▾] 
+╭ ▼ Design refresh 2 sessions───────────────────────────────────────────────────────────────────── [quick session] [▾]╮ 
 │ [1] ⠋ group-contracts                           codex     working                                     +84 -20 #481 …│ 
 │ [2] ○ group-keyboard                            codex     idle                                         +16 -4 #482 ✓│ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Input parity and minimum-width interaction verification 1 session───────────────────────────────[quick session] [▾]╮ 
+╭ ▼ Input parity and minimum-width interaction verification 1 session───────────────────────────── [quick session] [▾]╮ 
 │ [3] ○ input-routing                             codex     idle                                                +27 -6│ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Observer hardening 3 sessions───────────────────────────────────────────────────────────────────[quick session] [▾]╮ 
+╭ ▼ Observer hardening 3 sessions───────────────────────────────────────────────────────────────── [quick session] [▾]╮ 
 │ [4] ○ diagnostic-index                          codex     idle                                                +38 -7│ 
 │ [5] ! handoff-refusal                           codex     Agent needs approval.                      +53 -11 #476 x1│ 
 │ [6] ⠋ trace-readiness                           codex     working                                     +91 -22 #478 …│ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Post-launch 0 sessions──────────────────────────────────────────────────────────────────────────[quick session] [▾]╮ 
+╭ ▼ Post-launch 0 sessions──────────────────────────────────────────────────────────────────────── [quick session] [▾]╮ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Release train 3 sessions────────────────────────────────────────────────────────────────────────[quick session] [▾]╮ 
+╭ ▼ Release train 3 sessions────────────────────────────────────────────────────────────────────── [quick session] [▾]╮ 
 │ [7] x asset-proof                               codex     exited                                              +19 -2│ 
 │ [8] ⠋ installer-replay                          codex     working                                            +64 -12│ 
 │ [9] ○ rc-manifest                               codex     idle                                         +31 -3 #471 ✓│ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Runtime cleanup 1 session───────────────────────────────────────────────────────────────────────[quick session] [▾]╮ 
+╭ ▼ Runtime cleanup 1 session───────────────────────────────────────────────────────────────────── [quick session] [▾]╮ 
 │ [a] ○ runtime-cleanup                           codex     idle                                                 +9 -2│ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
  [b] ○ docs-refresh                              codex     idle                                          +8 -2 #479 ✓   
@@ -185,15 +185,15 @@ exports[`dashboard golden frames renders grouped-many-projects at 60x16 1`] = `
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited    
 ─────────────────────────────────────────────────────────── 
        SESSION                 AGENT     STATUS             
-▼ station  12 sessions · 6 Groups · 11 agents [sh] [qs] [▾] 
-╭▼ Design refresh 2 sessions──────────────────────[qs] [▾]╮ 
+ ▼ station  12 sessions · 6 Groups · 11 agen… [sh] [qs] [▾] 
+╭ ▼ Design refresh 2 sessions──────────────────── [qs] [▾]╮ 
 │ [1] ⠋ group-contracts         codex     working         │ 
 │ [2] ○ group-keyboard          codex     idle            │ 
 ╰─────────────────────────────────────────────────────────╯ 
-╭▼ Input parity and minimum-width interaction ve…─[qs] [▾]╮ 
+╭ ▼ Input parity and minimum-width interaction v… [qs] [▾]╮ 
 │ [3] ○ input-routing           codex     idle            │ 
 ╰─────────────────────────────────────────────────────────╯ 
-╭▼ Observer hardening 3 sessions──────────────────[qs] [▾]╮ 
+╭ ▼ Observer hardening 3 sessions──────────────── [qs] [▾]╮ 
 ▼ 9 below · showing 3 of 12                                 
 ─────────────────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/e… 
@@ -205,8 +205,8 @@ exports[`dashboard golden frames renders grouped-many-projects at 40x12 1`] = `
 FLEET  ● 0 ready  ⠋ 3 working  ! 1      
 ─────────────────────────────────────── 
        SESSION                          
-▼ station  12 sessions ·… [sh] [qs] [▾] 
-╭▼ Design refresh 2 sessions──[qs] [▾]╮ 
+ ▼ station  12 sessions … [sh] [qs] [▾] 
+╭ ▼ Design refresh 2 sessions [qs] [▾]╮ 
 │ [1] ⠋ group-contracts               │ 
 │ [2] ○ group-keyboard                │ 
 ╰─────────────────────────────────────╯ 
@@ -221,13 +221,13 @@ exports[`dashboard golden frames renders attention-and-failures at 80x24 1`] = `
 FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown  x 1 exited  ○ 0 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                        AGENT     STATUS                DIFF · PR 
-▼ station  4 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  4 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ! hook-scope                     codex     Agent needs appro… +8 -2 #12 x2 
  [2] ? metadata-refresh               codex     unknown                   +3 -1 
  [3] ! popup-latency                  codex     No progress was… +120 -44 #13 … 
  [4] ⠋ pr-info                        codex     working                   #11 ✓ 
                                                                                 
-▼ observer  2 sessions · 2 agents                                 [sh] [qs] [▾] 
+ ▼ observer  2 sessions · 2 agents                                [sh] [qs] [▾] 
  [5] x done-run                       opencode  exited                          
  [6] ! sqlite-cleanup                 opencode  Agent needs appro… +19 -2 #6 x1 
                                                                                 
@@ -249,13 +249,13 @@ exports[`dashboard golden frames renders attention-and-failures at 120x40 1`] = 
 FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown  x 1 exited  ○ 0 idle      2 projects · 6 sessions · 6 agents 
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
        SESSION                                   AGENT     STATUS                                             DIFF · PR 
-▼ station  4 sessions · 4 agents                                                            [shell] [quick session] [▾] 
+ ▼ station  4 sessions · 4 agents                                                           [shell] [quick session] [▾] 
  [1] ! hook-scope                                codex     Agent needs approval.                           +8 -2 #12 x2 
  [2] ? metadata-refresh                          codex     unknown                                                +3 -1 
  [3] ! popup-latency                             codex     No progress was observed recently.            +120 -44 #13 … 
  [4] ⠋ pr-info                                   codex     working                                                #11 ✓ 
                                                                                                                         
-▼ observer  2 sessions · 2 agents                                                           [shell] [quick session] [▾] 
+ ▼ observer  2 sessions · 2 agents                                                          [shell] [quick session] [▾] 
  [5] x done-run                                  opencode  exited                                                       
  [6] ! sqlite-cleanup                            opencode  Agent needs approval.                           +19 -2 #6 x1 
                                                                                                                         
@@ -293,13 +293,13 @@ exports[`dashboard golden frames renders attention-and-failures at 60x16 1`] = `
 FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown   
 ─────────────────────────────────────────────────────────── 
        SESSION            AGENT     STATUS               PR 
-▼ station  4 sessions · 4 agents              [sh] [qs] [▾] 
+ ▼ station  4 sessions · 4 agents             [sh] [qs] [▾] 
  [1] ! hook-scope         codex     Agent needs app… #12 x2 
  [2] ? metadata-refresh   codex     unknown                 
  [3] ! popup-latency      codex     No progress was … #13 … 
  [4] ⠋ pr-info            codex     working           #11 ✓ 
                                                             
-▼ observer  2 sessions · 2 agents             [sh] [qs] [▾] 
+ ▼ observer  2 sessions · 2 agents            [sh] [qs] [▾] 
  [5] x done-run           opencode  exited                  
  [6] ! sqlite-cleanup     opencode  Agent needs appr… #6 x1 
                                                             
@@ -313,7 +313,7 @@ exports[`dashboard golden frames renders attention-and-failures at 40x12 1`] = `
 FLEET  ● 0 ready  ⠋ 1 working  ! 3      
 ─────────────────────────────────────── 
        SESSION                          
-▼ station  4 sessions · … [sh] [qs] [▾] 
+ ▼ station  4 sessions ·… [sh] [qs] [▾] 
  [1] ! hook-scope                       
  [2] ? metadata-refresh                 
  [3] ! popup-latency                    
@@ -437,27 +437,27 @@ exports[`dashboard golden frames renders Group frames, counts, empty Groups, con
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle                  1 project · 12 sessions · 11 agents 
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
        SESSION                                   AGENT     STATUS                                           DIFF · PR   
-▼ station  12 sessions · 6 Groups · 11 agents                                               [shell] [quick session] [▾] 
-╭▼ Design refresh 2 sessions───────────────────────────────────────────────────────────────────────[quick session] [▾]╮ 
+ ▼ station  12 sessions · 6 Groups · 11 agents                                              [shell] [quick session] [▾] 
+╭ ▼ Design refresh 2 sessions───────────────────────────────────────────────────────────────────── [quick session] [▾]╮ 
 │ [1] ⠋ group-contracts                           codex     working                                     +84 -20 #481 …│ 
 │ [2] ○ group-keyboard                            codex     idle                                         +16 -4 #482 ✓│ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Input parity and minimum-width interaction verification 1 session───────────────────────────────[quick session] [▾]╮ 
+╭ ▼ Input parity and minimum-width interaction verification 1 session───────────────────────────── [quick session] [▾]╮ 
 │ [3] ○ input-routing                             codex     idle                                                +27 -6│ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Observer hardening 3 sessions───────────────────────────────────────────────────────────────────[quick session] [▾]╮ 
+╭ ▼ Observer hardening 3 sessions───────────────────────────────────────────────────────────────── [quick session] [▾]╮ 
 │ [4] ○ diagnostic-index                          codex     idle                                                +38 -7│ 
 │ [5] ! handoff-refusal                           codex     Agent needs approval.                      +53 -11 #476 x1│ 
 │ [6] ⠋ trace-readiness                           codex     working                                     +91 -22 #478 …│ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Post-launch 0 sessions──────────────────────────────────────────────────────────────────────────[quick session] [▾]╮ 
+╭ ▼ Post-launch 0 sessions──────────────────────────────────────────────────────────────────────── [quick session] [▾]╮ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Release train 3 sessions────────────────────────────────────────────────────────────────────────[quick session] [▾]╮ 
+╭ ▼ Release train 3 sessions────────────────────────────────────────────────────────────────────── [quick session] [▾]╮ 
 │ [7] x asset-proof                               codex     exited                                              +19 -2│ 
 │ [8] ⠋ installer-replay                          codex     working                                            +64 -12│ 
 │ [9] ○ rc-manifest                               codex     idle                                         +31 -3 #471 ✓│ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
- ▶ Runtime cleanup 1 session                                                                        [quick session] [▾] 
+  ▶ Runtime cleanup 1 session                                                                       [quick session] [▾] 
  [a] ○ docs-refresh                              codex     idle                                          +8 -2 #479 ✓   
  [b] - main                                      codex     no agent                                                     
                                                                                                                         
@@ -481,29 +481,29 @@ exports[`dashboard golden frames renders Group frames, counts, empty Groups, con
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle                  1 project · 12 sessions · 11 agents 
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
        SESSION                                   AGENT     STATUS                                           DIFF · PR   
-▼ station  12 sessions · 6 Groups · 11 agents                                               [shell] [quick session] [▾] 
-╭▼ Design refresh 2 sessions───────────────────────────────────────────────────────────────────────[quick session] [▾]╮ 
+ ▼ station  12 sessions · 6 Groups · 11 agents                                              [shell] [quick session] [▾] 
+╭ ▼ Design refresh 2 sessions───────────────────────────────────────────────────────────────────── [quick session] [▾]╮ 
 │ [1] ⠋ group-contracts                           codex     working                                     +84 -20 #481 …│ 
 │ [2] ○ group-keyboard                            codex     idle                                         +16 -4 #482 ✓│ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
  [3] ○ docs-refresh                              codex     idle                                          +8 -2 #479 ✓   
-╭▼ Input parity and minimum-width interaction verification 1 session───────────────────────────────[quick session] [▾]╮ 
+╭ ▼ Input parity and minimum-width interaction verification 1 session───────────────────────────── [quick session] [▾]╮ 
 │ [4] ○ input-routing                             codex     idle                                                +27 -6│ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
  [5] - main                                      codex     no agent                                                     
-╭▼ Observer hardening 3 sessions───────────────────────────────────────────────────────────────────[quick session] [▾]╮ 
+╭ ▼ Observer hardening 3 sessions───────────────────────────────────────────────────────────────── [quick session] [▾]╮ 
 │ [6] ○ diagnostic-index                          codex     idle                                                +38 -7│ 
 │ [7] ! handoff-refusal                           codex     Agent needs approval.                      +53 -11 #476 x1│ 
 │ [8] ⠋ trace-readiness                           codex     working                                     +91 -22 #478 …│ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Post-launch 0 sessions──────────────────────────────────────────────────────────────────────────[quick session] [▾]╮ 
+╭ ▼ Post-launch 0 sessions──────────────────────────────────────────────────────────────────────── [quick session] [▾]╮ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Release train 3 sessions────────────────────────────────────────────────────────────────────────[quick session] [▾]╮ 
+╭ ▼ Release train 3 sessions────────────────────────────────────────────────────────────────────── [quick session] [▾]╮ 
 │ [9] x asset-proof                               codex     exited                                              +19 -2│ 
 │ [a] ⠋ installer-replay                          codex     working                                            +64 -12│ 
 │ [b] ○ rc-manifest                               codex     idle                                         +31 -3 #471 ✓│ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Runtime cleanup 1 session───────────────────────────────────────────────────────────────────────[quick session] [▾]╮ 
+╭ ▼ Runtime cleanup 1 session───────────────────────────────────────────────────────────────────── [quick session] [▾]╮ 
 │ [c] ○ runtime-cleanup                           codex     idle                                                 +9 -2│ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
                                                                                                                         
@@ -525,18 +525,18 @@ exports[`dashboard golden frames renders filtered Group counts and clips framed 
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
 FILTER no-such-session                                             0/12 matches 
-▼ station  12 sessions · 6 Groups · 11 agents                     [sh] [qs] [▾] 
-╭▼ Design refresh 0 visible───────────────────────────────────────────[qs] [▾]╮ 
+ ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾] 
+╭ ▼ Design refresh 0 visible───────────────────────────────────────── [qs] [▾]╮ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Input parity and minimum-width interaction verification 0 visible──[qs] [▾]╮ 
+╭ ▼ Input parity and minimum-width interaction verification 0 visible [qs] [▾]╮ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Observer hardening 0 visible───────────────────────────────────────[qs] [▾]╮ 
+╭ ▼ Observer hardening 0 visible───────────────────────────────────── [qs] [▾]╮ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Post-launch 0 sessions─────────────────────────────────────────────[qs] [▾]╮ 
+╭ ▼ Post-launch 0 sessions─────────────────────────────────────────── [qs] [▾]╮ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Release train 0 visible────────────────────────────────────────────[qs] [▾]╮ 
+╭ ▼ Release train 0 visible────────────────────────────────────────── [qs] [▾]╮ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Runtime cleanup 0 visible──────────────────────────────────────────[qs] [▾]╮ 
+╭ ▼ Runtime cleanup 0 visible──────────────────────────────────────── [qs] [▾]╮ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
                                                                                 
                                                                                 
@@ -569,14 +569,14 @@ exports[`dashboard golden frames renders filtered Group counts and clips framed 
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
 ▲ 3 sessions above                                                              
-╭▼ Observer hardening 3 sessions──────────────────────────────────────[qs] [▾]╮ 
+╭ ▼ Observer hardening 3 sessions──────────────────────────────────── [qs] [▾]╮ 
 │ [1] ○ diagnostic-index            codex     idle                      +38 -7│ 
 │ [2] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│ 
 │ [3] ⠋ trace-readiness             codex     working           +91 -22 #478 …│ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Post-launch 0 sessions─────────────────────────────────────────────[qs] [▾]╮ 
+╭ ▼ Post-launch 0 sessions─────────────────────────────────────────── [qs] [▾]╮ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Release train 3 sessions───────────────────────────────────────────[qs] [▾]╮ 
+╭ ▼ Release train 3 sessions───────────────────────────────────────── [qs] [▾]╮ 
 │ [4] x asset-proof                 codex     exited                    +19 -2│ 
 ▼ 5 below · showing 4 of 12                                                     
 ─────────────────────────────────────────────────────────────────────────────── 
@@ -589,23 +589,23 @@ exports[`dashboard golden frames renders the persistent filter soft-preview edit
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle     4 projects · 10 sessions · 9 agents 
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
 ▏ FILTER /cli▏                                                                                               1/10 match 
-▼ station  5 sessions · 4 agents                                                            [shell] [quick session] [▾] 
+ ▼ station  5 sessions · 4 agents                                                           [shell] [quick session] [▾] 
  [1] ○ cli-help-man                              codex     idle                                            +14 -6 #70 ✓ 
  [2] - docs-cleanup                              codex     no agent                                                     
  [3] ○ pty-buffer                                codex     idle                                                   #73 ✓ 
  [4] + session-resume                            codex     starting                                                     
  [5] ⠋ station-overlay                           codex     working                                       +412 -96 #76 … 
                                                                                                                         
-▼ observer  3 sessions · 3 agents                                                           [shell] [quick session] [▾] 
+ ▼ observer  3 sessions · 3 agents                                                          [shell] [quick session] [▾] 
  [6] x batch-export                              opencode  exited                                                  #8 ✓ 
  [7] ⠋ provider-hooks                            opencode  working                                         +32 -8 #16 … 
  [8] ○ trace-bundle                              opencode  idle                                              +1 -1 #4 ✓ 
                                                                                                                         
-▼ scripts  2 sessions · 2 agents                                                            [shell] [quick session] [▾] 
+ ▼ scripts  2 sessions · 2 agents                                                           [shell] [quick session] [▾] 
  [9] ○ api-cache                                 opencode  idle                                            +14 -6 #5 x1 
  [a] ? metadata-refresh                          opencode  unknown                                            +3 -1 #10 
                                                                                                                         
-▼ empty-project  0 sessions                                                                 [shell] [quick session] [▾] 
+ ▼ empty-project  0 sessions                                                                [shell] [quick session] [▾] 
  no sessions yet · [ + add session ]                                                                                    
                                                                                                                         
                                                                                                                         
@@ -633,23 +633,23 @@ exports[`dashboard golden frames renders a recoverable zero-match persistent pre
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
 ▏ FILTER /no-such-session▏                                         0/10 matches 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-overlay                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
+ ▼ scripts  2 sessions · 2 agents                                 [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
                                                                                 
-▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
+ ▼ empty-project  0 sessions                                      [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
  FILTER   ←→ cursor  Enter apply  Tab condition  Ctrl-U clear  Esc cancel       
@@ -661,15 +661,15 @@ exports[`dashboard golden frames renders an applied persistent summary at compac
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown   
 ─────────────────────────────────────────────────────────── 
 FILTER working · Status=Working                2/10 matches 
-▼ station  5 sessions · 4 agents              [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents             [sh] [qs] [▾] 
  [1] ⠋ station-overlay         codex     working      #76 … 
                                                             
-▼ observer  3 sessions · 3 agents             [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents            [sh] [qs] [▾] 
  [2] ⠋ provider-hooks          opencode  working      #16 … 
                                                             
-▼ scripts  2 sessions · 2 agents              [sh] [qs] [▾] 
+ ▼ scripts  2 sessions · 2 agents             [sh] [qs] [▾] 
                                                             
-▼ empty-project  0 sessions                   [sh] [qs] [▾] 
+ ▼ empty-project  0 sessions                  [sh] [qs] [▾] 
                                                             
 ─────────────────────────────────────────────────────────── 
 / edit  Esc clear  ↵ activate  N new  Q:close               
@@ -681,7 +681,7 @@ exports[`dashboard golden frames clips a long persistent draft at minimum dashbo
 FLEET  ● 0 ready  ⠋ 2 working  ! 0      
 ─────────────────────────────────────── 
 ▏ FILTER /t-filter-draft▏  0/10 matches 
-▼ station  5 sessions · … [sh] [qs] [▾] 
+ ▼ station  5 sessions ·… [sh] [qs] [▾] 
  [1] ○ cli-help-man        idle         
  [2] - docs-cleanup        no agent     
  [3] ○ pty-buffer          idle         
@@ -697,23 +697,23 @@ exports[`dashboard golden frames wraps the complete actionable error at wide and
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle         4 · 10 · 9
 ──────────────────────────────────────────────────────────────────────────────────────────────────
        SESSION                                   AGENT     STATUS                        DIFF · PR
-▼ station  5 sessions · 4 agents                                       [shell] [quick session] [▾]
+ ▼ station  5 sessions · 4 agents                                      [shell] [quick session] [▾]
  [1] ○ cli-help-man                              codex     idle                       +14 -6 #70 ✓
  [2] - docs-cleanup                              codex     no agent
  [3] ○ pty-buffer                                codex     idle                              #73 ✓
  [4] + session-resume                            codex     starting
  [5] ⠋ station-overlay                           codex     working                  +412 -96 #76 …
 
-▼ observer  3 sessions · 3 agents                                      [shell] [quick session] [▾]
+ ▼ observer  3 sessions · 3 agents                                     [shell] [quick session] [▾]
  [6] x batch-export                              opencode  exited                             #8 ✓
  [7] ⠋ provider-hooks                            opencode  working                    +32 -8 #16 …
  [8] ○ trace-bundle      ┌──────────────────────────────────────────────────────────────────────┐✓
                          │ needs attention                                 [ copy ] [ dismiss ] │
-▼ scripts  2 sessions · 2│ Worktrunk failed to remove the selected checkout because the main    │]
+ ▼ scripts  2 sessions · │ Worktrunk failed to remove the selected checkout because the main    │]
  [9] ○ api-cache         │ worktree cannot be removed while Station is running there.           │1
  [a] ? metadata-refresh  │ Open a different linked checkout, select the session again, and      │0
                          │ retry after confirming the worktree path and branch. | trace         │
-▼ empty-project  0 sessio│ trace_worktree_remove_123 | diagnostic diag_worktree_remove_456      │]
+ ▼ empty-project  0 sessi│ trace_worktree_remove_123 | diagnostic diag_worktree_remove_456      │]
  no sessions yet · [ + ad└──────────────────────────────────────────────────────────────────────┘
 
 ──────────────────────────────────────────────────────────────────────────────────────────────────
@@ -726,23 +726,23 @@ exports[`dashboard golden frames wraps the complete actionable error at wide and
 FLEET  ● 0 ready  ⠋ 2 working  ! 0
 ───────────────────────────────────────
        SESSION             STATUS
-▼ station  5 sessions · … [sh] [qs] [▾]
+ ▼ station  5 sessions ·… [sh] [qs] [▾]
  [1] ○ cli-help-man        idle
  [┌──────────────────────────────────┐
  [│ needs       [ copy ] [ dismiss ] │
  [│ attention                        │
  [│ Worktrunk failed to remove the   │
   │ selected checkout because the    │
-▼ │ main worktree cannot be removed  │]
+ ▼│ main worktree cannot be removed  │]
  [│ while Station is running there.  │
  [│ Open a different linked          │
  [│ checkout, select the session     │
   │ again, and retry after           │
-▼ │ confirming the worktree path     │]
+ ▼│ confirming the worktree path     │]
  [│ and branch. | trace              │
  [│ trace_worktree_remove_123 |      │
   │ diagnostic                       │
-▼ │ diag_worktree_remove_456         │]
+ ▼│ diag_worktree_remove_456         │]
  n└──────────────────────────────────┘
 
 ───────────────────────────────────────

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -5,23 +5,23 @@ exports[`modal flow golden frames renders the help overlay 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ────────╭──────────────────────────────────────────────────────────────╮─────── 
        S│                         station help                         │FF · PR 
-▼ statio│  Ctrl-O     open/close project view                          │qs] [▾] 
+ ▼ stati│  Ctrl-O     open/close project view                          │qs] [▾] 
  [1] ○ c│  Ctrl-Q     quit Station                                     │6 #70 ✓ 
  [2] - d│  Ctrl-\\     split pane right                                 │        
  [3] ○ p│  Ctrl-^     split pane below (Ctrl-6)                        │  #73 ✓ 
  [4] + s│  Ctrl-]     focus next pane                                  │        
  [5] ⠋ s│  Ctrl-/     close split pane (Ctrl-_)                        │6 #76 … 
         │  Enter/Sp   open project view on welcome                     │        
-▼ observ│  Esc/↑↓     context menu close/move                          │qs] [▾] 
+ ▼ obser│  Esc/↑↓     context menu close/move                          │qs] [▾] 
  [6] x b│  Enter/Sp   context menu select                              │   #8 ✓ 
  [7] ⠋ p│                     station project view                     │8 #16 … 
  [8] ○ t│  ↑/↓        move cursor · wheel scroll                       │-1 #4 ✓ 
         │  ↵          open focused session                             │        
-▼ script│  tab        next session needing you                         │qs] [▾] 
+ ▼ scrip│  tab        next session needing you                         │qs] [▾] 
  [9] ○ a│  G/M        quick group/move to group                        │6 #5 x1 
  [a] ? m│  / ↵ Esc Q  edit/apply/cancel-clear/retain-close filter      │ -1 #10 
         │  Tab S/P/A  build filter conditions · F applies builder      │        
-▼ empty-│  1-9/a-z    open visible session or toggle condition         │qs] [▾] 
+ ▼ empty│  1-9/a-z    open visible session or toggle condition         │qs] [▾] 
         ╰──────────────────────────────────────────────────────────────╯        
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
@@ -33,23 +33,23 @@ exports[`modal flow golden frames renders the project menu 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs]▸[▾] 
  [1] ○ cli-help-man                       codex     idle┌──────────────────────┐
- [2] - docs-cleanup                       codex     no a│ Quick Group         G│
+ [2] - docs-cleanup                       codex     no a│▸Quick Group         G│
  [3] ○ pty-buffer                         codex     idle│ New Group…           │
  [4] + session-resume                     codex     star│ Set default agent    │
  [5] ⠋ station-XXXXXXy                    codex     work│ Project settings…    │
                                                         └──────────────────────┘
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
+ ▼ scripts  2 sessions · 2 agents                                 [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
                                                                                 
-▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
+ ▼ empty-project  0 sessions                                      [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
@@ -58,10 +58,10 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 
 exports[`modal flow golden frames renders the project menu above a short viewport 1`] = `
 "      ┌──────────────────────┐
-FLEET │ Quick Group         G│
+FLEET │▸Quick Group         G│
 ──────│ New Group…           │
       │ Set default agent    │
-▼ stat│ Project settings…    │
+ ▼ sta│ Project settings…    │
 ▼ 10 b└──────────────────────┘
 ───────────────────────────── 
 ↵ activate  N new  ⇥ next  /… 
@@ -73,22 +73,22 @@ exports[`modal flow golden frames renders the Group menu 1`] = `
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                     AGENT     STATUS                 DIFF · PR   
-▼ station  12 sessions · 6 Groups · 11 agents                     [sh] [qs] [▾] 
-╭▼ Design refresh 2 sessions──────────────────────────────────────────[qs] [▾]╮ 
+ ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾] 
+╭ ▼ Design refresh 2 sessions──────────────────────────────────────── [qs]▸[▾]╮ 
 │ [1] ⠋ group-contracts             codex     workin┌─Design refresh───────────┐
-│ [2] ○ group-keyboard              codex     idle  │ Quick session           Q│
+│ [2] ○ group-keyboard              codex     idle  │▸Quick session           Q│
 ╰───────────────────────────────────────────────────│ New session…            N│
-╭▼ Input parity and minimum-width interaction verifi│──────────────────────────│
+╭ ▼ Input parity and minimum-width interaction verif│──────────────────────────│
 │ [3] ○ input-routing               codex     idle  │ Group settings…         S│
 ╰───────────────────────────────────────────────────│──────────────────────────│
-╭▼ Observer hardening 3 sessions────────────────────│ Remove Group…           R│
+╭ ▼ Observer hardening 3 sessions───────────────────│ Remove Group…           R│
 │ [4] ○ diagnostic-index            codex     idle  └──────────────────────────┘
 │ [5] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│ 
 │ [6] ⠋ trace-readiness             codex     working           +91 -22 #478 …│ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Post-launch 0 sessions─────────────────────────────────────────────[qs] [▾]╮ 
+╭ ▼ Post-launch 0 sessions─────────────────────────────────────────── [qs] [▾]╮ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Release train 3 sessions───────────────────────────────────────────[qs] [▾]╮ 
+╭ ▼ Release train 3 sessions───────────────────────────────────────── [qs] [▾]╮ 
 │ [7] x asset-proof                 codex     exited                    +19 -2│ 
 ▼ 5 below · showing 7 of 12                                                     
 ─────────────────────────────────────────────────────────────────────────────── 
@@ -98,11 +98,11 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 1
 
 exports[`modal flow golden frames renders the Group menu above a short viewport 1`] = `
 "  ┌─Design refresh───────────┐
-FL│ Quick session           Q│
+FL│▸Quick session           Q│
 ──│ New session…            N│
   │──────────────────────────│
-▼ │ Group settings…         S│
-╭▼│──────────────────────────│
+ ▼│ Group settings…         S│
+╭ │──────────────────────────│
 ▼ │ Remove Group…           R│
 ──└──────────────────────────┘
 ↵ activate  N new  ⇥ next  /… 
@@ -114,19 +114,19 @@ exports[`modal flow golden frames renders the create group sheet 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
+ ▼ scripts  2 sessions · 2 agents                                 [sh] [qs] [▾] 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Create Group                                                                 │
 │  Name (N)    Release work                                                    │
@@ -142,8 +142,8 @@ exports[`modal flow golden frames renders the move to group destination sheet 1`
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                     AGENT     STATUS                 DIFF · PR   
-▼ station  12 sessions · 6 Groups · 11 agents                     [sh] [qs] [▾] 
-╭▼ Design refresh 2 sessions──────────────────────────────────────────[qs] [▾]╮ 
+ ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾] 
+╭ ▼ Design refresh 2 sessions──────────────────────────────────────── [qs] [▾]╮ 
 │ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│ 
 │ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
@@ -151,14 +151,14 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 1
 │ Move to Group                                                                │
 │ Session    group-contracts                                                   │
 │ Current    Design refresh                                                    │
-│ U Ungrouped                                                                  │
-│✓1 Design refresh                                                             │
-│ 2 Observer hardening                                                         │
-│ 3 Runtime cleanup                                                            │
-│ 4 Post-launch                                                                │
-│ 5 Release train                                                              │
-│ 6 Input parity and minimum-width interaction verification                    │
-│ N Create new Group…                                                          │
+│  U Ungrouped                                                                 │
+│▸✓1 Design refresh                                                            │
+│  2 Observer hardening                                                        │
+│  3 Runtime cleanup                                                           │
+│  4 Post-launch                                                               │
+│  5 Release train                                                             │
+│  6 Input parity and minimum-width interaction verification                   │
+│  N Create new Group…                                                         │
 │                                                                              │
 │ ↑↓ move   ↵ select   U ungrouped   N create   Esc cancel                     │
 └──────────────────────────────────────────────────────────────────────────────┘
@@ -170,15 +170,15 @@ exports[`modal flow golden frames renders the move to group create sheet 1`] = `
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                     AGENT     STATUS                 DIFF · PR   
-▼ station  12 sessions · 6 Groups · 11 agents                     [sh] [qs] [▾] 
-╭▼ Design refresh 2 sessions──────────────────────────────────────────[qs] [▾]╮ 
+ ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾] 
+╭ ▼ Design refresh 2 sessions──────────────────────────────────────── [qs] [▾]╮ 
 │ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│ 
 │ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Input parity and minimum-width interaction verification 1 session──[qs] [▾]╮ 
+╭ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]╮ 
 │ [3] ○ input-routing               codex     idle                      +27 -6│ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Observer hardening 3 sessions──────────────────────────────────────[qs] [▾]╮ 
+╭ ▼ Observer hardening 3 sessions──────────────────────────────────── [qs] [▾]╮ 
 │ [4] ○ diagnostic-index            codex     idle                      +38 -7│ 
 │ [5] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│ 
 │ [6] ⠋ trace-readiness             codex     working           +91 -22 #478 …│ 
@@ -198,23 +198,23 @@ exports[`modal flow golden frames renders the persistent filter header editor 1`
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
 ▏ FILTER /api▏                                                       1/10 match 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
+ ▼ scripts  2 sessions · 2 agents                                 [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
                                                                                 
-▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
+ ▼ empty-project  0 sessions                                      [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
  FILTER   ←→ cursor  Enter apply  Tab condition  Ctrl-U clear  Esc cancel       
@@ -238,11 +238,11 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
+ ▼ scripts  2 sessions · 2 agents                                 [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
                                                                                 
-▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
+ ▼ empty-project  0 sessions                                      [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
  CONDITION   S/P/A edit  ↑↓ move  Enter select  F apply filter  Esc text        
@@ -266,11 +266,11 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 │  8 [ ] Unknown                 │        opencode  working        +32 -8 #16 … 
 │  Done (Enter)                  │        opencode  idle             +1 -1 #4 ✓ 
 └────────────────────────────────┘                                              
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
+ ▼ scripts  2 sessions · 2 agents                                 [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
                                                                                 
-▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
+ ▼ empty-project  0 sessions                                      [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
  CONDITION   ← fields  ↑↓ move  Space/slot toggle  Enter done  Esc close        
@@ -298,23 +298,23 @@ exports[`modal flow golden frames renders the collapse project sheet 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
 ───────────────────────────────────────────────────────────────────────────────
        SESSION                            AGENT     STATUS            DIFF · PR
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾]
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
  [2] - docs-cleanup                       codex     no agent
  [3] ○ pty-buffer                         codex     idle                  #73 ✓
  [4] + session-resume                     codex     starting
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …
 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾]
  [6] x batch-export                       opencode  exited                 #8 ✓
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Collapse Project                                                             │
 │                                                                              │
-│ 1 station healthy                                                            │
-│ 2 observer healthy                                                           │
-│ 3 scripts healthy                                                            │
-│ 4 empty-project healthy                                                      │
+│▸ 1 station healthy                                                           │
+│  2 observer healthy                                                          │
+│  3 scripts healthy                                                           │
+│  4 empty-project healthy                                                     │
 │                                                                              │
 │ ↑↓ move   ↵ select   1-9/a-z jump   Esc cancel                               │
 └──────────────────────────────────────────────────────────────────────────────┘
@@ -325,24 +325,24 @@ exports[`modal flow golden frames renders the collapse project sheet windows a l
 "┌──────────────────────────────────────────────────────────────────────────────┐
 │ Collapse Project                                                             │
 │                                                                              │
-│ 1 station healthy                                                            │
-│ 2 observer healthy                                                           │
-│ 3 scripts healthy                                                            │
-│ 4 empty-project healthy                                                      │
-│ 5 filler-0 healthy                                                           │
-│ 6 filler-1 healthy                                                           │
-│ 7 filler-2 healthy                                                           │
-│ 8 filler-3 healthy                                                           │
-│ 9 filler-4 healthy                                                           │
-│ a filler-5 healthy                                                           │
-│ b filler-6 healthy                                                           │
-│ c filler-7 healthy                                                           │
-│ d filler-8 healthy                                                           │
-│ e filler-9 healthy                                                           │
-│ f filler-10 healthy                                                          │
-│ g filler-11 healthy                                                          │
-│ h filler-12 healthy                                                          │
-│ i filler-13 healthy                                                          │
+│▸ 1 station healthy                                                           │
+│  2 observer healthy                                                          │
+│  3 scripts healthy                                                           │
+│  4 empty-project healthy                                                     │
+│  5 filler-0 healthy                                                          │
+│  6 filler-1 healthy                                                          │
+│  7 filler-2 healthy                                                          │
+│  8 filler-3 healthy                                                          │
+│  9 filler-4 healthy                                                          │
+│  a filler-5 healthy                                                          │
+│  b filler-6 healthy                                                          │
+│  c filler-7 healthy                                                          │
+│  d filler-8 healthy                                                          │
+│  e filler-9 healthy                                                          │
+│  f filler-10 healthy                                                         │
+│  g filler-11 healthy                                                         │
+│  h filler-12 healthy                                                         │
+│  i filler-13 healthy                                                         │
 │                                                                              │
 │ ↑↓ move   ↵ select   1-18 of 25   Esc cancel                                 │
 └──────────────────────────────────────────────────────────────────────────────┘
@@ -354,23 +354,23 @@ exports[`modal flow golden frames renders the project settings picker sheet 1`] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
 ───────────────────────────────────────────────────────────────────────────────
        SESSION                            AGENT     STATUS            DIFF · PR
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾]
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
  [2] - docs-cleanup                       codex     no agent
  [3] ○ pty-buffer                         codex     idle                  #73 ✓
  [4] + session-resume                     codex     starting
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …
 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾]
  [6] x batch-export                       opencode  exited                 #8 ✓
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Project Settings                                                             │
 │                                                                              │
-│ 1 station healthy                                                            │
-│ 2 observer healthy                                                           │
-│ 3 scripts healthy                                                            │
-│ 4 empty-project healthy                                                      │
+│▸ 1 station healthy                                                           │
+│  2 observer healthy                                                          │
+│  3 scripts healthy                                                           │
+│  4 empty-project healthy                                                     │
 │                                                                              │
 │ ↑↓ move   ↵ select   1-9/a-z jump   Esc cancel                               │
 └──────────────────────────────────────────────────────────────────────────────┘
@@ -382,22 +382,22 @@ exports[`modal flow golden frames renders the group settings general 1`] = `
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ───┌────────────────────────────────────────────────────────────────────────┐── 
    │ Group settings · Design refresh                                        │   
-▼ s│ Design refresh           │ General                                     │▾] 
-╭▼ │▸ General                 │  Name Design refresh                        │]╮ 
+ ▼ │ Design refresh           │ General                                     │▾] 
+╭ ▼│▸ General                 │  Name Design refresh                        │]╮ 
 │ [│  Sessions                │ Save renames; sessions stay attached.       │…│ 
 │ [│  Remove Group            │                                             │✓│ 
 ╰──│                          │ Project station (read-only)                 │─╯ 
-╭▼ │                          │ /Users/example/Developer/station            │]╮ 
+╭ ▼│                          │ /Users/example/Developer/station            │]╮ 
 │ [│                          │                                             │6│ 
 ╰──│                          │  Save (Enter)    Cancel (Esc)               │─╯ 
-╭▼ │                          │                                             │]╮ 
+╭ ▼│                          │                                             │]╮ 
 │ [│                          │                                             │7│ 
 │ [│                          │                                             │1│ 
 │ [│                          │                                             │…│ 
 ╰──│                          │                                             │─╯ 
-╭▼ │                          │                                             │]╮ 
+╭ ▼│                          │                                             │]╮ 
 ╰──│                          │                                             │─╯ 
-╭▼ │                          │                                             │]╮ 
+╭ ▼│                          │                                             │]╮ 
 │ [│ ↑↓ or G/S/R select · →/enter edit · esc back                           │2│ 
 ▼ 5└────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
@@ -442,23 +442,23 @@ exports[`modal flow golden frames renders the project settings panel 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ───┌────────────────────────────────────────────────────────────────────────┐── 
    │ Project settings                                                       │PR 
-▼ s│ station                  │ Default agent                               │▾] 
- [1│▸ Default agent           │✓1 codex ● update v0.3.0 → v0.4.0            │ ✓ 
- [2│  Remove project          │ 2 opencode unknown                          │   
+ ▼ │ station                  │ Default agent                               │▾] 
+ [1│▸ Default agent           │ ✓1 codex ● update v0.3.0 → v0.4.0           │ ✓ 
+ [2│  Remove project          │  2 opencode unknown                         │   
  [3│                          │                                             │ ✓ 
  [4│                          │ ✓ current · ↑↓ ↵ · 1-9/a-z                  │   
  [5│                          │                                             │ … 
    │                          │                                             │   
-▼ o│                          │                                             │▾] 
+ ▼ │                          │                                             │▾] 
  [6│                          │                                             │ ✓ 
  [7│                          │                                             │ … 
  [8│                          │                                             │ ✓ 
    │                          │                                             │   
-▼ s│                          │                                             │▾] 
+ ▼ │                          │                                             │▾] 
  [9│                          │                                             │x1 
  [a│                          │                                             │10 
    │                          │                                             │   
-▼ e│ ↑↓ move   →/enter edit   esc close                                     │▾] 
+ ▼ │ ↑↓ move   →/enter edit   esc close                                     │▾] 
    └────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
@@ -485,8 +485,8 @@ exports[`modal flow golden frames renders the project settings compact detail 1`
 "┌──────────────────────────────────────┐
 │ Default agent · station              │
 │ Default agent                        │
-│✓1 codex ● update v0.3.0 → v0.4.0     │
-│ 2 opencode unknown                   │
+│▸✓1 codex ● update v0.3.0 → v0.4.0    │
+│  2 opencode unknown                  │
 │                                      │
 │ ✓ current · ↑↓ ↵ · 1-9/a-z           │
 │                                      │
@@ -502,23 +502,23 @@ exports[`modal flow golden frames renders the project settings remove pane 1`] =
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ───┌────────────────────────────────────────────────────────────────────────┐── 
    │ Project settings                                                       │PR 
-▼ s│ station                  │ Remove project                              │▾] 
+ ▼ │ station                  │ Remove project                              │▾] 
  [1│  Default agent           │ Removes it from Station.                    │ ✓ 
  [2│▸ Remove project          │ Worktrees & files stay on disk.             │   
  [3│                          │                                             │ ✓ 
  [4│                          │ Type "delete station" to confirm            │   
  [5│                          │ ▸ |delete station                           │ … 
    │                          │                                             │   
-▼ o│                          │ [ Remove project (R) ]                      │▾] 
+ ▼ │                          │ [ Remove project (R) ]                      │▾] 
  [6│                          │                                             │ ✓ 
  [7│                          │                                             │ … 
  [8│                          │                                             │ ✓ 
    │                          │                                             │   
-▼ s│                          │                                             │▾] 
+ ▼ │                          │                                             │▾] 
  [9│                          │                                             │x1 
  [a│                          │                                             │10 
    │                          │                                             │   
-▼ e│ ←/esc back                                                             │▾] 
+ ▼ │ ←/esc back                                                             │▾] 
    └────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
@@ -530,23 +530,23 @@ exports[`modal flow golden frames renders the project settings optimistic defaul
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ───┌────────────────────────────────────────────────────────────────────────┐── 
    │ Project settings                                                       │PR 
-▼ s│ station                  │ Default agent                               │▾] 
- [1│▸ Default agent           │ 1 codex ● update v0.3.0 → v0.4.0            │ ✓ 
- [2│  Remove project          │✓2 opencode unknown                 updating…│   
+ ▼ │ station                  │ Default agent                               │▾] 
+ [1│▸ Default agent           │  1 codex ● update v0.3.0 → v0.4.0           │ ✓ 
+ [2│  Remove project          │ ✓2 opencode unknown                updating…│   
  [3│                          │                                             │ ✓ 
  [4│                          │ ✓ current · ↑↓ ↵ · 1-9/a-z                  │   
  [5│                          │                                             │ … 
    │                          │                                             │   
-▼ o│                          │                                             │▾] 
+ ▼ │                          │                                             │▾] 
  [6│                          │                                             │ ✓ 
  [7│                          │                                             │ … 
  [8│                          │                                             │ ✓ 
    │                          │                                             │   
-▼ s│                          │                                             │▾] 
+ ▼ │                          │                                             │▾] 
  [9│                          │                                             │x1 
  [a│                          │                                             │10 
    │                          │                                             │   
-▼ e│ ↑↓ move   →/enter edit   esc close                                     │▾] 
+ ▼ │ ↑↓ move   →/enter edit   esc close                                     │▾] 
    └────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
@@ -558,19 +558,19 @@ exports[`modal flow golden frames renders the remove slot sheet 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
+ ▼ scripts  2 sessions · 2 agents                                 [sh] [qs] [▾] 
 ┌────────────────────────────────────────────┐code  idle           +14 -6 #5 x1 
 │ Select session to delete                   │code  unknown           +3 -1 #10 
 │                                            │                                  
@@ -586,14 +586,14 @@ exports[`modal flow golden frames renders the remove confirm sheet 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
@@ -614,14 +614,14 @@ exports[`modal flow golden frames renders the remove confirm delete focus 1`] = 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
@@ -642,7 +642,7 @@ exports[`modal flow golden frames renders the remove confirm narrow 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0      
 ─────────────────────────────────────── 
        SESSION             STATUS       
-▼ station  5 sessions · … [sh] [qs] [▾] 
+ ▼ station  5 sessions ·… [sh] [qs] [▾] 
  [1] ○ cli-help-man        idle         
  [2] - docs-cleanup        no agent     
 ┌──────────────────────────────────────┐
@@ -662,14 +662,14 @@ exports[`modal flow golden frames renders the external agent removal information
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
 ───────────────────────────────────────────────────────────────────────────────
        SESSION                            AGENT     STATUS            DIFF · PR
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾]
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
  [2] - docs-cleanup                       codex     no agent
  [3] ○ pty-buffer                         codex     idle                  #73 ✓
  [4] + session-resume                     codex     starting
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …
 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾]
  [6] x batch-export                       opencode  exited                 #8 ✓
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓
@@ -690,19 +690,19 @@ exports[`modal flow golden frames renders the rename slot prompt 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
+ ▼ scripts  2 sessions · 2 agents                                 [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
                                                                                 
@@ -718,13 +718,13 @@ exports[`modal flow golden frames renders the rename sheet 1`] = `
 FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown  x 1 exited  ○ 0 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                        AGENT     STATUS                DIFF · PR 
-▼ station  4 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  4 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ! hook-scope                     codex     Agent needs appro… +8 -2 #12 x2 
  [2] ? metadata-refresh               codex     unknown                   +3 -1 
  [3] ! popup-latency                  codex     No progress was… +120 -44 #13 … 
  [4] ⠋ pr-info                        codex     working                   #11 ✓ 
                                                                                 
-▼ observer  2 sessions · 2 agents                                 [sh] [qs] [▾] 
+ ▼ observer  2 sessions · 2 agents                                [sh] [qs] [▾] 
  [5] x done-run                       opencode  exited                          
  [6] ! sqlite-cleanup                 opencode  Agent needs appro… +19 -2 #6 x1 
                                                                                 
@@ -746,19 +746,19 @@ exports[`modal flow golden frames renders the fork slot sheet 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
+ ▼ scripts  2 sessions · 2 agents                                 [sh] [qs] [▾] 
 ┌────────────────────────────────────────────┐code  idle           +14 -6 #5 x1 
 │ Select session to fork                     │code  unknown           +3 -1 #10 
 │                                            │                                  
@@ -774,14 +774,14 @@ exports[`modal flow golden frames renders the fork details sheet 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
 ┌────────────────────────────────────────────┐code  working        +32 -8 #16 … 
 │ Fork Session                               │code  idle             +1 -1 #4 ✓ 
@@ -802,22 +802,22 @@ exports[`modal flow golden frames renders the fork details grouped source 1`] = 
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                     AGENT     STATUS                 DIFF · PR   
-▼ station  12 sessions · 6 Groups · 11 agents                     [sh] [qs] [▾] 
-╭▼ Design refresh 2 sessions──────────────────────────────────────────[qs] [▾]╮ 
+ ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾] 
+╭ ▼ Design refresh 2 sessions──────────────────────────────────────── [qs] [▾]╮ 
 │ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│ 
 │ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Input parity and minimum-width interaction verification 1 session──[qs] [▾]╮ 
+╭ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]╮ 
 │ [3] ○ input-routing               codex     idle                      +27 -6│ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Observer hardening 3 sessions──────────────────────────────────────[qs] [▾]╮ 
+╭ ▼ Observer hardening 3 sessions──────────────────────────────────── [qs] [▾]╮ 
 ┌────────────────────────────────────────────┐idle                      +38 -7│ 
 │ Fork Session                               │Agent needs app… +53 -11 #476 x1│ 
 │ Source   station · group-contracts         │working           +91 -22 #478 …│ 
 │  Name   group-contracts-fork               │────────────────────────────────╯ 
-│▸ Group  [x] create in Design refresh       │────────────────────────[qs] [▾]╮ 
+│▸ Group  [x] create in Design refresh       │─────────────────────── [qs] [▾]╮ 
 │  Copy   [x] uncommitted changes            │────────────────────────────────╯ 
-│ Source keeps running — copy is read-only.  │────────────────────────[qs] [▾]╮ 
+│ Source keeps running — copy is read-only.  │─────────────────────── [qs] [▾]╮ 
 │                                            │exited                    +19 -2│ 
 │  Fork (enter)                              │                                  
 │ Space/Enter toggle · ↑↓ focus · Esc back   │───────────────────────────────── 
@@ -830,14 +830,14 @@ exports[`modal flow golden frames renders the fork details copy focus 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
 ┌────────────────────────────────────────────┐code  working        +32 -8 #16 … 
 │ Fork Session                               │code  idle             +1 -1 #4 ✓ 
@@ -858,14 +858,14 @@ exports[`modal flow golden frames renders the fork details submit focus 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
 ┌────────────────────────────────────────────┐code  working        +32 -8 #16 … 
 │ Fork Session                               │code  idle             +1 -1 #4 ✓ 
@@ -886,7 +886,7 @@ exports[`modal flow golden frames renders the fork details narrow copy focus 1`]
 FLEET  ● 0 ready  ⠋ 2 working  ! 0      
 ─────────────────────────────────────── 
        SESSION             STATUS       
-▼ station  5 sessions · … [sh] [qs] [▾] 
+ ▼ station  5 sessions ·… [sh] [qs] [▾] 
 ┌──────────────────────────────────────┐
 │ Fork Session                         │
 │ Source   station · cli-help-man      │
@@ -906,14 +906,14 @@ exports[`modal flow golden frames renders the new session review 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
@@ -934,14 +934,14 @@ exports[`modal flow golden frames renders the new session review project focus 1
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
@@ -962,14 +962,14 @@ exports[`modal flow golden frames renders the new session review name focus 1`] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
@@ -990,14 +990,14 @@ exports[`modal flow golden frames renders the new session review agent focus 1`]
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
@@ -1018,14 +1018,14 @@ exports[`modal flow golden frames renders the new session review Group focus 1`]
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
@@ -1046,14 +1046,14 @@ exports[`modal flow golden frames renders the new session healthy agent 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
@@ -1074,14 +1074,14 @@ exports[`modal flow golden frames renders the new session degraded agent 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
@@ -1102,14 +1102,14 @@ exports[`modal flow golden frames renders the new session unavailable agent 1`] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
@@ -1130,14 +1130,14 @@ exports[`modal flow golden frames renders the new session edit name 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
@@ -1158,14 +1158,14 @@ exports[`modal flow golden frames renders the new session edit name save focus 1
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
@@ -1186,14 +1186,14 @@ exports[`modal flow golden frames renders the new session edit name back focus 1
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
@@ -1214,7 +1214,7 @@ exports[`modal flow golden frames renders the new session narrow review 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0      
 ─────────────────────────────────────── 
        SESSION             STATUS       
-▼ station  5 sessions · … [sh] [qs] [▾] 
+ ▼ station  5 sessions ·… [sh] [qs] [▾] 
  [1] ○ cli-help-man        idle         
  [2] - docs-cleanup        no agent     
 ┌──────────────────────────────────────┐
@@ -1234,23 +1234,23 @@ exports[`modal flow golden frames renders the new session pick project 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Project                                                               │
 │                                                                              │
-│ 1 station healthy                                                            │
-│ 2 observer healthy                                                           │
-│ 3 scripts healthy                                                            │
-│ 4 empty-project healthy                                                      │
+│▸ 1 station healthy                                                           │
+│  2 observer healthy                                                          │
+│  3 scripts healthy                                                           │
+│  4 empty-project healthy                                                     │
 │                                                                              │
 │ ↑↓ move   ↵ select   1-9/a-z jump   Esc back                                 │
 └──────────────────────────────────────────────────────────────────────────────┘
@@ -1262,14 +1262,14 @@ exports[`modal flow golden frames renders the new session pick agent 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
@@ -1277,8 +1277,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Agent                                                                 │
 │                                                                              │
-│ 1 codex ● update v0.3.0 → v0.4.0                                             │
-│ 2 opencode unknown                                                           │
+│▸ 1 codex ● update v0.3.0 → v0.4.0                                            │
+│  2 opencode unknown                                                          │
 │                                                                              │
 │ ↑↓ move   ↵ select   1-9/a-z jump   Esc back                                 │
 └──────────────────────────────────────────────────────────────────────────────┘
@@ -1290,23 +1290,23 @@ exports[`modal flow golden frames renders the new session pick Group 1`] = `
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                     AGENT     STATUS                 DIFF · PR   
-▼ station  12 sessions · 6 Groups · 11 agents                     [sh] [qs] [▾] 
-╭▼ Design refresh 2 sessions──────────────────────────────────────────[qs] [▾]╮ 
+ ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾] 
+╭ ▼ Design refresh 2 sessions──────────────────────────────────────── [qs] [▾]╮ 
 │ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│ 
 │ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Input parity and minimum-width interaction verification 1 session──[qs] [▾]╮ 
+╭ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]╮ 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Group                                                                 │
 │                                                                              │
-│✓U Ungrouped                                                                  │
-│ 1 Design refresh                                                             │
-│ 2 Observer hardening                                                         │
-│ 3 Runtime cleanup                                                            │
-│ 4 Post-launch                                                                │
-│ 5 Release train                                                              │
-│ 6 Input parity and minimum-width interaction verification                    │
-│ N Create new Group                                                           │
+│▸✓U Ungrouped                                                                 │
+│  1 Design refresh                                                            │
+│  2 Observer hardening                                                        │
+│  3 Runtime cleanup                                                           │
+│  4 Post-launch                                                               │
+│  5 Release train                                                             │
+│  6 Input parity and minimum-width interaction verification                   │
+│  N Create new Group                                                          │
 │                                                                              │
 │ ↑↓ move   ↵ select   U ungrouped   N create   Esc back                       │
 └──────────────────────────────────────────────────────────────────────────────┘
@@ -1318,15 +1318,15 @@ exports[`modal flow golden frames renders the new session edit inline Group 1`] 
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                     AGENT     STATUS                 DIFF · PR   
-▼ station  12 sessions · 6 Groups · 11 agents                     [sh] [qs] [▾] 
-╭▼ Design refresh 2 sessions──────────────────────────────────────────[qs] [▾]╮ 
+ ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾] 
+╭ ▼ Design refresh 2 sessions──────────────────────────────────────── [qs] [▾]╮ 
 │ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│ 
 │ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Input parity and minimum-width interaction verification 1 session──[qs] [▾]╮ 
+╭ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]╮ 
 │ [3] ○ input-routing               codex     idle                      +27 -6│ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Observer hardening 3 sessions──────────────────────────────────────[qs] [▾]╮ 
+╭ ▼ Observer hardening 3 sessions──────────────────────────────────── [qs] [▾]╮ 
 │ [4] ○ diagnostic-index            codex     idle                      +38 -7│ 
 │ [5] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│ 
 │ [6] ⠋ trace-readiness             codex     working           +91 -22 #478 …│ 
@@ -1346,14 +1346,14 @@ exports[`modal flow golden frames renders the new session creating progress 1`] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
@@ -1374,14 +1374,14 @@ exports[`modal flow golden frames renders the project default agent picker 1`] =
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
 ───────────────────────────────────────────────────────────────────────────────
        SESSION                            AGENT     STATUS            DIFF · PR
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾]
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
  [2] - docs-cleanup                       codex     no agent
  [3] ○ pty-buffer                         codex     idle                  #73 ✓
  [4] + session-resume                     codex     starting
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …
 
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾]
  [6] x batch-export                       opencode  exited                 #8 ✓
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓
@@ -1389,8 +1389,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Select default agent for station                                             │
 │                                                                              │
-│✓1 codex ● update v0.3.0 → v0.4.0                                             │
-│ 2 opencode unknown                                                           │
+│▸✓1 codex ● update v0.3.0 → v0.4.0                                            │
+│  2 opencode unknown                                                          │
 │                                                                              │
 │ ✓ current   ↑↓ move   ↵ select   1-9/a-z jump   Esc cancel                   │
 └──────────────────────────────────────────────────────────────────────────────┘
@@ -1402,7 +1402,7 @@ exports[`modal flow golden frames renders the add project sheet 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Add Project                                                                  │
@@ -1458,7 +1458,7 @@ exports[`modal flow golden frames renders the add project folder actions 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Project Folder                                                        │
@@ -1486,7 +1486,7 @@ exports[`modal flow golden frames renders the add project review actions 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Add Project: Review                                                          │
@@ -1514,7 +1514,7 @@ exports[`modal flow golden frames renders the add project Git recovery 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Add Project: Review                                                          │
@@ -1542,7 +1542,7 @@ exports[`modal flow golden frames renders the add project id editor actions 1`] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Add Project: Review                                                          │
@@ -1570,7 +1570,7 @@ exports[`modal flow golden frames renders the add project success action 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Project Added                                                                │
@@ -1598,7 +1598,7 @@ exports[`modal flow golden frames renders the add project failure actions 1`] = 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Add Project Failed                                                           │
@@ -1646,23 +1646,23 @@ exports[`modal flow golden frames renders the widget settings panel 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
 ───────────────────────────────────────────────────────────────────────────────
        SESSION                            AGENT     STATUS            DIFF · PR
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾]
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
  [2] - docs-cleanup                       codex     no agent
  [3] ○ pty-buffe┌──────────────────────────────────────────────┐          #73 ✓
  [4] + session-r│ widgets                                      │
  [5] ⠋ station-o│ saved to config.toml                         │ +412 -96 #76 …
                 │ ▸ [on ] time                               × │
-▼ observer  3 se│   [off] weather NYC                        × │  [sh] [qs] [▾]
+ ▼ observer  3 s│   [off] weather NYC                        × │  [sh] [qs] [▾]
  [6] x batch-exp│   [on ] moon                               × │           #8 ✓
  [7] ⠋ provider-│   [ + add widget ]                           │   +32 -8 #16 …
  [8] ○ trace-bun│ ↵ toggle   [ ] reorder   x remove   a add   e│     +1 -1 #4 ✓
                 └──────────────────────────────────────────────┘
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾]
+ ▼ scripts  2 sessions · 2 agents                                 [sh] [qs] [▾]
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10
 
-▼ empty-project  0 sessions                                       [sh] [qs] [▾]
+ ▼ empty-project  0 sessions                                      [sh] [qs] [▾]
 
 ───────────────────────────────────────────────────────────────────────────────
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close
@@ -1674,23 +1674,23 @@ exports[`modal flow golden frames renders the widget settings picker 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
 ───────────────────────────────────────────────────────────────────────────────
        SESSION                            AGENT     STATUS            DIFF · PR
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾]
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
  [2] - docs-cleanup                       codex     no agent
  [3] ○ pty-buffe┌──────────────────────────────────────────────┐          #73 ✓
  [4] + session-r│ add widget                                   │
  [5] ⠋ station-o│ weather and tz require config.toml           │ +412 -96 #76 …
                 │ ▸ time                                       │
-▼ observer  3 se│   fleet                                      │  [sh] [qs] [▾]
+ ▼ observer  3 s│   fleet                                      │  [sh] [qs] [▾]
  [6] x batch-exp│   open PRs                                   │           #8 ✓
  [7] ⠋ provider-│   moon                                       │   +32 -8 #16 …
  [8] ○ trace-bun│ ↵ add   esc back                             │     +1 -1 #4 ✓
                 └──────────────────────────────────────────────┘
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾]
+ ▼ scripts  2 sessions · 2 agents                                 [sh] [qs] [▾]
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10
 
-▼ empty-project  0 sessions                                       [sh] [qs] [▾]
+ ▼ empty-project  0 sessions                                      [sh] [qs] [▾]
 
 ───────────────────────────────────────────────────────────────────────────────
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close

--- a/station/src/station/view/dashboard.golden.test.tsx
+++ b/station/src/station/view/dashboard.golden.test.tsx
@@ -328,12 +328,21 @@ describe("dashboard golden frames", () => {
         quickSession: line.indexOf("[qs]"),
         menu: line.indexOf("[▾]"),
       } as const;
+      const markerColumns = {
+        identity: line.indexOf("▼ Design refresh") - 1,
+        quickSession: samples.quickSession - 1,
+        menu: samples.menu - 1,
+      } as const;
       const spans = setup.captureSpans();
+      const focusMarkerColumn = line.indexOf("▸");
 
       expect(spanHex(spanAtFrameCell(spans, row, 0))).toBe(
         stationColorSnapshotValue(nativeStationTheme.status.working),
       );
       expect((spanAtFrameCell(spans, row, 0)?.attributes ?? 0) & TextAttributes.DIM).toBe(0);
+      expect(line.match(/▸/gu)).toHaveLength(1);
+      expect(focusMarkerColumn).toBeGreaterThan(0);
+      expect(focusMarkerColumn).toBe(markerColumns[cellId as keyof typeof markerColumns]);
       for (const [target, column] of Object.entries(samples)) {
         expect(column).toBeGreaterThan(0);
         const background = spanBgHex(spanAtFrameCell(spans, row, column));
@@ -370,6 +379,8 @@ describe("dashboard golden frames", () => {
 
     expect(spanHex(ring)).toBe(stationColorSnapshotValue(nativeStationTheme.status.working));
     expect(((ring?.attributes ?? 0) & TextAttributes.DIM) !== 0).toBe(true);
+    expect(memberLines[memberRow]).toMatch(/^│▏/u);
+    expect(memberLines[memberRow]?.match(/▏/gu)).toHaveLength(1);
     expect(spanBgHex(spanAtFrameCell(spans, memberRow, memberColumn))).toBe(
       stationColorSnapshotValue(nativeStationTheme.interaction.keyboardFocus),
     );
@@ -1091,10 +1102,11 @@ describe("dashboard golden frames", () => {
         const shellStart = line.indexOf(shellLabel);
         const quickStart = line.indexOf(quickLabel);
         const defaultStart = line.indexOf("[▾]");
-        const primaryEnd = line.slice(0, shellStart).trimEnd().length;
+        const primaryEnd = line.slice(0, shellStart - 1).trimEnd().length;
         expect(row).toBeGreaterThan(0);
-        expect(line.trimStart().startsWith("▼ station")).toBe(true);
+        expect(line.trimStart()).toMatch(/^(?:▸)?▼ station/u);
         expect(line).not.toContain("▏");
+        expect(line.match(/▸/gu)).toHaveLength(1);
 
         const spans = setup.captureSpans();
         const samples = {
@@ -1103,6 +1115,13 @@ describe("dashboard golden frames", () => {
           quickSession: quickStart,
           menu: defaultStart,
         } as const;
+        const markerColumns = {
+          primary: line.indexOf("▼ station") - 1,
+          shell: shellStart - 1,
+          quickSession: quickStart - 1,
+          menu: defaultStart - 1,
+        } as const;
+        expect(line.indexOf("▸")).toBe(markerColumns[controls[index]]);
         for (const [control, column] of Object.entries(samples)) {
           const background = spanBgHex(spanAtFrameCell(spans, row, column));
           if (control === controls[index]) {

--- a/station/src/station/view/modals.golden.test.tsx
+++ b/station/src/station/view/modals.golden.test.tsx
@@ -29,6 +29,7 @@ import {
   applyAddProjectFolderReviewFailed,
   applyAddProjectFolderReviewed,
   applyAddProjectSubmitted,
+  activateSessionGroupMenuAction,
   createInitialTuiState,
   handleTuiKey,
   openRemoveWorktreeConfirmForRow,
@@ -322,10 +323,11 @@ const CASES: ModalCase[] = [
     snapshot: groupedManyProjectsSnapshot,
     size: { width: 40, height: 12 },
     prepare: (state) =>
-      handleTuiKey(
-        openGroupSettings(state, "group_design_refresh", "remove"),
-        { input: "", rightArrow: true },
-      ).state,
+      activateSessionGroupMenuAction(state, {
+        projectId: "station",
+        groupId: "group_design_refresh",
+        actionId: "remove",
+      }).state,
     expect: ["Remove Group", "remain open", "delete Design refresh", "Remove", "Back"],
   },
   {

--- a/station/src/station/view/sheets/MoveToGroupSheetView.test.tsx
+++ b/station/src/station/view/sheets/MoveToGroupSheetView.test.tsx
@@ -62,12 +62,16 @@ describe("MoveToGroupSheetView", () => {
       new Map([["moveToGroupDestination", "moveToGroup:existing:group_observer_hardening"]]),
     );
     const frame = setup.captureCharFrame();
+    const lines = frame.split("\n");
+    const currentLine = lines.find((line) => line.includes("1 Design refresh"));
+    const focusedLine = lines.find((line) => line.includes("2 Observer hardening"));
     expect(frame).toContain("Current    Design refresh");
     expect(frame).toContain("✓1 Design refresh");
-    expect(frame).toContain("2 Observer hardening");
+    expect(currentLine).not.toContain("▸");
+    expect(focusedLine).toContain("▸ 2 Observer hardening");
+    expect(focusedLine).not.toContain("✓");
     expect(frame).toContain("N Create new Group…");
 
-    const lines = frame.split("\n");
     for (const label of ["U Ungrouped", "2 Observer hardening", "N Create new Group…"]) {
       const row = lines.findIndex((line) => line.includes(label));
       await setup.mockMouse.click(lines[row]?.indexOf(label) ?? -1, row, MouseButtons.LEFT);
@@ -77,6 +81,18 @@ describe("MoveToGroupSheetView", () => {
       { kind: "sheetChoice", choiceKey: "2" },
       { kind: "sheetChoice", choiceKey: "N" },
     ]);
+
+    const { setup: currentSetup } = await render(
+      {
+        name: "moveToGroup",
+        step: "chooseDestination",
+        sessionId: "ses_wt_group_contracts",
+        sessionTitle: "group-contracts",
+        submitting: false,
+      },
+      new Map([["moveToGroupDestination", "moveToGroup:existing:group_design_refresh"]]),
+    );
+    expect(currentSetup.captureCharFrame()).toContain("▸✓1 Design refresh");
   });
 
   it("renders create-and-move progress without a duplicate submit target", async () => {

--- a/station/src/station/view/sheets/parts.tsx
+++ b/station/src/station/view/sheets/parts.tsx
@@ -153,12 +153,12 @@ export function SheetChoiceLine({
   const dispatch = useStationMouse();
   const [hover, setHover] = useStationHoverState();
   const focused = hover || selected;
-  // The marker reuses the prefix's leading margin column so the key/label
-  // columns stay aligned and the row width is unchanged whether or not it is set.
+  // Cursor and canonical selection stay independent without changing row width.
+  const cursor = selected ? "▸" : " ";
   const marker = current ? "✓" : " ";
   const keyPrefix = `${choiceKey} `;
   const detailPrefix = `${label} `;
-  const detailWidth = Math.max(0, width - 1 - keyPrefix.length - detailPrefix.length);
+  const detailWidth = Math.max(0, width - 2 - keyPrefix.length - detailPrefix.length);
   const visibleDetail = detail.slice(0, detailWidth);
   // Whatever the detail leaves unused is split into a gap then the right-aligned
   // note, so the row stays exactly `width` wide whether or not a note is set.
@@ -173,6 +173,7 @@ export function SheetChoiceLine({
       onMouseOver={() => setHover(true)}
       onMouseOut={() => setHover(false)}
     >
+      {cursor}
       <span {...(current ? { fg: toOpenTuiColor(theme.action.primary) } : {})}>{marker}</span>
       {keyPrefix}
       {detailPrefix}

--- a/tests/e2e/real/real-native-tui-mouse.test.ts
+++ b/tests/e2e/real/real-native-tui-mouse.test.ts
@@ -236,7 +236,7 @@ describeReal("real native Station mouse input", () => {
         runtime,
         (frame) =>
           frame.includes("[shell]") &&
-          frame.includes(`╭▼ ${groupName} 1 session`) &&
+          frame.includes(`╭ ▼ ${groupName} 1 session`) &&
           hasDashboardSessionRow(frame, branch),
         "The native-only Station overlay did not render its Group and real session.",
       );


### PR DESCRIPTION
## What this fixes

Station’s Group backend and workflows were already durable, but the final bake still left exact dashboard and menu focus dependent on color, conflated Move-to-Group membership with keyboard focus, omitted atomic placement coverage from the mandatory Observer lane, and had drift in documentation and real-terminal expectations. This matters in monochrome terminals and when switching between native Station and the standalone tmux renderer.

## What changed

- Added width-stable `▸` focus markers to Project and Group header targets and both menu renderers.
- Kept session focus, Group disclosure, canonical membership, and staged selection distinguishable without color.
- Preserved exact pointer geometry, inert separators and rails, hover behavior, responsive action visibility, and cross-renderer action parity.
- Expanded Q/N/S/R pointer, Enter, and shortcut coverage; refreshed native/standalone goldens and real-terminal predicates.
- Enrolled atomic session-and-Group placement in the mandatory Observer E2E lane.
- Documented Group authority, backend nesting, ordering, filtering, collapse/focus persistence, config boundaries, and practical-accessibility scope.

## Testing

- `pnpm build`
- `pnpm architecture:observer:generate && pnpm architecture:observer:check`
- `pnpm test:sqlite:bun`
- `cd station && bun run test` — 1,638 tests, 91 snapshots
- `pnpm test:e2e:setup:sqlite`
- `pnpm test:e2e:observer` — 21/21
- `pnpm test:all`
- `pnpm test:e2e:real:local tests/e2e/real/real-native-tui-mouse.test.ts` — 1/1
- `STATION_REAL_TMUX=1 pnpm test:tmux-popup:real` — 10/11; all Group/input routes pass, while the existing synthetic PTY does not answer OSC palette queries and therefore cannot satisfy the terminal-default background assertion

## Safety and scope

No Group persistence, command, client, provider, or connector contract changed. Existing durability, exclusive membership, nesting repair, safe deletion, lifecycle disposal, and cross-adapter behavior were revalidated rather than reimplemented. No nested Group authoring, configuration persistence, or accessibility-tree claim was added.

Closes #544.