### PR TITLE
fix(devbox): absorb checkout Observer build changes

### DIFF
--- a/apps/cli/src/commands/observer.ts
+++ b/apps/cli/src/commands/observer.ts
@@ -2,6 +2,8 @@ import type { StationConfig } from "@station/config";
 import type { ObserverHealth, ObserverStopReceipt } from "@station/contracts";
 import { parsePositiveIntegerOption } from "../args.js";
 import {
+  type ExactObserverBuildStatus,
+  ensureExactObserverBuild,
   getObserverStatus,
   type ObserverProcessDeps,
   type ObserverStatus,
@@ -20,6 +22,7 @@ import { type ObserverPaths, resolveObserverPaths } from "../paths.js";
 
 export type ObserverCommandResult =
   | ObserverStatus
+  | ExactObserverBuildStatus
   | ObserverStopReceipt
   | ObserverReapOutcome
   | {
@@ -35,6 +38,11 @@ export type ObserverCommandOptions = {
   reapDeps?: ObserverReapDeps;
 };
 
+/**
+ * COMPOSITION ROOT
+ *
+ * Selects Observer process lifecycle and duplicate-inspection adapters for one CLI action.
+ */
 export async function runObserverCommand(
   args: string[],
   options: ObserverCommandOptions = {},
@@ -60,6 +68,8 @@ export async function runObserverCommand(
       return getObserverStatus(runtimeOptions, deps);
     case "start":
       return startObserver(runtimeOptions, deps);
+    case "ensure-exact-build":
+      return ensureExactObserverBuild(runtimeOptions, deps);
     case "stop":
       return stopObserver(runtimeOptions, deps);
     case "restart":
@@ -160,6 +170,7 @@ export function observerCommandSummary(result: ObserverCommandResult): unknown {
       status: result.status,
       socketPath: result.paths.socketPath,
       health: result.health satisfies ObserverHealth,
+      ...("lifecycle" in result ? { lifecycle: result.lifecycle } : {}),
     };
   }
   if ("paths" in result) {

--- a/apps/cli/src/commands/registry/observer.ts
+++ b/apps/cli/src/commands/registry/observer.ts
@@ -13,6 +13,7 @@ export const observerCliCommand: CliCommandNode = {
   run: runObserverCliCommand,
   usage: [
     "stn observer start",
+    "stn observer ensure-exact-build",
     "stn observer status",
     "stn observer stop",
     "stn observer restart",
@@ -32,6 +33,14 @@ export const observerCliCommand: CliCommandNode = {
       usage: ["stn observer start [--timeout-ms <ms>]"],
       options: [{ name: "--timeout-ms <ms>", description: "Override the startup health timeout." }],
       examples: ["pnpm stn observer start"],
+    },
+    {
+      name: "ensure-exact-build",
+      description:
+        "Reuse or cooperatively replace the configured Observer so its immutable build exactly matches this CLI.",
+      usage: ["stn observer ensure-exact-build [--timeout-ms <ms>]"],
+      options: [{ name: "--timeout-ms <ms>", description: "Override the activation timeout." }],
+      examples: ["pnpm stn observer ensure-exact-build"],
     },
     {
       name: "status",
@@ -76,7 +85,7 @@ async function runObserverCliCommand(context: CliCommandRunContext) {
   );
   const action = parseObserverCommandAction(context.args);
   const failedStart =
-    (action === "start" || action === "restart") &&
+    (action === "start" || action === "restart" || action === "ensure-exact-build") &&
     "status" in result &&
     result.status !== "running";
   return { code: failedStart ? 1 : 0, output: observerCommandSummary(result) };

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,4 +1,9 @@
 export { runCli } from "./main.js";
+export type {
+  ExactObserverActivationPhase,
+  ExactObserverBuildStatus,
+  ExactObserverIncumbentDisposition,
+} from "./observerProcess.js";
 export {
   ensureExactObserverBuild,
   getObserverStatus,

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,5 +1,6 @@
 export { runCli } from "./main.js";
 export {
+  ensureExactObserverBuild,
   getObserverStatus,
   restartObserver,
   startObserver,

--- a/apps/cli/src/internal.ts
+++ b/apps/cli/src/internal.ts
@@ -16,5 +16,11 @@ export * from "./commands/setup/index.js";
 export * from "./commands/snapshot.js";
 export * from "./commands/tui.js";
 export { runCliMain, shouldSuppressCliProcessOutput } from "./main.js";
-export type { ChildProcessLike, ObserverProcessDeps } from "./observerProcess.js";
+export type {
+  ChildProcessLike,
+  ExactObserverActivationPhase,
+  ExactObserverBuildStatus,
+  ExactObserverIncumbentDisposition,
+  ObserverProcessDeps,
+} from "./observerProcess.js";
 export * from "./selfExec.js";

--- a/apps/cli/src/observerProcess.ts
+++ b/apps/cli/src/observerProcess.ts
@@ -64,7 +64,9 @@ export async function getObserverStatus(
   }
 
   const healthTimeoutMs = remainingStatusTimeoutMs(deadlineMs);
-  if (healthTimeoutMs <= 0) return observerHealthTimedOut(paths);
+  if (healthTimeoutMs <= 0) {
+    return probe.status === "absent" ? { status: "stopped", paths } : observerHealthTimedOut(paths);
+  }
 
   const client =
     deps.clientFactory?.(paths.socketPath, {

--- a/apps/cli/src/observerProcess.ts
+++ b/apps/cli/src/observerProcess.ts
@@ -22,6 +22,7 @@ import {
 } from "./observerProcess/health.js";
 import { startObserverProcess } from "./observerProcess/startup.js";
 import type {
+  ExactObserverBuildStatus,
   ObserverProcessDeps,
   ObserverProcessOptions,
   ObserverStatus,
@@ -31,6 +32,7 @@ import { type ObserverPaths, resolveObserverPaths } from "./paths.js";
 // Commands intentionally keep one stable lifecycle import while implementation lives in observerProcess/.
 export type {
   ChildProcessLike,
+  ExactObserverBuildStatus,
   ObserverProcessDeps,
   ObserverProcessOptions,
   ObserverStatus,
@@ -201,6 +203,109 @@ export async function stopObserver(
     );
   }
   return stopRunningObserver(status, options, deps);
+}
+
+/**
+ * ADAPTER
+ *
+ * Converges one configured Observer socket to this caller's exact immutable build through
+ * identity-pinned cooperative replacement without changing generic singleton ordering.
+ */
+export async function ensureExactObserverBuild(
+  options: ObserverProcessOptions = {},
+  deps: ObserverProcessDeps = {},
+): Promise<ExactObserverBuildStatus> {
+  const paths = options.paths ?? resolveObserverPaths(options.config);
+  const timeoutMs = options.timeoutMs ?? 10_000;
+  const deadlineMs = Date.now() + timeoutMs;
+  const buildVersion = deps.buildVersion ?? stationObserverBuildVersion();
+  const status = await getObserverStatus(
+    { ...options, paths, timeoutMs: remainingStopTimeoutMs(deadlineMs) },
+    deps,
+  );
+
+  if (status.status === "running" && status.health.version === buildVersion) {
+    return { ...status, lifecycle: "reused" };
+  }
+  if (status.status === "unhealthy") {
+    return status;
+  }
+
+  const incumbent = status.status === "running" ? status.health : undefined;
+  if (status.status === "running") {
+    try {
+      await stopRunningObserver(
+        status,
+        { ...options, paths, timeoutMs: remainingStopTimeoutMs(deadlineMs) },
+        deps,
+      );
+    } catch (error) {
+      const remainingMs = remainingStopTimeoutMs(deadlineMs);
+      if (remainingMs <= 0) {
+        return exactBuildActivationFailure(paths, error);
+      }
+      const current = await getObserverStatus({ ...options, paths, timeoutMs: remainingMs }, deps);
+      if (current.status === "running" && current.health.version === buildVersion) {
+        return { ...current, lifecycle: "replaced" };
+      }
+      if (current.status !== "stopped" && current.status !== "stale") {
+        return exactBuildActivationFailure(paths, error);
+      }
+    }
+  }
+
+  const remainingMs = remainingStopTimeoutMs(deadlineMs);
+  if (remainingMs <= 0) {
+    return exactBuildActivationFailure(paths, observerStopTimeoutError());
+  }
+  const started = await startObserver(
+    {
+      ...options,
+      paths,
+      timeoutMs: remainingMs,
+      startupDeadlineMs: deadlineMs,
+    },
+    deps,
+  );
+  if (started.status !== "running") {
+    if (started.error === undefined || incumbent === undefined) return started;
+    return { ...started, error: annotateReplacedIncumbent(started.error, incumbent) };
+  }
+  if (started.health.version !== buildVersion) {
+    return {
+      status: "unhealthy",
+      paths,
+      error: exactBuildMismatchError(started.health, buildVersion),
+    };
+  }
+  return {
+    ...started,
+    lifecycle: incumbent === undefined ? "started" : "replaced",
+  };
+}
+
+function exactBuildActivationFailure(
+  paths: ObserverPaths,
+  error: unknown,
+): ExactObserverBuildStatus {
+  return {
+    status: "unhealthy",
+    paths,
+    error: safeErrorFromUnknown(error, {
+      tag: "ObserverStartupError",
+      code: "OBSERVER_EXACT_BUILD_ACTIVATION_FAILED",
+      message: "The exact Observer build could not be activated safely.",
+    }),
+  };
+}
+
+function exactBuildMismatchError(health: ObserverHealth, requestedVersion: string): SafeError {
+  return {
+    tag: "ObserverStartupError",
+    code: "OBSERVER_EXACT_BUILD_ACTIVATION_FAILED",
+    message: "The exact Observer build could not be activated safely.",
+    hint: `Running build: ${formatObserverBuild(health.version)}. Requested build: ${formatObserverBuild(requestedVersion)}. The configured socket changed owners during activation; the running Observer was preserved.`,
+  };
 }
 
 async function stopRunningObserver(

--- a/apps/cli/src/observerProcess.ts
+++ b/apps/cli/src/observerProcess.ts
@@ -22,7 +22,9 @@ import {
 } from "./observerProcess/health.js";
 import { startObserverProcess } from "./observerProcess/startup.js";
 import type {
+  ExactObserverActivationPhase,
   ExactObserverBuildStatus,
+  ExactObserverIncumbentDisposition,
   ObserverProcessDeps,
   ObserverProcessOptions,
   ObserverStatus,
@@ -32,7 +34,9 @@ import { type ObserverPaths, resolveObserverPaths } from "./paths.js";
 // Commands intentionally keep one stable lifecycle import while implementation lives in observerProcess/.
 export type {
   ChildProcessLike,
+  ExactObserverActivationPhase,
   ExactObserverBuildStatus,
+  ExactObserverIncumbentDisposition,
   ObserverProcessDeps,
   ObserverProcessOptions,
   ObserverStatus,
@@ -49,7 +53,9 @@ export async function getObserverStatus(
   deps: ObserverProcessDeps = {},
 ): Promise<ObserverStatus> {
   const paths = options.paths ?? resolveObserverPaths(options.config);
-  const probe = await probeUnixSocket(paths.socketPath);
+  const timeoutMs = observerStatusHealthTimeoutMs(options.timeoutMs);
+  const deadlineMs = Date.now() + timeoutMs;
+  const probe = await (deps.probeSocket ?? probeUnixSocket)(paths.socketPath, { timeoutMs });
   if (probe.status === "stale") {
     return { status: "stale", paths };
   }
@@ -57,14 +63,17 @@ export async function getObserverStatus(
     return { status: "unhealthy", paths, error: observerSocketInaccessibleError(paths.socketPath) };
   }
 
+  const healthTimeoutMs = remainingStatusTimeoutMs(deadlineMs);
+  if (healthTimeoutMs <= 0) return observerHealthTimedOut(paths);
+
   const client =
     deps.clientFactory?.(paths.socketPath, {
-      timeoutMs: observerStatusHealthTimeoutMs(options.timeoutMs),
+      timeoutMs: healthTimeoutMs,
       acceptPreviousLifecycleSchema: true,
     }) ??
     createObserverClient({
       socketPath: paths.socketPath,
-      timeoutMs: observerStatusHealthTimeoutMs(options.timeoutMs),
+      timeoutMs: healthTimeoutMs,
       acceptPreviousLifecycleSchema: true,
     });
   try {
@@ -84,6 +93,23 @@ export async function getObserverStatus(
   }
 }
 
+function remainingStatusTimeoutMs(deadlineMs: number): number {
+  return Math.max(0, Math.floor(deadlineMs - Date.now()));
+}
+
+function observerHealthTimedOut(paths: ObserverPaths): ObserverStatus {
+  return {
+    status: "unhealthy",
+    paths,
+    error: {
+      tag: "ObserverConnectionError",
+      code: "OBSERVER_HEALTH_TIMEOUT",
+      message: `Observer status did not complete within its deadline for ${paths.socketPath}.`,
+      hint: "Retry after checking socket ownership and Observer health.",
+    },
+  };
+}
+
 /**
  * ADAPTER
  *
@@ -93,6 +119,14 @@ export async function getObserverStatus(
 export async function startObserver(
   options: ObserverProcessOptions = {},
   deps: ObserverProcessDeps = {},
+): Promise<ObserverStatus> {
+  return startObserverWithPolicy(options, deps);
+}
+
+async function startObserverWithPolicy(
+  options: ObserverProcessOptions,
+  deps: ObserverProcessDeps,
+  incumbentPolicy?: "preserve",
 ): Promise<ObserverStatus> {
   const paths = options.paths ?? resolveObserverPaths(options.config);
   const timeoutMs = options.timeoutMs ?? 10_000;
@@ -139,6 +173,7 @@ export async function startObserver(
       ...(options.onStartupProgress === undefined
         ? {}
         : { onStartupProgress: options.onStartupProgress }),
+      ...(incumbentPolicy === undefined ? {} : { incumbentPolicy }),
     },
     deps,
   );
@@ -208,8 +243,10 @@ export async function stopObserver(
 /**
  * ADAPTER
  *
- * Converges one configured Observer socket to this caller's exact immutable build through
- * identity-pinned cooperative replacement without changing generic singleton ordering.
+ * Converges one configured Observer socket to this caller's exact immutable build within one
+ * deadline. At most the admitted identity-pinned incumbent is stopped cooperatively; the child
+ * preserves any later non-exact owner. Failures report their phase and the admitted incumbent's
+ * last proven disposition without changing generic singleton ordering.
  */
 export async function ensureExactObserverBuild(
   options: ObserverProcessOptions = {},
@@ -228,10 +265,16 @@ export async function ensureExactObserverBuild(
     return { ...status, lifecycle: "reused" };
   }
   if (status.status === "unhealthy") {
-    return status;
+    return exactBuildActivationFailure(paths, {
+      phase: "inspection",
+      incumbentDisposition: "preserved",
+      error: status.error,
+    });
   }
 
   const incumbent = status.status === "running" ? status.health : undefined;
+  let incumbentDisposition: ExactObserverIncumbentDisposition =
+    incumbent === undefined ? "none" : "unknown";
   if (status.status === "running") {
     try {
       await stopRunningObserver(
@@ -239,26 +282,40 @@ export async function ensureExactObserverBuild(
         { ...options, paths, timeoutMs: remainingStopTimeoutMs(deadlineMs) },
         deps,
       );
+      incumbentDisposition = "stopped";
     } catch (error) {
       const remainingMs = remainingStopTimeoutMs(deadlineMs);
       if (remainingMs <= 0) {
-        return exactBuildActivationFailure(paths, error);
+        return exactBuildActivationFailure(paths, {
+          phase: "stop",
+          incumbentDisposition: "unknown",
+          error,
+        });
       }
       const current = await getObserverStatus({ ...options, paths, timeoutMs: remainingMs }, deps);
       if (current.status === "running" && current.health.version === buildVersion) {
         return { ...current, lifecycle: "replaced" };
       }
       if (current.status !== "stopped" && current.status !== "stale") {
-        return exactBuildActivationFailure(paths, error);
+        return exactBuildActivationFailure(paths, {
+          phase: "stop",
+          incumbentDisposition: "unknown",
+          error,
+        });
       }
+      incumbentDisposition = "stopped";
     }
   }
 
   const remainingMs = remainingStopTimeoutMs(deadlineMs);
   if (remainingMs <= 0) {
-    return exactBuildActivationFailure(paths, observerStopTimeoutError());
+    return exactBuildActivationFailure(paths, {
+      phase: "start",
+      incumbentDisposition,
+      error: observerStopTimeoutError(),
+    });
   }
-  const started = await startObserver(
+  const started = await startObserverWithPolicy(
     {
       ...options,
       paths,
@@ -266,17 +323,25 @@ export async function ensureExactObserverBuild(
       startupDeadlineMs: deadlineMs,
     },
     deps,
+    "preserve",
   );
   if (started.status !== "running") {
-    if (started.error === undefined || incumbent === undefined) return started;
-    return { ...started, error: annotateReplacedIncumbent(started.error, incumbent) };
+    return exactBuildActivationFailure(paths, {
+      phase: "start",
+      incumbentDisposition,
+      error: started.error ?? {
+        tag: "ObserverStartupError",
+        code: "OBSERVER_START_FAILED",
+        message: "Observer startup failed without a diagnostic.",
+      },
+    });
   }
   if (started.health.version !== buildVersion) {
-    return {
-      status: "unhealthy",
-      paths,
+    return exactBuildActivationFailure(paths, {
+      phase: "verification",
+      incumbentDisposition,
       error: exactBuildMismatchError(started.health, buildVersion),
-    };
+    });
   }
   return {
     ...started,
@@ -286,17 +351,49 @@ export async function ensureExactObserverBuild(
 
 function exactBuildActivationFailure(
   paths: ObserverPaths,
-  error: unknown,
+  input: {
+    phase: ExactObserverActivationPhase;
+    incumbentDisposition: ExactObserverIncumbentDisposition;
+    error: unknown;
+  },
 ): ExactObserverBuildStatus {
+  const cause = safeErrorFromUnknown(input.error, {
+    tag: "ObserverStartupError",
+    code: "OBSERVER_EXACT_BUILD_ACTIVATION_CAUSE_UNKNOWN",
+    message: "The exact Observer build activation failed for an unknown reason.",
+  });
+  const error: SafeError = {
+    tag: "ObserverStartupError",
+    code: "OBSERVER_EXACT_BUILD_ACTIVATION_FAILED",
+    message: "The exact Observer build could not be activated safely.",
+    hint: exactBuildFailureHint(input.phase, input.incumbentDisposition, cause),
+  };
+  if (cause.traceId !== undefined) error.traceId = cause.traceId;
+  if (cause.diagnosticId !== undefined) error.diagnosticId = cause.diagnosticId;
   return {
     status: "unhealthy",
     paths,
-    error: safeErrorFromUnknown(error, {
-      tag: "ObserverStartupError",
-      code: "OBSERVER_EXACT_BUILD_ACTIVATION_FAILED",
-      message: "The exact Observer build could not be activated safely.",
-    }),
+    error,
+    phase: input.phase,
+    incumbentDisposition: input.incumbentDisposition,
   };
+}
+
+function exactBuildFailureHint(
+  phase: ExactObserverActivationPhase,
+  incumbentDisposition: ExactObserverIncumbentDisposition,
+  cause: SafeError,
+): string {
+  const recovery =
+    incumbentDisposition === "stopped"
+      ? "The admitted incumbent stopped, but no exact successor was confirmed; retry the same activation command."
+      : incumbentDisposition === "preserved"
+        ? "No stop was attempted; resolve the reported access or ownership failure before retrying."
+        : incumbentDisposition === "none"
+          ? "No incumbent was observed, and no exact successor was confirmed; retry after resolving the startup failure."
+          : "The admitted incumbent's final state could not be proven; inspect status before retrying.";
+  const causeHint = cause.hint === undefined ? "" : ` ${cause.hint}`;
+  return `Activation phase: ${phase}. Incumbent: ${incumbentDisposition}. ${recovery} Cause (${cause.code}): ${cause.message}${causeHint}`;
 }
 
 function exactBuildMismatchError(health: ObserverHealth, requestedVersion: string): SafeError {

--- a/apps/cli/src/observerProcess/spawn.ts
+++ b/apps/cli/src/observerProcess/spawn.ts
@@ -33,7 +33,7 @@ export async function defaultSpawnObserver(
     const [command, ...args] = argv;
     child = spawn(command, args, {
       detached: process.env.STATION_RUNTIME_OWNER_FOREGROUND !== "1",
-      env: environmentWithoutGitLocals(),
+      env: observerSpawnEnvironment(input),
       stdio: ["ignore", bootLog.fd, bootLog.fd],
     });
     const startedChild = Object.assign(
@@ -51,6 +51,22 @@ export async function defaultSpawnObserver(
     }
     throw error;
   }
+}
+
+/**
+ * Builds a child environment that defaults to generic singleton ordering and only
+ * opts into preserve-incumbent admission for an explicit exact-build activation.
+ */
+export function observerSpawnEnvironment(
+  input: Pick<DefaultSpawnObserverInput, "incumbentPolicy">,
+  inheritedEnvironment: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const env = environmentWithoutGitLocals(inheritedEnvironment);
+  delete env.STATION_OBSERVER_STARTUP_POLICY;
+  if (input.incumbentPolicy === "preserve") {
+    env.STATION_OBSERVER_STARTUP_POLICY = "preserve-incumbent";
+  }
+  return env;
 }
 
 export function observerSpawnArgv(input: DefaultSpawnObserverInput): [string, ...string[]] {

--- a/apps/cli/src/observerProcess/startup.ts
+++ b/apps/cli/src/observerProcess/startup.ts
@@ -42,6 +42,7 @@ export async function startObserverProcess(
     clock: RuntimeClock;
     configPath?: string;
     observerCommand?: SpawnObserverInput["observerCommand"];
+    incumbentPolicy?: SpawnObserverInput["incumbentPolicy"];
     onStartupProgress?: ObserverProcessOptions["onStartupProgress"];
   },
   deps: ObserverProcessDeps,
@@ -80,6 +81,9 @@ export async function startObserverProcess(
         }
         if (input.observerCommand !== undefined) {
           spawnInput.observerCommand = input.observerCommand;
+        }
+        if (input.incumbentPolicy !== undefined) {
+          spawnInput.incumbentPolicy = input.incumbentPolicy;
         }
         child =
           deps.spawnObserver === undefined

--- a/apps/cli/src/observerProcess/types.ts
+++ b/apps/cli/src/observerProcess/types.ts
@@ -2,7 +2,11 @@ import type { ChildProcess } from "node:child_process";
 import type { StationConfig } from "@station/config";
 import type { ObserverHealth, SafeError } from "@station/contracts";
 import type { JsonlLogger } from "@station/observability";
-import type { CreateObserverClientOptions, createObserverClient } from "@station/protocol";
+import type {
+  CreateObserverClientOptions,
+  createObserverClient,
+  probeUnixSocket,
+} from "@station/protocol";
 import type { RuntimeClock } from "@station/runtime";
 import type { ObserverPaths } from "../paths.js";
 import type { ExecutableArgv } from "../selfExec.js";
@@ -20,6 +24,14 @@ export type ObserverStatus =
       error?: SafeError;
     };
 
+export type ExactObserverActivationPhase = "inspection" | "stop" | "start" | "verification";
+
+export type ExactObserverIncumbentDisposition = "none" | "preserved" | "stopped" | "unknown";
+
+/**
+ * Result of converging one configured socket to the caller's exact immutable build.
+ * Failures identify the phase and the last proven state of the Observer present at admission.
+ */
 export type ExactObserverBuildStatus =
   | {
       status: "running";
@@ -27,7 +39,13 @@ export type ExactObserverBuildStatus =
       health: ObserverHealth;
       lifecycle: "reused" | "started" | "replaced";
     }
-  | Exclude<ObserverStatus, { status: "running" }>;
+  | {
+      status: "unhealthy";
+      paths: ObserverPaths;
+      error: SafeError;
+      phase: ExactObserverActivationPhase;
+      incumbentDisposition: ExactObserverIncumbentDisposition;
+    };
 
 export type ObserverProcessDeps = {
   /** Requested Observer build selector; production defaults to this executable's immutable selector. */
@@ -39,6 +57,8 @@ export type ObserverProcessDeps = {
       "acceptPreviousLifecycleSchema" | "expectedObserverIdentity" | "timeoutMs"
     >,
   ) => ReturnType<typeof createObserverClient>;
+  /** Test/composition seam for bounded Unix-socket ownership inspection. */
+  probeSocket?: typeof probeUnixSocket;
   spawnObserver?: (input: SpawnObserverInput) => ChildProcessLike | Promise<ChildProcessLike>;
   clock?: RuntimeClock;
   sleep?: (ms: number) => Promise<void>;
@@ -50,6 +70,8 @@ export type SpawnObserverInput = {
   configPath?: string;
   /** Finalized executable and fixed prefix arguments for the Observer child. */
   observerCommand?: ExecutableArgv;
+  /** Preserve any listening incumbent instead of invoking generic automatic handoff. */
+  incumbentPolicy?: "preserve";
 };
 
 export type ChildProcessExit = {

--- a/apps/cli/src/observerProcess/types.ts
+++ b/apps/cli/src/observerProcess/types.ts
@@ -20,6 +20,15 @@ export type ObserverStatus =
       error?: SafeError;
     };
 
+export type ExactObserverBuildStatus =
+  | {
+      status: "running";
+      paths: ObserverPaths;
+      health: ObserverHealth;
+      lifecycle: "reused" | "started" | "replaced";
+    }
+  | Exclude<ObserverStatus, { status: "running" }>;
+
 export type ObserverProcessDeps = {
   /** Requested Observer build selector; production defaults to this executable's immutable selector. */
   buildVersion?: string;

--- a/apps/cli/test/integration/observer-commands.test.ts
+++ b/apps/cli/test/integration/observer-commands.test.ts
@@ -47,6 +47,9 @@ describe("CLI observer commands", () => {
       runObserverCommand(["start"], { config: fixture.config }, deps),
     ).resolves.toMatchObject({ status: "running" });
     await expect(
+      runObserverCommand(["ensure-exact-build"], { config: fixture.config }, deps),
+    ).resolves.toMatchObject({ status: "running", lifecycle: "reused" });
+    await expect(
       runObserverCommand(["status"], { config: fixture.config }, deps),
     ).resolves.toMatchObject({ status: "running" });
     await expect(
@@ -98,6 +101,18 @@ describe("CLI observer commands", () => {
         status: "running",
         socketPath: fixture.socketPath,
         health: { status: "healthy" },
+      },
+    });
+    await expect(
+      runCli(["--config", configPath, "observer", "ensure-exact-build"], {
+        observerDeps: deps,
+      }),
+    ).resolves.toMatchObject({
+      code: 0,
+      output: {
+        status: "running",
+        socketPath: fixture.socketPath,
+        lifecycle: "reused",
       },
     });
     await expect(
@@ -208,7 +223,7 @@ describe("CLI observer commands", () => {
           error: { code: "OBSERVER_SOCKET_INACCESSIBLE" },
         },
       });
-      for (const action of ["start", "restart"]) {
+      for (const action of ["start", "ensure-exact-build", "restart"]) {
         await expect(
           runCli(["--config", configPath, "observer", action], { observerDeps }),
         ).resolves.toMatchObject({

--- a/apps/cli/test/integration/observer-commands.test.ts
+++ b/apps/cli/test/integration/observer-commands.test.ts
@@ -224,15 +224,30 @@ describe("CLI observer commands", () => {
         },
       });
       for (const action of ["start", "ensure-exact-build", "restart"]) {
-        await expect(
-          runCli(["--config", configPath, "observer", action], { observerDeps }),
-        ).resolves.toMatchObject({
+        const result = await runCli(["--config", configPath, "observer", action], {
+          observerDeps,
+        });
+        expect(result).toMatchObject({
           code: 1,
           output: {
             status: "unhealthy",
-            error: { code: "OBSERVER_SOCKET_INACCESSIBLE" },
+            error: {
+              code:
+                action === "ensure-exact-build"
+                  ? "OBSERVER_EXACT_BUILD_ACTIVATION_FAILED"
+                  : "OBSERVER_SOCKET_INACCESSIBLE",
+            },
           },
         });
+        if (action === "ensure-exact-build") {
+          expect(result).toMatchObject({
+            output: {
+              phase: "inspection",
+              incumbentDisposition: "preserved",
+              error: { hint: expect.stringContaining("OBSERVER_SOCKET_INACCESSIBLE") },
+            },
+          });
+        }
       }
       await expect(runCli(["--config", configPath, "doctor"], { observerDeps })).rejects.toThrow(
         /OBSERVER_SOCKET_INACCESSIBLE/u,

--- a/apps/cli/test/unit/observer-process/lifecycle.test.ts
+++ b/apps/cli/test/unit/observer-process/lifecycle.test.ts
@@ -22,6 +22,33 @@ const exactOneBuildVersion = `1.0.0+station.${"a".repeat(64)}`;
 const exactTwoBuildVersion = `2.0.0+station.${"a".repeat(64)}`;
 
 describe("CLI observer process lifecycle", () => {
+  it("reports an absent socket as stopped without spending the remaining deadline on health", async () => {
+    const fixture = await createTempState();
+    let healthRequested = false;
+    const dateNow = vi.spyOn(Date, "now").mockReturnValueOnce(100).mockReturnValue(101);
+
+    try {
+      const result = await getObserverStatus(
+        { config: fixture.config, timeoutMs: 1 },
+        {
+          probeSocket: async () => ({ status: "absent" }),
+          clientFactory: () => {
+            healthRequested = true;
+            throw new Error("health must not be requested without a socket");
+          },
+        },
+      );
+
+      expect(result).toMatchObject({
+        status: "stopped",
+        paths: { socketPath: fixture.socketPath },
+      });
+      expect(healthRequested).toBe(false);
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
   it("maps stale sockets distinctly from stopped observers", async () => {
     const fixture = await createTempState();
     await createRealStaleSocket(fixture.socketPath);

--- a/apps/cli/test/unit/observer-process/lifecycle.test.ts
+++ b/apps/cli/test/unit/observer-process/lifecycle.test.ts
@@ -1,6 +1,12 @@
 import { chmod, lstat, readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { getObserverStatus, restartObserver, startObserver, stopObserver } from "@station/cli";
+import {
+  ensureExactObserverBuild,
+  getObserverStatus,
+  restartObserver,
+  startObserver,
+  stopObserver,
+} from "@station/cli";
 import type { ChildProcessLike } from "@station/cli/internal";
 import { listenUnixSocket } from "@station/protocol";
 import { describe, expect, it, vi } from "vitest";
@@ -264,7 +270,12 @@ describe("CLI observer process lifecycle", () => {
     });
     try {
       await chmod(fixture.socketPath, 0o000);
-      for (const operation of [getObserverStatus, startObserver, restartObserver]) {
+      for (const operation of [
+        getObserverStatus,
+        startObserver,
+        ensureExactObserverBuild,
+        restartObserver,
+      ]) {
         await expect(
           operation(
             { config: fixture.config, timeoutMs: 100 },
@@ -318,6 +329,144 @@ describe("CLI observer process lifecycle", () => {
       expect(result).toMatchObject({ status: "running", health: { version, pid: 1234 } });
     }
     expect(spawned).toBe(false);
+  });
+
+  it("reuses an exact Observer build without stopping or spawning", async () => {
+    const fixture = await createTempState();
+    const stop = vi.fn();
+    const spawnObserver = vi.fn();
+
+    const result = await ensureExactObserverBuild(
+      { config: fixture.config },
+      {
+        buildVersion: losingBuildVersion,
+        spawnObserver,
+        clientFactory: () =>
+          ({
+            health: async () => ({
+              schemaVersion: "0.11.0",
+              status: "healthy",
+              pid: 1234,
+              startedAt: now,
+              version: losingBuildVersion,
+              socketPath: fixture.socketPath,
+            }),
+            stop,
+          }) as never,
+      },
+    );
+
+    expect(result).toMatchObject({
+      status: "running",
+      lifecycle: "reused",
+      health: { pid: 1234, version: losingBuildVersion },
+    });
+    expect(stop).not.toHaveBeenCalled();
+    expect(spawnObserver).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["same-version deterministic winner", winningBuildVersion],
+    ["higher public version", exactTwoBuildVersion],
+  ])("replaces a %s when exact build activation is explicit", async (_label, incumbentVersion) => {
+    const fixture = await createTempState();
+    let running = true;
+    let version = incumbentVersion;
+    let pid = 1234;
+    let stopExpectation: unknown;
+    const lifecycle: string[] = [];
+
+    const result = await ensureExactObserverBuild(
+      { config: fixture.config, timeoutMs: 500 },
+      {
+        buildVersion: losingBuildVersion,
+        spawnObserver: async () => {
+          lifecycle.push("spawn");
+          running = true;
+          version = losingBuildVersion;
+          pid = 5678;
+          return { pid, unref: () => undefined };
+        },
+        clientFactory: (_socketPath, options) => {
+          if (options?.expectedObserverIdentity !== undefined) {
+            stopExpectation = options.expectedObserverIdentity;
+          }
+          return {
+            health: async () => {
+              if (!running) throw new Error("stopped");
+              return {
+                schemaVersion: "0.11.0",
+                status: "healthy",
+                pid,
+                startedAt: now,
+                version,
+                socketPath: fixture.socketPath,
+              };
+            },
+            stop: async () => {
+              lifecycle.push("stop");
+              running = false;
+              return { schemaVersion: "0.11.0", stopped: true, at: now };
+            },
+          } as never;
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      status: "running",
+      lifecycle: "replaced",
+      health: { pid: 5678, version: losingBuildVersion },
+    });
+    expect(stopExpectation).toEqual({
+      pid: 1234,
+      startedAt: now,
+      version: incumbentVersion,
+      socketPath: fixture.socketPath,
+    });
+    expect(lifecycle).toEqual(["stop", "spawn"]);
+  });
+
+  it("refuses a non-exact final Observer selected during activation", async () => {
+    const fixture = await createTempState();
+    let healthCalls = 0;
+    let spawned = false;
+
+    const result = await ensureExactObserverBuild(
+      { config: fixture.config, timeoutMs: 200 },
+      {
+        buildVersion: losingBuildVersion,
+        spawnObserver: async () => {
+          spawned = true;
+          return { pid: 5678, unref: () => undefined };
+        },
+        clientFactory: () =>
+          ({
+            health: async () => {
+              healthCalls += 1;
+              if (!spawned) throw new Error("stopped");
+              return {
+                schemaVersion: "0.11.0",
+                status: "healthy",
+                pid: 9999,
+                startedAt: now,
+                version: exactTwoBuildVersion,
+                socketPath: fixture.socketPath,
+              };
+            },
+          }) as never,
+        sleep: async () => undefined,
+      },
+    );
+
+    expect(healthCalls).toBeGreaterThanOrEqual(3);
+    expect(result).toMatchObject({
+      status: "unhealthy",
+      error: {
+        code: "OBSERVER_EXACT_BUILD_ACTIVATION_FAILED",
+        hint: expect.stringContaining("configured socket changed owners"),
+      },
+    });
   });
 
   it("refuses without spawning when a same-version incumbent has the winning identity", async () => {

--- a/apps/cli/test/unit/observer-process/lifecycle.test.ts
+++ b/apps/cli/test/unit/observer-process/lifecycle.test.ts
@@ -276,15 +276,26 @@ describe("CLI observer process lifecycle", () => {
         ensureExactObserverBuild,
         restartObserver,
       ]) {
-        await expect(
-          operation(
-            { config: fixture.config, timeoutMs: 100 },
-            { buildVersion: zeroBuildVersion, spawnObserver, clientFactory },
-          ),
-        ).resolves.toMatchObject({
+        const result = await operation(
+          { config: fixture.config, timeoutMs: 100 },
+          { buildVersion: zeroBuildVersion, spawnObserver, clientFactory },
+        );
+        expect(result).toMatchObject({
           status: "unhealthy",
-          error: { code: "OBSERVER_SOCKET_INACCESSIBLE" },
+          error: {
+            code:
+              operation === ensureExactObserverBuild
+                ? "OBSERVER_EXACT_BUILD_ACTIVATION_FAILED"
+                : "OBSERVER_SOCKET_INACCESSIBLE",
+          },
         });
+        if (operation === ensureExactObserverBuild) {
+          expect(result).toMatchObject({
+            phase: "inspection",
+            incumbentDisposition: "preserved",
+            error: { hint: expect.stringContaining("OBSERVER_SOCKET_INACCESSIBLE") },
+          });
+        }
       }
       const after = await lstat(fixture.socketPath, { bigint: true });
       expect({ ino: after.ino, birthtimeNs: after.birthtimeNs }).toEqual({
@@ -374,13 +385,15 @@ describe("CLI observer process lifecycle", () => {
     let version = incumbentVersion;
     let pid = 1234;
     let stopExpectation: unknown;
+    let spawnInput: unknown;
     const lifecycle: string[] = [];
 
     const result = await ensureExactObserverBuild(
       { config: fixture.config, timeoutMs: 500 },
       {
         buildVersion: losingBuildVersion,
-        spawnObserver: async () => {
+        spawnObserver: async (input) => {
+          spawnInput = input;
           lifecycle.push("spawn");
           running = true;
           version = losingBuildVersion;
@@ -425,6 +438,96 @@ describe("CLI observer process lifecycle", () => {
       socketPath: fixture.socketPath,
     });
     expect(lifecycle).toEqual(["stop", "spawn"]);
+    expect(spawnInput).toMatchObject({ incumbentPolicy: "preserve" });
+  });
+
+  it("does not authorize a second non-exact owner for replacement after the pinned stop", async () => {
+    const fixture = await createTempState();
+    let running = true;
+    let version = exactTwoBuildVersion;
+    let pid = 1234;
+    let stops = 0;
+    let spawnInput: unknown;
+
+    const result = await ensureExactObserverBuild(
+      { config: fixture.config, timeoutMs: 100 },
+      {
+        buildVersion: losingBuildVersion,
+        spawnObserver: async (input) => {
+          spawnInput = input;
+          running = true;
+          version = zeroBuildVersion;
+          pid = 9999;
+          return { pid: 5678, unref: () => undefined };
+        },
+        clientFactory: () =>
+          ({
+            health: async () => {
+              if (!running) throw new Error("stopped");
+              return {
+                schemaVersion: "0.11.0",
+                status: "healthy",
+                pid,
+                startedAt: now,
+                version,
+                socketPath: fixture.socketPath,
+              };
+            },
+            stop: async () => {
+              stops += 1;
+              running = false;
+              return { schemaVersion: "0.11.0", stopped: true, at: now };
+            },
+          }) as never,
+        sleep: async () => new Promise((resolve) => setTimeout(resolve, 1)),
+      },
+    );
+
+    expect(spawnInput).toMatchObject({ incumbentPolicy: "preserve" });
+    expect(stops).toBe(1);
+    expect(result).toMatchObject({
+      status: "unhealthy",
+      phase: "start",
+      incumbentDisposition: "stopped",
+      error: {
+        code: "OBSERVER_EXACT_BUILD_ACTIVATION_FAILED",
+        hint: expect.stringContaining("no exact successor was confirmed"),
+      },
+    });
+  });
+
+  it("shares one status deadline between socket inspection and health", async () => {
+    const fixture = await createTempState();
+    let clientTimeoutMs: number | undefined;
+    const startedAt = Date.now();
+
+    const result = await getObserverStatus(
+      { config: fixture.config, timeoutMs: 60 },
+      {
+        probeSocket: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 35));
+          return { status: "listening", identity: { ino: 1n, birthtimeNs: 1n } };
+        },
+        clientFactory: (_socketPath, options) => {
+          clientTimeoutMs = options?.timeoutMs;
+          return {
+            health: async () => ({
+              schemaVersion: "0.11.0",
+              status: "healthy",
+              pid: 1234,
+              startedAt: now,
+              version: losingBuildVersion,
+              socketPath: fixture.socketPath,
+            }),
+          } as never;
+        },
+      },
+    );
+
+    expect(result.status).toBe("running");
+    expect(clientTimeoutMs).toBeGreaterThan(0);
+    expect(clientTimeoutMs).toBeLessThan(40);
+    expect(Date.now() - startedAt).toBeLessThan(200);
   });
 
   it("refuses a non-exact final Observer selected during activation", async () => {

--- a/apps/cli/test/unit/observer-process/spawn.test.ts
+++ b/apps/cli/test/unit/observer-process/spawn.test.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { observerSpawnArgv } from "../../../src/observerProcess/spawn.js";
+import { observerSpawnArgv, observerSpawnEnvironment } from "../../../src/observerProcess/spawn.js";
 import { selfExecArgv } from "../../../src/selfExec.js";
 
 const paths = {
@@ -69,6 +69,19 @@ describe("observer spawn argv", () => {
         execPath: "/opt/station/stn",
       }),
     ).toEqual(["/opt/station/stn", "__observer"]);
+  });
+
+  it("keeps generic startup fail-closed and opts only exact activation into preservation", () => {
+    const inherited = {
+      PATH: "/usr/bin",
+      STATION_OBSERVER_STARTUP_POLICY: "preserve-incumbent",
+    };
+
+    expect(observerSpawnEnvironment({}, inherited)).toEqual({ PATH: "/usr/bin" });
+    expect(observerSpawnEnvironment({ incumbentPolicy: "preserve" }, inherited)).toEqual({
+      PATH: "/usr/bin",
+      STATION_OBSERVER_STARTUP_POLICY: "preserve-incumbent",
+    });
   });
 
   it("keeps real Worktrunk hook auto-start on the CLI observer entry", async () => {

--- a/apps/observer/src/runtime/main.ts
+++ b/apps/observer/src/runtime/main.ts
@@ -110,6 +110,8 @@ export type RunObserverMainDeps = {
   duplicateProcessEvidence?: ObserverDuplicateProcessEvidenceSource;
   handoffNow?: () => number;
   handoffSleep?: (ms: number) => Promise<void>;
+  /** Test/composition override for the child-side incumbent admission policy. */
+  startupPolicy?: "generic" | "preserve-incumbent";
   exit?: (code: number) => void;
 };
 
@@ -147,6 +149,9 @@ export async function runObserverMain(
     throw new Error("--build-version must match the running Observer build selector.");
   }
   const handoffNow = deps.handoffNow ?? Date.now;
+  const startupPolicy = deps.startupPolicy ?? observerStartupPolicy(process.env);
+  // This is one-child admission authority, not launch context for providers or hosted agents.
+  delete process.env.STATION_OBSERVER_STARTUP_POLICY;
   const startupDeadline = handoffNow() + options.startupTimeoutMs;
   await mkdir(stateDir, { recursive: true, mode: 0o700 });
   const claimResult = await acquireObserverBootClaim({
@@ -160,14 +165,37 @@ export async function runObserverMain(
   // This outer lifetime keeps the claim through any pre-ready socket and
   // pidfile cleanup; the ready gate performs the normal early release.
   try {
-    const processEvidence = deps.processEvidence ?? createLocalObserverProcessEvidence();
+    const probeTimeoutMs = Math.max(MIN_STARTUP_BUDGET_MS, startupDeadline - handoffNow());
+    const processEvidence =
+      startupPolicy === "generic"
+        ? (deps.processEvidence ?? createLocalObserverProcessEvidence())
+        : undefined;
     const socketProbe = await probeObserverSocket(socketPath, {
-      timeoutMs: DEFAULT_STARTUP_TIMEOUT_MS,
-      socketHolders: (path: string) => processEvidence.socketHolders(path),
+      timeoutMs: probeTimeoutMs,
+      ...(processEvidence === undefined
+        ? {}
+        : { socketHolders: (path: string) => processEvidence.socketHolders(path) }),
     });
     if (socketProbe.status === "inaccessible") throw socketProbe.error;
     if (socketProbe.status === "listening") {
       const remainingStartupMs = Math.max(MIN_STARTUP_BUDGET_MS, startupDeadline - handoffNow());
+      if (startupPolicy === "preserve-incumbent") {
+        const lifecycle =
+          deps.incumbentLifecycle ??
+          createObserverLifecycleClient({ timeoutMs: remainingStartupMs });
+        const incumbent = await lifecycle.health(socketPath, {
+          timeoutMs: remainingStartupMs,
+        });
+        if (incumbent.version === buildVersion) return 0;
+        throw preserveIncumbentRefusal(
+          socketPath,
+          incumbent.version ?? "legacy/unknown build",
+          buildVersion,
+        );
+      }
+      if (processEvidence === undefined) {
+        throw new Error("Generic Observer startup requires process evidence.");
+      }
       const parentReserveMs = Math.min(
         HANDOFF_PARENT_RESERVE_MAX_MS,
         Math.max(
@@ -215,6 +243,30 @@ export async function runObserverMain(
   } finally {
     releaseObserverBootClaim(claimResult);
   }
+}
+
+/** Reads the internal child policy strictly so inherited or misspelled values fail closed. */
+function observerStartupPolicy(
+  env: Readonly<Record<string, string | undefined>>,
+): "generic" | "preserve-incumbent" {
+  const value = env.STATION_OBSERVER_STARTUP_POLICY;
+  if (value === undefined || value === "") return "generic";
+  if (value === "preserve-incumbent") return value;
+  throw new Error("STATION_OBSERVER_STARTUP_POLICY must be empty or preserve-incumbent.");
+}
+
+function preserveIncumbentRefusal(
+  socketPath: string,
+  incumbentVersion: string,
+  requestedVersion: string,
+): Error & SafeError {
+  const safeError: SafeError = {
+    tag: "ObserverStartupError",
+    code: "OBSERVER_EXACT_BUILD_ACTIVATION_FAILED",
+    message: "The exact Observer build could not claim the configured socket safely.",
+    hint: `A different Observer (${incumbentVersion}) claimed ${socketPath} before ${requestedVersion} could start. That new owner was preserved.`,
+  };
+  return Object.assign(new Error(safeError.message), safeError);
 }
 
 async function runClaimedObserverRuntime(input: {

--- a/apps/observer/test/unit/observerBootClaim.test.ts
+++ b/apps/observer/test/unit/observerBootClaim.test.ts
@@ -11,6 +11,7 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { listenUnixSocket } from "@station/protocol";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createObserverStartupGate, runObserverMain } from "../../src/runtime/main.js";
 import {
@@ -349,6 +350,83 @@ describe("observer boot claim", () => {
       code: "ENOENT",
     });
     expect((await lstat(path)).isDirectory()).toBe(true);
+  });
+
+  it("preserves a non-exact owner when exact activation loses the post-stop race", async () => {
+    const root = await tempRoot();
+    const stateDir = join(root, "state");
+    const socketPath = join(root, "run", "observer.sock");
+    const server = await listenUnixSocket({ socketPath, onConnection: () => undefined });
+    const providerRegistryFactory = vi.fn();
+    const stop = vi.fn();
+    const signal = vi.fn();
+
+    try {
+      await expect(
+        runObserverMain(
+          ["--state-dir", stateDir, "--socket", socketPath, "--startup-timeout-ms", "500"],
+          {
+            providerRegistryFactory,
+            buildVersion: "1.0.0+station.candidate",
+            startupPolicy: "preserve-incumbent",
+            incumbentLifecycle: {
+              health: vi.fn(async () => ({
+                schemaVersion: "0.11.0",
+                status: "healthy",
+                pid: 4321,
+                startedAt: "2026-08-19T12:00:00.000Z",
+                version: "0.9.0+station.new-owner",
+                socketPath,
+              })),
+              stop,
+            },
+            processEvidence: { socketHolders: vi.fn(), signal } as never,
+          },
+        ),
+      ).rejects.toMatchObject({ code: "OBSERVER_EXACT_BUILD_ACTIVATION_FAILED" });
+      expect(stop).not.toHaveBeenCalled();
+      expect(signal).not.toHaveBeenCalled();
+      expect(providerRegistryFactory).not.toHaveBeenCalled();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("accepts an exact successor without constructing a competing runtime", async () => {
+    const root = await tempRoot();
+    const stateDir = join(root, "state");
+    const socketPath = join(root, "run", "observer.sock");
+    const buildVersion = "1.0.0+station.exact-owner";
+    const server = await listenUnixSocket({ socketPath, onConnection: () => undefined });
+    const providerRegistryFactory = vi.fn();
+
+    try {
+      await expect(
+        runObserverMain(
+          ["--state-dir", stateDir, "--socket", socketPath, "--startup-timeout-ms", "500"],
+          {
+            providerRegistryFactory,
+            buildVersion,
+            startupPolicy: "preserve-incumbent",
+            incumbentLifecycle: {
+              health: vi.fn(async () => ({
+                schemaVersion: "0.11.0",
+                status: "healthy",
+                pid: 4321,
+                startedAt: "2026-08-19T12:00:00.000Z",
+                version: buildVersion,
+                socketPath,
+              })),
+              stop: vi.fn(),
+            },
+            processEvidence: { socketHolders: vi.fn() } as never,
+          },
+        ),
+      ).resolves.toBe(0);
+      expect(providerRegistryFactory).not.toHaveBeenCalled();
+    } finally {
+      await server.close();
+    }
   });
 });
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,6 +82,12 @@ When these disagree, reconcile from config, providers, and current observer stat
 - Station resolves managed-terminal attachments through its own host attacher. An absent attachment permits the existing local launch; an advertised attachment that cannot resolve fails visibly and must never fall through to a local spawn.
 - The Station UI is a client. It renders snapshots/events and dispatches typed commands; shared dispatch/completion normalization belongs to `@station/client`, while optimistic rows, fallback copy, toasts, and renderer effects remain dashboard or composition policy. Station must not import providers, read SQLite, run `wt`, run `tmux`, run `git`/`gh`, or parse raw provider payloads for core behavior.
 - Observer singleton selection remains generic: non-UI commands, hooks, ingress, and protocol clients may use the healthy handoff winner selected by Observer build ordering. A command-capable Station UI launcher adds a stricter composition check after that selection and proceeds only when its complete caller selector exactly equals the accepted Observer selector. Native Station directly operates Station Host, while the pane-free popup dashboard can dispatch commands that produce later Host work, so both refuse before renderer, reconcile, popup, Host, PTY, or layout effects.
+- Checkout-local devbox orchestration explicitly converges only its configured
+  Observer socket to the checkout's exact immutable build before private hook
+  preparation and UI launch. The CLI lifecycle adapter may cooperatively stop a
+  different identity-pinned incumbent for that explicit operation, but it does
+  not change generic singleton ordering, inspect other sockets, or address the
+  separate persistent Station Host.
 - The outer terminal environment is authoritative only for Station's OpenTUI
   renderer. Its strictly observed palette is appearance authority only for the
   embedded standalone/tmux dashboard; Station resolves that evidence into one

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -238,14 +238,17 @@ attach to different code. Compare `lsof -t <socket>` with the strict pidfile and
 or conflicting evidence. Automatic handoff never uses SIGKILL.
 
 `OBSERVER_EXACT_BUILD_ACTIVATION_FAILED` means an explicit configured-runtime
-activation could not finish with the caller's exact immutable selector. In a
-checkout devbox, the persistent Host, hosted agents, and `.dev-state` remain
-preserved. If the incumbent could not be pinned or the socket became
-inaccessible, inspect `pnpm station:devbox status` and the named evidence before
-retrying. If the cooperative stop completed but successor startup failed, the
-isolated Observer may be down while Host-owned PTYs remain live; rerun the same
-`pnpm station:devbox start` or `dev` command. Do not use reset as routine build
-recovery. Exact activation never signals, reaps, or invokes devbox Host teardown.
+activation could not finish with the caller's exact immutable selector. The
+result's `phase` is `inspection`, `stop`, `start`, or `verification`, and
+`incumbentDisposition` reports `none`, `preserved`, `stopped`, or `unknown` for
+the Observer admitted at operation start. The hint retains the underlying safe
+cause code. In a checkout devbox, exact activation does not target the Station
+Host or hosted agents and does not reset `.dev-state`. Resolve inaccessible
+ownership before retrying a `preserved` result. Inspect status first for
+`unknown`. For `stopped`, the isolated Observer may be down while Host-owned
+PTYs remain live; rerun the same `pnpm station:devbox start` or `dev` command.
+Do not use reset as routine build recovery. Exact activation never signals,
+reaps, invokes devbox Host teardown, or hands off a later non-exact owner.
 
 ## Preserve Sessions Before Runtime Surgery
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -237,6 +237,16 @@ attach to different code. Compare `lsof -t <socket>` with the strict pidfile and
 `ps -ww -p <pid> -o lstart=,command=`, then retry only after resolving missing
 or conflicting evidence. Automatic handoff never uses SIGKILL.
 
+`OBSERVER_EXACT_BUILD_ACTIVATION_FAILED` means an explicit configured-runtime
+activation could not finish with the caller's exact immutable selector. In a
+checkout devbox, the persistent Host, hosted agents, and `.dev-state` remain
+preserved. If the incumbent could not be pinned or the socket became
+inaccessible, inspect `pnpm station:devbox status` and the named evidence before
+retrying. If the cooperative stop completed but successor startup failed, the
+isolated Observer may be down while Host-owned PTYs remain live; rerun the same
+`pnpm station:devbox start` or `dev` command. Do not use reset as routine build
+recovery. Exact activation never signals, reaps, or invokes devbox Host teardown.
+
 ## Preserve Sessions Before Runtime Surgery
 
 When an Observer or Host handoff is blocked and live agent work must survive,

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -12969,18 +12969,11 @@
       "declaration": "ensureExactObserverBuild",
       "kind": "function",
       "role": "ADAPTER",
-      "purpose": "Converges one configured Observer socket to this caller's exact immutable build through identity-pinned cooperative replacement without changing generic singleton ordering.",
+      "purpose": "Converges one configured Observer socket to this caller's exact immutable build within one deadline. At most the admitted identity-pinned incumbent is stopped cooperatively; the child preserves any later non-exact owner. Failures report their phase and the admitted incumbent's last proven disposition without changing generic singleton ordering.",
       "dependencies": [
         {
           "path": "apps/cli/src/observerProcess.ts",
           "declaration": "getObserverStatus",
-          "kind": "function",
-          "role": "ADAPTER",
-          "edgeKind": "runtime"
-        },
-        {
-          "path": "apps/cli/src/observerProcess.ts",
-          "declaration": "startObserver",
           "kind": "function",
           "role": "ADAPTER",
           "edgeKind": "runtime"

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -12310,6 +12310,64 @@
       ]
     },
     {
+      "path": "apps/cli/src/commands/observer.ts",
+      "declaration": "runObserverCommand",
+      "kind": "function",
+      "role": "COMPOSITION ROOT",
+      "purpose": "Selects Observer process lifecycle and duplicate-inspection adapters for one CLI action.",
+      "dependencies": [
+        {
+          "path": "apps/cli/src/observerProcess.ts",
+          "declaration": "ensureExactObserverBuild",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/cli/src/observerProcess.ts",
+          "declaration": "getObserverStatus",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/cli/src/observerProcess.ts",
+          "declaration": "restartObserver",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/cli/src/observerProcess.ts",
+          "declaration": "startObserver",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/cli/src/observerProcess.ts",
+          "declaration": "stopObserver",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/cli/src/observerReap.ts",
+          "declaration": "createLocalObserverReap",
+          "kind": "function",
+          "role": "COMPOSITION ROOT",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/cli/src/observerReap.ts",
+          "declaration": "runObserverReap",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        }
+      ]
+    },
+    {
       "path": "apps/cli/src/commands/popup.ts",
       "declaration": "runPopupCommand",
       "kind": "function",
@@ -12902,6 +12960,36 @@
           "declaration": "runObserverMain",
           "kind": "function",
           "role": "COMPOSITION ROOT",
+          "edgeKind": "runtime"
+        }
+      ]
+    },
+    {
+      "path": "apps/cli/src/observerProcess.ts",
+      "declaration": "ensureExactObserverBuild",
+      "kind": "function",
+      "role": "ADAPTER",
+      "purpose": "Converges one configured Observer socket to this caller's exact immutable build through identity-pinned cooperative replacement without changing generic singleton ordering.",
+      "dependencies": [
+        {
+          "path": "apps/cli/src/observerProcess.ts",
+          "declaration": "getObserverStatus",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/cli/src/observerProcess.ts",
+          "declaration": "startObserver",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "packages/protocol/src/client.ts",
+          "declaration": "createObserverClient",
+          "kind": "function",
+          "role": "ADAPTER",
           "edgeKind": "runtime"
         }
       ]

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -78,10 +78,13 @@ Use reset only when this checkout's runtime and sessions are disposable.
 ## Isolation and safety
 
 The devbox generates `.dev-state/config.toml`, places Observer state under
-`.dev-state`, and uses a short checkout-keyed socket directory. Its default
-terminal is `noop-terminal`, so the isolated Observer does not enumerate agents
-from the machine-global tmux server. Native Host-backed Station panes remain
-available.
+`.dev-state`, uses a short checkout-keyed socket directory, and pins the native
+Host socket and layout snapshot to that same checkout. It clears inherited
+Station build, source, Host-handoff, UI, session, worktree, and hook-routing
+selectors before refreshing hooks or opening the renderer, so launching from a
+Station-owned pane cannot select the outer Station runtime. Its default terminal
+is `noop-terminal`, so the isolated Observer does not enumerate agents from the
+machine-global tmux server. Native Host-backed Station panes remain available.
 
 Codex, Claude, Cursor, and OpenCode receive checkout-local provider homes and
 Station hook configuration. This protects global configuration and hook files,
@@ -96,9 +99,12 @@ instructions, inspect `station:devbox status`, and retry the same start command.
 Exact-build activation is scoped to the checkout-keyed socket in the generated
 config. It uses the Observer's identity-pinned cooperative stop, never the
 devbox `stop` teardown, and never signals, reaps, or unlinks an incumbent. A
-failed replacement preserves `.dev-state`, the persistent Host, and hosted
-agents. If the old Observer stopped before its successor failed, retry the same
-`start` or `dev` command; do not reset the lane.
+replacement child also preserves any non-exact owner that wins the socket after
+the admitted incumbent exits. Failure output names the activation phase and the
+admitted incumbent's last proven disposition. The Host and hosted agents are not
+targeted and `.dev-state` is not reset. If the old Observer is reported
+`stopped`, retry the same `start` or `dev` command; if its disposition is
+`unknown`, inspect `status` first. Do not reset the lane for routine recovery.
 
 There is no `STATION_STATE_DIR` environment variable. Manual isolation uses
 `[observer] state_dir` and `socket_path` in a config file. `--config` is a global

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -20,7 +20,11 @@ pnpm station:devbox dev
 The command builds this checkout and gives it a private `.dev-state`, Observer,
 Station Host, socket, provider homes, and hook configuration. Another checkout's
 devbox and hosted sessions keep running. Quitting the UI also leaves this
-checkout's runtime and hosted sessions available for the next start.
+checkout's runtime and hosted sessions available for the next start. Reopening
+an exact build reuses its Observer; when the checkout build changes, the same
+command cooperatively recycles only this checkout's Observer, refreshes and
+validates its private provider hooks, and then opens the UI. The persistent Host
+and its agents remain running through that Observer replacement.
 
 Do not run `pnpm station:link`, `pnpm station:reset`, or a globally installed
 `stn` while comparing worktrees. Those commands can select or mutate a different
@@ -32,7 +36,7 @@ checkout.
 | --- | --- |
 | Isolated Station | `pnpm station:devbox` |
 | Isolated Station with UI HMR | `pnpm station:devbox dev` |
-| Rebuild and recycle the isolated Observer | `pnpm station:devbox restart` |
+| Force a rebuild and isolated Observer recycle | `pnpm station:devbox restart` |
 | Isolated real tmux popup | `pnpm station:devbox tmux dev` |
 | Node CLI watcher with generated isolation | `pnpm dev` |
 | Headless command against the devbox | `pnpm stn --config .dev-state/config.toml <command>` |
@@ -53,10 +57,13 @@ pnpm station:devbox stop
 pnpm station:devbox reset -- --yes
 ```
 
-- `start` builds and opens the isolated Station workspace.
-- `dev` adds Bun hot reload for changes under `station/src/**`.
+- `start` builds, ensures the isolated Observer exactly matches the checkout,
+  prepares private hooks, and opens the isolated Station workspace.
+- `dev` performs the same exact-build preparation and adds Bun hot reload for
+  changes under `station/src/**`.
 - `restart` rebuilds and recycles the Observer while the persistent Host and its
-  agents survive and reconnect.
+  agents survive and reconnect. It remains useful when an exact build needs a
+  deliberate recycle; ordinary build changes do not require it.
 - Changes to Station Host code require `stop` followed by `start`; `restart`
   intentionally preserves the current Host.
 - `status` inspects this checkout's Observer and Host and reports the separate
@@ -85,6 +92,13 @@ The devbox refuses unsafe socket ownership or an inaccessible incumbent socket
 rather than unlinking it. When it reports `OBSERVER_SOCKET_INACCESSIBLE`, keep
 the existing process and state, follow the printed permission or `lsof` recovery
 instructions, inspect `station:devbox status`, and retry the same start command.
+
+Exact-build activation is scoped to the checkout-keyed socket in the generated
+config. It uses the Observer's identity-pinned cooperative stop, never the
+devbox `stop` teardown, and never signals, reaps, or unlinks an incumbent. A
+failed replacement preserves `.dev-state`, the persistent Host, and hosted
+agents. If the old Observer stopped before its successor failed, retry the same
+`start` or `dev` command; do not reset the lane.
 
 There is no `STATION_STATE_DIR` environment variable. Manual isolation uses
 `[observer] state_dir` and `socket_path` in a config file. `--config` is a global
@@ -153,7 +167,9 @@ Observer. Use the private tmux devbox for popup work.
 - **Station connects to the wrong Observer:** check the printed socket and use
   the devbox's config for every headless command.
 - **A launch reports missing status hooks:** use the devbox-generated provider
-  home and hook configuration; do not install test hooks into global homes.
+  home and hook configuration; `start` and `dev` repair and validate those
+  private artifacts before opening the UI. Do not install test hooks into global
+  homes.
 - **`status` reports a Host build mismatch:** use `stop` followed by `start` to
   recycle the source Host after accounting for its sessions.
 - **Cleanup or socket ownership is uncertain:** stop and follow

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -324,6 +324,14 @@ Application composition proceeds around that boundary in this order:
 Station Host is outside the Observer singleton lifecycle and continues to own
 live PTYs independently.
 
+Checkout-local devbox composition may explicitly request exact-build activation
+for its configured socket. The CLI process adapter reuses exact health or
+cooperatively stops the identity-pinned non-exact incumbent before starting the
+caller build, then requires exact health as the postcondition. This orchestration
+does not address the Station Host socket, so the Host and its PTYs remain outside
+the replacement. It is an explicit configured-runtime operation rather than a
+change to singleton ordering or automatic handoff authority.
+
 Singleton startup may hand commands, hooks, ingress, and generic protocol clients
 the healthy winner selected by the existing attach-versus-handoff policy. After
 acceptance, clients pin that exact selector. Each later operation checks health

--- a/docs/observer-singleton.md
+++ b/docs/observer-singleton.md
@@ -97,11 +97,17 @@ operation for a caller that intentionally owns the configured runtime, such as a
 checkout-local devbox. Exact health is reused. A different healthy selector is
 stopped only through the existing identity-pinned cooperative stop connection;
 the operation waits for endpoint closure, starts the caller build, and requires
-that exact selector as its final postcondition. An owner change is re-probed only
+that exact selector as its final postcondition. Its inspection, socket-holder
+evidence, health, stop convergence, child startup, and verification share one
+deadline. The replacement child uses preserve-incumbent admission: it may accept
+an exact successor or claim an absent/proven-stale endpoint, but it cannot invoke
+ordinary automatic handoff against a later non-exact owner. An owner change is re-probed only
 to accept an already-established exact successor or stopped endpoint; the
 operation does not repeatedly stop moving non-exact owners. It never uses reap,
 signals, forced cleanup, or a weaker socket probe. Ordinary `start`, automatic
-handoff, and deterministic winner selection retain the policy above.
+handoff, and deterministic winner selection retain the policy above. Failure
+results name the activation phase and the last proven disposition of the
+incumbent admitted at the beginning of the operation.
 
 A winning replacement candidate may coordinate handoff only while holding the boot claim.
 It revalidates holder, health, pidfile, argv, socket, and OS start token before controlled

--- a/docs/observer-singleton.md
+++ b/docs/observer-singleton.md
@@ -92,6 +92,17 @@ after this singleton decision. That UI-only check is not another ordering, attac
 handoff rule; non-UI commands, hooks, ingress, and generic clients continue to use the
 winner selected here.
 
+An explicit `stn observer ensure-exact-build` request is a separate CLI lifecycle
+operation for a caller that intentionally owns the configured runtime, such as a
+checkout-local devbox. Exact health is reused. A different healthy selector is
+stopped only through the existing identity-pinned cooperative stop connection;
+the operation waits for endpoint closure, starts the caller build, and requires
+that exact selector as its final postcondition. An owner change is re-probed only
+to accept an already-established exact successor or stopped endpoint; the
+operation does not repeatedly stop moving non-exact owners. It never uses reap,
+signals, forced cleanup, or a weaker socket probe. Ordinary `start`, automatic
+handoff, and deterministic winner selection retain the policy above.
+
 A winning replacement candidate may coordinate handoff only while holding the boot claim.
 It revalidates holder, health, pidfile, argv, socket, and OS start token before controlled
 stop and before the one permitted SIGTERM. The controlled health-plus-stop exchange uses one
@@ -204,6 +215,8 @@ Station fails closed for singleton mutation:
 - process, socket, holder, pidfile, or argv change before or after grace refuses further signaling;
 - startup claim contention refuses explicit reap without waiting;
 - automatic handoff never sends SIGKILL; only explicit force may escalate after revalidation;
+- exact-build activation uses only identity-pinned cooperative stop and preserves
+  a changed or unpinnable incumbent;
 - an inaccessible socket is preserved for operator diagnosis.
 
 The actionable operator surfaces are `stn doctor`, `stn observer status`,

--- a/packages/protocol/src/transport.ts
+++ b/packages/protocol/src/transport.ts
@@ -66,9 +66,12 @@ export type UnixSocketProbeOptions = {
 };
 
 type UnixSocketHolderReaderOptions = {
+  /** Bounds the holder-evidence subprocess; defaults to the socket probe timeout. */
+  timeoutMs?: number;
   runLsof?: (
     file: string,
     args: readonly string[],
+    timeoutMs: number,
   ) => Pick<SpawnSyncReturns<string>, "error" | "signal" | "status" | "stderr" | "stdout">;
 };
 
@@ -109,6 +112,7 @@ export async function probeUnixSocket(
     MIN_SOCKET_PROBE_TIMEOUT_MS,
     options.timeoutMs ?? DEFAULT_SOCKET_PROBE_TIMEOUT_MS,
   );
+  const deadlineMs = Date.now() + timeoutMs;
   const connect = options.connect ?? probeUnixSocketConnection;
 
   try {
@@ -144,7 +148,11 @@ export async function probeUnixSocket(
       return inaccessibleSocket("unclassified", error, initialIdentity);
     }
     try {
-      const holders = await (options.socketHolders ?? readUnixSocketHolderPids)(socketPath);
+      const holderTimeoutMs = Math.max(MIN_SOCKET_PROBE_TIMEOUT_MS, deadlineMs - Date.now());
+      const holders = await (
+        options.socketHolders ??
+        ((path: string) => readUnixSocketHolderPids(path, { timeoutMs: holderTimeoutMs }))
+      )(socketPath);
       return holders.length === 0
         ? { status: "stale", identity: initialIdentity }
         : inaccessibleSocket("live-holder", error, initialIdentity);
@@ -164,7 +172,15 @@ export function readUnixSocketHolderPids(
   socketPath: string,
   options: UnixSocketHolderReaderOptions = {},
 ): number[] {
-  const result = (options.runLsof ?? runLsof)(unixSocketHolderEvidencePath(), ["-t", socketPath]);
+  const timeoutMs = Math.max(
+    MIN_SOCKET_PROBE_TIMEOUT_MS,
+    options.timeoutMs ?? DEFAULT_SOCKET_PROBE_TIMEOUT_MS,
+  );
+  const result = (options.runLsof ?? runLsof)(
+    unixSocketHolderEvidencePath(),
+    ["-t", socketPath],
+    timeoutMs,
+  );
   const stdout = result.stdout;
   const stderr = result.stderr;
   if (
@@ -670,11 +686,13 @@ function errorCode(error: unknown): string | undefined {
   return parsed.success ? parsed.data.code : undefined;
 }
 
-function runLsof(file: string, args: readonly string[]) {
+function runLsof(file: string, args: readonly string[], timeoutMs: number) {
   return spawnSync(file, [...args], {
     encoding: "utf8",
     env: { ...process.env, LC_ALL: "C" },
     maxBuffer: 8 * 1024 * 1024,
+    timeout: timeoutMs,
+    killSignal: "SIGKILL",
   });
 }
 

--- a/packages/protocol/test/unit/transport.test.ts
+++ b/packages/protocol/test/unit/transport.test.ts
@@ -201,6 +201,26 @@ describe("Unix socket NDJSON transport", () => {
     }
   });
 
+  it("bounds holder evidence with the caller's socket-probe timeout", () => {
+    let observedTimeoutMs: number | undefined;
+    expect(() =>
+      readUnixSocketHolderPids("/tmp/socket", {
+        timeoutMs: 25,
+        runLsof: (_file, _args, timeoutMs) => {
+          observedTimeoutMs = timeoutMs;
+          return {
+            status: null,
+            stdout: "",
+            stderr: "",
+            signal: "SIGKILL",
+            error: Object.assign(new Error("timed out"), { code: "ETIMEDOUT" }),
+          };
+        },
+      }),
+    ).toThrow(expect.objectContaining({ code: "PROTOCOL_SOCKET_EVIDENCE_UNAVAILABLE" }));
+    expect(observedTimeoutMs).toBe(25);
+  });
+
   it("abandons a displaced listener without deleting its successor pathname", async () => {
     const { socketPath } = await createTempSocketPath();
     const displaced = await listenUnixSocket({ socketPath, onConnection: () => undefined });

--- a/scripts/station-devbox.mjs
+++ b/scripts/station-devbox.mjs
@@ -11,6 +11,11 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+// An installed Station pane can carry a Bun-embedded asset path that is valid
+// only inside that binary process. Source devbox children must resolve their
+// checkout plugin body instead.
+delete process.env.STATION_OPENCODE_PLUGIN_BODY_PATH;
+
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const DS = join(repoRoot, ".dev-state");
 const CFG = join(DS, "config.toml");
@@ -190,8 +195,8 @@ function help() {
     [
       "Usage: pnpm station:devbox [start|dev|restart|status|logs|stop|reset]",
       "",
-      "  start            (default) build if needed, then start the isolated Station sandbox",
-      "  dev, --hot       build if needed, then start the isolated Station sandbox with UI HMR",
+      "  start            (default) build, sync the isolated Observer to this checkout, then open Station",
+      "  dev, --hot       build, sync the isolated Observer to this checkout, then open with UI HMR",
       "  restart          rebuild + recycle the isolated observer (persistent host/agents survive)",
       "  status           report the isolated observer/host (+ host build mismatch warning) and global observer",
       "  logs [--follow]  tail the isolated observer/host/cli logs",

--- a/scripts/test-runners/run-station-devbox-smoke.mjs
+++ b/scripts/test-runners/run-station-devbox-smoke.mjs
@@ -7,7 +7,7 @@
 // Warning: runs against the real .dev-state for this checkout — it starts and
 // then STOPS the devbox, so a live devbox here will be stopped.
 import { spawn, spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   chmodSync,
   existsSync,
@@ -44,6 +44,7 @@ const codexProfileConfig = join(ds, "codex-home", "station.config.toml");
 const globalStateFragment = join(".local", "state", "station");
 const bunShimRoot = mkdtempSync(join(tmpdir(), "station-devbox-smoke-bun-"));
 const bunInvocationLog = join(bunShimRoot, "invocations.log");
+const rendererEnvironmentLog = join(bunShimRoot, "renderer-environment.log");
 const bunShim = join(bunShimRoot, "bun");
 const resolvedBun = spawnSync("bash", ["-c", "command -v bun"], { encoding: "utf8" });
 assert(resolvedBun.status === 0, `bun is unavailable: ${resolvedBun.stderr}`);
@@ -55,12 +56,30 @@ set -euo pipefail
   for argument in "$@"; do printf '%s\\037' "$argument"; done
   printf '\\n'
 } >> "$STATION_DEVBOX_SMOKE_BUN_LOG"
+if [ "\${STATION_DEVBOX_SMOKE_CAPTURE_RENDERER_ENV:-}" = "1" ] && [ "\${1:-}" = "run" ] && { [ "\${2:-}" = "station" ] || [ "\${2:-}" = "dev" ]; }; then
+  : > "$STATION_DEVBOX_SMOKE_RENDERER_ENV_LOG"
+  for name in \
+    STATION_SOURCE STATION_SCENARIO STATION_HOST_SOCKET_PATH STATION_LAYOUT_PATH \
+    STATION_OBSERVER_SOCKET_PATH STATION_CONFIG_PATH STATION_OBSERVER_STATE_DIR \
+    STATION_STATE_DIR STATION_HOOK_SPOOL_DIR STATION_INGRESS_BIN STATION_HOST_HANDOFF \
+    STATION_CLIENT_BUILD_VERSION STATION_OBSERVER_BUILD_VERSION STATION_UI_RUN_ID \
+    STATION_PROJECT_ID STATION_WORKTREE_ID STATION_SESSION_ID STATION_CURSOR_HOOKS_PATH
+  do
+    if value="$(printenv "$name")"; then
+      printf '%s=%s\n' "$name" "$value" >> "$STATION_DEVBOX_SMOKE_RENDERER_ENV_LOG"
+    else
+      printf '%s=__ABSENT__\n' "$name" >> "$STATION_DEVBOX_SMOKE_RENDERER_ENV_LOG"
+    fi
+  done
+  exit 0
+fi
 exec "$STATION_DEVBOX_SMOKE_REAL_BUN" "$@"
 `,
   { mode: 0o700 },
 );
 let socketRestricted = false;
 let hostPid;
+let alternateObserverPid;
 
 process.stderr.write(
   "station:devbox smoke — starts and STOPS this checkout's devbox (.dev-state).\n",
@@ -164,6 +183,35 @@ try {
   );
   process.kill(hostPid, 0);
 
+  // A source renderer launched from an existing Station pane must discard that
+  // pane's runtime selectors before it can inspect a Host, layout, or hook path.
+  devbox(["start"], "hostile inherited environment", {
+    PATH: `${bunShimRoot}:${process.env.PATH ?? ""}`,
+    STATION_DEVBOX_SMOKE_BUN_LOG: bunInvocationLog,
+    STATION_DEVBOX_SMOKE_REAL_BUN: resolvedBun.stdout.trim(),
+    STATION_DEVBOX_SMOKE_CAPTURE_RENDERER_ENV: "1",
+    STATION_DEVBOX_SMOKE_RENDERER_ENV_LOG: rendererEnvironmentLog,
+    STATION_HOST_SOCKET_PATH: "/tmp/another-station-host.sock",
+    STATION_LAYOUT_PATH: "/tmp/another-station-layout.json",
+    STATION_HOST_HANDOFF: "1",
+    STATION_CLIENT_BUILD_VERSION: "another-checkout-client",
+    STATION_OBSERVER_BUILD_VERSION: "another-checkout-observer",
+    STATION_SOURCE: "mock",
+    STATION_SCENARIO: "disconnected",
+    STATION_HOOK_SPOOL_DIR: "/tmp/another-station-spool",
+    STATION_OBSERVER_STATE_DIR: "/tmp/another-station-state",
+    STATION_STATE_DIR: "/tmp/another-station-state",
+    STATION_INGRESS_BIN: "/tmp/another-checkout/stn-ingress",
+    STATION_CURSOR_HOOKS_PATH: "/tmp/another-cursor-hooks.json",
+    STATION_UI_RUN_ID: "ui_outer",
+    STATION_PROJECT_ID: "outer-project",
+    STATION_WORKTREE_ID: "outer-worktree",
+    STATION_SESSION_ID: "outer-session",
+  });
+  assertRendererEnvironment();
+  process.kill(originalPid, 0);
+  process.kill(hostPid, 0);
+
   chmodSync(observerSock, 0o000);
   socketRestricted = true;
   const blocked = spawnResult("node", [wrapper, "start"], {
@@ -175,10 +223,10 @@ try {
     `inaccessible devbox start hid the Observer diagnosis\n${blocked.stderr}`,
   );
   assert(
-    blocked.stderr.includes(
-      "The persistent Station Host, hosted agents, and .dev-state were preserved.",
-    ),
-    `inaccessible devbox start omitted preservation guidance\n${blocked.stderr}`,
+    blocked.stderr.includes('"phase": "inspection"') &&
+      blocked.stderr.includes('"incumbentDisposition": "preserved"') &&
+      blocked.stderr.includes("The Station Host and hosted agents were not targeted"),
+    `inaccessible devbox start omitted exact activation state\n${blocked.stderr}`,
   );
   assert(
     blocked.stderr.includes("pnpm station:devbox status") &&
@@ -206,17 +254,64 @@ try {
     "restoring socket access did not reconnect to the original devbox Observer",
   );
 
-  devbox(["restart"], "restart");
+  const recoveredHealth = parseJson(
+    recoveredStatus.stdout,
+    "recovered isolated observer status",
+  ).health;
+  const requestedVersion = recoveredHealth?.version;
+  assert(typeof requestedVersion === "string", "recovered Observer omitted its build selector");
+  const differentVersion = differentBuildSelector(requestedVersion);
+  spawnChecked("node", [cli, "--config", cfg, "observer", "stop"], {
+    label: "stop exact Observer before changed-build start",
+    env: sourceCliEnv(),
+  });
+  await waitForPathAbsent(observerSock, "exact Observer socket");
+  const alternateObserver = spawn(
+    process.execPath,
+    [
+      join(repoRoot, "tests", "support", "observerMain.js"),
+      "--socket",
+      observerSock,
+      "--state-dir",
+      join(ds, "observer"),
+      "--startup-timeout-ms",
+      "10000",
+      "--build-version",
+      differentVersion,
+      "--process-token",
+      randomUUID(),
+    ],
+    {
+      cwd: repoRoot,
+      detached: true,
+      stdio: "ignore",
+      env: { ...sourceCliEnv(), STATION_TEST_REPO_ROOT: repoRoot },
+    },
+  );
+  alternateObserver.unref();
+  alternateObserverPid = alternateObserver.pid;
+  assert(Number.isInteger(alternateObserverPid), "failed to launch different-build incumbent");
+  await waitForPath(observerSock, "different-build Observer socket");
+
+  const changedBuildStart = devbox(["start"], "changed-build start", {
+    STATION_ISOLATED_NO_LAUNCH: "1",
+  });
+  assert(
+    changedBuildStart.stdout.includes("Checkout build changed"),
+    `start did not report exact-build replacement\n${changedBuildStart.stdout}`,
+  );
+  await waitForProcessExit(alternateObserverPid, "different-build incumbent");
+  alternateObserverPid = undefined;
   const restartedStatus = spawnChecked("node", [cli, "--config", cfg, "observer", "status"], {
-    label: "restarted isolated observer status",
+    label: "changed-build start observer status",
     env: sourceCliEnv(),
   });
   assert(
-    parseJson(restartedStatus.stdout, "restarted isolated observer status").health?.pid !==
-      originalPid,
-    "devbox restart did not replace the isolated Observer",
+    parseJson(restartedStatus.stdout, "changed-build start observer status").health?.version ===
+      requestedVersion,
+    "devbox start did not activate this checkout's exact Observer build",
   );
-  assertHookDoctors("restart");
+  assertHookDoctors("changed-build start");
   assertCodexHookDelivery();
   process.kill(hostPid, 0);
 
@@ -231,6 +326,7 @@ try {
 } catch (error) {
   // Best-effort teardown so a failed assertion never leaves the observer running.
   if (socketRestricted) chmodSync(observerSock, 0o600);
+  if (alternateObserverPid !== undefined) process.kill(alternateObserverPid, "SIGKILL");
   spawnSync("node", [wrapper, "stop"], { cwd: repoRoot, encoding: "utf8", timeout: 30_000 });
   throw error;
 } finally {
@@ -244,6 +340,29 @@ async function waitForPath(path, label) {
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
   throw new Error(`${label} was not created at ${path}`);
+}
+
+async function waitForPathAbsent(path, label) {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (!existsSync(path)) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`${label} remained at ${path}`);
+}
+
+async function waitForProcessExit(pid, label) {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch (error) {
+      if (error?.code === "ESRCH") return;
+      throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`${label} PID ${pid} remained alive`);
 }
 
 function parseArgs(args) {
@@ -276,6 +395,47 @@ function assertNoGlobalLeak(output, label) {
     !output.includes(globalStateFragment),
     `${label} leaked the global state dir (${globalStateFragment}); it must stay on .dev-state\n${output}`,
   );
+}
+
+function assertRendererEnvironment() {
+  const environment = Object.fromEntries(
+    readFileSync(rendererEnvironmentLog, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => {
+        const equals = line.indexOf("=");
+        return [line.slice(0, equals), line.slice(equals + 1)];
+      }),
+  );
+  const expected = {
+    STATION_SOURCE: "observer",
+    STATION_SCENARIO: "__ABSENT__",
+    STATION_HOST_SOCKET_PATH: hostSock,
+    STATION_LAYOUT_PATH: join(ds, "station", "layout.json"),
+    STATION_OBSERVER_SOCKET_PATH: observerSock,
+    STATION_CONFIG_PATH: cfg,
+    STATION_OBSERVER_STATE_DIR: join(ds, "observer"),
+    STATION_STATE_DIR: "__ABSENT__",
+    STATION_HOOK_SPOOL_DIR: join(ds, "observer", "spool", "hooks"),
+    STATION_INGRESS_BIN: join(repoRoot, "bin", "stn-ingress"),
+    STATION_HOST_HANDOFF: "__ABSENT__",
+    STATION_CLIENT_BUILD_VERSION: "__ABSENT__",
+    STATION_OBSERVER_BUILD_VERSION: "__ABSENT__",
+    STATION_UI_RUN_ID: "__ABSENT__",
+    STATION_PROJECT_ID: "__ABSENT__",
+    STATION_WORKTREE_ID: "__ABSENT__",
+    STATION_SESSION_ID: "__ABSENT__",
+    STATION_CURSOR_HOOKS_PATH: "__ABSENT__",
+  };
+  assert(
+    JSON.stringify(environment) === JSON.stringify(expected),
+    `renderer environment escaped devbox isolation\nexpected=${JSON.stringify(expected, null, 2)}\nactual=${JSON.stringify(environment, null, 2)}`,
+  );
+}
+
+function differentBuildSelector(version) {
+  const replacement = version.endsWith("f") ? "e" : "f";
+  return `${version.slice(0, -1)}${replacement}`;
 }
 
 function assertHookDoctors(label) {

--- a/scripts/test-runners/run-station-devbox-smoke.mjs
+++ b/scripts/test-runners/run-station-devbox-smoke.mjs
@@ -6,7 +6,7 @@
 //
 // Warning: runs against the real .dev-state for this checkout — it starts and
 // then STOPS the devbox, so a live devbox here will be stopped.
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   chmodSync,
@@ -36,6 +36,7 @@ const socketDir = join(
 );
 const observerSock = join(socketDir, "observer.sock");
 const hostSock = join(socketDir, "station-host.sock");
+const hostEntry = join(repoRoot, "station", "src", "host", "hostMain.ts");
 const hooksDir = join(ds, "observer", "hooks");
 const hookLog = join(ds, "observer", "logs", "hooks.jsonl");
 const codexHookScript = join(hooksDir, "station-codex-hook.sh");
@@ -59,6 +60,7 @@ exec "$STATION_DEVBOX_SMOKE_REAL_BUN" "$@"
   { mode: 0o700 },
 );
 let socketRestricted = false;
+let hostPid;
 
 process.stderr.write(
   "station:devbox smoke — starts and STOPS this checkout's devbox (.dev-state).\n",
@@ -117,6 +119,20 @@ try {
   );
   assertHookDoctors("initial start");
 
+  spawnChecked("bash", [join(repoRoot, "station", "scripts", "link-station-packages.sh")], {
+    label: "link Station packages for persistent Host smoke",
+    env: { ...process.env, STATION_QUIET_PRELAUNCH: "1" },
+  });
+  const host = spawn(
+    resolvedBun.stdout.trim(),
+    [hostEntry, "--socket", hostSock, "--state-dir", join(ds, "observer")],
+    { cwd: join(repoRoot, "station"), detached: true, stdio: "ignore" },
+  );
+  host.unref();
+  hostPid = host.pid;
+  assert(Number.isInteger(hostPid), "failed to launch the persistent source Host");
+  await waitForPath(hostSock, "persistent Host socket");
+
   // status through the wrapper reports the isolated socket; the direct isolated
   // observer status must not leak the global state dir.
   const status = devbox(["status"], "status");
@@ -126,6 +142,7 @@ try {
   );
   const isoStatus = spawnChecked("node", [cli, "--config", cfg, "observer", "status"], {
     label: "isolated observer status",
+    env: sourceCliEnv(),
   });
   assertNoGlobalLeak(isoStatus.stdout, "isolated observer status");
   const healthyStatus = parseJson(isoStatus.stdout, "isolated observer status");
@@ -135,6 +152,17 @@ try {
     `isolated status did not report a PID\n${isoStatus.stdout}`,
   );
   const originalSocket = statSync(observerSock);
+
+  devbox(["start"], "exact reopen", { STATION_ISOLATED_NO_LAUNCH: "1" });
+  const exactReopenStatus = spawnChecked("node", [cli, "--config", cfg, "observer", "status"], {
+    label: "exact reopen observer status",
+    env: sourceCliEnv(),
+  });
+  assert(
+    parseJson(exactReopenStatus.stdout, "exact reopen observer status").health?.pid === originalPid,
+    "an exact devbox reopen unnecessarily recycled the Observer",
+  );
+  process.kill(hostPid, 0);
 
   chmodSync(observerSock, 0o000);
   socketRestricted = true;
@@ -147,7 +175,9 @@ try {
     `inaccessible devbox start hid the Observer diagnosis\n${blocked.stderr}`,
   );
   assert(
-    blocked.stderr.includes("The isolated Observer and .dev-state were preserved."),
+    blocked.stderr.includes(
+      "The persistent Station Host, hosted agents, and .dev-state were preserved.",
+    ),
     `inaccessible devbox start omitted preservation guidance\n${blocked.stderr}`,
   );
   assert(
@@ -156,6 +186,7 @@ try {
     `inaccessible devbox start omitted recovery commands\n${blocked.stderr}`,
   );
   process.kill(originalPid, 0);
+  process.kill(hostPid, 0);
   const blockedSocket = statSync(observerSock);
   assert(
     blockedSocket.dev === originalSocket.dev && blockedSocket.ino === originalSocket.ino,
@@ -167,6 +198,7 @@ try {
   devbox(["start"], "recovery start", { STATION_ISOLATED_NO_LAUNCH: "1" });
   const recoveredStatus = spawnChecked("node", [cli, "--config", cfg, "observer", "status"], {
     label: "recovered isolated observer status",
+    env: sourceCliEnv(),
   });
   assert(
     parseJson(recoveredStatus.stdout, "recovered isolated observer status").health?.pid ===
@@ -177,6 +209,7 @@ try {
   devbox(["restart"], "restart");
   const restartedStatus = spawnChecked("node", [cli, "--config", cfg, "observer", "status"], {
     label: "restarted isolated observer status",
+    env: sourceCliEnv(),
   });
   assert(
     parseJson(restartedStatus.stdout, "restarted isolated observer status").health?.pid !==
@@ -185,6 +218,7 @@ try {
   );
   assertHookDoctors("restart");
   assertCodexHookDelivery();
+  process.kill(hostPid, 0);
 
   // stop removes the isolated observer + host sockets (teardown scoped to .dev-state).
   devbox(["stop"], "stop");
@@ -201,6 +235,15 @@ try {
   throw error;
 } finally {
   rmSync(bunShimRoot, { recursive: true, force: true });
+}
+
+async function waitForPath(path, label) {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (existsSync(path)) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`${label} was not created at ${path}`);
 }
 
 function parseArgs(args) {
@@ -240,7 +283,7 @@ function assertHookDoctors(label) {
     const result = spawnChecked("node", [cli, "--config", cfg, "hooks", "doctor", provider], {
       label: `${label} ${provider} hook doctor`,
       env: {
-        ...process.env,
+        ...sourceCliEnv(),
         CLAUDE_CONFIG_DIR: join(ds, "claude-home"),
         CODEX_HOME: join(ds, "codex-home"),
         OPENCODE_CONFIG_DIR: join(ds, "opencode-config"),
@@ -271,7 +314,7 @@ function assertCodexHookDelivery() {
     label: "restarted Codex hook delivery",
     input: payload,
     env: {
-      ...process.env,
+      ...sourceCliEnv(),
       STATION_CONFIG_PATH: cfg,
       STATION_HOOK_SPOOL_DIR: join(ds, "observer", "spool", "hooks"),
       STATION_OBSERVER_SOCKET_PATH: observerSock,
@@ -291,6 +334,12 @@ function assertCodexHookDelivery() {
     ),
     `Codex hook did not deliver to the restarted Observer\n${JSON.stringify(newRecords, null, 2)}`,
   );
+}
+
+function sourceCliEnv() {
+  const env = { ...process.env };
+  delete env.STATION_OPENCODE_PLUGIN_BODY_PATH;
+  return env;
 }
 
 function readBunInvocations() {

--- a/station/scripts/station-isolated.sh
+++ b/station/scripts/station-isolated.sh
@@ -59,6 +59,38 @@ if [ "$COMMAND" != "start" ] && [ "$COMMAND" != "dev" ]; then
   exit 1
 fi
 
+# A devbox may be launched from a Station-owned pane. Remove that outer runtime's
+# selectors before any hooks or renderer inherit them, then pin every devbox-owned path.
+unset STATION_CLIENT_BUILD_VERSION \
+  STATION_OBSERVER_BUILD_VERSION \
+  STATION_SCENARIO \
+  STATION_UI_RUN_ID \
+  STATION_UI_CLIENT_KIND \
+  STATION_HOST_HANDOFF \
+  STATION_PROJECT_ID \
+  STATION_WORKTREE_ID \
+  STATION_WORKTREE_PATH \
+  STATION_WORKTREE_MANAGED_ROOT \
+  STATION_SESSION_ID \
+  STATION_TERMINAL_PROVIDER \
+  STATION_TERMINAL_TARGET_ID \
+  STATION_HARNESS_PROVIDER \
+  STATION_HOSTED \
+  STATION_PANE \
+  STATION_FOCUS_CLIENT_ID \
+  STATION_FOCUS_PROVIDER \
+  STATION_TUI_POPUP \
+  STATION_TUI_PERSISTENT \
+  STATION_OBSERVER_STARTUP_POLICY \
+  STATION_STATE_DIR \
+  STATION_CURSOR_HOOKS_PATH
+export STATION_SOURCE="observer"
+export STATION_HOST_SOCKET_PATH="$HOST_SOCK"
+export STATION_LAYOUT_PATH="$DS/station/layout.json"
+export STATION_OBSERVER_STATE_DIR="$DS/observer"
+export STATION_HOOK_SPOOL_DIR="$DS/observer/spool/hooks"
+export STATION_INGRESS_BIN="$ROOT/bin/stn-ingress"
+
 (
   cd "$STATION_DIR"
   bun install --frozen-lockfile
@@ -301,8 +333,9 @@ seed_cursor_link "$HOME/.config/git" "$STATION_CURSOR_HOME/.config/git"
 if ! observer_activation_output="$(node "$CLI" --config "$CFG" observer ensure-exact-build 2>&1)"; then
   printf '%s\n' "$observer_activation_output" >&2
   echo >&2
-  echo "The persistent Station Host, hosted agents, and .dev-state were preserved." >&2
-  echo "Restore the socket access or evidence named above, then run:" >&2
+  echo "Exact-build activation did not complete; its phase and incumbent disposition are reported above." >&2
+  echo "The Station Host and hosted agents were not targeted by this operation." >&2
+  echo "Inspect current state, resolve the reported cause, then retry:" >&2
   echo "  pnpm station:devbox status" >&2
   echo "  pnpm station:devbox start" >&2
   echo "For intentionally disposable state only, 'pnpm station:devbox reset -- --yes' deletes .dev-state and its agents." >&2
@@ -317,7 +350,7 @@ for harness in codex claude cursor opencode; do
     printf '%s\n' "$hook_output" >&2
     echo >&2
     echo "Private $harness hook refresh failed; the Station UI was not opened." >&2
-    echo "The isolated Observer, persistent Host, hosted agents, and .dev-state were preserved." >&2
+    echo "Hook refresh did not stop the isolated Observer or Host; some private hook files may already be updated." >&2
     echo "Retry: pnpm station:devbox $COMMAND" >&2
     exit 1
   fi
@@ -325,14 +358,14 @@ for harness in codex claude cursor opencode; do
     printf '%s\n' "$hook_doctor_output" >&2
     echo >&2
     echo "Private $harness hook validation failed; the Station UI was not opened." >&2
-    echo "The isolated Observer, persistent Host, hosted agents, and .dev-state were preserved." >&2
+    echo "Hook validation did not stop the isolated Observer or Host; inspect the private hook diagnosis above." >&2
     echo "Retry: pnpm station:devbox $COMMAND" >&2
     exit 1
   fi
 done
 
 if printf '%s\n' "$observer_activation_output" | grep -q '"lifecycle": "replaced"'; then
-  echo "Checkout build changed — recycled only this devbox's Observer; persistent Host and agents were preserved."
+  echo "Checkout build changed — recycled only this devbox's Observer; the Host and agents were left untouched."
 fi
 echo "Isolated observer up — $STATION_OBSERVER_SOCKET_PATH"
 if [ "$COMMAND" = "dev" ]; then

--- a/station/scripts/station-isolated.sh
+++ b/station/scripts/station-isolated.sh
@@ -4,6 +4,10 @@
 # tears the isolated observer and host down.
 set -euo pipefail
 
+# The compiled Station binary exports a Bun-embedded OpenCode asset path to its
+# panes. That path is not readable by source checkout processes.
+unset STATION_OPENCODE_PLUGIN_BODY_PATH
+
 # Resolve THIS worktree's root from the script's own location, so the tooling
 # always targets the checkout it lives in (never the global state).
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -292,11 +296,12 @@ seed_cursor_link "$HOME/.git-credentials" "$STATION_CURSOR_HOME/.git-credentials
 seed_cursor_link "$HOME/.ssh" "$STATION_CURSOR_HOME/.ssh"
 seed_cursor_link "$HOME/.config/git" "$STATION_CURSOR_HOME/.config/git"
 
-# Idempotent: reuses a healthy observer, so reopening Station leaves agents alone.
-if ! observer_start_output="$(node "$CLI" --config "$CFG" observer start 2>&1)"; then
-  printf '%s\n' "$observer_start_output" >&2
+# Exact reopen is idempotent. A changed checkout build cooperatively replaces
+# only this checkout's Observer; the separate persistent Host keeps its PTYs.
+if ! observer_activation_output="$(node "$CLI" --config "$CFG" observer ensure-exact-build 2>&1)"; then
+  printf '%s\n' "$observer_activation_output" >&2
   echo >&2
-  echo "The isolated Observer and .dev-state were preserved." >&2
+  echo "The persistent Station Host, hosted agents, and .dev-state were preserved." >&2
   echo "Restore the socket access or evidence named above, then run:" >&2
   echo "  pnpm station:devbox status" >&2
   echo "  pnpm station:devbox start" >&2
@@ -305,11 +310,30 @@ if ! observer_start_output="$(node "$CLI" --config "$CFG" observer start 2>&1)";
 fi
 
 # Install status hooks against THIS observer so the launch guard lets these
-# harnesses spawn; each writes into its own isolated home/state, never globals.
+# harnesses spawn; then verify the private artifacts before opening the UI.
+# Each command writes or reads its own isolated home/state, never globals.
 for harness in codex claude cursor opencode; do
-  node "$CLI" --config "$CFG" hooks install "$harness" --yes >/dev/null
+  if ! hook_output="$(node "$CLI" --config "$CFG" hooks install "$harness" --yes 2>&1)"; then
+    printf '%s\n' "$hook_output" >&2
+    echo >&2
+    echo "Private $harness hook refresh failed; the Station UI was not opened." >&2
+    echo "The isolated Observer, persistent Host, hosted agents, and .dev-state were preserved." >&2
+    echo "Retry: pnpm station:devbox $COMMAND" >&2
+    exit 1
+  fi
+  if ! hook_doctor_output="$(node "$CLI" --config "$CFG" hooks doctor "$harness" 2>&1)"; then
+    printf '%s\n' "$hook_doctor_output" >&2
+    echo >&2
+    echo "Private $harness hook validation failed; the Station UI was not opened." >&2
+    echo "The isolated Observer, persistent Host, hosted agents, and .dev-state were preserved." >&2
+    echo "Retry: pnpm station:devbox $COMMAND" >&2
+    exit 1
+  fi
 done
 
+if printf '%s\n' "$observer_activation_output" | grep -q '"lifecycle": "replaced"'; then
+  echo "Checkout build changed — recycled only this devbox's Observer; persistent Host and agents were preserved."
+fi
 echo "Isolated observer up — $STATION_OBSERVER_SOCKET_PATH"
 if [ "$COMMAND" = "dev" ]; then
   echo "  Hot reload: edit station/src/**; Bun HMR updates the isolated UI."

--- a/tests/diagnostics/agent-scripts.test.ts
+++ b/tests/diagnostics/agent-scripts.test.ts
@@ -1491,13 +1491,20 @@ describe("tui dev script", () => {
     expect(nodePtyRepairScript).toMatch(/cd \\"\$\{root\}\\" && bun install --frozen-lockfile/u);
 
     const frozenInstall = isolatedScript.indexOf("bun install --frozen-lockfile");
+    expect(isolatedScript).toContain("unset STATION_OPENCODE_PLUGIN_BODY_PATH");
+    expect(devboxScript).toContain("delete process.env.STATION_OPENCODE_PLUGIN_BODY_PATH");
     expect(isolatedScript).toContain('if [ "$COMMAND" = "inventory" ]');
     expect(isolatedScript.indexOf('if [ "$COMMAND" = "inventory" ]')).toBeLessThan(frozenInstall);
     expect(isolatedScript).toContain('if [ "$COMMAND" = "prune" ]');
     expect(isolatedScript.indexOf('if [ "$COMMAND" = "prune" ]')).toBeLessThan(frozenInstall);
     expect(frozenInstall).toBeGreaterThan(isolatedScript.indexOf('if [ "$COMMAND" = "stop" ]'));
     expect(frozenInstall).toBeLessThan(isolatedScript.indexOf('mkdir -p "$DS/observer"'));
-    expect(frozenInstall).toBeLessThan(isolatedScript.indexOf("observer start 2>&1"));
+    const exactActivation = isolatedScript.indexOf("observer ensure-exact-build 2>&1");
+    const hookInstall = isolatedScript.indexOf('hooks install "$harness" --yes');
+    const hookDoctor = isolatedScript.indexOf('hooks doctor "$harness"');
+    expect(frozenInstall).toBeLessThan(exactActivation);
+    expect(exactActivation).toBeLessThan(hookInstall);
+    expect(hookInstall).toBeLessThan(hookDoctor);
     expect(isolatedScript).toContain("exec bun run dev");
     expect(devboxScript).toContain('run("bun", ["run", "station:isolated", "dev"]');
     expect(stationPackage.scripts?.dev).not.toContain("bun --hot");

--- a/tests/diagnostics/agent-scripts.test.ts
+++ b/tests/diagnostics/agent-scripts.test.ts
@@ -1492,6 +1492,16 @@ describe("tui dev script", () => {
 
     const frozenInstall = isolatedScript.indexOf("bun install --frozen-lockfile");
     expect(isolatedScript).toContain("unset STATION_OPENCODE_PLUGIN_BODY_PATH");
+    expect(isolatedScript).toContain("STATION_CLIENT_BUILD_VERSION");
+    expect(isolatedScript).toContain("STATION_OBSERVER_BUILD_VERSION");
+    expect(isolatedScript).toContain("STATION_HOST_HANDOFF");
+    expect(isolatedScript).toContain("STATION_CURSOR_HOOKS_PATH");
+    expect(isolatedScript).toContain('export STATION_SOURCE="observer"');
+    expect(isolatedScript).toContain('export STATION_HOST_SOCKET_PATH="$HOST_SOCK"');
+    expect(isolatedScript).toContain('export STATION_LAYOUT_PATH="$DS/station/layout.json"');
+    expect(isolatedScript).toContain('export STATION_OBSERVER_STATE_DIR="$DS/observer"');
+    expect(isolatedScript).toContain('export STATION_HOOK_SPOOL_DIR="$DS/observer/spool/hooks"');
+    expect(isolatedScript).toContain('export STATION_INGRESS_BIN="$ROOT/bin/stn-ingress"');
     expect(devboxScript).toContain("delete process.env.STATION_OPENCODE_PLUGIN_BODY_PATH");
     expect(isolatedScript).toContain('if [ "$COMMAND" = "inventory" ]');
     expect(isolatedScript.indexOf('if [ "$COMMAND" = "inventory" ]')).toBeLessThan(frozenInstall);

--- a/tests/e2e/observer-lifecycle.test.ts
+++ b/tests/e2e/observer-lifecycle.test.ts
@@ -17,7 +17,13 @@ import {
 import { dirname, join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { promisify } from "node:util";
-import { getObserverStatus, restartObserver, runCli, startObserver } from "@station/cli";
+import {
+  ensureExactObserverBuild,
+  getObserverStatus,
+  restartObserver,
+  runCli,
+  startObserver,
+} from "@station/cli";
 import { emptyConfig } from "@station/config";
 import { ObserverProcessIdentitySchema, ObserverProcessTokenSchema } from "@station/contracts";
 import { acquireObserverBootClaim, observerBootClaimPath } from "@station/observer/internal";
@@ -336,7 +342,7 @@ describe("observer lifecycle e2e", () => {
     }
   });
 
-  it("refuses a losing same-version build until the incumbent is explicitly stopped", async () => {
+  it("keeps ordinary losing-build refusal but explicitly activates an exact build", async () => {
     const fixture = await createTempState();
     const build = stationBuildInfo();
     const incumbentVersion = stationObserverBuildVersion({
@@ -378,18 +384,20 @@ describe("observer lifecycle e2e", () => {
         version: incumbentVersion,
       });
 
-      await incumbent.client.stop();
-      await waitForSocketClosed(fixture.socketPath);
-      await expectProcessExit(incumbent.child.pid);
-      const restarted = await startObserver({
-        config: observerConfig(fixture.stateDir, fixture.socketPath),
-        timeoutMs: 10_000,
-      });
-      expect(restarted).toMatchObject({
+      const activated = await ensureExactObserverBuild(
+        {
+          config: observerConfig(fixture.stateDir, fixture.socketPath),
+          timeoutMs: 10_000,
+        },
+        { buildVersion: candidateVersion },
+      );
+      expect(activated).toMatchObject({
         status: "running",
+        lifecycle: "replaced",
         health: { version: candidateVersion },
       });
-      successorStarted = restarted.status === "running";
+      successorStarted = activated.status === "running";
+      await expectProcessExit(incumbent.child.pid);
     } finally {
       if (successorStarted) {
         await successorClient.stop().catch(() => undefined);


### PR DESCRIPTION
## What this fixes

Station's checkout-local devbox must converge its private Observer to the checkout build without disturbing another runtime. Exact activation could hand its post-stop race to generic Observer handoff, allowing a later non-exact owner to be stopped or signaled. A devbox launched from a Station pane could also inherit Host, layout, build, source, and hook-routing selectors from that outer Station. Deadline and partial-failure output did not fully describe or bound those transitions.

## What changed

- Limits exact activation to one identity-pinned cooperative stop; the replacement child accepts an exact successor but preserves any later non-exact owner without handoff or signals.
- Keeps generic singleton ordering unchanged and explicitly strips exact-only child authority from ordinary startup.
- Applies one activation deadline across socket probing, bounded `lsof` evidence, health, stop convergence, startup, and final exact-build verification.
- Treats a deadline-expired absent socket as stopped instead of leaking a schedule-dependent health-timeout result.
- Returns exact-activation failures with `phase`, admitted-incumbent disposition, the stable exact-activation error code, and the underlying safe cause.
- Pins devbox Host, layout, Observer state, hook spool, ingress launcher, provider homes, and live source while removing inherited Station identity and handoff selectors before hook refresh or UI launch.
- Makes hook and activation recovery guidance accurate for preserved, stopped, unknown, and partially refreshed states.

## Testing

- Full `pnpm test:all`: build, typecheck, lint/Observer architecture, 2,635 unit tests, 78 contract tests, 689 integration tests, 161 diagnostics tests, scripted-agent tests, 28 setup E2E tests, 21 Observer/session E2E tests, and installer smoke.
- Focused post-CI regression: 30 lifecycle unit tests and 10 command integration tests, including deadline-expired absent-socket startup.
- `pnpm station:devbox:smoke -- --skip-build`: exact PID reuse, hostile inherited renderer environment, inaccessible-socket preservation/recovery, changed-build `start` replacement, private hook delivery, and persistent Host survival.
- Pre-commit and pre-push lint/architecture hooks passed.

## User-visible behavior

An exact reopen keeps its Observer PID. A changed checkout build replaces only the admitted devbox Observer, leaves the Host and hosted agents untouched, refreshes private hooks, and opens the UI only after validation. Failures now report whether inspection, stop, start, or verification failed and whether the admitted Observer was preserved, stopped, absent, or left in an unknown state.