### PR TITLE
fix(sessions): validate interrupted recovery identity

### DIFF
--- a/apps/observer/src/commands/router.ts
+++ b/apps/observer/src/commands/router.ts
@@ -149,6 +149,7 @@ export function registerObserverCommandHandlers(
       clock: options.clock,
       idFactory: options.idFactory,
       logger: options.logger,
+      worktreeMutations,
     }),
     "session.importRecoveryHandle": createSessionImportRecoveryHandleHandler({
       getProjects,

--- a/apps/observer/src/commands/session/resumeAgent.ts
+++ b/apps/observer/src/commands/session/resumeAgent.ts
@@ -115,22 +115,24 @@ export function createSessionResumeAgentHandler(
       });
       await options.launchPreflight(recovery.harness.id, context.signal);
 
-      const sessionIdIsFresh = recovery.stationSession === undefined;
+      const sessionNeedsSeed = recovery.stationSession === undefined;
       const sessionId =
         recovery.stationSession?.id ?? recovery.handle.sessionId ?? idFactory.sessionId();
       let sessionSeeded = false;
       try {
-        await seedSession({
-          persistence: options.persistence,
-          sessionId,
-          projectId: project.id,
-          worktreeId: worktree.id,
-          initialTitle: row?.title ?? worktree.branch,
-          harness: recovery.harness.id,
-          terminalProvider: terminalProviderId,
-          clock: options.clock,
-        });
-        sessionSeeded = true;
+        if (sessionNeedsSeed) {
+          await seedSession({
+            persistence: options.persistence,
+            sessionId,
+            projectId: project.id,
+            worktreeId: worktree.id,
+            initialTitle: row?.title ?? worktree.branch,
+            harness: recovery.harness.id,
+            terminalProvider: terminalProviderId,
+            clock: options.clock,
+          });
+          sessionSeeded = true;
+        }
         throwIfAborted(context.signal);
 
         // The harness adapter alone translates this provider-native resume target into CLI args.
@@ -153,7 +155,7 @@ export function createSessionResumeAgentHandler(
         });
         throwIfAborted(context.signal);
       } catch (error) {
-        if (sessionIdIsFresh && sessionSeeded) {
+        if (sessionSeeded) {
           await discardSessionSeedBestEffort({
             persistence: options.persistence,
             sessionId,

--- a/apps/observer/src/commands/session/resumeAgent.ts
+++ b/apps/observer/src/commands/session/resumeAgent.ts
@@ -9,6 +9,10 @@ import type { ObserverEventBus } from "../../runtime/eventBus.js";
 import { resolveSessionRecovery } from "../../sessionRecovery.js";
 import type { StationLogger } from "../../stationLogger.js";
 import { nowIso } from "../../utils/time.js";
+import {
+  createWorktreeMutationCoordinator,
+  type WorktreeMutationCoordinator,
+} from "../../worktreeMutationCoordinator.js";
 import { assertCommandType } from "../assertCommand.js";
 import { worktreeMissingError } from "../errors.js";
 import type { HarnessLaunchPreflight } from "../harnessLaunchPreflight.js";
@@ -40,14 +44,16 @@ export type CreateSessionResumeAgentHandlerOptions = {
   clock?: RuntimeClock | undefined;
   idFactory?: Partial<SessionCommandIdFactory> | undefined;
   logger?: StationLogger | undefined;
+  worktreeMutations?: WorktreeMutationCoordinator | undefined;
 };
 
 /**
  * USE CASE
  *
- * Requires the selected worktree in the current Observer snapshot, then validates and preflights
- * provider-native recovery, reusing a handle's Station identity or minting one when absent. Automatic
- * native activation recovery is owned separately by external launch. Failed cleanup discards only a newly minted projection.
+ * Serializes recovery with close for one worktree, binds to its canonical open Station session when
+ * present, then validates and preflights provider-native resume. Explicit imported handles may seed
+ * their absent session identity; ended or contradictory local lifecycle is never reopened. Failed
+ * cleanup discards only a session seeded by this command.
  */
 export function createSessionResumeAgentHandler(
   options: CreateSessionResumeAgentHandlerOptions,
@@ -56,6 +62,7 @@ export function createSessionResumeAgentHandler(
     ...defaultSessionCommandIdFactory,
     ...options.idFactory,
   };
+  const worktreeMutations = options.worktreeMutations ?? createWorktreeMutationCoordinator();
 
   return async (context) => {
     assertCommandType(context, "session.resumeAgent");
@@ -72,103 +79,106 @@ export function createSessionResumeAgentHandler(
     }
 
     const payload = context.command.payload;
-    const project = findProjectOrThrow(options.getProjects(), payload.projectId);
-    const terminalProviderId = payload.terminal?.provider ?? project.defaults.terminal;
-    const terminal = resolveTerminalProviderOrThrow(options.providers, terminalProviderId);
-    const snapshot = options.core.getSnapshot();
-    const row = snapshot.rows.find((candidate) => candidate.id === payload.worktreeId);
-    validateSnapshotRow(row, payload.projectId);
-    // Resume is recovery for a lost primary agent, not a second way to launch
-    // another provider process next to a healthy row.
-    assertResumeAllowed(row);
-
-    if (row === undefined) {
-      throw worktreeMissingError({
-        projectId: payload.projectId,
-        worktreeId: payload.worktreeId,
-        message: "The requested worktree is not visible in the current snapshot.",
-      });
-    }
-    const worktree = worktreeObservationFromRow(
-      row,
-      options.providers.worktree.id,
-      nowIso(options.clock),
-    );
-    throwIfAborted(context.signal);
-
-    const recovery = await resolveSessionRecovery({
-      persistence: options.persistence,
-      providers: options.providers,
-      projectId: payload.projectId,
-      worktreeId: payload.worktreeId,
-      worktree,
-      recoveryHandleId: payload.recoveryHandleId,
-    });
-    await options.launchPreflight(recovery.harness.id, context.signal);
-
-    const sessionIdIsFresh = recovery.handle.sessionId === undefined;
-    const sessionId = recovery.handle.sessionId ?? idFactory.sessionId();
-    let sessionSeeded = false;
-    try {
-      await seedSession({
-        persistence: options.persistence,
-        sessionId,
-        projectId: project.id,
-        worktreeId: worktree.id,
-        initialTitle: row?.title ?? worktree.branch,
-        harness: recovery.harness.id,
-        terminalProvider: terminalProviderId,
-        clock: options.clock,
-      });
-      sessionSeeded = true;
+    await worktreeMutations.run(payload.projectId, payload.worktreeId, async () => {
       throwIfAborted(context.signal);
+      const project = findProjectOrThrow(options.getProjects(), payload.projectId);
+      const terminalProviderId = payload.terminal?.provider ?? project.defaults.terminal;
+      const terminal = resolveTerminalProviderOrThrow(options.providers, terminalProviderId);
+      const snapshot = options.core.getSnapshot();
+      const row = snapshot.rows.find((candidate) => candidate.id === payload.worktreeId);
+      validateSnapshotRow(row, payload.projectId);
+      // Resume is recovery for a lost primary agent, not a second way to launch
+      // another provider process next to a healthy row.
+      assertResumeAllowed(row);
 
-      // The harness adapter alone translates this provider-native resume target into CLI args.
-      await ensureAgentWorkspace({
-        terminal,
-        harness: recovery.harness,
-        launchPreflight: options.launchPreflight,
-        project,
-        worktree,
-        sessionId,
-        harnessOptions: { mode: "interactive" },
-        layout: payload.terminal?.layout ?? project.defaults.layout,
-        focus: payload.terminal?.focus,
-        origin: payload.terminal?.origin,
-        initialPrompt: payload.initialPrompt,
-        resume: recovery.resume,
-        context,
-        clock: options.clock,
-        logger: options.logger,
-      });
-      throwIfAborted(context.signal);
-      await options.persistence.reopenSession(sessionId);
-    } catch (error) {
-      if (sessionIdIsFresh && sessionSeeded) {
-        await discardSessionSeedBestEffort({
-          persistence: options.persistence,
-          sessionId,
-          context,
-          logger: options.logger,
+      if (row === undefined) {
+        throw worktreeMissingError({
+          projectId: payload.projectId,
+          worktreeId: payload.worktreeId,
+          message: "The requested worktree is not visible in the current snapshot.",
         });
       }
-      throw error;
-    }
+      const worktree = worktreeObservationFromRow(
+        row,
+        options.providers.worktree.id,
+        nowIso(options.clock),
+      );
+      throwIfAborted(context.signal);
 
-    const nextSnapshot = await reconcileAndPublish({
-      core: options.core,
-      eventBus: options.eventBus,
-      clock: options.clock,
-      reason: "command:session.resumeAgent",
-      trace: context.trace,
-    });
-    await publishSessionCreated({
-      snapshot: nextSnapshot,
-      sessionId,
-      persistence: options.persistence,
-      eventBus: options.eventBus,
-      context,
-      clock: options.clock,
+      const recovery = await resolveSessionRecovery({
+        persistence: options.persistence,
+        providers: options.providers,
+        projectId: payload.projectId,
+        worktreeId: payload.worktreeId,
+        worktree,
+        recoveryHandleId: payload.recoveryHandleId,
+      });
+      await options.launchPreflight(recovery.harness.id, context.signal);
+
+      const sessionIdIsFresh = recovery.stationSession === undefined;
+      const sessionId =
+        recovery.stationSession?.id ?? recovery.handle.sessionId ?? idFactory.sessionId();
+      let sessionSeeded = false;
+      try {
+        await seedSession({
+          persistence: options.persistence,
+          sessionId,
+          projectId: project.id,
+          worktreeId: worktree.id,
+          initialTitle: row?.title ?? worktree.branch,
+          harness: recovery.harness.id,
+          terminalProvider: terminalProviderId,
+          clock: options.clock,
+        });
+        sessionSeeded = true;
+        throwIfAborted(context.signal);
+
+        // The harness adapter alone translates this provider-native resume target into CLI args.
+        await ensureAgentWorkspace({
+          terminal,
+          harness: recovery.harness,
+          launchPreflight: options.launchPreflight,
+          project,
+          worktree,
+          sessionId,
+          harnessOptions: { mode: "interactive" },
+          layout: payload.terminal?.layout ?? project.defaults.layout,
+          focus: payload.terminal?.focus,
+          origin: payload.terminal?.origin,
+          initialPrompt: payload.initialPrompt,
+          resume: recovery.resume,
+          context,
+          clock: options.clock,
+          logger: options.logger,
+        });
+        throwIfAborted(context.signal);
+      } catch (error) {
+        if (sessionIdIsFresh && sessionSeeded) {
+          await discardSessionSeedBestEffort({
+            persistence: options.persistence,
+            sessionId,
+            context,
+            logger: options.logger,
+          });
+        }
+        throw error;
+      }
+
+      const nextSnapshot = await reconcileAndPublish({
+        core: options.core,
+        eventBus: options.eventBus,
+        clock: options.clock,
+        reason: "command:session.resumeAgent",
+        trace: context.trace,
+      });
+      await publishSessionCreated({
+        snapshot: nextSnapshot,
+        sessionId,
+        persistence: options.persistence,
+        eventBus: options.eventBus,
+        context,
+        clock: options.clock,
+      });
     });
   };
 }

--- a/apps/observer/src/persistence/ports.ts
+++ b/apps/observer/src/persistence/ports.ts
@@ -144,7 +144,9 @@ export interface ReconcileStore {
  * native execution bindings, canonical worktree-scoped titles, recovery, and readiness. Seed,
  * explicit root Group placement or current source-Group inheritance, and provenance-safe discard
  * are one atomic conversation; canonical-title handoff and recovery import also commit before
- * recovery reconciles.
+ * recovery reconciles. Provider-native recovery keys permanently bind project and worktree,
+ * may fill Station session identity once, and reject contradictory identity before mutable evidence
+ * can refresh.
  */
 export interface SessionStore {
   listSessions(): Promise<PersistedSession[]>;

--- a/apps/observer/src/persistence/sessionRecoveryHandles.ts
+++ b/apps/observer/src/persistence/sessionRecoveryHandles.ts
@@ -31,10 +31,23 @@ export function upsertSessionRecoveryHandle(
     id: recoveryHandleId(input),
   });
   const targetValue = recoveryTargetValue(handle);
+  const existingRow = database
+    .prepare(
+      `
+        SELECT * FROM session_recovery_handles
+        WHERE provider = ? AND target_kind = ? AND target_value = ?
+      `,
+    )
+    .get(handle.provider, handle.target.kind, targetValue) as
+    | SqliteSessionRecoveryHandleRow
+    | undefined;
+  if (existingRow !== undefined) {
+    assertRecoveryIdentityAgrees(handleFromRow(existingRow), handle);
+  }
 
   // Providers may omit different correlation fields on repeated reports. Keep
-  // previously observed metadata unless a newer report supplies a replacement,
-  // while always refreshing the handle's owning worktree and liveness.
+  // previously observed mutable evidence unless a report supplies a replacement.
+  // Identity agreement is checked before any of these fields can refresh.
   database
     .prepare(
       `
@@ -43,8 +56,6 @@ export function upsertSessionRecoveryHandle(
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(provider, target_kind, target_value) DO UPDATE SET
           id = excluded.id,
-          project_id = excluded.project_id,
-          worktree_id = excluded.worktree_id,
           session_id = COALESCE(excluded.session_id, session_recovery_handles.session_id),
           cwd = COALESCE(excluded.cwd, session_recovery_handles.cwd),
           terminal_target_id = COALESCE(excluded.terminal_target_id, session_recovery_handles.terminal_target_id),
@@ -159,5 +170,20 @@ function recoveryTargetValue(handle: SessionRecoveryHandle): string {
       return handle.target.id;
     case "session-file":
       return handle.target.path;
+  }
+}
+
+function assertRecoveryIdentityAgrees(
+  existing: SessionRecoveryHandle,
+  incoming: SessionRecoveryHandle,
+): void {
+  if (
+    existing.projectId !== incoming.projectId ||
+    existing.worktreeId !== incoming.worktreeId ||
+    (existing.sessionId !== undefined &&
+      incoming.sessionId !== undefined &&
+      existing.sessionId !== incoming.sessionId)
+  ) {
+    throw new Error(`Session recovery handle ${existing.id} has conflicting Station identity.`);
   }
 }

--- a/apps/observer/src/reconcile/graph.ts
+++ b/apps/observer/src/reconcile/graph.ts
@@ -26,6 +26,7 @@ import {
 } from "@station/contracts";
 import { pathIsSameOrInside } from "@station/runtime";
 import { harnessRunCanActivateSession, terminalCanActivateSession } from "../sessionActivation.js";
+import { sessionRecoveryEligibility } from "../sessionRecoveryEligibility.js";
 import { countsForSnapshot } from "./snapshotCounts.js";
 
 export type ObserverGraphInput = {
@@ -153,10 +154,15 @@ export function buildStationSnapshot(input: ObserverGraphInput): StationSnapshot
           rowInput.terminalCapabilities = terminalCapabilities;
         const row = buildWorktreeRow(rowInput);
         attachTurnReadiness(row, turnReadinessBySessionId);
+        const retainedSession = retainedSessionByWorktree.get(
+          sessionWorktreeKey(project.id, worktree.id),
+        );
         const recovery = recoveryActionForRow({
           row,
           recoveryHandles: input.recoveryHandles ?? [],
           harnessCapabilities: input.harnessCapabilities ?? {},
+          sessionMetadata: input.sessionMetadata ?? [],
+          retainedSession,
           featureFlags: input.featureFlags,
         });
         if (recovery !== undefined) {
@@ -175,9 +181,6 @@ export function buildStationSnapshot(input: ObserverGraphInput): StationSnapshot
         if (terminalCapabilities !== undefined) {
           sessionInput.terminalCapabilities = terminalCapabilities;
         }
-        const retainedSession = retainedSessionByWorktree.get(
-          sessionWorktreeKey(project.id, worktree.id),
-        );
         if (retainedSession !== undefined) {
           sessionInput.retainedSession = retainedSession;
         }
@@ -353,6 +356,8 @@ function recoveryActionForRow(input: {
   row: WorktreeRow;
   recoveryHandles: readonly SessionRecoveryHandle[];
   harnessCapabilities: Record<string, HarnessCapabilities>;
+  sessionMetadata: readonly ObserverSessionMetadata[];
+  retainedSession?: ObserverSessionMetadata | undefined;
   featureFlags?: ClientFeatureFlags | undefined;
 }): WorktreeRecoveryAction | undefined {
   // Snapshots expose a safe action hint only. The observer resolves the handle
@@ -361,17 +366,35 @@ function recoveryActionForRow(input: {
     return undefined;
   }
 
-  const matching = input.recoveryHandles.filter(
-    (handle) =>
-      handle.projectId === input.row.projectId &&
-      handle.worktreeId === input.row.id &&
-      input.harnessCapabilities[handle.provider]?.canResume === true,
-  );
-  if (matching.length !== 1) {
+  const eligible = input.recoveryHandles.flatMap((handle) => {
+    const capabilities = input.harnessCapabilities[handle.provider];
+    const eligibilityInput: Parameters<typeof sessionRecoveryEligibility>[0] = {
+      handle,
+      projectId: input.row.projectId,
+      worktreeId: input.row.id,
+      worktreePath: input.row.path,
+      stationSessions: input.sessionMetadata,
+      allowNoLocalSession: true,
+    };
+    if (input.retainedSession?.harness !== undefined) {
+      eligibilityInput.expectedSession = {
+        id: input.retainedSession.id,
+        harness: input.retainedSession.harness,
+      };
+    }
+    if (capabilities !== undefined) {
+      eligibilityInput.registeredHarness = {
+        id: handle.provider,
+        canResume: capabilities.canResume,
+      };
+    }
+    return sessionRecoveryEligibility(eligibilityInput).kind === "eligible" ? [handle] : [];
+  });
+  if (eligible.length !== 1) {
     return undefined;
   }
 
-  const handle = matching[0];
+  const handle = eligible[0];
   if (handle === undefined) {
     return undefined;
   }

--- a/apps/observer/src/runtime/externalLaunch.ts
+++ b/apps/observer/src/runtime/externalLaunch.ts
@@ -56,11 +56,11 @@ export type ExternalLaunchOutcome<T> = {
  *
  * Returns a live or attachable managed identity first, then exactly recovers the canonical open
  * Station session unless explicit, identity-bound user consent requests a fresh provider execution.
- * Both launch paths preflight only the selected provider and pass provider-neutral resume options to
- * the harness. A fresh Station identity is atomically seeded with explicit root placement or the
- * requested source session's current Group before target publication, and confirmed failed launch
- * cleanup removes only its membership and owned inline Group without touching source or retained
- * recovery state.
+ * Recovery retains that session's identity and durable state, passes only provider-neutral resume
+ * options, and releases only its replacement target generation on failure. Both launch paths
+ * preflight only the selected provider. A fresh Station identity is atomically seeded with explicit
+ * root placement or the requested source session's current Group before target publication, and
+ * confirmed failed launch cleanup removes only its membership and owned inline Group.
  */
 export async function prepareExternalLaunch(
   deps: ExternalLaunchDeps,

--- a/apps/observer/src/sessionRecovery.ts
+++ b/apps/observer/src/sessionRecovery.ts
@@ -1,15 +1,18 @@
 import type {
   HarnessProvider,
-  HarnessResumeOptions,
   SafeError,
   SessionRecoveryHandle,
   WorktreeObservation,
 } from "@station/contracts";
-import { pathIsSameOrInside } from "@station/runtime";
 import { resolveHarnessProviderOrThrow } from "./commands/providers.js";
 import { commandValidationError } from "./commands/session/shared.js";
 import type { SessionStore } from "./persistence/index.js";
 import type { ProviderRegistry } from "./providers/registry.js";
+import {
+  type SessionRecoveryEligibility,
+  type SessionRecoveryEligibilityInput,
+  sessionRecoveryEligibility,
+} from "./sessionRecoveryEligibility.js";
 
 type SessionRecoveryExpectation = {
   sessionId: string;
@@ -19,14 +22,17 @@ type SessionRecoveryExpectation = {
 type ResolvedSessionRecovery = {
   handle: SessionRecoveryHandle;
   harness: HarnessProvider;
-  resume: HarnessResumeOptions;
+  resume: Extract<SessionRecoveryEligibility, { kind: "eligible" }>["resume"];
+  stationSession?: Extract<SessionRecoveryEligibility, { kind: "eligible" }>["stationSession"];
 };
 
 /**
  * USE CASE
  *
- * Resolves one provider-native recovery handle through durable session state and
- * provider capability, returning only typed provider-neutral resume authority.
+ * Filters durable handles through exact lifecycle and provider-neutral eligibility before applying
+ * zero/one/many cardinality, then returns only typed resume authority for the selected provider.
+ * Explicit selection retains imported-handle compatibility only when no contradictory local
+ * Station lifecycle exists.
  */
 export async function resolveSessionRecovery(input: {
   persistence: SessionStore;
@@ -37,29 +43,35 @@ export async function resolveSessionRecovery(input: {
   recoveryHandleId?: string | undefined;
   expected?: SessionRecoveryExpectation | undefined;
 }): Promise<ResolvedSessionRecovery> {
-  const handle = await resolveRecoveryHandle(input);
-  assertHandleMatchesExpectation(handle, input.expected);
-  assertHandleMatchesWorktree(handle, input.worktree, input.expected !== undefined);
+  const sessions = await input.persistence.listSessions();
+  const selected = await resolveRecoveryHandle(input, sessions);
+  const handle = selected.handle;
   const harness = resolveHarnessProviderOrThrow(input.providers, handle.provider);
-  assertHarnessCanResume(harness, handle);
-
-  const resume: HarnessResumeOptions = {
-    target: handle.target,
-    recoveryHandleId: handle.id,
+  return {
+    handle,
+    harness,
+    resume: selected.eligibility.resume,
+    ...(selected.eligibility.stationSession === undefined
+      ? {}
+      : { stationSession: selected.eligibility.stationSession }),
   };
-  if (handle.sessionId !== undefined) {
-    resume.previousSessionId = handle.sessionId;
-  }
-  return { handle, harness, resume };
 }
 
-async function resolveRecoveryHandle(input: {
-  persistence: SessionStore;
-  providers: ProviderRegistry;
-  projectId: string;
-  worktreeId: string;
-  recoveryHandleId?: string | undefined;
-}): Promise<SessionRecoveryHandle> {
+async function resolveRecoveryHandle(
+  input: {
+    persistence: SessionStore;
+    providers: ProviderRegistry;
+    projectId: string;
+    worktreeId: string;
+    worktree: WorktreeObservation;
+    recoveryHandleId?: string | undefined;
+    expected?: SessionRecoveryExpectation | undefined;
+  },
+  sessions: Awaited<ReturnType<SessionStore["listSessions"]>>,
+): Promise<{
+  handle: SessionRecoveryHandle;
+  eligibility: Extract<SessionRecoveryEligibility, { kind: "eligible" }>;
+}> {
   if (input.recoveryHandleId !== undefined) {
     const handle = await input.persistence.getSessionRecoveryHandle(input.recoveryHandleId);
     if (handle === undefined) {
@@ -70,28 +82,25 @@ async function resolveRecoveryHandle(input: {
         worktreeId: input.worktreeId,
       });
     }
-    if (handle.projectId !== input.projectId || handle.worktreeId !== input.worktreeId) {
-      throw commandValidationError({
-        code: "SESSION_RECOVERY_HANDLE_MISMATCH",
-        message: "The requested recovery handle belongs to a different worktree.",
-        projectId: input.projectId,
-        worktreeId: input.worktreeId,
-      });
+    const eligibility = evaluateHandle(input, sessions, handle, true);
+    if (eligibility.kind === "ineligible") {
+      throwSelectedHandleError(input, handle, eligibility.reason);
     }
-    return handle;
+    return { handle, eligibility };
   }
 
-  // Automatic recovery is exact only when provider capability leaves one choice.
-  const handles = (
-    await input.persistence.listSessionRecoveryHandles({
-      projectId: input.projectId,
-      worktreeId: input.worktreeId,
-    })
-  ).filter((handle) => handleIsActionable(handle, input.providers));
-  if (handles.length === 1) {
-    return handles[0] as SessionRecoveryHandle;
+  const candidates = await input.persistence.listSessionRecoveryHandles({
+    projectId: input.projectId,
+    worktreeId: input.worktreeId,
+  });
+  const eligible = candidates.flatMap((handle) => {
+    const eligibility = evaluateHandle(input, sessions, handle, false);
+    return eligibility.kind === "eligible" ? [{ handle, eligibility }] : [];
+  });
+  if (eligible.length === 1) {
+    return eligible[0] as (typeof eligible)[number];
   }
-  if (handles.length > 1) {
+  if (eligible.length > 1) {
     throw commandValidationError({
       code: "SESSION_RECOVERY_HANDLE_AMBIGUOUS",
       message: "More than one recovery handle is available for this worktree.",
@@ -108,60 +117,74 @@ async function resolveRecoveryHandle(input: {
   });
 }
 
-function handleIsActionable(handle: SessionRecoveryHandle, providers: ProviderRegistry): boolean {
-  return providers.harnesses.get(handle.provider)?.capabilities().canResume === true;
+function evaluateHandle(
+  input: {
+    providers: ProviderRegistry;
+    projectId: string;
+    worktreeId: string;
+    worktree: WorktreeObservation;
+    expected?: SessionRecoveryExpectation | undefined;
+  },
+  sessions: Awaited<ReturnType<SessionStore["listSessions"]>>,
+  handle: SessionRecoveryHandle,
+  explicitlySelected: boolean,
+): SessionRecoveryEligibility {
+  const provider = input.providers.harnesses.get(handle.provider);
+  const eligibilityInput: SessionRecoveryEligibilityInput = {
+    handle,
+    projectId: input.projectId,
+    worktreeId: input.worktreeId,
+    worktreePath: input.worktree.path,
+    stationSessions: sessions,
+    allowNoLocalSession: explicitlySelected,
+  };
+  if (input.expected !== undefined) {
+    eligibilityInput.expectedSession = {
+      id: input.expected.sessionId,
+      harness: input.expected.provider,
+    };
+  }
+  if (provider !== undefined) {
+    eligibilityInput.registeredHarness = {
+      id: provider.id,
+      canResume: provider.capabilities().canResume,
+    };
+  }
+  return sessionRecoveryEligibility(eligibilityInput);
 }
 
-function assertHandleMatchesExpectation(
+function throwSelectedHandleError(
+  input: { providers: ProviderRegistry; projectId: string; worktreeId: string },
   handle: SessionRecoveryHandle,
-  expected: SessionRecoveryExpectation | undefined,
-): void {
-  if (
-    expected === undefined ||
-    (handle.sessionId === expected.sessionId && handle.provider === expected.provider)
-  ) {
-    return;
+  reason: Exclude<SessionRecoveryEligibility, { kind: "eligible" }>["reason"],
+): never {
+  if (reason === "harness_provider_missing") {
+    resolveHarnessProviderOrThrow(input.providers, handle.provider);
+  }
+  if (reason === "harness_resume_unsupported") {
+    throw {
+      tag: "HarnessProviderError",
+      code: "HARNESS_RESUME_UNSUPPORTED",
+      message: "The requested harness provider does not support agent resume.",
+      provider: handle.provider,
+      worktreeId: handle.worktreeId,
+      sessionId: handle.sessionId,
+    } satisfies SafeError;
+  }
+  if (reason === "cwd_missing" || reason === "cwd_outside_worktree") {
+    throw commandValidationError({
+      code: "SESSION_RECOVERY_CWD_MISMATCH",
+      message: "The recovery handle does not prove a cwd inside the requested worktree.",
+      projectId: input.projectId,
+      worktreeId: input.worktreeId,
+      sessionId: handle.sessionId,
+    });
   }
   throw commandValidationError({
     code: "SESSION_RECOVERY_HANDLE_MISMATCH",
     message: "The recovery handle does not match the canonical open session.",
-    projectId: handle.projectId,
-    worktreeId: handle.worktreeId,
-    sessionId: expected.sessionId,
-  });
-}
-
-function assertHarnessCanResume(provider: HarnessProvider, handle: SessionRecoveryHandle): void {
-  // canResume is configuration-gated even when the adapter implements resume mechanics.
-  if (provider.capabilities().canResume) {
-    return;
-  }
-  throw {
-    tag: "HarnessProviderError",
-    code: "HARNESS_RESUME_UNSUPPORTED",
-    message: "The requested harness provider does not support agent resume.",
-    provider: provider.id,
-    worktreeId: handle.worktreeId,
-    sessionId: handle.sessionId,
-  } satisfies SafeError;
-}
-
-function assertHandleMatchesWorktree(
-  handle: SessionRecoveryHandle,
-  worktree: WorktreeObservation,
-  requireCwd: boolean,
-): void {
-  if (
-    (handle.cwd === undefined && !requireCwd) ||
-    (handle.cwd !== undefined && pathIsSameOrInside(handle.cwd, worktree.path))
-  ) {
-    return;
-  }
-  throw commandValidationError({
-    code: "SESSION_RECOVERY_CWD_MISMATCH",
-    message: "The recovery handle does not prove a cwd inside the requested worktree.",
-    projectId: handle.projectId,
-    worktreeId: handle.worktreeId,
+    projectId: input.projectId,
+    worktreeId: input.worktreeId,
     sessionId: handle.sessionId,
   });
 }

--- a/apps/observer/src/sessionRecoveryEligibility.ts
+++ b/apps/observer/src/sessionRecoveryEligibility.ts
@@ -1,0 +1,164 @@
+import type { HarnessResumeOptions, SessionRecoveryHandle } from "@station/contracts";
+import { pathIsSameOrInside } from "@station/runtime";
+
+export type SessionRecoveryStationSession = {
+  id: string;
+  projectId: string;
+  worktreeId: string;
+  lifecycle: "legacy" | "open" | "ended";
+  harness?: string;
+  endedAt?: string;
+  createdAt: string;
+  lastSeenAt: string;
+};
+
+export type SessionRecoveryEligibilityReason =
+  | "project_mismatch"
+  | "worktree_mismatch"
+  | "station_session_missing"
+  | "station_session_mismatch"
+  | "station_session_legacy"
+  | "station_session_ended"
+  | "harness_mismatch"
+  | "harness_provider_missing"
+  | "harness_resume_unsupported"
+  | "cwd_missing"
+  | "cwd_outside_worktree";
+
+export type SessionRecoveryEligibility =
+  | {
+      kind: "eligible";
+      resume: HarnessResumeOptions;
+      stationSession?: SessionRecoveryStationSession;
+    }
+  | { kind: "ineligible"; reason: SessionRecoveryEligibilityReason };
+
+export type SessionRecoveryEligibilityInput = {
+  handle: SessionRecoveryHandle;
+  projectId: string;
+  worktreeId: string;
+  worktreePath: string;
+  stationSessions: readonly SessionRecoveryStationSession[];
+  expectedSession?: { id: string; harness: string };
+  allowNoLocalSession: boolean;
+  registeredHarness?: { id: string; canResume: boolean };
+};
+
+/**
+ * POLICY
+ *
+ * Admits one opaque recovery handle only when its provider-neutral identity, open Station
+ * lifecycle, registered harness capability, and cwd evidence authorize the exact worktree.
+ * A deliberately selected imported handle may proceed without a local lifecycle row, but local
+ * legacy, ended, or contradictory identity always wins over that compatibility path.
+ */
+export function sessionRecoveryEligibility(
+  input: SessionRecoveryEligibilityInput,
+): SessionRecoveryEligibility {
+  const handle = input.handle;
+  if (handle.projectId !== input.projectId) {
+    return { kind: "ineligible", reason: "project_mismatch" };
+  }
+  if (handle.worktreeId !== input.worktreeId) {
+    return { kind: "ineligible", reason: "worktree_mismatch" };
+  }
+  if (handle.sessionId === undefined) {
+    return { kind: "ineligible", reason: "station_session_missing" };
+  }
+
+  const registeredHarness = input.registeredHarness;
+  if (registeredHarness === undefined || registeredHarness.id !== handle.provider) {
+    return { kind: "ineligible", reason: "harness_provider_missing" };
+  }
+  if (!registeredHarness.canResume) {
+    return { kind: "ineligible", reason: "harness_resume_unsupported" };
+  }
+
+  const stationSession = sessionForRecovery(input);
+  if (stationSession === undefined) {
+    if (input.expectedSession !== undefined || !input.allowNoLocalSession) {
+      return { kind: "ineligible", reason: "station_session_missing" };
+    }
+  } else {
+    if (
+      stationSession.projectId !== input.projectId ||
+      stationSession.worktreeId !== input.worktreeId ||
+      handle.sessionId !== stationSession.id
+    ) {
+      return { kind: "ineligible", reason: "station_session_mismatch" };
+    }
+    if (stationSession.lifecycle === "ended" || stationSession.endedAt !== undefined) {
+      return { kind: "ineligible", reason: "station_session_ended" };
+    }
+    if (stationSession.lifecycle !== "open") {
+      return { kind: "ineligible", reason: "station_session_legacy" };
+    }
+    if (
+      stationSession.harness === undefined ||
+      handle.provider !== stationSession.harness ||
+      (input.expectedSession !== undefined &&
+        stationSession.harness !== input.expectedSession.harness)
+    ) {
+      return { kind: "ineligible", reason: "harness_mismatch" };
+    }
+  }
+
+  if (handle.cwd === undefined) {
+    return { kind: "ineligible", reason: "cwd_missing" };
+  }
+  if (!pathIsSameOrInside(handle.cwd, input.worktreePath)) {
+    return { kind: "ineligible", reason: "cwd_outside_worktree" };
+  }
+
+  const resume: HarnessResumeOptions = {
+    target: handle.target,
+    recoveryHandleId: handle.id,
+  };
+  resume.previousSessionId = handle.sessionId;
+  return {
+    kind: "eligible",
+    resume,
+    ...(stationSession === undefined ? {} : { stationSession }),
+  };
+}
+
+function sessionForRecovery(
+  input: SessionRecoveryEligibilityInput,
+): SessionRecoveryStationSession | undefined {
+  if (input.expectedSession !== undefined) {
+    const expectedSessionId = input.expectedSession.id;
+    return input.stationSessions.find((session) => session.id === expectedSessionId);
+  }
+
+  const worktreeSessions = input.stationSessions.filter(
+    (session) => session.projectId === input.projectId && session.worktreeId === input.worktreeId,
+  );
+  const canonicalOpenSession = worktreeSessions
+    .filter(
+      (session) =>
+        session.lifecycle === "open" &&
+        session.endedAt === undefined &&
+        session.harness !== undefined,
+    )
+    .sort(compareSessionRecency)[0];
+  if (canonicalOpenSession !== undefined) {
+    return canonicalOpenSession;
+  }
+
+  if (input.handle.sessionId !== undefined) {
+    const boundSessionId = input.handle.sessionId;
+    return input.stationSessions.find((session) => session.id === boundSessionId);
+  }
+  return undefined;
+}
+
+function compareSessionRecency(
+  left: SessionRecoveryStationSession,
+  right: SessionRecoveryStationSession,
+): number {
+  return (
+    Date.parse(right.lastSeenAt) - Date.parse(left.lastSeenAt) ||
+    Date.parse(right.createdAt) - Date.parse(left.createdAt) ||
+    right.id.localeCompare(left.id)
+  );
+}

--- a/apps/observer/test/integration/session-commands.test.ts
+++ b/apps/observer/test/integration/session-commands.test.ts
@@ -1651,31 +1651,15 @@ describe("session command vertical slice", () => {
         ],
       }),
     });
-    await fixture.persistence.persistReconcileResult({
-      worktrees: [
-        createFakeWorktree({
-          id: "wt_web_resume",
-          projectId: "web",
-          branch: "resume",
-          now,
-        }),
-      ],
-      terminalTargets: [],
-      harnessRuns: [
-        createFakeHarnessRun({
-          id: "run_previous",
-          projectId: "web",
-          worktreeId: "wt_web_resume",
-          sessionId: "ses_previous",
-          state: "idle",
-          now,
-        }),
-      ],
-      observedAt: now,
-    });
-    await fixture.persistence.markSessionsEnded({
-      subject: { kind: "session", sessionId: "ses_previous" },
-      endedAt: now,
+    await fixture.persistence.seedSession({
+      sessionId: "ses_previous",
+      projectId: "web",
+      worktreeId: "wt_web_resume",
+      initialTitle: "resume",
+      harness: "fake-harness",
+      terminalProvider: "fake-terminal",
+      createdAt: now,
+      lastSeenAt: now,
     });
     await fixture.core.reconcile("pre-import-resume");
     const importReceipt = await fixture.queue.dispatch({
@@ -1851,7 +1835,73 @@ describe("session command vertical slice", () => {
     fixture.sqlite.close();
   });
 
-  it("mints a fresh resume identity while preserving the canonical worktree title", async () => {
+  it("resumes an explicitly imported handle when no local session row exists", async () => {
+    const existing = createFakeWorktree({
+      id: "wt_web_imported_resume",
+      projectId: "web",
+      branch: "imported-resume",
+      now,
+    });
+    const harness = new CapturingHarnessProvider({ now });
+    const fixture = createFixture({
+      harness,
+      featureFlags: { sessionResumeAgent: true },
+      managedTerminal: persistentManagedTerminal(),
+      worktree: new FakeWorktreeProvider({ now, worktrees: [existing] }),
+    });
+    await fixture.core.reconcile("pre-imported-resume");
+    const imported = await fixture.queue.dispatch({
+      type: "session.importRecoveryHandle",
+      payload: {
+        projectId: "web",
+        worktreeId: existing.id,
+        expectedPath: existing.path,
+        handle: {
+          id: "rec_imported_resume",
+          provider: "fake-harness",
+          projectId: "web",
+          worktreeId: existing.id,
+          sessionId: "ses_imported_resume",
+          target: { kind: "native-session", id: "native_imported_resume" },
+          cwd: existing.path,
+          observedAt: now,
+          lastSeenAt: now,
+        },
+      },
+    });
+    await fixture.queue.drain();
+    await expect(fixture.persistence.getCommand(imported.commandId)).resolves.toMatchObject({
+      status: "succeeded",
+    });
+    const [handle] = await fixture.persistence.listSessionRecoveryHandles({
+      worktreeId: existing.id,
+    });
+    if (handle === undefined) throw new Error("Expected imported recovery handle.");
+
+    const resumed = await fixture.queue.dispatch({
+      type: "session.resumeAgent",
+      payload: {
+        projectId: "web",
+        worktreeId: existing.id,
+        recoveryHandleId: handle.id,
+      },
+    });
+    await fixture.queue.drain();
+
+    await expect(fixture.persistence.getCommand(resumed.commandId)).resolves.toMatchObject({
+      status: "succeeded",
+    });
+    expect(harness.lastBuildRequest).toMatchObject({
+      sessionId: "ses_imported_resume",
+      resume: { previousSessionId: "ses_imported_resume", recoveryHandleId: handle.id },
+    });
+    await expect(fixture.persistence.listSessions()).resolves.toContainEqual(
+      expect.objectContaining({ id: "ses_imported_resume", lifecycle: "open" }),
+    );
+    fixture.sqlite.close();
+  });
+
+  it("refuses to revive an ended local session from retained recovery evidence", async () => {
     const harness = new FakeHarnessProvider({ now });
     const terminal = new FakeTerminalProvider({
       now,
@@ -1872,7 +1922,6 @@ describe("session command vertical slice", () => {
       terminal,
       harness,
       featureFlags: { sessionResumeAgent: true },
-      sessionIds: ["ses_resume_fresh"],
       worktree: new FakeWorktreeProvider({
         now,
         worktrees: [
@@ -1910,6 +1959,7 @@ describe("session command vertical slice", () => {
       provider: "fake-harness",
       projectId: "web",
       worktreeId: "wt_web_resume_fresh",
+      sessionId: "ses_resume_history",
       target: { kind: "native-session", id: "native_resume_fresh" },
       cwd: "/tmp/station/web/resume-fresh",
       observedAt: now,
@@ -1929,19 +1979,204 @@ describe("session command vertical slice", () => {
     await fixture.queue.drain();
 
     await expect(fixture.persistence.getCommand(receipt.commandId)).resolves.toMatchObject({
-      status: "succeeded",
+      status: "failed",
+      error: { code: "SESSION_RECOVERY_HANDLE_MISMATCH" },
     });
+    expect(terminal.snapshot().launches).toEqual([]);
     expect(fixture.core.getSnapshot().rows[0]).toMatchObject({
       title: "Durable resumed workspace",
       branch: "resume-fresh",
-      agent: { sessionId: "ses_resume_fresh", state: "working" },
     });
-    expect(fixture.core.getSnapshot().sessions).toEqual([
+    expect(fixture.core.getSnapshot().rows[0]).not.toHaveProperty("recovery");
+    await expect(fixture.persistence.listSessions()).resolves.toContainEqual(
       expect.objectContaining({
-        id: "ses_resume_fresh",
-        title: "Durable resumed workspace",
+        id: "ses_resume_history",
+        lifecycle: "ended",
+        endedAt: now,
       }),
-    ]);
+    );
+    fixture.sqlite.close();
+  });
+
+  it("lets a queued close end the exact session after resume wins the worktree lane", async () => {
+    const existing = createFakeWorktree({
+      id: "wt_web_resume_then_close",
+      projectId: "web",
+      branch: "resume-then-close",
+      now,
+    });
+    const harness = new FakeHarnessProvider({ now });
+    let launchStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      launchStarted = resolve;
+    });
+    let finishLaunch!: () => void;
+    const launchGate = new Promise<void>((resolve) => {
+      finishLaunch = resolve;
+    });
+    const terminal = new FakeTerminalProvider({
+      now,
+      onLaunch: async ({ launchPlan }) => {
+        harness.addRun(
+          createFakeHarnessRun({
+            id: "run_resume_then_close",
+            projectId: "web",
+            worktreeId: existing.id,
+            sessionId: launchPlan.env?.STATION_SESSION_ID,
+            state: "working",
+            now,
+          }),
+        );
+        launchStarted();
+        await launchGate;
+      },
+    });
+    const fixture = createFixture({
+      worktree: new FakeWorktreeProvider({ now, worktrees: [existing] }),
+      terminal,
+      harness,
+      featureFlags: { sessionResumeAgent: true },
+    });
+    await fixture.persistence.seedSession({
+      sessionId: "ses_resume_then_close",
+      projectId: "web",
+      worktreeId: existing.id,
+      initialTitle: "Resume then close",
+      harness: "fake-harness",
+      terminalProvider: "fake-terminal",
+      createdAt: now,
+      lastSeenAt: now,
+    });
+    const handle = await fixture.persistence.upsertSessionRecoveryHandle({
+      id: "rec_resume_then_close",
+      provider: "fake-harness",
+      projectId: "web",
+      worktreeId: existing.id,
+      sessionId: "ses_resume_then_close",
+      target: { kind: "native-session", id: "native_resume_then_close" },
+      cwd: existing.path,
+      observedAt: now,
+      lastSeenAt: now,
+    });
+    await fixture.core.reconcile("pre-resume-then-close");
+
+    const resumed = await fixture.queue.dispatch({
+      type: "session.resumeAgent",
+      payload: {
+        projectId: "web",
+        worktreeId: existing.id,
+        recoveryHandleId: handle.id,
+      },
+    });
+    await started;
+    const closed = await fixture.queue.dispatch({
+      type: "session.close",
+      payload: { sessionId: "ses_resume_then_close", mode: "terminal", force: true },
+    });
+    finishLaunch();
+    await fixture.queue.drain();
+
+    await expect(fixture.persistence.getCommand(resumed.commandId)).resolves.toMatchObject({
+      status: "succeeded",
+    });
+    await expect(fixture.persistence.getCommand(closed.commandId)).resolves.toMatchObject({
+      status: "succeeded",
+    });
+    await expect(fixture.persistence.listSessions()).resolves.toContainEqual(
+      expect.objectContaining({ id: "ses_resume_then_close", lifecycle: "ended", endedAt: now }),
+    );
+    fixture.sqlite.close();
+  });
+
+  it("refuses resume after close wins the worktree lane", async () => {
+    const existing = createFakeWorktree({
+      id: "wt_web_close_then_resume",
+      projectId: "web",
+      branch: "close-then-resume",
+      now,
+    });
+    let closeStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      closeStarted = resolve;
+    });
+    let finishClose!: () => void;
+    const closeGate = new Promise<void>((resolve) => {
+      finishClose = resolve;
+    });
+    class BlockingCloseTerminal extends FakeTerminalProvider {
+      override async closeTarget(targetId: Parameters<FakeTerminalProvider["closeTarget"]>[0]) {
+        closeStarted();
+        await closeGate;
+        return super.closeTarget(targetId);
+      }
+    }
+    const terminal = new BlockingCloseTerminal({
+      now,
+      targets: [
+        createFakeTerminalTarget({
+          id: "term_close_then_resume",
+          projectId: "web",
+          worktreeId: existing.id,
+          sessionId: "ses_close_then_resume",
+          now,
+        }),
+      ],
+    });
+    const fixture = createFixture({
+      worktree: new FakeWorktreeProvider({ now, worktrees: [existing] }),
+      terminal,
+      featureFlags: { sessionResumeAgent: true },
+    });
+    await fixture.persistence.seedSession({
+      sessionId: "ses_close_then_resume",
+      projectId: "web",
+      worktreeId: existing.id,
+      initialTitle: "Close then resume",
+      harness: "fake-harness",
+      terminalProvider: "fake-terminal",
+      createdAt: now,
+      lastSeenAt: now,
+    });
+    const handle = await fixture.persistence.upsertSessionRecoveryHandle({
+      id: "rec_close_then_resume",
+      provider: "fake-harness",
+      projectId: "web",
+      worktreeId: existing.id,
+      sessionId: "ses_close_then_resume",
+      target: { kind: "native-session", id: "native_close_then_resume" },
+      cwd: existing.path,
+      observedAt: now,
+      lastSeenAt: now,
+    });
+    await fixture.core.reconcile("pre-close-then-resume");
+
+    const closed = await fixture.queue.dispatch({
+      type: "session.close",
+      payload: { sessionId: "ses_close_then_resume", mode: "terminal" },
+    });
+    await started;
+    const resumed = await fixture.queue.dispatch({
+      type: "session.resumeAgent",
+      payload: {
+        projectId: "web",
+        worktreeId: existing.id,
+        recoveryHandleId: handle.id,
+      },
+    });
+    finishClose();
+    await fixture.queue.drain();
+
+    await expect(fixture.persistence.getCommand(closed.commandId)).resolves.toMatchObject({
+      status: "succeeded",
+    });
+    await expect(fixture.persistence.getCommand(resumed.commandId)).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "SESSION_RECOVERY_HANDLE_MISMATCH" },
+    });
+    expect(terminal.snapshot().launches).toEqual([]);
+    await expect(fixture.persistence.listSessions()).resolves.toContainEqual(
+      expect.objectContaining({ id: "ses_close_then_resume", lifecycle: "ended", endedAt: now }),
+    );
     fixture.sqlite.close();
   });
 

--- a/apps/observer/test/integration/session-commands.test.ts
+++ b/apps/observer/test/integration/session-commands.test.ts
@@ -1752,6 +1752,78 @@ describe("session command vertical slice", () => {
     fixture.sqlite.close();
   });
 
+  it("preserves retained session metadata when provider-native resume launch fails", async () => {
+    const existing = createFakeWorktree({
+      id: "wt_web_resume_failure",
+      projectId: "web",
+      branch: "resume-failure",
+      now,
+    });
+    const terminal = new FakeTerminalProvider({ now });
+    const harness = new FakeHarnessProvider({
+      now,
+      failures: {
+        buildLaunch: {
+          tag: "HarnessProviderError",
+          code: "FAKE_HARNESS_BUILD_FAILED",
+          message: "The fake harness provider could not build a resume launch plan.",
+          provider: "fake-harness",
+        },
+      },
+    });
+    const fixture = createFixture({
+      worktree: new FakeWorktreeProvider({ now, worktrees: [existing] }),
+      terminal,
+      harness,
+      featureFlags: { sessionResumeAgent: true },
+    });
+    await fixture.persistence.seedSession({
+      sessionId: "ses_resume_failure",
+      projectId: "web",
+      worktreeId: existing.id,
+      initialTitle: "Retained recovery title",
+      harness: "fake-harness",
+      terminalProvider: "prior-terminal",
+      createdAt: "2026-08-08T10:00:00.000Z",
+      lastSeenAt: "2026-08-08T11:00:00.000Z",
+    });
+    const handle = await fixture.persistence.upsertSessionRecoveryHandle({
+      id: "rec_resume_failure",
+      provider: "fake-harness",
+      projectId: "web",
+      worktreeId: existing.id,
+      sessionId: "ses_resume_failure",
+      target: { kind: "native-session", id: "native_resume_failure" },
+      cwd: existing.path,
+      observedAt: now,
+      lastSeenAt: now,
+    });
+    await fixture.core.reconcile("pre-resume-failure");
+    const sessionsBefore = await fixture.persistence.listSessions();
+
+    const receipt = await fixture.queue.dispatch({
+      type: "session.resumeAgent",
+      payload: {
+        projectId: "web",
+        worktreeId: existing.id,
+        recoveryHandleId: handle.id,
+        terminal: { provider: "fake-terminal" },
+      },
+    });
+    await fixture.queue.drain();
+
+    await expect(fixture.persistence.getCommand(receipt.commandId)).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "FAKE_HARNESS_BUILD_FAILED", provider: "fake-harness" },
+    });
+    await expect(fixture.persistence.listSessions()).resolves.toEqual(sessionsBefore);
+    expect(terminal.snapshot().closed).toEqual(["term_fake"]);
+    await expect(
+      fixture.persistence.listSessionRecoveryHandles({ worktreeId: existing.id }),
+    ).resolves.toEqual([handle]);
+    fixture.sqlite.close();
+  });
+
   it("fails session.resumeAgent before reopening or terminal mutation", async () => {
     const existing = createFakeWorktree({
       id: "wt_web_resume_gate",

--- a/apps/observer/test/support/inMemoryObserverPersistence.ts
+++ b/apps/observer/test/support/inMemoryObserverPersistence.ts
@@ -1165,8 +1165,15 @@ function upsertSessionRecoveryHandle(
     return handle;
   }
 
-  existing.projectId = handle.projectId;
-  existing.worktreeId = handle.worktreeId;
+  if (
+    existing.projectId !== handle.projectId ||
+    existing.worktreeId !== handle.worktreeId ||
+    (existing.sessionId !== undefined &&
+      handle.sessionId !== undefined &&
+      existing.sessionId !== handle.sessionId)
+  ) {
+    throw new Error(`Session recovery handle ${handle.id} has conflicting Station identity.`);
+  }
   if (handle.sessionId !== undefined) existing.sessionId = handle.sessionId;
   if (handle.cwd !== undefined) existing.cwd = handle.cwd;
   if (handle.terminalTargetId !== undefined) existing.terminalTargetId = handle.terminalTargetId;

--- a/apps/observer/test/support/observerPersistenceContract.ts
+++ b/apps/observer/test/support/observerPersistenceContract.ts
@@ -1946,6 +1946,14 @@ export function observerPersistenceContract(
           ).resolves.toEqual(imported);
           await expect(persistence.listSessionRecoveryHandles()).resolves.toEqual([imported]);
 
+          await expectPersistenceFailure(
+            persistence.importSessionRecoveryHandle({
+              handle: { ...handle, sessionId: "ses_conflicting_import" },
+              title: "Must roll back identity conflict",
+              importedAt: latest,
+            }),
+          );
+
           const invalidHandle = {
             ...handle,
             target: { kind: "native-session", id: "" },
@@ -2164,14 +2172,13 @@ export function observerPersistenceContract(
         });
       });
 
-      it("keeps stable recovery identity, merges optional correlation, and filters handles", async () => {
+      it("fills recovery session identity once, rejects conflicts atomically, and refreshes evidence", async () => {
         await withPersistence(createFixture, async ({ persistence }) => {
           const firstInput: SessionRecoveryHandle = {
             id: "report_first",
             provider: "codex",
             projectId: "web",
             worktreeId: "wt_recovery",
-            sessionId: "ses_recovery",
             target: { kind: "native-session", id: "native_123" },
             cwd: "/tmp/station/web/recovery",
             terminalTargetId: "term_recovery",
@@ -2185,7 +2192,11 @@ export function observerPersistenceContract(
             provider: "codex",
             projectId: "web",
             worktreeId: "wt_recovery",
+            sessionId: "ses_recovery",
             target: { kind: "native-session", id: "native_123" },
+            cwd: "/tmp/station/web/recovery-refreshed",
+            terminalTargetId: "term_recovery_refreshed",
+            harnessRunId: "run_recovery_refreshed",
             observedAt: earlier,
             lastSeenAt: later,
           });
@@ -2198,9 +2209,9 @@ export function observerPersistenceContract(
             worktreeId: "wt_recovery",
             sessionId: "ses_recovery",
             target: { kind: "native-session", id: "native_123" },
-            cwd: "/tmp/station/web/recovery",
-            terminalTargetId: "term_recovery",
-            harnessRunId: "run_recovery",
+            cwd: "/tmp/station/web/recovery-refreshed",
+            terminalTargetId: "term_recovery_refreshed",
+            harnessRunId: "run_recovery_refreshed",
             observedAt: earlier,
             lastSeenAt: later,
           });
@@ -2208,6 +2219,22 @@ export function observerPersistenceContract(
           await expect(
             persistence.getSessionRecoveryHandle("rec_missing"),
           ).resolves.toBeUndefined();
+
+          for (const conflictingIdentity of [
+            { projectId: "other", worktreeId: "wt_recovery", sessionId: "ses_recovery" },
+            { projectId: "web", worktreeId: "wt_other", sessionId: "ses_recovery" },
+            { projectId: "web", worktreeId: "wt_recovery", sessionId: "ses_other" },
+          ]) {
+            await expectPersistenceFailure(
+              persistence.upsertSessionRecoveryHandle({
+                ...merged,
+                ...conflictingIdentity,
+                cwd: "/tmp/station/must-not-commit",
+                lastSeenAt: latest,
+              }),
+            );
+            await expect(persistence.getSessionRecoveryHandle(first.id)).resolves.toEqual(merged);
+          }
 
           const other = await persistence.upsertSessionRecoveryHandle({
             id: "report_other",

--- a/apps/observer/test/unit/external-launch.test.ts
+++ b/apps/observer/test/unit/external-launch.test.ts
@@ -844,6 +844,13 @@ describe("prepareExternalLaunch", () => {
       renamedAt: now,
     });
     const persistedHandle = await persistence.upsertSessionRecoveryHandle(recoveryHandle());
+    const ineligibleHandle = await persistence.upsertSessionRecoveryHandle(
+      recoveryHandle({
+        id: "rec_wrong_session",
+        sessionId: "ses_other",
+        target: { kind: "native-session", id: "native_wrong_session" },
+      }),
+    );
     const harness = new CapturingHarness({ id: "fake-harness", now: () => new Date(now) });
     const station = new FakeManagedTerminalLifecycle();
 
@@ -876,7 +883,92 @@ describe("prepareExternalLaunch", () => {
     await expect(persistence.listSessions()).resolves.toEqual([
       expect.objectContaining({ id: "ses_recoverable", title: "Canonical recovered title" }),
     ]);
-    await expect(persistence.listSessionRecoveryHandles()).resolves.toEqual([persistedHandle]);
+    const retainedHandles = await persistence.listSessionRecoveryHandles();
+    expect(retainedHandles).toHaveLength(2);
+    expect(retainedHandles).toEqual(expect.arrayContaining([persistedHandle, ineligibleHandle]));
+  });
+
+  it("keeps multiple eligible recovery handles ambiguous before terminal mutation", async () => {
+    const persistence = createInMemoryObserverPersistence({
+      clock: { now: () => new Date(now) },
+    });
+    await persistence.seedSession({
+      sessionId: "ses_recoverable",
+      projectId: "web",
+      worktreeId: "wt_web_feature",
+      initialTitle: "Readable login task",
+      harness: "fake-harness",
+      terminalProvider: "fake-terminal",
+      createdAt: now,
+      lastSeenAt: now,
+    });
+    await persistence.upsertSessionRecoveryHandle(recoveryHandle());
+    await persistence.upsertSessionRecoveryHandle(
+      recoveryHandle({
+        id: "rec_other",
+        target: { kind: "native-session", id: "native_other" },
+      }),
+    );
+    const station = new FakeManagedTerminalLifecycle();
+
+    await expect(
+      prepareExternalLaunch(
+        deps([row()], station, undefined, persistence, {
+          sessions: [retainedSession()],
+          sessionResumeAgentEnabled: true,
+        }),
+        prepareParams,
+      ),
+    ).rejects.toMatchObject({ code: "SESSION_RECOVERY_HANDLE_AMBIGUOUS" });
+    expect(await station.listTargets()).toEqual([]);
+  });
+
+  it.each([
+    "ended",
+    "mismatched",
+    "unsupported",
+  ] as const)("rejects %s recovery evidence before terminal mutation", async (scenario) => {
+    const persistence = createInMemoryObserverPersistence({
+      clock: { now: () => new Date(now) },
+    });
+    await persistence.seedSession({
+      sessionId: "ses_recoverable",
+      projectId: "web",
+      worktreeId: "wt_web_feature",
+      initialTitle: "Readable login task",
+      harness: "fake-harness",
+      terminalProvider: "fake-terminal",
+      createdAt: now,
+      lastSeenAt: now,
+    });
+    if (scenario === "ended") {
+      await persistence.markSessionsEnded({
+        subject: { kind: "session", sessionId: "ses_recoverable" },
+        endedAt: now,
+      });
+    }
+    await persistence.upsertSessionRecoveryHandle(
+      recoveryHandle({
+        ...(scenario === "mismatched" ? { sessionId: "ses_other" } : {}),
+      }),
+    );
+    const harness = new FakeHarnessProvider({
+      id: "fake-harness",
+      now: () => new Date(now),
+      ...(scenario === "unsupported" ? { capabilities: { canResume: false } } : {}),
+    });
+    const station = new FakeManagedTerminalLifecycle();
+
+    await expect(
+      prepareExternalLaunch(
+        deps([row()], station, [harness], persistence, {
+          sessions: [retainedSession()],
+          sessionResumeAgentEnabled: true,
+        }),
+        prepareParams,
+      ),
+    ).rejects.toMatchObject({ code: "SESSION_RECOVERY_HANDLE_NOT_FOUND" });
+    expect(await station.listTargets()).toEqual([]);
   });
 
   it("starts fresh under explicit retained-session consent and retires old recovery identity", async () => {

--- a/apps/observer/test/unit/graph.test.ts
+++ b/apps/observer/test/unit/graph.test.ts
@@ -1,8 +1,11 @@
 import type {
+  ClientFeatureFlags,
+  HarnessCapabilities,
   HarnessRunObservation,
   ProviderHealth,
   ProviderProjectConfig,
   SessionGroupView,
+  SessionRecoveryHandle,
   TerminalTargetObservation,
   WorktreeObservation,
 } from "@station/contracts";
@@ -157,6 +160,9 @@ function build(overrides: {
   worktreeDisplayTitles?: ObserverWorktreeDisplayTitle[];
   turnReadiness?: ObserverTurnReadiness[];
   providerHealth?: Record<string, ProviderHealth>;
+  recoveryHandles?: SessionRecoveryHandle[];
+  harnessCapabilities?: Record<string, HarnessCapabilities>;
+  featureFlags?: ClientFeatureFlags;
 }) {
   return buildStationSnapshot({
     generatedAt,
@@ -172,10 +178,152 @@ function build(overrides: {
     sessionMetadata: overrides.sessionMetadata ?? [],
     worktreeDisplayTitles: overrides.worktreeDisplayTitles ?? [],
     turnReadiness: overrides.turnReadiness ?? [],
+    recoveryHandles: overrides.recoveryHandles ?? [],
+    harnessCapabilities: overrides.harnessCapabilities ?? {},
+    ...(overrides.featureFlags === undefined ? {} : { featureFlags: overrides.featureFlags }),
   });
 }
 
+const resumableHarnessCapabilities: HarnessCapabilities = {
+  canLaunch: true,
+  canDiscoverRuns: true,
+  canEmitEvents: true,
+  canReceivePrompt: false,
+  canResume: true,
+  canStop: true,
+  canRunNonInteractive: true,
+  canExposeApprovalState: false,
+  supportsModifiedEnterSoftNewline: false,
+};
+
+const recoveryFeatureFlags: ClientFeatureFlags = {
+  revision: "recovery-enabled",
+  flags: { sessionResumeAgent: true },
+};
+
+function recoveryHandle(
+  worktree: WorktreeObservation,
+  overrides: Partial<SessionRecoveryHandle> = {},
+): SessionRecoveryHandle {
+  return {
+    id: "rec_graph",
+    provider: "fake-harness",
+    projectId: worktree.projectId,
+    worktreeId: worktree.id,
+    sessionId: `ses_${worktree.id}`,
+    target: { kind: "native-session", id: "native_graph" },
+    cwd: worktree.path,
+    observedAt: generatedAt,
+    lastSeenAt: generatedAt,
+    ...overrides,
+  };
+}
+
+function recoverySession(
+  worktree: WorktreeObservation,
+  overrides: Partial<ObserverSessionMetadata> = {},
+): ObserverSessionMetadata {
+  return {
+    id: `ses_${worktree.id}`,
+    projectId: worktree.projectId,
+    worktreeId: worktree.id,
+    lifecycle: "open",
+    harness: "fake-harness",
+    createdAt: generatedAt,
+    lastSeenAt: generatedAt,
+    ...overrides,
+  };
+}
+
 describe("observer graph derivation", () => {
+  it("projects recovery only for one exact eligible open-session handle", () => {
+    const recoverable = worktree("wt_web_recoverable", "web", "recoverable");
+    const valid = recoveryHandle(recoverable);
+    const wrongSession = recoveryHandle(recoverable, {
+      id: "rec_wrong_session",
+      sessionId: "ses_other",
+      target: { kind: "native-session", id: "native_wrong_session" },
+    });
+    const snapshot = build({
+      worktrees: [recoverable],
+      recoveryHandles: [valid, wrongSession],
+      sessionMetadata: [recoverySession(recoverable)],
+      harnessCapabilities: { "fake-harness": resumableHarnessCapabilities },
+      featureFlags: recoveryFeatureFlags,
+    });
+
+    expect(snapshot.rows[0]?.recovery).toEqual({
+      kind: "agent-resume",
+      handleId: valid.id,
+      provider: "fake-harness",
+      targetKind: "native-session",
+      sessionId: valid.sessionId,
+      lastSeenAt: generatedAt,
+    });
+  });
+
+  it.each([
+    [
+      "ended lifecycle",
+      (worktree: WorktreeObservation) => ({
+        sessionMetadata: [recoverySession(worktree, { lifecycle: "ended", endedAt: generatedAt })],
+        recoveryHandles: [recoveryHandle(worktree)],
+        harnessCapabilities: { "fake-harness": resumableHarnessCapabilities },
+      }),
+    ],
+    [
+      "mismatched session identity",
+      (worktree: WorktreeObservation) => ({
+        sessionMetadata: [recoverySession(worktree)],
+        recoveryHandles: [recoveryHandle(worktree, { sessionId: "ses_other" })],
+        harnessCapabilities: { "fake-harness": resumableHarnessCapabilities },
+      }),
+    ],
+    [
+      "unsupported harness",
+      (worktree: WorktreeObservation) => ({
+        sessionMetadata: [recoverySession(worktree)],
+        recoveryHandles: [recoveryHandle(worktree)],
+        harnessCapabilities: {
+          "fake-harness": { ...resumableHarnessCapabilities, canResume: false },
+        },
+      }),
+    ],
+    [
+      "outside cwd",
+      (worktree: WorktreeObservation) => ({
+        sessionMetadata: [recoverySession(worktree)],
+        recoveryHandles: [recoveryHandle(worktree, { cwd: "/tmp/station/other" })],
+        harnessCapabilities: { "fake-harness": resumableHarnessCapabilities },
+      }),
+    ],
+  ] as const)("does not project recovery for %s", (_name, scenario) => {
+    const candidate = worktree("wt_web_ineligible", "web", "ineligible");
+    const snapshot = build({
+      worktrees: [candidate],
+      ...scenario(candidate),
+      featureFlags: recoveryFeatureFlags,
+    });
+
+    expect(snapshot.rows[0]).not.toHaveProperty("recovery");
+  });
+
+  it("projects an imported handle when no local lifecycle row exists", () => {
+    const imported = worktree("wt_web_imported", "web", "imported");
+    const handle = recoveryHandle(imported, { sessionId: "ses_imported" });
+    const snapshot = build({
+      worktrees: [imported],
+      recoveryHandles: [handle],
+      harnessCapabilities: { "fake-harness": resumableHarnessCapabilities },
+      featureFlags: recoveryFeatureFlags,
+    });
+
+    expect(snapshot.rows[0]?.recovery).toMatchObject({
+      handleId: handle.id,
+      sessionId: "ses_imported",
+    });
+  });
+
   it("projects configured Groups in deterministic parent-first order from canonical sessions", () => {
     const web = worktree("wt_web_group", "web", "group");
     const api = worktree("wt_api_group", "api", "group");

--- a/apps/observer/test/unit/sessionRecovery.test.ts
+++ b/apps/observer/test/unit/sessionRecovery.test.ts
@@ -48,11 +48,30 @@ async function resolveRecovery(
     harnesses?: HarnessProvider[];
     recoveryHandleId?: string;
     expected?: { sessionId: string; provider: string };
+    localSession?: "open" | "ended" | "none";
   } = {},
 ) {
   const persistence = createInMemoryObserverPersistence({
     clock: { now: () => new Date(now) },
   });
+  if (options.localSession !== "none") {
+    await persistence.seedSession({
+      sessionId: "ses_feature",
+      projectId: "web",
+      worktreeId: worktree.id,
+      initialTitle: "feature",
+      harness: "fake-harness",
+      terminalProvider: "fake-terminal",
+      createdAt: now,
+      lastSeenAt: now,
+    });
+    if (options.localSession === "ended") {
+      await persistence.markSessionsEnded({
+        subject: { kind: "session", sessionId: "ses_feature" },
+        endedAt: now,
+      });
+    }
+  }
   const persistedIds = new Map<string, string>();
   for (const handle of options.handles ?? []) {
     const persisted = await persistence.upsertSessionRecoveryHandle(handle);
@@ -104,19 +123,17 @@ describe("resolveSessionRecovery", () => {
     });
   });
 
-  it("omits previousSessionId when the selected handle has no Station identity", async () => {
+  it("rejects a selected handle with no Station identity", async () => {
     const handle = recoveryHandle();
     delete handle.sessionId;
 
-    const result = await resolveRecovery({
-      handles: [handle],
-      recoveryHandleId: handle.id,
-    });
-
-    expect(result.resume).toEqual({
-      target: handle.target,
-      recoveryHandleId: result.handle.id,
-    });
+    await expect(
+      resolveRecovery({
+        handles: [handle],
+        recoveryHandleId: handle.id,
+        localSession: "none",
+      }),
+    ).rejects.toMatchObject({ code: "SESSION_RECOVERY_HANDLE_MISMATCH" });
   });
 
   it("rejects missing and cross-worktree selected handles", async () => {
@@ -178,9 +195,14 @@ describe("resolveSessionRecovery", () => {
       provider: "unregistered-harness",
       target: { kind: "native-session", id: "native_unregistered" },
     });
+    const wrongSession = recoveryHandle({
+      id: "rec_wrong_session",
+      sessionId: "ses_other",
+      target: { kind: "native-session", id: "native_wrong_session" },
+    });
 
     const result = await resolveRecovery({
-      handles: [selected, disabled, unregistered],
+      handles: [selected, disabled, unregistered, wrongSession],
       harnesses: [
         new FakeHarnessProvider({ id: "fake-harness", now }),
         new FakeHarnessProvider({
@@ -224,36 +246,56 @@ describe("resolveSessionRecovery", () => {
     const missingSession = recoveryHandle();
     delete missingSession.sessionId;
     await expect(resolveRecovery({ handles: [missingSession], expected })).rejects.toMatchObject({
-      code: "SESSION_RECOVERY_HANDLE_MISMATCH",
+      code: "SESSION_RECOVERY_HANDLE_NOT_FOUND",
     });
     await expect(
       resolveRecovery({ handles: [recoveryHandle({ sessionId: "ses_other" })], expected }),
-    ).rejects.toMatchObject({ code: "SESSION_RECOVERY_HANDLE_MISMATCH" });
+    ).rejects.toMatchObject({ code: "SESSION_RECOVERY_HANDLE_NOT_FOUND" });
     await expect(
       resolveRecovery({
         handles: [recoveryHandle({ provider: "other-harness" })],
         harnesses: [new FakeHarnessProvider({ id: "other-harness", now })],
         expected,
       }),
-    ).rejects.toMatchObject({ code: "SESSION_RECOVERY_HANDLE_MISMATCH" });
+    ).rejects.toMatchObject({ code: "SESSION_RECOVERY_HANDLE_NOT_FOUND" });
   });
 
-  it("accepts absent or nested cwd and rejects recovery outside the worktree", async () => {
+  it("requires present cwd evidence inside the current worktree", async () => {
     const withoutCwd = recoveryHandle();
     delete withoutCwd.cwd;
-    const withoutCwdResult = await resolveRecovery({ handles: [withoutCwd] });
-    expect(withoutCwdResult.handle).not.toHaveProperty("cwd");
     await expect(
-      resolveRecovery({
-        handles: [withoutCwd],
-        expected: { sessionId: "ses_feature", provider: "fake-harness" },
-      }),
+      resolveRecovery({ handles: [withoutCwd], recoveryHandleId: withoutCwd.id }),
     ).rejects.toMatchObject({ code: "SESSION_RECOVERY_CWD_MISMATCH" });
     await expect(
       resolveRecovery({ handles: [recoveryHandle({ cwd: `${worktree.path}/nested` })] }),
     ).resolves.toMatchObject({ handle: { cwd: `${worktree.path}/nested` } });
     await expect(
       resolveRecovery({ handles: [recoveryHandle({ cwd: "/tmp/station/other" })] }),
-    ).rejects.toMatchObject({ code: "SESSION_RECOVERY_CWD_MISMATCH" });
+    ).rejects.toMatchObject({ code: "SESSION_RECOVERY_HANDLE_NOT_FOUND" });
+  });
+
+  it("rejects a selected handle bound to a locally ended session", async () => {
+    const selected = recoveryHandle();
+    await expect(
+      resolveRecovery({
+        handles: [selected],
+        recoveryHandleId: selected.id,
+        localSession: "ended",
+      }),
+    ).rejects.toMatchObject({ code: "SESSION_RECOVERY_HANDLE_MISMATCH" });
+  });
+
+  it("retains explicit imported-handle compatibility when no local session exists", async () => {
+    const selected = recoveryHandle();
+    await expect(
+      resolveRecovery({
+        handles: [selected],
+        recoveryHandleId: selected.id,
+        localSession: "none",
+      }),
+    ).resolves.toMatchObject({
+      handle: { sessionId: "ses_feature" },
+      resume: { previousSessionId: "ses_feature" },
+    });
   });
 });

--- a/apps/observer/test/unit/sessionRecoveryEligibility.test.ts
+++ b/apps/observer/test/unit/sessionRecoveryEligibility.test.ts
@@ -1,0 +1,161 @@
+import type { SessionRecoveryHandle } from "@station/contracts";
+import { describe, expect, it } from "vitest";
+import {
+  type SessionRecoveryEligibilityInput,
+  type SessionRecoveryStationSession,
+  sessionRecoveryEligibility,
+} from "../../src/sessionRecoveryEligibility";
+
+const now = "2026-08-20T12:00:00.000Z";
+const worktreePath = "/tmp/station/web/feature";
+
+function handle(overrides: Partial<SessionRecoveryHandle> = {}): SessionRecoveryHandle {
+  return {
+    id: "rec_feature",
+    provider: "fake-harness",
+    projectId: "web",
+    worktreeId: "wt_feature",
+    sessionId: "ses_feature",
+    target: { kind: "native-session", id: "native_feature" },
+    cwd: worktreePath,
+    observedAt: now,
+    lastSeenAt: now,
+    ...overrides,
+  };
+}
+
+function session(
+  overrides: Partial<SessionRecoveryStationSession> = {},
+): SessionRecoveryStationSession {
+  return {
+    id: "ses_feature",
+    projectId: "web",
+    worktreeId: "wt_feature",
+    lifecycle: "open",
+    harness: "fake-harness",
+    createdAt: now,
+    lastSeenAt: now,
+    ...overrides,
+  };
+}
+
+function input(
+  overrides: Partial<SessionRecoveryEligibilityInput> = {},
+): SessionRecoveryEligibilityInput {
+  return {
+    handle: handle(),
+    projectId: "web",
+    worktreeId: "wt_feature",
+    worktreePath,
+    stationSessions: [session()],
+    expectedSession: { id: "ses_feature", harness: "fake-harness" },
+    allowNoLocalSession: false,
+    registeredHarness: { id: "fake-harness", canResume: true },
+    ...overrides,
+  };
+}
+
+describe("sessionRecoveryEligibility", () => {
+  it("returns provider-neutral resume authority for one exact open Station session", () => {
+    expect(sessionRecoveryEligibility(input())).toEqual({
+      kind: "eligible",
+      stationSession: session(),
+      resume: {
+        target: { kind: "native-session", id: "native_feature" },
+        previousSessionId: "ses_feature",
+        recoveryHandleId: "rec_feature",
+      },
+    });
+  });
+
+  it("allows an explicitly selected imported handle only when its local lifecycle row is absent", () => {
+    const imported = input({
+      stationSessions: [
+        session({
+          id: "ses_unrelated",
+          lifecycle: "ended",
+          endedAt: now,
+        }),
+      ],
+      expectedSession: undefined,
+      allowNoLocalSession: true,
+    });
+    expect(sessionRecoveryEligibility(imported)).toMatchObject({
+      kind: "eligible",
+      resume: { previousSessionId: "ses_feature" },
+    });
+    expect(sessionRecoveryEligibility({ ...imported, allowNoLocalSession: false })).toEqual({
+      kind: "ineligible",
+      reason: "station_session_missing",
+    });
+  });
+
+  it.each([
+    ["project identity", input({ handle: handle({ projectId: "other" }) }), "project_mismatch"],
+    [
+      "worktree identity",
+      input({ handle: handle({ worktreeId: "wt_other" }) }),
+      "worktree_mismatch",
+    ],
+    [
+      "missing Station identity",
+      input({ handle: handle({ sessionId: undefined }) }),
+      "station_session_missing",
+    ],
+    [
+      "different Station identity",
+      input({ handle: handle({ sessionId: "ses_other" }) }),
+      "station_session_mismatch",
+    ],
+    [
+      "legacy lifecycle",
+      input({ stationSessions: [session({ lifecycle: "legacy" })] }),
+      "station_session_legacy",
+    ],
+    [
+      "ended lifecycle",
+      input({ stationSessions: [session({ lifecycle: "ended", endedAt: now })] }),
+      "station_session_ended",
+    ],
+    [
+      "harness identity",
+      input({
+        handle: handle({ provider: "other-harness" }),
+        registeredHarness: { id: "other-harness", canResume: true },
+      }),
+      "harness_mismatch",
+    ],
+    ["missing provider", input({ registeredHarness: undefined }), "harness_provider_missing"],
+    [
+      "resume capability",
+      input({ registeredHarness: { id: "fake-harness", canResume: false } }),
+      "harness_resume_unsupported",
+    ],
+    ["missing cwd", input({ handle: handle({ cwd: undefined }) }), "cwd_missing"],
+    [
+      "outside cwd",
+      input({ handle: handle({ cwd: "/tmp/station/other" }) }),
+      "cwd_outside_worktree",
+    ],
+  ] as const)("rejects mismatched %s with a stable reason", (_name, policyInput, reason) => {
+    expect(sessionRecoveryEligibility(policyInput)).toEqual({ kind: "ineligible", reason });
+  });
+
+  it("uses the newest open worktree session as canonical identity", () => {
+    const older = session({ id: "ses_older", lastSeenAt: "2026-08-20T11:00:00.000Z" });
+    const newer = session({ id: "ses_newer", lastSeenAt: "2026-08-20T13:00:00.000Z" });
+    const policyInput = input({
+      handle: handle({ sessionId: newer.id }),
+      stationSessions: [older, newer],
+      expectedSession: undefined,
+    });
+
+    expect(sessionRecoveryEligibility(policyInput)).toMatchObject({
+      kind: "eligible",
+      stationSession: { id: newer.id },
+    });
+    expect(
+      sessionRecoveryEligibility({ ...policyInput, handle: handle({ sessionId: older.id }) }),
+    ).toEqual({ kind: "ineligible", reason: "station_session_mismatch" });
+  });
+});

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -1731,7 +1731,7 @@
           "name": "createSessionResumeAgentHandler",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Requires the selected worktree in the current Observer snapshot, then validates and preflights provider-native recovery, reusing a handle's Station identity or minting one when absent. Automatic native activation recovery is owned separately by external launch. Failed cleanup discards only a newly minted projection."
+          "purpose": "Serializes recovery with close for one worktree, binds to its canonical open Station session when present, then validates and preflights provider-native resume. Explicit imported handles may seed their absent session identity; ended or contradictory local lifecycle is never reopened. Failed cleanup discards only a session seeded by this command."
         },
         {
           "name": "CreateSessionResumeAgentHandlerOptions",
@@ -1852,6 +1852,18 @@
           "resolvedPath": "apps/observer/src/utils/time.ts",
           "edgeKind": "runtime",
           "bindings": ["nowIso"]
+        },
+        {
+          "specifier": "../../worktreeMutationCoordinator.js",
+          "resolvedPath": "apps/observer/src/worktreeMutationCoordinator.ts",
+          "edgeKind": "runtime",
+          "bindings": ["createWorktreeMutationCoordinator"]
+        },
+        {
+          "specifier": "../../worktreeMutationCoordinator.js",
+          "resolvedPath": "apps/observer/src/worktreeMutationCoordinator.ts",
+          "edgeKind": "type-only",
+          "bindings": ["WorktreeMutationCoordinator"]
         },
         {
           "specifier": "@station/contracts",
@@ -5284,7 +5296,7 @@
           "name": "SessionStore",
           "kind": "interface",
           "role": "DRIVEN PORT",
-          "purpose": "Admits Observer-owned sessions with selected provider identity and maintains their lifecycle, native execution bindings, canonical worktree-scoped titles, recovery, and readiness. Seed, explicit root Group placement or current source-Group inheritance, and provenance-safe discard are one atomic conversation; canonical-title handoff and recovery import also commit before recovery reconciles."
+          "purpose": "Admits Observer-owned sessions with selected provider identity and maintains their lifecycle, native execution bindings, canonical worktree-scoped titles, recovery, and readiness. Seed, explicit root Group placement or current source-Group inheritance, and provenance-safe discard are one atomic conversation; canonical-title handoff and recovery import also commit before recovery reconciles. Provider-native recovery keys permanently bind project and worktree, may fill Station session identity once, and reject contradictory identity before mutable evidence can refresh."
         },
         {
           "name": "SessionTurnReadinessMutation",
@@ -7331,7 +7343,7 @@
           "name": "SessionStore",
           "kind": "interface",
           "role": "DRIVEN PORT",
-          "purpose": "Admits Observer-owned sessions with selected provider identity and maintains their lifecycle, native execution bindings, canonical worktree-scoped titles, recovery, and readiness. Seed, explicit root Group placement or current source-Group inheritance, and provenance-safe discard are one atomic conversation; canonical-title handoff and recovery import also commit before recovery reconciles."
+          "purpose": "Admits Observer-owned sessions with selected provider identity and maintains their lifecycle, native execution bindings, canonical worktree-scoped titles, recovery, and readiness. Seed, explicit root Group placement or current source-Group inheritance, and provenance-safe discard are one atomic conversation; canonical-title handoff and recovery import also commit before recovery reconciles. Provider-native recovery keys permanently bind project and worktree, may fill Station session identity once, and reject contradictory identity before mutable evidence can refresh."
         },
         {
           "name": "SessionTurnReadinessMutation",
@@ -7634,7 +7646,7 @@
           "name": "SessionStore",
           "kind": "interface",
           "role": "DRIVEN PORT",
-          "purpose": "Admits Observer-owned sessions with selected provider identity and maintains their lifecycle, native execution bindings, canonical worktree-scoped titles, recovery, and readiness. Seed, explicit root Group placement or current source-Group inheritance, and provenance-safe discard are one atomic conversation; canonical-title handoff and recovery import also commit before recovery reconciles."
+          "purpose": "Admits Observer-owned sessions with selected provider identity and maintains their lifecycle, native execution bindings, canonical worktree-scoped titles, recovery, and readiness. Seed, explicit root Group placement or current source-Group inheritance, and provenance-safe discard are one atomic conversation; canonical-title handoff and recovery import also commit before recovery reconciles. Provider-native recovery keys permanently bind project and worktree, may fill Station session identity once, and reject contradictory identity before mutable evidence can refresh."
         },
         {
           "name": "WorktreeMetadataStore",
@@ -9181,6 +9193,12 @@
           "bindings": ["harnessRunCanActivateSession", "terminalCanActivateSession"]
         },
         {
+          "specifier": "../sessionRecoveryEligibility.js",
+          "resolvedPath": "apps/observer/src/sessionRecoveryEligibility.ts",
+          "edgeKind": "runtime",
+          "bindings": ["sessionRecoveryEligibility"]
+        },
+        {
           "specifier": "@station/contracts",
           "resolvedPath": "packages/contracts/src/index.ts",
           "edgeKind": "runtime",
@@ -10365,7 +10383,7 @@
           "name": "prepareExternalLaunch",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Returns a live or attachable managed identity first, then exactly recovers the canonical open Station session unless explicit, identity-bound user consent requests a fresh provider execution. Both launch paths preflight only the selected provider and pass provider-neutral resume options to the harness. A fresh Station identity is atomically seeded with explicit root placement or the requested source session's current Group before target publication, and confirmed failed launch cleanup removes only its membership and owned inline Group without touching source or retained recovery state."
+          "purpose": "Returns a live or attachable managed identity first, then exactly recovers the canonical open Station session unless explicit, identity-bound user consent requests a fresh provider execution. Recovery retains that session's identity and durable state, passes only provider-neutral resume options, and releases only its replacement target generation on failure. Both launch paths preflight only the selected provider. A fresh Station identity is atomically seeded with explicit root placement or the requested source session's current Group before target publication, and confirmed failed launch cleanup removes only its membership and owned inline Group."
         },
         {
           "name": "reportExternalExit",
@@ -11937,7 +11955,7 @@
           "name": "resolveSessionRecovery",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Resolves one provider-native recovery handle through durable session state and provider capability, returning only typed provider-neutral resume authority."
+          "purpose": "Filters durable handles through exact lifecycle and provider-neutral eligibility before applying zero/one/many cardinality, then returns only typed resume authority for the selected provider. Explicit selection retains imported-handle compatibility only when no contradictory local Station lifecycle exists."
         }
       ],
       "imports": [
@@ -11966,16 +11984,70 @@
           "bindings": ["ProviderRegistry"]
         },
         {
+          "specifier": "./sessionRecoveryEligibility.js",
+          "resolvedPath": "apps/observer/src/sessionRecoveryEligibility.ts",
+          "edgeKind": "runtime",
+          "bindings": ["sessionRecoveryEligibility"]
+        },
+        {
+          "specifier": "./sessionRecoveryEligibility.js",
+          "resolvedPath": "apps/observer/src/sessionRecoveryEligibility.ts",
+          "edgeKind": "type-only",
+          "bindings": ["SessionRecoveryEligibility", "SessionRecoveryEligibilityInput"]
+        },
+        {
           "specifier": "@station/contracts",
           "resolvedPath": "packages/contracts/src/index.ts",
           "edgeKind": "type-only",
           "bindings": [
             "HarnessProvider",
-            "HarnessResumeOptions",
             "SafeError",
             "SessionRecoveryHandle",
             "WorktreeObservation"
           ]
+        }
+      ]
+    },
+    {
+      "path": "apps/observer/src/sessionRecoveryEligibility.ts",
+      "exports": [
+        {
+          "name": "sessionRecoveryEligibility",
+          "kind": "function",
+          "role": "POLICY",
+          "purpose": "Admits one opaque recovery handle only when its provider-neutral identity, open Station lifecycle, registered harness capability, and cwd evidence authorize the exact worktree. A deliberately selected imported handle may proceed without a local lifecycle row, but local legacy, ended, or contradictory identity always wins over that compatibility path."
+        },
+        {
+          "name": "SessionRecoveryEligibility",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "SessionRecoveryEligibilityInput",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "SessionRecoveryEligibilityReason",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "SessionRecoveryStationSession",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        }
+      ],
+      "imports": [
+        {
+          "specifier": "@station/contracts",
+          "resolvedPath": "packages/contracts/src/index.ts",
+          "edgeKind": "type-only",
+          "bindings": ["HarnessResumeOptions", "SessionRecoveryHandle"]
         },
         {
           "specifier": "@station/runtime",
@@ -13583,7 +13655,7 @@
       "declaration": "createSessionResumeAgentHandler",
       "kind": "function",
       "role": "USE CASE",
-      "purpose": "Requires the selected worktree in the current Observer snapshot, then validates and preflights provider-native recovery, reusing a handle's Station identity or minting one when absent. Automatic native activation recovery is owned separately by external launch. Failed cleanup discards only a newly minted projection.",
+      "purpose": "Serializes recovery with close for one worktree, binds to its canonical open Station session when present, then validates and preflights provider-native resume. Explicit imported handles may seed their absent session identity; ended or contradictory local lifecycle is never reopened. Failed cleanup discards only a session seeded by this command.",
       "dependencies": [
         {
           "path": "apps/observer/src/sessionRecovery.ts",
@@ -13924,7 +13996,7 @@
       "declaration": "SessionStore",
       "kind": "interface",
       "role": "DRIVEN PORT",
-      "purpose": "Admits Observer-owned sessions with selected provider identity and maintains their lifecycle, native execution bindings, canonical worktree-scoped titles, recovery, and readiness. Seed, explicit root Group placement or current source-Group inheritance, and provenance-safe discard are one atomic conversation; canonical-title handoff and recovery import also commit before recovery reconciles.",
+      "purpose": "Admits Observer-owned sessions with selected provider identity and maintains their lifecycle, native execution bindings, canonical worktree-scoped titles, recovery, and readiness. Seed, explicit root Group placement or current source-Group inheritance, and provenance-safe discard are one atomic conversation; canonical-title handoff and recovery import also commit before recovery reconciles. Provider-native recovery keys permanently bind project and worktree, may fill Station session identity once, and reject contradictory identity before mutable evidence can refresh.",
       "dependencies": []
     },
     {
@@ -13969,6 +14041,13 @@
         {
           "path": "apps/observer/src/reconcile/snapshotCounts.ts",
           "declaration": "countsForSnapshot",
+          "kind": "function",
+          "role": "POLICY",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/observer/src/sessionRecoveryEligibility.ts",
+          "declaration": "sessionRecoveryEligibility",
           "kind": "function",
           "role": "POLICY",
           "edgeKind": "runtime"
@@ -14222,7 +14301,7 @@
       "declaration": "prepareExternalLaunch",
       "kind": "function",
       "role": "USE CASE",
-      "purpose": "Returns a live or attachable managed identity first, then exactly recovers the canonical open Station session unless explicit, identity-bound user consent requests a fresh provider execution. Both launch paths preflight only the selected provider and pass provider-neutral resume options to the harness. A fresh Station identity is atomically seeded with explicit root placement or the requested source session's current Group before target publication, and confirmed failed launch cleanup removes only its membership and owned inline Group without touching source or retained recovery state.",
+      "purpose": "Returns a live or attachable managed identity first, then exactly recovers the canonical open Station session unless explicit, identity-bound user consent requests a fresh provider execution. Recovery retains that session's identity and durable state, passes only provider-neutral resume options, and releases only its replacement target generation on failure. Both launch paths preflight only the selected provider. A fresh Station identity is atomically seeded with explicit root placement or the requested source session's current Group before target publication, and confirmed failed launch cleanup removes only its membership and owned inline Group.",
       "dependencies": [
         {
           "path": "apps/observer/src/commands/harnessLaunchPreflight.ts",
@@ -14694,7 +14773,7 @@
       "declaration": "resolveSessionRecovery",
       "kind": "function",
       "role": "USE CASE",
-      "purpose": "Resolves one provider-native recovery handle through durable session state and provider capability, returning only typed provider-neutral resume authority.",
+      "purpose": "Filters durable handles through exact lifecycle and provider-neutral eligibility before applying zero/one/many cardinality, then returns only typed resume authority for the selected provider. Explicit selection retains imported-handle compatibility only when no contradictory local Station lifecycle exists.",
       "dependencies": [
         {
           "path": "apps/observer/src/persistence/ports.ts",
@@ -14704,6 +14783,13 @@
           "edgeKind": "type-only"
         },
         {
+          "path": "apps/observer/src/sessionRecoveryEligibility.ts",
+          "declaration": "sessionRecoveryEligibility",
+          "kind": "function",
+          "role": "POLICY",
+          "edgeKind": "runtime"
+        },
+        {
           "path": "packages/contracts/src/providers.ts",
           "declaration": "HarnessProvider",
           "kind": "interface",
@@ -14711,6 +14797,14 @@
           "edgeKind": "type-only"
         }
       ]
+    },
+    {
+      "path": "apps/observer/src/sessionRecoveryEligibility.ts",
+      "declaration": "sessionRecoveryEligibility",
+      "kind": "function",
+      "role": "POLICY",
+      "purpose": "Admits one opaque recovery handle only when its provider-neutral identity, open Station lifecycle, registered harness capability, and cwd evidence authorize the exact worktree. A deliberately selected imported handle may proceed without a local lifecycle row, but local legacy, ended, or contradictory identity always wins over that compatibility path.",
+      "dependencies": []
     },
     {
       "path": "apps/observer/src/stationLogger.ts",

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -633,10 +633,15 @@ Target discovery includes Station Host reconstruction, so negotiated handoff and
 orphan-bridge adoption retain their existing PTY instead of entering provider
 recovery. A retained canonical Station session with no such target fails with
 `SESSION_RESUME_DISABLED` while recovery is disabled. When enabled, preparation
-requires one actionable handle whose Station session, harness provider, worktree,
-and present cwd match that canonical view, then preflights that provider and passes only
-typed provider-neutral resume options to its launch adapter. Missing or ambiguous
-handles and identity, capability, or cwd mismatches fail before terminal mutation.
+uses the IO-free `sessionRecoveryEligibility` policy to admit only handles whose
+Station session is explicitly open, harness provider and worktree identities match,
+registered provider can resume, and present cwd remains inside the current worktree.
+Eligibility is applied before cardinality: zero eligible handles is unavailable, one
+is exact recovery authority, and more than one remains an ambiguity with no ordering
+or selection until a separate resolution feature is implemented. An explicitly
+selected imported handle may proceed without a local lifecycle row, while legacy,
+ended, or contradictory local identity always refuses. All failures occur before
+terminal mutation, and only typed provider-neutral resume options reach the launch adapter.
 
 Automatic recovery opens and launches the replacement target under the retained
 Station session ID without seeding, reopening, renaming, discarding, or copying
@@ -794,6 +799,9 @@ when it changes several tables:
   definition, root parentage, sole membership, and absence of children remain unchanged. Any drift
   aborts session, title, membership, and Group cleanup together. Rename, seed/discard, confirmed
   worktree retirement, and canonical-title/recovery import keep their multi-table changes atomic.
+  Recovery persistence is keyed by provider plus opaque native target: project and worktree are
+  immutable, Station session identity may be filled once but never replaced, and conflicting
+  updates roll back before cwd, execution correlation, or liveness timestamps can refresh.
 - `SessionGroupStore` owns recorded Group definitions, exclusive direct membership, parent changes,
   deletion-to-ungroup with child reparenting, and atomic reconcile repair of parseable membership
   and parent relationships. Stale versions and expected assignments return conflicts without


### PR DESCRIPTION
> **Dependency satisfied:** #610 is merged. This PR now targets `main` and preserves its explicit fresh-start consent and UI.

## What this fixes

Observer recovery could treat durable provider evidence as actionable without proving that it belonged to the one canonical open Station session. Ended or mismatched identity could therefore reach launch or dashboard projection, while conflicting persistence refreshes could rewrite recovery ownership. This makes interrupted-session recovery fail closed before terminal mutation.

Closes #264.

## What changed

- Adds an IO-free, provider-neutral eligibility policy requiring exact project, worktree, Station session, harness, open lifecycle, registered resume capability, and cwd evidence inside the current worktree.
- Applies eligibility before cardinality: zero eligible handles is unavailable, one is exact recovery authority, and multiple remain ambiguous without ordering or selection.
- Serializes explicit resume with close and binds resume to the canonical open Station session, so an ended session cannot be revived by a race.
- Retains the existing `ses_*` identity and durable state during external recovery, and projects dashboard recovery only from eligible evidence.
- Preserves explicit imported-handle compatibility when no corresponding local lifecycle row exists.
- Makes provider plus opaque native target identity immutable, permits Station session identity to fill once, and rejects conflicts before mutable evidence refreshes.
- Preserves #610's fresh-start contract and leaves multi-handle selection and pruning to #638.

## Testing

- `pnpm test:all`
- Exact rebased head: `pnpm build`, `pnpm typecheck`, and `pnpm lint`
- Focused Observer unit coverage: 117 tests passed
- Focused Observer integration and persistence coverage: 171 tests passed
- `cd station && bun run typecheck`
- `cd station && bun run test`: 1,644 tests passed
- Observer architecture manifest generation and conformance check

## User-visible behavior

When a user activates an interrupted Station session:

1. **A Host target or live agent still exists** → Station attaches to or focuses that existing session. Recovery is not attempted. This precedence is unchanged.
2. **No live agent, exactly one eligible recovery handle** → Station resumes the provider conversation under the same Station `ses_*` ID, retaining the session title, status, readiness, and other durable state.
3. **No live agent, zero eligible recovery handles** → The row exposes no **Resume** action. #610's existing **Start fresh?** sheet offers:
   - **Start fresh** to begin a new provider conversation while keeping the worktree, panes, and Station session identity.
   - **Cancel** to leave the interrupted session untouched.
4. **No live agent, two or more eligible recovery handles** → Station does not choose one. The dashboard has no single **Resume** action and may offer the same explicit **Start fresh / Cancel** escape hatch; a direct recovery request remains blocked as ambiguous. A picker or newest-handle policy belongs to #638.

**Added by this PR:** a handle is eligible only when it proves the exact project, worktree, open Station session, matching registered resume-capable harness, and a cwd inside the current worktree. Ended or legacy sessions, missing or conflicting Station identity, mismatched provider/worktree identity, absent or outside cwd, unavailable providers, and providers with `canResume: false` are treated as zero eligible recovery evidence before any terminal is changed. Conflicting persistence refreshes also cannot rewrite an existing handle's ownership. An explicitly imported handle with no local session row remains supported, but a handle tied to a locally ended session cannot reopen it.

**Already owned by #610:** the **Start fresh / Cancel** sheet, keyboard and mouse flow, stale-consent checks, and atomic retirement of superseded recovery state. This PR adds no new screen or reset action.

Manual verification: enable persistent resume, stop only the owning Host, and reactivate the row. One exact eligible handle should resume the transcript under the same `ses_*` ID. End that session, or make its evidence invalid, and confirm the row offers **Start fresh / Cancel** instead of **Resume**. With two eligible handles, confirm no handle is silently selected.