### PR TITLE
fix(observer): preserve lifecycle failures across automation

### DIFF
--- a/apps/cli/src/commands/command.ts
+++ b/apps/cli/src/commands/command.ts
@@ -12,9 +12,8 @@ import { createObserverClient, type ObserverClient } from "@station/protocol";
 import { isSafeError, runRuntimeBoundaryWithTimeout } from "@station/runtime";
 import { parsePositiveIntegerOption } from "../args.js";
 import {
+  assertObserverRunning,
   type ObserverProcessDeps,
-  type ObserverStatus,
-  observerStatusErrorMessage,
   startObserver,
 } from "../observerProcess.js";
 import { resolveObserverPaths } from "../paths.js";
@@ -68,7 +67,7 @@ export async function runCommandCommand(
   const timeoutMs = parsed.timeoutMs ?? options.timeoutMs ?? 30_000;
   const paths = resolveObserverPaths(options.config);
   const status = await startObserver({ ...options, paths, timeoutMs }, deps);
-  assertRunning(status);
+  assertObserverRunning(status);
   const client =
     deps.clientFactory?.(paths.socketPath) ??
     createObserverClient({
@@ -303,12 +302,4 @@ function parseCommandId(value: string): CommandId {
     throw new Error(`Invalid command id: ${parsed.error.message}`);
   }
   return parsed.data;
-}
-
-function assertRunning(
-  status: ObserverStatus,
-): asserts status is Extract<ObserverStatus, { status: "running" }> {
-  if (status.status !== "running") {
-    throw new Error(observerStatusErrorMessage(status));
-  }
 }

--- a/apps/cli/src/commands/debugBundle.ts
+++ b/apps/cli/src/commands/debugBundle.ts
@@ -6,9 +6,8 @@ import { createObserverClient } from "@station/protocol";
 import { runRuntimeBoundary, runRuntimeBoundaryWithTimeout } from "@station/runtime";
 import { parseRequiredOptionValue } from "../args.js";
 import {
+  assertObserverRunning,
   type ObserverProcessDeps,
-  type ObserverStatus,
-  observerStatusErrorMessage,
   startObserver,
 } from "../observerProcess.js";
 import { resolveObserverPaths } from "../paths.js";
@@ -34,7 +33,7 @@ export async function runDebugBundleCommand(
   const collectionOptions = parseDebugBundleOptions(args);
   const paths = resolveObserverPaths(options.config);
   const status = await startObserver({ ...options, paths }, deps);
-  assertRunning(status);
+  assertObserverRunning(status);
   const client =
     deps.clientFactory?.(paths.socketPath) ??
     createObserverClient({
@@ -157,12 +156,4 @@ function sinceFromDuration(input: string): string {
           ? 60 * 60 * 1000
           : 24 * 60 * 60 * 1000;
   return new Date(Date.now() - amount * unitMs).toISOString();
-}
-
-function assertRunning(
-  status: ObserverStatus,
-): asserts status is Extract<ObserverStatus, { status: "running" }> {
-  if (status.status !== "running") {
-    throw new Error(observerStatusErrorMessage(status));
-  }
 }

--- a/apps/cli/src/commands/debugLogs.ts
+++ b/apps/cli/src/commands/debugLogs.ts
@@ -1,11 +1,7 @@
 import { readFile } from "node:fs/promises";
 import type { StationConfig } from "@station/config";
 import type { LogRecord, ObserverStartupEvidence, SafeError } from "@station/contracts";
-import {
-  LogRecordSchema,
-  ObserverLifecycleFailureSchema,
-  SafeErrorSchema,
-} from "@station/contracts";
+import { LogRecordSchema } from "@station/contracts";
 import { componentLogPath } from "@station/observability";
 import { resolveObserverPaths } from "../paths.js";
 import {
@@ -21,6 +17,12 @@ import {
   projectOperationalBoundaryEvidence,
   retainedFailureSignal,
 } from "./diagnosticEvidence.js";
+import {
+  type LifecycleErrorSummary,
+  parseLifecycleLogEvidence,
+  parseLogSafeError,
+  summarizeLifecycleError,
+} from "./lifecycleLogEvidence.js";
 
 export type DebugLogsCommandOptions = {
   config?: StationConfig;
@@ -66,12 +68,7 @@ type DebugLogRecordSummary = {
   startupEvidence?: ObserverStartupEvidence;
 };
 
-type DebugLogErrorSummary = {
-  code?: string;
-  message?: string;
-  provider?: string;
-  diagnosticId?: string;
-  traceId?: string;
+type DebugLogErrorSummary = LifecycleErrorSummary & {
   commandId?: string;
 };
 
@@ -101,8 +98,6 @@ const allComponents: DebugLogComponent[] = [
   "station-host",
 ];
 const logLevels: DebugLogLevel[] = ["debug", "info", "warn", "error"];
-const SafeErrorViewSchema = SafeErrorSchema.strip();
-const LifecycleLogAttributesSchema = ObserverLifecycleFailureSchema.passthrough();
 
 /**
  * ADAPTER
@@ -284,8 +279,11 @@ function logSummary(
   includeOperationalBoundaryEvidence: boolean,
 ): DebugLogRecordSummary {
   const context = projectDiagnosticContext(record);
-  const lifecycle = lifecycleFailure(record.attributes);
-  const error = lifecycle?.error ?? errorSummary(record.attributes?.error);
+  const lifecycle = parseLifecycleLogEvidence(record.attributes);
+  const error =
+    lifecycle === undefined
+      ? errorSummary(record.attributes?.error)
+      : debugLogErrorSummary(lifecycle.error);
   const summary: DebugLogRecordSummary = {
     timestamp: record.timestamp,
     level: record.level,
@@ -321,7 +319,7 @@ function logSummary(
     if (matchEvidence.length > 0) summary.matchEvidence = matchEvidence;
   }
   if (error !== undefined) summary.error = error;
-  if (lifecycle?.cause !== undefined) summary.cause = lifecycle.cause;
+  if (lifecycle?.cause !== undefined) summary.cause = debugLogErrorSummary(lifecycle.cause);
   if (lifecycle?.startupEvidence !== undefined) {
     summary.startupEvidence = lifecycle.startupEvidence;
   }
@@ -337,42 +335,12 @@ function contextString(
 }
 
 function errorSummary(value: unknown): DebugLogErrorSummary | undefined {
-  const safeError = SafeErrorViewSchema.safeParse(value);
-  if (safeError.success) {
-    return safeErrorSummary(safeError.data);
-  }
-  return undefined;
+  const safeError = parseLogSafeError(value);
+  return safeError === undefined ? undefined : debugLogErrorSummary(safeError);
 }
 
-function lifecycleFailure(attributes: LogRecord["attributes"] | undefined):
-  | {
-      error: DebugLogErrorSummary;
-      cause?: DebugLogErrorSummary;
-      startupEvidence?: ObserverStartupEvidence;
-    }
-  | undefined {
-  const parsed = LifecycleLogAttributesSchema.safeParse(attributes);
-  if (!parsed.success) return undefined;
-  const result: {
-    error: DebugLogErrorSummary;
-    cause?: DebugLogErrorSummary;
-    startupEvidence?: ObserverStartupEvidence;
-  } = { error: safeErrorSummary(parsed.data.error) };
-  if (parsed.data.cause !== undefined) result.cause = safeErrorSummary(parsed.data.cause);
-  if (parsed.data.startupEvidence !== undefined) {
-    result.startupEvidence = parsed.data.startupEvidence;
-  }
-  return result;
-}
-
-function safeErrorSummary(error: SafeError): DebugLogErrorSummary {
-  const summary: DebugLogErrorSummary = {
-    code: error.code,
-    message: error.message,
-  };
-  if (error.provider !== undefined) summary.provider = error.provider;
-  if (error.diagnosticId !== undefined) summary.diagnosticId = error.diagnosticId;
-  if (error.traceId !== undefined) summary.traceId = error.traceId;
+function debugLogErrorSummary(error: SafeError): DebugLogErrorSummary {
+  const summary: DebugLogErrorSummary = summarizeLifecycleError(error);
   if (error.commandId !== undefined) summary.commandId = error.commandId;
   return summary;
 }

--- a/apps/cli/src/commands/debugLogs.ts
+++ b/apps/cli/src/commands/debugLogs.ts
@@ -1,7 +1,11 @@
 import { readFile } from "node:fs/promises";
 import type { StationConfig } from "@station/config";
-import type { LogRecord, SafeError } from "@station/contracts";
-import { LogRecordSchema, SafeErrorSchema } from "@station/contracts";
+import type { LogRecord, ObserverStartupEvidence, SafeError } from "@station/contracts";
+import {
+  LogRecordSchema,
+  ObserverLifecycleFailureSchema,
+  SafeErrorSchema,
+} from "@station/contracts";
 import { componentLogPath } from "@station/observability";
 import { resolveObserverPaths } from "../paths.js";
 import {
@@ -35,7 +39,7 @@ export type DebugLogsResult = {
   };
   causeAssessment: Pick<
     CauseAssessment,
-    "status" | "observedFailureCodes" | "observedFailureSignals"
+    "status" | "explicitRootCauseCodes" | "observedFailureCodes" | "observedFailureSignals"
   >;
   evidenceRoles: DiagnosticEvidenceRoles;
   records: DebugLogRecordSummary[];
@@ -58,6 +62,8 @@ type DebugLogRecordSummary = {
   context?: DiagnosticContextEntry[];
   matchEvidence?: DiagnosticMatchEvidence[];
   error?: DebugLogErrorSummary;
+  cause?: DebugLogErrorSummary;
+  startupEvidence?: ObserverStartupEvidence;
 };
 
 type DebugLogErrorSummary = {
@@ -95,7 +101,15 @@ const allComponents: DebugLogComponent[] = [
   "station-host",
 ];
 const logLevels: DebugLogLevel[] = ["debug", "info", "warn", "error"];
+const SafeErrorViewSchema = SafeErrorSchema.strip();
+const LifecycleLogAttributesSchema = ObserverLifecycleFailureSchema.passthrough();
 
+/**
+ * ADAPTER
+ *
+ * Reads redacted lifecycle logs and projects strict outer, causal, and startup
+ * evidence fields without treating the logging component as failure ownership.
+ */
 export async function runDebugLogsCommand(
   args: string[],
   options: DebugLogsCommandOptions = {},
@@ -127,12 +141,15 @@ export async function runDebugLogsCommand(
   const observedFailureCodes = records.flatMap((record) =>
     record.error?.code === undefined ? [] : [record.error.code],
   );
+  const explicitRootCauseCodes = records.flatMap((record) =>
+    record.cause?.code === undefined ? [] : [record.cause.code],
+  );
   const observedFailureSignals = records.flatMap((record) => {
     const signal = retainedFailureSignal(contextString(record.context ?? [], "/attributes/kind"));
     return signal === undefined ? [] : [signal];
   });
   const assessedCause = assessCauseEvidence({
-    explicitRootCauseCodes: [],
+    explicitRootCauseCodes,
     observedFailureCodes,
     observedFailureSignals,
     matched: selected.length > 0,
@@ -142,6 +159,7 @@ export async function runDebugLogsCommand(
   });
   const causeAssessment: DebugLogsResult["causeAssessment"] = {
     status: assessedCause.status,
+    explicitRootCauseCodes: assessedCause.explicitRootCauseCodes,
     observedFailureCodes: assessedCause.observedFailureCodes,
   };
   if (assessedCause.observedFailureSignals !== undefined) {
@@ -266,7 +284,8 @@ function logSummary(
   includeOperationalBoundaryEvidence: boolean,
 ): DebugLogRecordSummary {
   const context = projectDiagnosticContext(record);
-  const error = errorSummary(record.attributes?.error);
+  const lifecycle = lifecycleFailure(record.attributes);
+  const error = lifecycle?.error ?? errorSummary(record.attributes?.error);
   const summary: DebugLogRecordSummary = {
     timestamp: record.timestamp,
     level: record.level,
@@ -302,6 +321,10 @@ function logSummary(
     if (matchEvidence.length > 0) summary.matchEvidence = matchEvidence;
   }
   if (error !== undefined) summary.error = error;
+  if (lifecycle?.cause !== undefined) summary.cause = lifecycle.cause;
+  if (lifecycle?.startupEvidence !== undefined) {
+    summary.startupEvidence = lifecycle.startupEvidence;
+  }
   return summary;
 }
 
@@ -314,29 +337,32 @@ function contextString(
 }
 
 function errorSummary(value: unknown): DebugLogErrorSummary | undefined {
-  const safeError = SafeErrorSchema.safeParse(value);
+  const safeError = SafeErrorViewSchema.safeParse(value);
   if (safeError.success) {
     return safeErrorSummary(safeError.data);
   }
-  if (!value || typeof value !== "object") {
-    return undefined;
+  return undefined;
+}
+
+function lifecycleFailure(attributes: LogRecord["attributes"] | undefined):
+  | {
+      error: DebugLogErrorSummary;
+      cause?: DebugLogErrorSummary;
+      startupEvidence?: ObserverStartupEvidence;
+    }
+  | undefined {
+  const parsed = LifecycleLogAttributesSchema.safeParse(attributes);
+  if (!parsed.success) return undefined;
+  const result: {
+    error: DebugLogErrorSummary;
+    cause?: DebugLogErrorSummary;
+    startupEvidence?: ObserverStartupEvidence;
+  } = { error: safeErrorSummary(parsed.data.error) };
+  if (parsed.data.cause !== undefined) result.cause = safeErrorSummary(parsed.data.cause);
+  if (parsed.data.startupEvidence !== undefined) {
+    result.startupEvidence = parsed.data.startupEvidence;
   }
-  const candidate = value as {
-    code?: unknown;
-    message?: unknown;
-    provider?: unknown;
-    diagnosticId?: unknown;
-    traceId?: unknown;
-    commandId?: unknown;
-  };
-  const summary: DebugLogErrorSummary = {};
-  if (typeof candidate.code === "string") summary.code = candidate.code;
-  if (typeof candidate.message === "string") summary.message = candidate.message;
-  if (typeof candidate.provider === "string") summary.provider = candidate.provider;
-  if (typeof candidate.diagnosticId === "string") summary.diagnosticId = candidate.diagnosticId;
-  if (typeof candidate.traceId === "string") summary.traceId = candidate.traceId;
-  if (typeof candidate.commandId === "string") summary.commandId = candidate.commandId;
-  return Object.keys(summary).length === 0 ? undefined : summary;
+  return result;
 }
 
 function safeErrorSummary(error: SafeError): DebugLogErrorSummary {

--- a/apps/cli/src/commands/debugTrace.ts
+++ b/apps/cli/src/commands/debugTrace.ts
@@ -56,17 +56,21 @@ export type DebugTraceResult = {
     spanId?: string;
   };
   error?: {
+    tag: string;
     id?: string;
     code?: string;
     message?: string;
+    hint?: string;
     provider?: string;
     diagnosticId?: string;
     diagnostics?: DiagnosticDetail[];
     traceId?: string;
   };
   cause?: {
+    tag: string;
     code?: string;
     message?: string;
+    hint?: string;
     provider?: string;
     diagnosticId?: string;
     traceId?: string;
@@ -529,6 +533,7 @@ function errorSummary(error: ErrorEnvelope | undefined): DebugTraceResult["error
     return undefined;
   }
   const summary: DebugTraceErrorSummary = {
+    tag: error.tag,
     id: error.id,
     code: error.code,
     message: error.message,
@@ -556,10 +561,13 @@ function commandErrorSummary(command: CommandRecord | undefined): DebugTraceResu
   if (command?.error === undefined && command?.diagnostics === undefined) {
     return undefined;
   }
-  const summary: DebugTraceErrorSummary = {};
+  const summary: DebugTraceErrorSummary = {
+    tag: command.error?.tag ?? "CommandDiagnostics",
+  };
   if (command.error !== undefined) {
     summary.code = command.error.code;
     summary.message = command.error.message;
+    if (command.error.hint !== undefined) summary.hint = command.error.hint;
     if (command.error.provider !== undefined) summary.provider = command.error.provider;
     if (command.error.diagnosticId !== undefined) summary.diagnosticId = command.error.diagnosticId;
   }

--- a/apps/cli/src/commands/debugTrace.ts
+++ b/apps/cli/src/commands/debugTrace.ts
@@ -7,6 +7,7 @@ import type {
   DiagnosticEvidenceIndex,
   ErrorEnvelope,
   LogRecord,
+  ObserverStartupEvidence,
   SafeError,
 } from "@station/contracts";
 import {
@@ -15,6 +16,7 @@ import {
   DiagnosticEvidenceIndexSchema,
   ErrorEnvelopeSchema,
   LogRecordSchema,
+  ObserverLifecycleFailureSchema,
   SafeErrorSchema,
   SpanIdSchema,
   TraceIdSchema,
@@ -58,7 +60,16 @@ export type DebugTraceResult = {
     provider?: string;
     diagnosticId?: string;
     diagnostics?: DiagnosticDetail[];
+    traceId?: string;
   };
+  cause?: {
+    code?: string;
+    message?: string;
+    provider?: string;
+    diagnosticId?: string;
+    traceId?: string;
+  };
+  startupEvidence?: ObserverStartupEvidence;
   rootCauseCodes: string[];
   causeAssessment: CauseAssessment;
   evidenceRoles: DiagnosticEvidenceRoles;
@@ -88,6 +99,8 @@ type DebugTraceMatch = {
   bundlePath?: string;
   command?: DebugTraceResult["command"];
   error?: DebugTraceResult["error"];
+  cause?: DebugTraceResult["cause"];
+  startupEvidence?: ObserverStartupEvidence;
   traceId?: string;
   spanId?: string;
   rootCauseCodes: string[];
@@ -109,6 +122,8 @@ type ParsedDebugTraceLogAttributes = {
   operation?: string;
   kind?: string;
   error?: DebugTraceErrorSummary;
+  cause?: NonNullable<DebugTraceResult["cause"]>;
+  startupEvidence?: ObserverStartupEvidence;
 };
 
 const DebugTraceLogAttributesSchema = z
@@ -122,7 +137,15 @@ const DebugTraceLogAttributesSchema = z
     error: z.unknown().optional(),
   })
   .passthrough();
+const LifecycleLogAttributesSchema = ObserverLifecycleFailureSchema.passthrough();
+const SafeErrorViewSchema = SafeErrorSchema.strip();
 
+/**
+ * ADAPTER
+ *
+ * Correlates existing bundle and log evidence, projecting a strict lifecycle
+ * cause as explicit causal evidence while retaining its outer reporting boundary.
+ */
 export async function runDebugTraceCommand(
   args: string[],
   options: DebugTraceCommandOptions = {},
@@ -163,6 +186,10 @@ export async function runDebugTraceCommand(
   if (match?.spanId !== undefined) result.spanId = match.spanId;
   if (match?.command !== undefined) result.command = match.command;
   if (match?.error !== undefined) result.error = match.error;
+  if (match?.cause !== undefined) result.cause = match.cause;
+  if (match?.startupEvidence !== undefined) {
+    result.startupEvidence = match.startupEvidence;
+  }
   const operationalInput: OperationalBoundaryEvidence = {};
   if (result.command?.type !== undefined) operationalInput.commandType = result.command.type;
   if (match?.reportedBy?.operation !== undefined) {
@@ -412,7 +439,7 @@ function errorMatchesQuery(error: ErrorEnvelope, query: string): boolean {
 function matchFromLog(log: LogRecord, path: string, query: string | undefined): DebugTraceMatch {
   const attributes = parseDebugTraceLogAttributes(log.attributes);
   const commandId = attributes.commandId ?? log.commandId;
-  const traceId = attributes.traceId ?? log.traceId;
+  const traceId = attributes.traceId ?? log.traceId ?? attributes.cause?.traceId;
   const spanId = attributes.spanId ?? log.spanId;
   const commandType = attributes.commandType;
   const reportedBy: DebugTraceReportingProvenance = { component: log.component };
@@ -434,8 +461,10 @@ function matchFromLog(log: LogRecord, path: string, query: string | undefined): 
     ...(command === undefined ? {} : { command }),
     ...(traceId === undefined ? {} : { traceId }),
     ...(spanId === undefined ? {} : { spanId }),
-    rootCauseCodes: errorResult?.code === undefined ? [] : [errorResult.code],
-    explicitRootCauseCodes: [],
+    rootCauseCodes: [errorResult?.code, attributes.cause?.code].filter(
+      (code): code is string => code !== undefined,
+    ),
+    explicitRootCauseCodes: attributes.cause?.code === undefined ? [] : [attributes.cause.code],
     observedFailureCodes: errorResult?.code === undefined ? [] : [errorResult.code],
     observedFailureRecord: log.level === "warn" || log.level === "error",
     reportedBy,
@@ -446,6 +475,10 @@ function matchFromLog(log: LogRecord, path: string, query: string | undefined): 
   const signalKind = retainedFailureSignal(attributes.kind);
   if (signalKind !== undefined) match.signalKind = signalKind;
   if (errorResult !== undefined) match.error = errorResult;
+  if (attributes.cause !== undefined) match.cause = attributes.cause;
+  if (attributes.startupEvidence !== undefined) {
+    match.startupEvidence = attributes.startupEvidence;
+  }
   return match;
 }
 
@@ -586,13 +619,14 @@ function rootCauseCodes(
   return [...codes].sort();
 }
 
-function safeErrorSummary(error: SafeError): DebugTraceResult["error"] {
+function safeErrorSummary(error: SafeError): DebugTraceErrorSummary {
   const summary: DebugTraceErrorSummary = {
     code: error.code,
     message: error.message,
   };
   if (error.provider !== undefined) summary.provider = error.provider;
   if (error.diagnosticId !== undefined) summary.diagnosticId = error.diagnosticId;
+  if (error.traceId !== undefined) summary.traceId = error.traceId;
   return summary;
 }
 
@@ -610,13 +644,22 @@ function parseDebugTraceLogAttributes(
   if (parsed.data.commandType !== undefined) result.commandType = parsed.data.commandType;
   if (parsed.data.operation !== undefined) result.operation = parsed.data.operation;
   if (parsed.data.kind !== undefined) result.kind = parsed.data.kind;
-  const error = parseLogAttributeError(parsed.data.error);
+  const lifecycle = LifecycleLogAttributesSchema.safeParse(attributes);
+  const error = lifecycle.success
+    ? safeErrorSummary(lifecycle.data.error)
+    : parseLogAttributeError(parsed.data.error);
   if (error !== undefined) result.error = error;
+  if (lifecycle.success && lifecycle.data.cause !== undefined) {
+    result.cause = safeErrorSummary(lifecycle.data.cause);
+  }
+  if (lifecycle.success && lifecycle.data.startupEvidence !== undefined) {
+    result.startupEvidence = lifecycle.data.startupEvidence;
+  }
   return result;
 }
 
 function parseLogAttributeError(error: unknown): DebugTraceResult["error"] {
-  const safeError = SafeErrorSchema.safeParse(error);
+  const safeError = SafeErrorViewSchema.safeParse(error);
   if (safeError.success) {
     return safeErrorSummary(safeError.data);
   }

--- a/apps/cli/src/commands/debugTrace.ts
+++ b/apps/cli/src/commands/debugTrace.ts
@@ -8,7 +8,6 @@ import type {
   ErrorEnvelope,
   LogRecord,
   ObserverStartupEvidence,
-  SafeError,
 } from "@station/contracts";
 import {
   CommandIdSchema,
@@ -16,8 +15,6 @@ import {
   DiagnosticEvidenceIndexSchema,
   ErrorEnvelopeSchema,
   LogRecordSchema,
-  ObserverLifecycleFailureSchema,
-  SafeErrorSchema,
   SpanIdSchema,
   TraceIdSchema,
 } from "@station/contracts";
@@ -32,6 +29,11 @@ import {
   projectOperationalBoundaryEvidence,
   retainedFailureSignal,
 } from "./diagnosticEvidence.js";
+import {
+  parseLifecycleLogEvidence,
+  parseLogSafeError,
+  summarizeLifecycleError,
+} from "./lifecycleLogEvidence.js";
 
 export type DebugTraceCommandOptions = {
   config?: StationConfig;
@@ -137,8 +139,6 @@ const DebugTraceLogAttributesSchema = z
     error: z.unknown().optional(),
   })
   .passthrough();
-const LifecycleLogAttributesSchema = ObserverLifecycleFailureSchema.passthrough();
-const SafeErrorViewSchema = SafeErrorSchema.strip();
 
 /**
  * ADAPTER
@@ -619,17 +619,6 @@ function rootCauseCodes(
   return [...codes].sort();
 }
 
-function safeErrorSummary(error: SafeError): DebugTraceErrorSummary {
-  const summary: DebugTraceErrorSummary = {
-    code: error.code,
-    message: error.message,
-  };
-  if (error.provider !== undefined) summary.provider = error.provider;
-  if (error.diagnosticId !== undefined) summary.diagnosticId = error.diagnosticId;
-  if (error.traceId !== undefined) summary.traceId = error.traceId;
-  return summary;
-}
-
 function parseDebugTraceLogAttributes(
   attributes: LogRecord["attributes"] | undefined,
 ): ParsedDebugTraceLogAttributes {
@@ -644,24 +633,25 @@ function parseDebugTraceLogAttributes(
   if (parsed.data.commandType !== undefined) result.commandType = parsed.data.commandType;
   if (parsed.data.operation !== undefined) result.operation = parsed.data.operation;
   if (parsed.data.kind !== undefined) result.kind = parsed.data.kind;
-  const lifecycle = LifecycleLogAttributesSchema.safeParse(attributes);
-  const error = lifecycle.success
-    ? safeErrorSummary(lifecycle.data.error)
-    : parseLogAttributeError(parsed.data.error);
+  const lifecycle = parseLifecycleLogEvidence(attributes);
+  const error =
+    lifecycle !== undefined
+      ? summarizeLifecycleError(lifecycle.error)
+      : parseLogAttributeError(parsed.data.error);
   if (error !== undefined) result.error = error;
-  if (lifecycle.success && lifecycle.data.cause !== undefined) {
-    result.cause = safeErrorSummary(lifecycle.data.cause);
+  if (lifecycle?.cause !== undefined) {
+    result.cause = summarizeLifecycleError(lifecycle.cause);
   }
-  if (lifecycle.success && lifecycle.data.startupEvidence !== undefined) {
-    result.startupEvidence = lifecycle.data.startupEvidence;
+  if (lifecycle?.startupEvidence !== undefined) {
+    result.startupEvidence = lifecycle.startupEvidence;
   }
   return result;
 }
 
 function parseLogAttributeError(error: unknown): DebugTraceResult["error"] {
-  const safeError = SafeErrorViewSchema.safeParse(error);
-  if (safeError.success) {
-    return safeErrorSummary(safeError.data);
+  const safeError = parseLogSafeError(error);
+  if (safeError !== undefined) {
+    return summarizeLifecycleError(safeError);
   }
   const envelope = ErrorEnvelopeSchema.safeParse(error);
   if (envelope.success) {

--- a/apps/cli/src/commands/diagnosticEvidence.ts
+++ b/apps/cli/src/commands/diagnosticEvidence.ts
@@ -81,7 +81,8 @@ export function assessCauseEvidence(input: {
   const explicitRootCauseCodes = uniqueSorted(input.explicitRootCauseCodes);
   const observedFailureCodes = uniqueSorted(input.observedFailureCodes);
   const observedFailureSignals = uniqueSorted(input.observedFailureSignals ?? []);
-  // Only diagnostic-index root-cause declarations authorize this status; an error code is evidence of a failure, not proof of its underlying cause.
+  // Diagnostic-index declarations and strict lifecycle cause fields authorize this status;
+  // an unclassified error code remains failure evidence rather than proof of a deeper mechanism.
   // An exactly matched warning or error record establishes its retained event as a proximate failure without establishing a deeper mechanism.
   let status: CauseAssessmentStatus = "insufficient_evidence";
   if (explicitRootCauseCodes.length > 0) {

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -15,9 +15,8 @@ import {
 } from "@station/runtime";
 import { parseRequiredOptionValue } from "../args.js";
 import {
+  assertObserverRunning,
   type ObserverProcessDeps,
-  type ObserverStatus,
-  observerStatusErrorMessage,
   startObserver,
 } from "../observerProcess.js";
 import { resolveObserverPaths } from "../paths.js";
@@ -76,7 +75,7 @@ export async function runDoctorCommand(
     observerOptions.configPath = options.configPath;
   }
   const status = await startObserver(observerOptions, deps);
-  assertRunning(status);
+  assertObserverRunning(status);
   const client =
     deps.clientFactory?.(paths.socketPath) ??
     createObserverClient({
@@ -293,12 +292,4 @@ function doctorStatusWithCheck(report: DoctorReport, check: DoctorCheck): Doctor
     return "degraded";
   }
   return report.status;
-}
-
-function assertRunning(
-  status: ObserverStatus,
-): asserts status is Extract<ObserverStatus, { status: "running" }> {
-  if (status.status !== "running") {
-    throw new Error(observerStatusErrorMessage(status));
-  }
 }

--- a/apps/cli/src/commands/lifecycleLogEvidence.ts
+++ b/apps/cli/src/commands/lifecycleLogEvidence.ts
@@ -1,0 +1,33 @@
+import type { LogRecord, ObserverLifecycleFailure, SafeError } from "@station/contracts";
+import { ObserverLifecycleFailureSchema, SafeErrorSchema } from "@station/contracts";
+
+const LifecycleLogAttributesSchema = ObserverLifecycleFailureSchema.passthrough();
+const SafeErrorViewSchema = SafeErrorSchema.strip();
+
+export type LifecycleErrorSummary = {
+  code: string;
+  message: string;
+  provider?: string;
+  diagnosticId?: string;
+  traceId?: string;
+};
+
+export function parseLifecycleLogEvidence(
+  attributes: LogRecord["attributes"] | undefined,
+): ObserverLifecycleFailure | undefined {
+  const parsed = LifecycleLogAttributesSchema.safeParse(attributes);
+  return parsed.success ? parsed.data : undefined;
+}
+
+export function parseLogSafeError(value: unknown): SafeError | undefined {
+  const parsed = SafeErrorViewSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
+}
+
+export function summarizeLifecycleError(error: SafeError): LifecycleErrorSummary {
+  const summary: LifecycleErrorSummary = { code: error.code, message: error.message };
+  if (error.provider !== undefined) summary.provider = error.provider;
+  if (error.diagnosticId !== undefined) summary.diagnosticId = error.diagnosticId;
+  if (error.traceId !== undefined) summary.traceId = error.traceId;
+  return summary;
+}

--- a/apps/cli/src/commands/lifecycleLogEvidence.ts
+++ b/apps/cli/src/commands/lifecycleLogEvidence.ts
@@ -5,8 +5,10 @@ const LifecycleLogAttributesSchema = ObserverLifecycleFailureSchema.passthrough(
 const SafeErrorViewSchema = SafeErrorSchema.strip();
 
 export type LifecycleErrorSummary = {
+  tag: string;
   code: string;
   message: string;
+  hint?: string;
   provider?: string;
   diagnosticId?: string;
   traceId?: string;
@@ -25,7 +27,12 @@ export function parseLogSafeError(value: unknown): SafeError | undefined {
 }
 
 export function summarizeLifecycleError(error: SafeError): LifecycleErrorSummary {
-  const summary: LifecycleErrorSummary = { code: error.code, message: error.message };
+  const summary: LifecycleErrorSummary = {
+    tag: error.tag,
+    code: error.code,
+    message: error.message,
+  };
+  if (error.hint !== undefined) summary.hint = error.hint;
   if (error.provider !== undefined) summary.provider = error.provider;
   if (error.diagnosticId !== undefined) summary.diagnosticId = error.diagnosticId;
   if (error.traceId !== undefined) summary.traceId = error.traceId;

--- a/apps/cli/src/commands/observe/index.ts
+++ b/apps/cli/src/commands/observe/index.ts
@@ -8,9 +8,8 @@ import {
 import { createObserverClient } from "@station/protocol";
 import { Effect, runRuntimeBoundaryWithTimeout } from "@station/runtime";
 import {
+  assertObserverRunning,
   type ObserverProcessDeps,
-  type ObserverStatus,
-  observerStatusErrorMessage,
   startObserver,
 } from "../../observerProcess.js";
 import { resolveObserverPaths } from "../../paths.js";
@@ -97,7 +96,7 @@ export async function runObserveCommand(
     observerOptions.configPath = options.configPath;
   }
   const status = await startObserver(observerOptions, observerDeps);
-  assertRunning(status);
+  assertObserverRunning(status);
 
   const client =
     observerDeps.clientFactory?.(paths.socketPath) ??
@@ -558,12 +557,4 @@ function isBrokenPipeError(error: unknown): boolean {
     "code" in error &&
     (error as { code?: unknown }).code === "EPIPE"
   );
-}
-
-function assertRunning(
-  status: ObserverStatus,
-): asserts status is Extract<ObserverStatus, { status: "running" }> {
-  if (status.status !== "running") {
-    throw new Error(observerStatusErrorMessage(status));
-  }
 }

--- a/apps/cli/src/commands/reconcile.ts
+++ b/apps/cli/src/commands/reconcile.ts
@@ -3,9 +3,8 @@ import type { ReconcileReceipt } from "@station/contracts";
 import { createObserverClient } from "@station/protocol";
 import { runRuntimeBoundaryWithTimeout } from "@station/runtime";
 import {
+  assertObserverRunning,
   type ObserverProcessDeps,
-  type ObserverStatus,
-  observerStatusErrorMessage,
   startObserver,
 } from "../observerProcess.js";
 import { resolveObserverPaths } from "../paths.js";
@@ -25,7 +24,7 @@ export async function runReconcileCommand(
   const timeoutMs = options.timeoutMs ?? 30_000;
   const paths = resolveObserverPaths(options.config);
   const status = await startObserver({ ...options, paths, timeoutMs }, deps);
-  assertRunning(status);
+  assertObserverRunning(status);
   const client =
     deps.clientFactory?.(paths.socketPath) ??
     createObserverClient({
@@ -75,12 +74,4 @@ function parseReconcileArgs(args: string[]): { reason?: string } {
   }
 
   return { reason };
-}
-
-function assertRunning(
-  status: ObserverStatus,
-): asserts status is Extract<ObserverStatus, { status: "running" }> {
-  if (status.status !== "running") {
-    throw new Error(observerStatusErrorMessage(status));
-  }
 }

--- a/apps/cli/src/commands/setup/adapters/observerActivation.ts
+++ b/apps/cli/src/commands/setup/adapters/observerActivation.ts
@@ -1,7 +1,8 @@
 import { loadConfig, resolveObserverPaths } from "@station/config";
+import type { ObserverLifecycleFailure } from "@station/contracts";
 import { publicSafeErrorFromUnknown, safeErrorFromUnknown } from "@station/runtime";
 import type { SetupObserverActivationPort } from "@station/setup-core";
-import { restartObserver } from "../../../observerProcess.js";
+import { observerLifecycleFailure, restartObserver } from "../../../observerProcess.js";
 
 export type SetupObserverActivationAdapterOptions = {
   readonly configPath: () => string | undefined;
@@ -12,14 +13,14 @@ export type SetupObserverActivationAdapterOptions = {
     configPath: string;
     homeDir: string;
     onStartupProgress?: (message: string) => void;
-  }) => Promise<void>;
+  }) => Promise<ObserverLifecycleFailure | undefined>;
 };
 
 /**
  * ADAPTER
  *
  * Translates setup activation into config loading, Observer path resolution, restart, and health confirmation.
- * Forwards Observer startup progress to the caller-supplied callback without interpreting it.
+ * Forwards startup progress and retains lifecycle cause/evidence without interpreting either.
  */
 export function createObserverActivationAdapter(
   options: SetupObserverActivationAdapterOptions,
@@ -30,13 +31,16 @@ export function createObserverActivationAdapter(
       return failedActivation(operation.id, observerActivationError);
     }
     try {
-      await (options.activateObserverConfig ?? activateObserverConfig)({
+      const lifecycleFailure = await (options.activateObserverConfig ?? activateObserverConfig)({
         configPath,
         homeDir: options.homeDir,
         ...(options.onStartupProgress === undefined
           ? {}
           : { onStartupProgress: options.onStartupProgress }),
       });
+      if (lifecycleFailure !== undefined) {
+        return failedActivation(operation.id, lifecycleFailure);
+      }
       return {
         status: "completed",
         operationId: operation.id,
@@ -55,7 +59,7 @@ async function activateObserverConfig(input: {
   configPath: string;
   homeDir: string;
   onStartupProgress?: (message: string) => void;
-}): Promise<void> {
+}): Promise<ObserverLifecycleFailure | undefined> {
   try {
     const loaded = await loadConfig({ configPath: input.configPath, homeDir: input.homeDir });
     const paths = resolveObserverPaths(loaded.config, input.homeDir);
@@ -68,8 +72,9 @@ async function activateObserverConfig(input: {
         : { onStartupProgress: input.onStartupProgress }),
     });
     if (status.status !== "running") {
-      throw safeErrorFromUnknown(status.error, observerActivationError);
+      return observerLifecycleFailure(status);
     }
+    return undefined;
   } catch (error) {
     throw safeErrorFromUnknown(error, observerActivationError);
   }
@@ -83,7 +88,18 @@ const observerActivationError = {
 
 function failedActivation(
   operationId: "activate-observer-config",
-  error: ReturnType<typeof publicSafeErrorFromUnknown>,
+  failure: ReturnType<typeof publicSafeErrorFromUnknown> | ObserverLifecycleFailure,
 ) {
-  return { status: "failed" as const, operationId, error };
+  if ("error" in failure) {
+    return {
+      status: "failed" as const,
+      operationId,
+      error: failure.error,
+      ...(failure.cause === undefined ? {} : { cause: failure.cause }),
+      ...(failure.startupEvidence === undefined
+        ? {}
+        : { startupEvidence: failure.startupEvidence }),
+    };
+  }
+  return { status: "failed" as const, operationId, error: failure };
 }

--- a/apps/cli/src/commands/setup/presentation/projectSessionView.ts
+++ b/apps/cli/src/commands/setup/presentation/projectSessionView.ts
@@ -1,4 +1,4 @@
-import type { SafeError } from "@station/contracts";
+import type { ObserverStartupEvidence, SafeError } from "@station/contracts";
 import type {
   SetupPlan,
   SetupSessionBlockedState,
@@ -34,6 +34,8 @@ export type ProjectSetupSessionView = {
   readonly operationOutcomes: readonly SetupSessionOperationOutcome[];
   readonly blockReason?: SetupSessionBlockedState["reason"];
   readonly error?: SafeError;
+  readonly cause?: SafeError;
+  readonly startupEvidence?: ObserverStartupEvidence;
 };
 
 export function projectSessionView(state: SetupSessionState): ProjectSetupSessionView {
@@ -50,6 +52,8 @@ export function projectSessionView(state: SetupSessionState): ProjectSetupSessio
         blockReason: state.reason,
         ...(state.plan === undefined ? {} : { plan: state.plan }),
         ...(state.error === undefined ? {} : { error: state.error }),
+        ...(state.cause === undefined ? {} : { cause: state.cause }),
+        ...(state.startupEvidence === undefined ? {} : { startupEvidence: state.startupEvidence }),
       };
     case "completed":
       return { ...base, plan: state.plan, result: state.result };

--- a/apps/cli/src/commands/setup/types.ts
+++ b/apps/cli/src/commands/setup/types.ts
@@ -1,6 +1,7 @@
 import type {
   CliSetupHarnessId,
   HarnessHooksStatus,
+  ObserverLifecycleFailure,
   ProviderHookArtifactOwner,
 } from "@station/contracts";
 import type { ExternalCommandRunner } from "@station/runtime";
@@ -76,7 +77,7 @@ export type SetupCommandDeps = {
     configPath: string;
     homeDir: string;
     onStartupProgress?: (message: string) => void;
-  }) => Promise<void>;
+  }) => Promise<ObserverLifecycleFailure | undefined>;
   now?: () => Date;
   nodeVersion?: string;
   // Defaults to process.platform; injected by machine-state tests to drive the

--- a/apps/cli/src/commands/snapshot.ts
+++ b/apps/cli/src/commands/snapshot.ts
@@ -3,10 +3,9 @@ import type { StationSnapshot } from "@station/contracts";
 import { createObserverClient } from "@station/protocol";
 import { runRuntimeBoundaryWithTimeout } from "@station/runtime";
 import {
+  assertObserverRunning,
   getObserverStatus,
   type ObserverProcessDeps,
-  type ObserverStatus,
-  observerStatusErrorMessage,
   startObserver,
 } from "../observerProcess.js";
 import { resolveObserverPaths } from "../paths.js";
@@ -35,7 +34,7 @@ export async function runSnapshotCommand(
   const status = parsed.requireRunning
     ? await getObserverStatus(processOptions, deps)
     : await startObserver(processOptions, deps);
-  assertRunning(status);
+  assertObserverRunning(status);
   const client =
     deps.clientFactory?.(paths.socketPath) ??
     createObserverClient({
@@ -79,12 +78,4 @@ function parseSnapshotArgs(args: string[]): { includeDebug: boolean; requireRunn
     includeDebug: args.includes("--include-debug"),
     requireRunning: args.includes("--require-running"),
   };
-}
-
-function assertRunning(
-  status: ObserverStatus,
-): asserts status is Extract<ObserverStatus, { status: "running" }> {
-  if (status.status !== "running") {
-    throw new Error(observerStatusErrorMessage(status));
-  }
 }

--- a/apps/cli/src/commands/update.ts
+++ b/apps/cli/src/commands/update.ts
@@ -1,5 +1,10 @@
 import type { StationConfig } from "@station/config";
 import {
+  type ObserverLifecycleFailure,
+  ObserverLifecycleFailureSchema,
+  ObserverRestartCommandResultSchema,
+} from "@station/contracts";
+import {
   type ExternalCommandRunner,
   runExternalCommand,
   type StationBuildInfo,
@@ -161,7 +166,20 @@ async function crossOverRuntime(
     String(OBSERVER_CROSSOVER_TIMEOUT_MS),
   ]);
   try {
-    await runCrossover(observerCommand, commandRunner);
+    const lifecycleFailure = await runObserverCrossover(observerCommand, commandRunner);
+    if (lifecycleFailure !== undefined) {
+      return failedUpdateResult(
+        report,
+        "observer-restart",
+        updateErrorFromUnknown(undefined, {
+          code: "UPDATE_RUNTIME_CROSSOVER_FAILED",
+          message: "Station installed the new build but runtime crossover did not complete.",
+        }),
+        [observerCommand],
+        request.output,
+        lifecycleFailure,
+      );
+    }
     report.steps.push(
       updateStep(
         "observer-restart",
@@ -202,6 +220,41 @@ async function runCrossover(command: UpdateCommandArgv, runner: ExternalCommandR
       },
       runner,
     );
+  } catch (error) {
+    throw updateErrorFromUnknown(error, {
+      code: "UPDATE_RUNTIME_CROSSOVER_FAILED",
+      message: "Station installed the new build but runtime crossover did not complete.",
+    });
+  }
+}
+
+async function runObserverCrossover(
+  command: UpdateCommandArgv,
+  runner: ExternalCommandRunner | undefined,
+): Promise<ObserverLifecycleFailure | undefined> {
+  const [executable, ...args] = command;
+  try {
+    const result = await runExternalCommand(
+      {
+        command: executable,
+        args,
+        timeoutMs: 60_000,
+        maxOutputChars: 64 * 1024,
+        allowedExitCodes: [1],
+      },
+      runner,
+    );
+    const parsed = ObserverRestartCommandResultSchema.parse(JSON.parse(result.stdout));
+    if (result.exitCode === 0 && parsed.status === "running") return undefined;
+    if (result.exitCode !== 0 && parsed.status !== "running") {
+      const failure: ObserverLifecycleFailure = { error: parsed.error };
+      if (parsed.cause !== undefined) failure.cause = parsed.cause;
+      if (parsed.startupEvidence !== undefined) {
+        failure.startupEvidence = parsed.startupEvidence;
+      }
+      return ObserverLifecycleFailureSchema.parse(failure);
+    }
+    throw new Error("Observer restart result contradicted its process exit status.");
   } catch (error) {
     throw updateErrorFromUnknown(error, {
       code: "UPDATE_RUNTIME_CROSSOVER_FAILED",

--- a/apps/cli/src/commands/update/report.ts
+++ b/apps/cli/src/commands/update/report.ts
@@ -1,4 +1,5 @@
 import type {
+  ObserverLifecycleFailure,
   UpdateCommandArgv,
   UpdateCommandReport,
   UpdateCommandStep,
@@ -168,10 +169,17 @@ export function failedUpdateResult(
   error: unknown,
   recoveryCommands: readonly UpdateCommandArgv[],
   output: UpdateRequest["output"],
+  lifecycleFailure?: ObserverLifecycleFailure,
 ): CliRunResult {
   const safeError = publicSafeErrorFromUnknown(error, updateFailureFallback);
   report.status = "failed";
   report.error = safeError;
+  if (lifecycleFailure !== undefined) {
+    report.cause = lifecycleFailure.cause ?? lifecycleFailure.error;
+    if (lifecycleFailure.startupEvidence !== undefined) {
+      report.startupEvidence = lifecycleFailure.startupEvidence;
+    }
+  }
   report.recoveryCommands.push(...recoveryCommands);
   report.steps.push(updateStep(phase, "failed", safeError.message, recoveryCommands[0]));
   if (phase === "apply") {
@@ -221,6 +229,11 @@ function renderUpdateReport(report: UpdateCommandReport): string {
   for (const warning of report.warnings) lines.push(`warning: ${warning.message}`);
   if (report.error !== undefined)
     lines.push(`error: ${report.error.message} (${report.error.code})`);
+  if (report.cause !== undefined)
+    lines.push(`cause: ${report.cause.message} (${report.cause.code})`);
+  if (report.startupEvidence !== undefined) {
+    lines.push(`observer boot log: ${report.startupEvidence.bootLogPath}`);
+  }
   if (report.recoveryCommands.length > 0) {
     lines.push("recovery:");
     for (const command of report.recoveryCommands) lines.push(`  ${formatCommand(command)}`);

--- a/apps/cli/src/observerMain.ts
+++ b/apps/cli/src/observerMain.ts
@@ -16,12 +16,11 @@ export type RunCliObserverMainOptions = {
   startupReadinessSink?: ObserverStartupReadinessSink;
 };
 
-export type RunCliObserverProcessOptions = {
+type RunCliObserverProcessOptions = {
   startupFailureReporter?: ObserverStartupFailureReporter;
-  startupReadinessSink?: ObserverStartupReadinessSink;
 };
 
-export type CliObserverProcessOperation = (
+type CliObserverProcessOperation = (
   startupReadinessSink: ObserverStartupReadinessSink,
 ) => Promise<number>;
 
@@ -72,24 +71,15 @@ export async function runCliObserverProcess(
   options: RunCliObserverProcessOptions = {},
 ): Promise<number> {
   const reporter = options.startupFailureReporter ?? createObserverStartupFailureReporter();
-  let reportChannelClosed = false;
-  const closeReportChannel = (): void => {
-    if (reportChannelClosed) return;
-    reportChannelClosed = true;
+  let reportClosed = false;
+  const closeReport = (): void => {
+    if (reportClosed) return;
+    reportClosed = true;
     reporter.ready();
   };
-  const readinessSink: ObserverStartupReadinessSink = {
-    ready: () => {
-      try {
-        options.startupReadinessSink?.ready();
-      } finally {
-        closeReportChannel();
-      }
-    },
-  };
   try {
-    const code = await operation(readinessSink);
-    closeReportChannel();
+    const code = await operation({ ready: closeReport });
+    closeReport();
     return code;
   } catch (error) {
     const report = reporter.failure(error);

--- a/apps/cli/src/observerMain.ts
+++ b/apps/cli/src/observerMain.ts
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 import type { ProviderHookArtifactOwner } from "@station/contracts";
-import { runObserverMain } from "@station/observer";
+import { type ObserverStartupReadinessSink, runObserverMain } from "@station/observer";
 import { providerHookArtifactOwner, stationBuildInfo } from "@station/runtime";
+import {
+  createObserverStartupFailureReporter,
+  type ObserverStartupFailureReporter,
+} from "./observerProcess/failureReport.js";
 import { type CreateProviderRegistryOptions, createProviderRegistry } from "./observerProviders.js";
 import { resolveDefaultIngressLauncher } from "./worktrunkHookExpectation.js";
 
@@ -9,12 +13,23 @@ export type RunCliObserverMainOptions = {
   preparePiExtension?: (stateDir: string) => string | Promise<string>;
   providerHookIngressLauncher?: string;
   providerHookArtifactOwner?: ProviderHookArtifactOwner;
+  startupReadinessSink?: ObserverStartupReadinessSink;
 };
+
+export type RunCliObserverProcessOptions = {
+  startupFailureReporter?: ObserverStartupFailureReporter;
+  startupReadinessSink?: ObserverStartupReadinessSink;
+};
+
+export type CliObserverProcessOperation = (
+  startupReadinessSink: ObserverStartupReadinessSink,
+) => Promise<number>;
 
 /**
  * COMPOSITION ROOT
  *
- * Chooses CLI-owned provider composition and joins it to the Observer runtime lifecycle.
+ * Chooses CLI-owned provider composition and joins it to the Observer runtime lifecycle,
+ * including private startup-readiness notification for the spawning CLI.
  */
 export async function runCliObserverMain(
   argv: readonly string[] = process.argv.slice(2),
@@ -40,18 +55,57 @@ export async function runCliObserverMain(
       registryOptions.providerHookArtifactOwner = artifactOwner;
       return createProviderRegistry(config, registryOptions);
     },
+    ...(options.startupReadinessSink === undefined
+      ? {}
+      : { startupReadinessSink: options.startupReadinessSink }),
   });
 }
 
-async function runCliObserverProcess(): Promise<void> {
+/**
+ * ADAPTER
+ *
+ * Applies one shared source/compiled Observer process boundary: typed startup
+ * reporting, redacted stderr, readiness closure, and exit-code translation.
+ */
+export async function runCliObserverProcess(
+  operation: CliObserverProcessOperation,
+  options: RunCliObserverProcessOptions = {},
+): Promise<number> {
+  const reporter = options.startupFailureReporter ?? createObserverStartupFailureReporter();
+  let reportChannelClosed = false;
+  const closeReportChannel = (): void => {
+    if (reportChannelClosed) return;
+    reportChannelClosed = true;
+    reporter.ready();
+  };
+  const readinessSink: ObserverStartupReadinessSink = {
+    ready: () => {
+      try {
+        options.startupReadinessSink?.ready();
+      } finally {
+        closeReportChannel();
+      }
+    },
+  };
   try {
-    process.exitCode = await runCliObserverMain();
+    const code = await operation(readinessSink);
+    closeReportChannel();
+    return code;
   } catch (error) {
-    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-    process.exitCode = 1;
+    const report = reporter.failure(error);
+    const lines = [`${report.error.message} (${report.error.code})`];
+    if (report.cause !== undefined) {
+      lines.push(`Cause: ${report.cause.message} (${report.cause.code})`);
+    }
+    process.stderr.write(`${lines.join("\n")}\n`);
+    return 1;
   }
 }
 
 if (import.meta.main) {
-  void runCliObserverProcess();
+  void runCliObserverProcess((startupReadinessSink) =>
+    runCliObserverMain(process.argv.slice(2), { startupReadinessSink }),
+  ).then((code) => {
+    process.exitCode = code;
+  });
 }

--- a/apps/cli/src/observerProcess.ts
+++ b/apps/cli/src/observerProcess.ts
@@ -1,4 +1,9 @@
-import type { ObserverHealth, ObserverStopReceipt, SafeError } from "@station/contracts";
+import type {
+  ObserverHealth,
+  ObserverStartupEvidence,
+  ObserverStopReceipt,
+  SafeError,
+} from "@station/contracts";
 import { componentLogPath, createJsonlLogger, createTraceContext } from "@station/observability";
 import {
   createObserverClient,
@@ -117,6 +122,7 @@ function observerHealthTimedOut(paths: ObserverPaths): ObserverStatus {
  *
  * Translates CLI startup intent into exact-build Observer attachment or child
  * startup while leaving socket ownership mutation to the child's boot lifecycle.
+ * Startup failures retain their typed child cause and bounded boot evidence.
  */
 export async function startObserver(
   options: ObserverProcessOptions = {},
@@ -192,6 +198,8 @@ async function startObserverWithPolicy(
     operation: "cli.observer.start",
     trace,
     error: result.error,
+    ...(result.cause === undefined ? {} : { cause: result.cause }),
+    ...(result.startupEvidence === undefined ? {} : { startupEvidence: result.startupEvidence }),
     deps,
     clock,
   });
@@ -199,6 +207,8 @@ async function startObserverWithPolicy(
     status: "unhealthy",
     paths,
     error: result.error,
+    ...(result.cause === undefined ? {} : { cause: result.cause }),
+    ...(result.startupEvidence === undefined ? {} : { startupEvidence: result.startupEvidence }),
   };
 }
 
@@ -248,7 +258,8 @@ export async function stopObserver(
  * Converges one configured Observer socket to this caller's exact immutable build within one
  * deadline. At most the admitted identity-pinned incumbent is stopped cooperatively; the child
  * preserves any later non-exact owner. Failures report their phase and the admitted incumbent's
- * last proven disposition without changing generic singleton ordering.
+ * last proven disposition while retaining a separate typed cause and startup evidence, without
+ * changing generic singleton ordering.
  */
 export async function ensureExactObserverBuild(
   options: ObserverProcessOptions = {},
@@ -271,6 +282,8 @@ export async function ensureExactObserverBuild(
       phase: "inspection",
       incumbentDisposition: "preserved",
       error: status.error,
+      ...(status.cause === undefined ? {} : { cause: status.cause }),
+      ...(status.startupEvidence === undefined ? {} : { startupEvidence: status.startupEvidence }),
     });
   }
 
@@ -336,6 +349,10 @@ export async function ensureExactObserverBuild(
         code: "OBSERVER_START_FAILED",
         message: "Observer startup failed without a diagnostic.",
       },
+      ...(started.cause === undefined ? {} : { cause: started.cause }),
+      ...(started.startupEvidence === undefined
+        ? {}
+        : { startupEvidence: started.startupEvidence }),
     });
   }
   if (started.health.version !== buildVersion) {
@@ -357,18 +374,22 @@ function exactBuildActivationFailure(
     phase: ExactObserverActivationPhase;
     incumbentDisposition: ExactObserverIncumbentDisposition;
     error: unknown;
+    cause?: SafeError;
+    startupEvidence?: ObserverStartupEvidence;
   },
 ): ExactObserverBuildStatus {
-  const cause = safeErrorFromUnknown(input.error, {
-    tag: "ObserverStartupError",
-    code: "OBSERVER_EXACT_BUILD_ACTIVATION_CAUSE_UNKNOWN",
-    message: "The exact Observer build activation failed for an unknown reason.",
-  });
+  const cause =
+    input.cause ??
+    safeErrorFromUnknown(input.error, {
+      tag: "ObserverStartupError",
+      code: "OBSERVER_EXACT_BUILD_ACTIVATION_CAUSE_UNKNOWN",
+      message: "The exact Observer build activation failed for an unknown reason.",
+    });
   const error: SafeError = {
     tag: "ObserverStartupError",
     code: "OBSERVER_EXACT_BUILD_ACTIVATION_FAILED",
     message: "The exact Observer build could not be activated safely.",
-    hint: exactBuildFailureHint(input.phase, input.incumbentDisposition, cause),
+    hint: exactBuildFailureHint(input.phase, input.incumbentDisposition),
   };
   if (cause.traceId !== undefined) error.traceId = cause.traceId;
   if (cause.diagnosticId !== undefined) error.diagnosticId = cause.diagnosticId;
@@ -376,6 +397,8 @@ function exactBuildActivationFailure(
     status: "unhealthy",
     paths,
     error,
+    cause,
+    ...(input.startupEvidence === undefined ? {} : { startupEvidence: input.startupEvidence }),
     phase: input.phase,
     incumbentDisposition: input.incumbentDisposition,
   };
@@ -384,7 +407,6 @@ function exactBuildActivationFailure(
 function exactBuildFailureHint(
   phase: ExactObserverActivationPhase,
   incumbentDisposition: ExactObserverIncumbentDisposition,
-  cause: SafeError,
 ): string {
   const recovery =
     incumbentDisposition === "stopped"
@@ -394,8 +416,7 @@ function exactBuildFailureHint(
         : incumbentDisposition === "none"
           ? "No incumbent was observed, and no exact successor was confirmed; retry after resolving the startup failure."
           : "The admitted incumbent's final state could not be proven; inspect status before retrying.";
-  const causeHint = cause.hint === undefined ? "" : ` ${cause.hint}`;
-  return `Activation phase: ${phase}. Incumbent: ${incumbentDisposition}. ${recovery} Cause (${cause.code}): ${cause.message}${causeHint}`;
+  return `Activation phase: ${phase}. Incumbent: ${incumbentDisposition}. ${recovery}`;
 }
 
 function exactBuildMismatchError(health: ObserverHealth, requestedVersion: string): SafeError {
@@ -529,7 +550,8 @@ function hasLegacyObserverBuildIdentity(health: ObserverHealth): boolean {
  *
  * Translates a CLI restart request while preserving a newer winning Observer build.
  * An explicit higher-build restart cooperatively stops the identity-pinned incumbent before spawn.
- * A failed replacement annotates the error hint with the incumbent build identity it tried to replace.
+ * A failed replacement retains its typed cause and startup evidence while annotating only the outer
+ * error hint with the incumbent build identity it tried to replace.
  */
 export async function restartObserver(
   options: ObserverProcessOptions = {},
@@ -589,6 +611,7 @@ function annotateReplacedIncumbent(error: SafeError, incumbent: ObserverHealth):
   return { ...error, hint };
 }
 
+/** Renders a concise lifecycle failure with a separate cause and one executable next step. */
 export function observerStatusErrorMessage(
   status: Exclude<ObserverStatus, { status: "running" }>,
 ): string {
@@ -597,21 +620,30 @@ export function observerStatusErrorMessage(
     return "Observer is not running.";
   }
 
-  const lines = [error.message];
-  if (error.hint !== undefined) {
-    lines.push(`Hint: ${error.hint}`);
+  const lines = [`${error.message} (${error.code})`];
+  if (status.cause !== undefined) {
+    lines.push(`Cause: ${status.cause.message} (${status.cause.code})`);
   }
-  if (error.code !== undefined) {
-    lines.push(`Code: ${error.code}`);
-  }
+  const traceId = error.traceId ?? status.cause?.traceId;
+  lines.push(
+    traceId === undefined ? "Next: stn observer status" : `Next: stn debug trace ${traceId}`,
+  );
   return lines.join("\n");
 }
 
+/**
+ * ADAPTER
+ *
+ * Persists one redacted CLI lifecycle boundary with distinct outer error,
+ * causal failure, and bounded startup evidence fields.
+ */
 export async function logObserverLifecycleFailure(input: {
   paths: ObserverPaths;
   operation: string;
   trace: RuntimeTraceContext;
   error: SafeError;
+  cause?: SafeError;
+  startupEvidence?: ObserverStartupEvidence;
   deps: ObserverProcessDeps;
   clock: RuntimeClock;
 }): Promise<void> {
@@ -633,6 +665,8 @@ export async function logObserverLifecycleFailure(input: {
         socketPath: input.paths.socketPath,
         stateDir: input.paths.stateDir,
         error: input.error,
+        ...(input.cause === undefined ? {} : { cause: input.cause }),
+        ...(input.startupEvidence === undefined ? {} : { startupEvidence: input.startupEvidence }),
       },
     });
   } catch {

--- a/apps/cli/src/observerProcess.ts
+++ b/apps/cli/src/observerProcess.ts
@@ -1,9 +1,11 @@
 import type {
   ObserverHealth,
+  ObserverLifecycleFailure,
   ObserverStartupEvidence,
   ObserverStopReceipt,
   SafeError,
 } from "@station/contracts";
+import { ObserverLifecycleFailureSchema, textLineTerminatorPattern } from "@station/contracts";
 import { componentLogPath, createJsonlLogger, createTraceContext } from "@station/observability";
 import {
   createObserverClient,
@@ -141,6 +143,7 @@ async function startObserverWithPolicy(
   const clock = deps.clock ?? systemClock;
   const buildVersion = deps.buildVersion ?? stationObserverBuildVersion();
   const trace = createTraceContext({ operation: "cli.observer.start" });
+  let replaceableIncumbent: ObserverHealth | undefined;
   const statusTimeoutMs = remainingObserverStartBudget(timeoutMs, options.startupDeadlineMs);
   if (statusTimeoutMs <= 0) return observerStartTimedOut(paths);
   const existing = await getObserverStatus({ ...options, paths, timeoutMs: statusTimeoutMs }, deps);
@@ -155,6 +158,9 @@ async function startObserverWithPolicy(
         paths,
         error: observerHandoffRefusedError(existing.health, buildVersion, classification.reason),
       };
+    }
+    if (classification.action === "replace") {
+      replaceableIncumbent = existing.health;
     }
   }
   if (
@@ -174,6 +180,7 @@ async function startObserverWithPolicy(
       trace,
       clock,
       buildVersion,
+      ...(replaceableIncumbent === undefined ? {} : { replaceableIncumbent }),
       ...(options.configPath === undefined ? {} : { configPath: options.configPath }),
       ...(options.observerCommand === undefined
         ? {}
@@ -624,11 +631,43 @@ export function observerStatusErrorMessage(
   if (status.cause !== undefined) {
     lines.push(`Cause: ${status.cause.message} (${status.cause.code})`);
   }
+  if (status.cause === undefined && error.hint !== undefined) {
+    lines.push(`Next: ${error.hint.split(textLineTerminatorPattern).join(" ")}`);
+    return lines.join("\n");
+  }
   const traceId = error.traceId ?? status.cause?.traceId;
   lines.push(
     traceId === undefined ? "Next: stn observer status" : `Next: stn debug trace ${traceId}`,
   );
   return lines.join("\n");
+}
+
+/**
+ * Preserves the strict lifecycle envelope when an auto-starting command cannot obtain a running Observer.
+ */
+export function assertObserverRunning(
+  status: ObserverStatus,
+): asserts status is Extract<ObserverStatus, { status: "running" }> {
+  if (status.status === "running") return;
+  throw observerLifecycleFailure(status);
+}
+
+/** Builds the strict public lifecycle envelope from one non-running Observer status. */
+export function observerLifecycleFailure(
+  status: Exclude<ObserverStatus, { status: "running" }>,
+): ObserverLifecycleFailure {
+  const failure: ObserverLifecycleFailure = {
+    error:
+      status.error ??
+      ({
+        tag: "ObserverStartupError",
+        code: "OBSERVER_NOT_RUNNING",
+        message: "Observer is not running.",
+      } satisfies SafeError),
+  };
+  if (status.cause !== undefined) failure.cause = status.cause;
+  if (status.startupEvidence !== undefined) failure.startupEvidence = status.startupEvidence;
+  return ObserverLifecycleFailureSchema.parse(failure);
 }
 
 /**

--- a/apps/cli/src/observerProcess/failureReport.ts
+++ b/apps/cli/src/observerProcess/failureReport.ts
@@ -101,72 +101,33 @@ export function createObserverStartupFailureReporter(
 export function readObserverStartupFailureReport(
   stream: Readable,
 ): ObserverStartupFailureReportReader {
-  const chunks: Buffer[] = [];
-  let bytes = 0;
-  let settled = false;
-  let resolveReport!: (report: ObserverStartupFailureReport | undefined) => void;
-  let rejectReport!: (error: Error) => void;
-  const report = new Promise<ObserverStartupFailureReport | undefined>((resolve, reject) => {
-    resolveReport = resolve;
-    rejectReport = reject;
-  });
-
-  const cleanup = (): void => {
-    stream.off("data", onData);
-    stream.off("end", onEnd);
-    stream.off("error", onError);
-    stream.off("close", onClose);
-  };
-  const resolve = (value: ObserverStartupFailureReport | undefined): void => {
-    if (settled) return;
-    settled = true;
-    cleanup();
-    resolveReport(value);
-  };
-  const reject = (error: Error): void => {
-    if (settled) return;
-    settled = true;
-    cleanup();
-    rejectReport(error);
-  };
-  const onData = (chunk: Buffer | string): void => {
-    const buffer = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
-    bytes += buffer.byteLength;
-    if (bytes > OBSERVER_STARTUP_FAILURE_REPORT_MAX_BYTES) {
-      reject(new Error("Observer startup failure report exceeded its byte limit."));
-      stream.destroy();
-      return;
-    }
-    chunks.push(buffer);
-  };
-  const onEnd = (): void => {
-    if (bytes === 0) {
-      resolve(undefined);
-      return;
-    }
+  let disposed = false;
+  const report = (async (): Promise<ObserverStartupFailureReport | undefined> => {
+    const chunks: Buffer[] = [];
+    let bytes = 0;
     try {
-      resolve(parseObserverStartupFailureReport(Buffer.concat(chunks, bytes)));
+      for await (const chunk of stream as AsyncIterable<Buffer | string>) {
+        const buffer = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+        bytes += buffer.byteLength;
+        if (bytes > OBSERVER_STARTUP_FAILURE_REPORT_MAX_BYTES) {
+          stream.destroy();
+          throw new Error("Observer startup failure report exceeded its byte limit.");
+        }
+        chunks.push(buffer);
+      }
     } catch (error) {
-      reject(
-        error instanceof Error ? error : new Error("Observer startup failure report was invalid."),
-      );
+      if (disposed) return undefined;
+      throw error;
     }
-  };
-  const onError = (error: Error): void => reject(error);
-  const onClose = (): void => {
-    if (!settled) reject(new Error("Observer startup failure report ended before EOF."));
-  };
-
-  stream.on("data", onData);
-  stream.once("end", onEnd);
-  stream.once("error", onError);
-  stream.once("close", onClose);
+    if (disposed || bytes === 0) return undefined;
+    return parseObserverStartupFailureReport(Buffer.concat(chunks, bytes));
+  })();
 
   return {
     report,
     dispose: () => {
-      if (settled) return;
-      resolve(undefined);
+      if (disposed) return;
+      disposed = true;
       stream.destroy();
     },
   };

--- a/apps/cli/src/observerProcess/failureReport.ts
+++ b/apps/cli/src/observerProcess/failureReport.ts
@@ -6,6 +6,7 @@ import {
   ObserverStartupFailureReportSchema,
   type SafeError,
   SafeErrorSchema,
+  textLineTerminatorPattern,
 } from "@station/contracts";
 import { redact } from "@station/observability";
 import type { ObserverStartupReadinessSink } from "@station/observer";
@@ -215,7 +216,7 @@ function normalizeStartupFailureNode(value: unknown): SafeError {
     return SafeErrorSchema.parse(redact(safeError).value);
   }
   if (value instanceof Error) {
-    const [firstLine] = redact(value.message).value.split(/\r?\n/u);
+    const [firstLine] = redact(value.message).value.split(textLineTerminatorPattern);
     return {
       tag: "ObserverStartupCauseError",
       code: "OBSERVER_STARTUP_CAUSE_ERROR",

--- a/apps/cli/src/observerProcess/failureReport.ts
+++ b/apps/cli/src/observerProcess/failureReport.ts
@@ -1,0 +1,287 @@
+import { closeSync, writeSync } from "node:fs";
+import type { Readable } from "node:stream";
+import {
+  OBSERVER_STARTUP_FAILURE_REPORT_MAX_BYTES,
+  type ObserverStartupFailureReport,
+  ObserverStartupFailureReportSchema,
+  type SafeError,
+  SafeErrorSchema,
+} from "@station/contracts";
+import { redact } from "@station/observability";
+import type { ObserverStartupReadinessSink } from "@station/observer";
+import { z } from "zod";
+
+/** Private inherited descriptor used only for one child startup failure report. */
+export const STATION_OBSERVER_STARTUP_FAILURE_FD = "STATION_OBSERVER_STARTUP_FAILURE_FD";
+
+/** The private report descriptor is fixed so process evidence retains a stable argv. */
+export const OBSERVER_STARTUP_FAILURE_FD = 3;
+
+const SafeErrorViewSchema = SafeErrorSchema.strip();
+const CauseCarrierSchema = z.object({ cause: z.unknown() }).passthrough();
+
+type ObserverStartupFailureReporterDeps = {
+  write?: (fd: number, buffer: Uint8Array, offset: number) => number;
+  close?: (fd: number) => void;
+};
+
+export type ObserverStartupFailureReporter = ObserverStartupReadinessSink & {
+  failure(error: unknown): ObserverStartupFailureReport;
+};
+
+export type ObserverStartupFailureReportReader = {
+  report: Promise<ObserverStartupFailureReport | undefined>;
+  dispose(): void;
+};
+
+/**
+ * ADAPTER
+ *
+ * Writes at most one strict, redacted Observer startup failure to the inherited
+ * report descriptor and closes the descriptor on either readiness or failure.
+ */
+export function createObserverStartupFailureReporter(
+  env: NodeJS.ProcessEnv = process.env,
+  deps: ObserverStartupFailureReporterDeps = {},
+): ObserverStartupFailureReporter {
+  const configuredFd = env[STATION_OBSERVER_STARTUP_FAILURE_FD];
+  delete env[STATION_OBSERVER_STARTUP_FAILURE_FD];
+  const fd =
+    configuredFd === String(OBSERVER_STARTUP_FAILURE_FD) ? OBSERVER_STARTUP_FAILURE_FD : undefined;
+  const write = deps.write ?? ((targetFd, buffer, offset) => writeSync(targetFd, buffer, offset));
+  const close = deps.close ?? closeSync;
+  let closed = fd === undefined;
+
+  const closeOnce = (): void => {
+    if (closed || fd === undefined) return;
+    closed = true;
+    try {
+      close(fd);
+    } catch {
+      // Failure reporting is best-effort and must not replace the startup result.
+    }
+  };
+
+  return {
+    ready: closeOnce,
+    failure: (error) => {
+      let report = normalizeObserverStartupFailure(error);
+      if (!closed && fd !== undefined) {
+        try {
+          let payload: Uint8Array;
+          try {
+            payload = serializeObserverStartupFailureReport(report);
+          } catch {
+            report = unknownObserverStartupFailureReport();
+            payload = serializeObserverStartupFailureReport(report);
+          }
+          let offset = 0;
+          while (offset < payload.byteLength) {
+            const written = write(fd, payload, offset);
+            if (written <= 0) throw new Error("Observer startup failure report write stalled.");
+            offset += written;
+          }
+        } catch {
+          // The original startup failure remains authoritative if the private pipe is unavailable.
+        } finally {
+          closeOnce();
+        }
+      }
+      return report;
+    },
+  };
+}
+
+/**
+ * ADAPTER
+ *
+ * Consumes one bounded inherited-pipe payload and validates the strict private
+ * child report before exposing typed failure evidence to lifecycle orchestration.
+ */
+export function readObserverStartupFailureReport(
+  stream: Readable,
+): ObserverStartupFailureReportReader {
+  const chunks: Buffer[] = [];
+  let bytes = 0;
+  let settled = false;
+  let resolveReport!: (report: ObserverStartupFailureReport | undefined) => void;
+  let rejectReport!: (error: Error) => void;
+  const report = new Promise<ObserverStartupFailureReport | undefined>((resolve, reject) => {
+    resolveReport = resolve;
+    rejectReport = reject;
+  });
+
+  const cleanup = (): void => {
+    stream.off("data", onData);
+    stream.off("end", onEnd);
+    stream.off("error", onError);
+    stream.off("close", onClose);
+  };
+  const resolve = (value: ObserverStartupFailureReport | undefined): void => {
+    if (settled) return;
+    settled = true;
+    cleanup();
+    resolveReport(value);
+  };
+  const reject = (error: Error): void => {
+    if (settled) return;
+    settled = true;
+    cleanup();
+    rejectReport(error);
+  };
+  const onData = (chunk: Buffer | string): void => {
+    const buffer = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+    bytes += buffer.byteLength;
+    if (bytes > OBSERVER_STARTUP_FAILURE_REPORT_MAX_BYTES) {
+      reject(new Error("Observer startup failure report exceeded its byte limit."));
+      stream.destroy();
+      return;
+    }
+    chunks.push(buffer);
+  };
+  const onEnd = (): void => {
+    if (bytes === 0) {
+      resolve(undefined);
+      return;
+    }
+    try {
+      resolve(parseObserverStartupFailureReport(Buffer.concat(chunks, bytes)));
+    } catch (error) {
+      reject(
+        error instanceof Error ? error : new Error("Observer startup failure report was invalid."),
+      );
+    }
+  };
+  const onError = (error: Error): void => reject(error);
+  const onClose = (): void => {
+    if (!settled) reject(new Error("Observer startup failure report ended before EOF."));
+  };
+
+  stream.on("data", onData);
+  stream.once("end", onEnd);
+  stream.once("error", onError);
+  stream.once("close", onClose);
+
+  return {
+    report,
+    dispose: () => {
+      if (settled) return;
+      resolve(undefined);
+      stream.destroy();
+    },
+  };
+}
+
+/** Serializes one strict report and rejects output over the inherited-pipe byte limit. */
+export function serializeObserverStartupFailureReport(
+  report: ObserverStartupFailureReport,
+): Uint8Array {
+  const parsed = ObserverStartupFailureReportSchema.parse(report);
+  const payload = Buffer.from(`${JSON.stringify(parsed)}\n`, "utf8");
+  if (payload.byteLength > OBSERVER_STARTUP_FAILURE_REPORT_MAX_BYTES) {
+    throw new Error("Observer startup failure report exceeded its byte limit.");
+  }
+  return payload;
+}
+
+/** Parses exactly one strict report from a bounded pipe payload. */
+export function parseObserverStartupFailureReport(
+  payload: Uint8Array,
+): ObserverStartupFailureReport {
+  if (payload.byteLength > OBSERVER_STARTUP_FAILURE_REPORT_MAX_BYTES) {
+    throw new Error("Observer startup failure report exceeded its byte limit.");
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(Buffer.from(payload).toString("utf8"));
+  } catch {
+    throw new Error("Observer startup failure report was not one complete JSON value.");
+  }
+  const parsed = ObserverStartupFailureReportSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new Error("Observer startup failure report did not match its strict contract.");
+  }
+  return parsed.data;
+}
+
+/** Normalizes one unknown startup escape without retaining raw objects, stacks, or serialization. */
+export function normalizeObserverStartupFailure(error: unknown): ObserverStartupFailureReport {
+  try {
+    const chain = startupFailureChain(error);
+    const report: ObserverStartupFailureReport = {
+      kind: "observer-startup-failure",
+      version: 1,
+      error: normalizeStartupFailureNode(chain[0]),
+    };
+    const deepestTyped = [...chain].reverse().find((node) => safeErrorView(node) !== undefined);
+    const causeNode =
+      deepestTyped !== undefined && deepestTyped !== chain[0]
+        ? deepestTyped
+        : chain.length > 1
+          ? chain[chain.length - 1]
+          : undefined;
+    if (causeNode !== undefined) {
+      report.cause = normalizeStartupFailureNode(causeNode);
+    }
+    return ObserverStartupFailureReportSchema.parse(report);
+  } catch {
+    return unknownObserverStartupFailureReport();
+  }
+}
+
+function startupFailureChain(error: unknown): unknown[] {
+  const chain: unknown[] = [error];
+  const seen = new Set<unknown>();
+  let current = error;
+  while (current !== null && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    let carrier: ReturnType<typeof CauseCarrierSchema.safeParse>;
+    try {
+      carrier = CauseCarrierSchema.safeParse(current);
+    } catch {
+      break;
+    }
+    if (!carrier.success || carrier.data.cause === undefined || seen.has(carrier.data.cause)) break;
+    current = carrier.data.cause;
+    chain.push(current);
+  }
+  return chain;
+}
+
+function normalizeStartupFailureNode(value: unknown): SafeError {
+  const safeError = safeErrorView(value);
+  if (safeError !== undefined) {
+    return SafeErrorSchema.parse(redact(safeError).value);
+  }
+  if (value instanceof Error) {
+    const [firstLine] = redact(value.message).value.split(/\r?\n/u);
+    return {
+      tag: "ObserverStartupCauseError",
+      code: "OBSERVER_STARTUP_CAUSE_ERROR",
+      message:
+        firstLine === undefined || firstLine.length === 0 ? "Observer startup failed." : firstLine,
+    };
+  }
+  return unknownObserverStartupFailureReport().error;
+}
+
+function safeErrorView(value: unknown): SafeError | undefined {
+  try {
+    const parsed = SafeErrorViewSchema.safeParse(value);
+    return parsed.success ? parsed.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function unknownObserverStartupFailureReport(): ObserverStartupFailureReport {
+  return {
+    kind: "observer-startup-failure",
+    version: 1,
+    error: {
+      tag: "ObserverStartupCauseError",
+      code: "OBSERVER_STARTUP_CAUSE_UNKNOWN",
+      message: "Observer startup failed for an unknown reason.",
+    },
+  };
+}

--- a/apps/cli/src/observerProcess/spawn.ts
+++ b/apps/cli/src/observerProcess/spawn.ts
@@ -6,6 +6,7 @@ import { Readable } from "node:stream";
 import {
   OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_BYTES,
   OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_LINES,
+  textLineTerminatorPattern,
 } from "@station/contracts";
 import { environmentWithoutGitLocals, stationObserverBuildVersion } from "@station/runtime";
 import { selfExecArgv } from "../selfExec.js";
@@ -123,13 +124,15 @@ function childWithExit(
   failureReportReader: ObserverStartupFailureReportReader,
 ): ChildProcessLike {
   let disposeExitWait!: () => void;
+  // Report parsing can finish before the child exits, so rejection handling must exist immediately.
+  const handledReport = failureReportReader.report.catch(() => undefined);
   const exited = new Promise<ChildExitResult>((resolve) => {
     let settled = false;
     const finish = async (result: ChildExitResult) => {
       if (settled) return;
       settled = true;
       disposeExitWait();
-      const report = await failureReportReader.report.catch(() => undefined);
+      const report = await handledReport;
       resolve(report === undefined ? result : { ...result, report });
     };
     const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
@@ -195,10 +198,15 @@ async function readObserverBootLogTailFromHandle(bootLog: FileHandle): Promise<s
   const { bytesRead } = await bootLog.read(buffer, 0, length, size - length);
   let content = buffer.subarray(0, bytesRead).toString("utf8");
   if (size > length) {
-    const firstNewline = content.indexOf("\n");
-    if (firstNewline !== -1) content = content.slice(firstNewline + 1);
+    const firstTerminator = textLineTerminatorPattern.exec(content);
+    if (firstTerminator !== null) {
+      content = content.slice(firstTerminator.index + firstTerminator[0].length);
+    }
   }
   content = content.trimEnd();
   if (content.trim().length === 0) return undefined;
-  return content.split(/\r?\n/).slice(-OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_LINES).join("\n");
+  return content
+    .split(textLineTerminatorPattern)
+    .slice(-OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_LINES)
+    .join("\n");
 }

--- a/apps/cli/src/observerProcess/spawn.ts
+++ b/apps/cli/src/observerProcess/spawn.ts
@@ -2,8 +2,19 @@ import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { type FileHandle, mkdir, open, rename, unlink } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import { Readable } from "node:stream";
+import {
+  OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_BYTES,
+  OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_LINES,
+} from "@station/contracts";
 import { environmentWithoutGitLocals, stationObserverBuildVersion } from "@station/runtime";
 import { selfExecArgv } from "../selfExec.js";
+import {
+  OBSERVER_STARTUP_FAILURE_FD,
+  type ObserverStartupFailureReportReader,
+  readObserverStartupFailureReport,
+  STATION_OBSERVER_STARTUP_FAILURE_FD,
+} from "./failureReport.js";
 import type { ChildExitResult, ChildProcessLike, SpawnObserverInput } from "./types.js";
 
 type DefaultSpawnObserverInput = SpawnObserverInput & {
@@ -12,6 +23,12 @@ type DefaultSpawnObserverInput = SpawnObserverInput & {
   processToken?: string;
 };
 
+/**
+ * ADAPTER
+ *
+ * Spawns one detached Observer with a private failure-report descriptor and
+ * child-owned boot log, then exposes bounded exit and diagnostic cleanup.
+ */
 export async function defaultSpawnObserver(
   input: DefaultSpawnObserverInput,
 ): Promise<ChildProcessLike> {
@@ -22,6 +39,7 @@ export async function defaultSpawnObserver(
   const bootLog = await open(pendingBootLogPath, "wx", 0o600);
   let child: ChildProcess | undefined;
   let bootLogReader: FileHandle | undefined;
+  let failureReportReader: ObserverStartupFailureReportReader | undefined;
   let published = false;
   try {
     await bootLog.chmod(0o600);
@@ -34,10 +52,15 @@ export async function defaultSpawnObserver(
     child = spawn(command, args, {
       detached: process.env.STATION_RUNTIME_OWNER_FOREGROUND !== "1",
       env: observerSpawnEnvironment(input),
-      stdio: ["ignore", bootLog.fd, bootLog.fd],
+      stdio: ["ignore", bootLog.fd, bootLog.fd, "pipe"],
     });
+    const failureReportStream = child.stdio[OBSERVER_STARTUP_FAILURE_FD];
+    if (!(failureReportStream instanceof Readable)) {
+      throw new Error("Observer startup failure report pipe was unavailable.");
+    }
+    failureReportReader = readObserverStartupFailureReport(failureReportStream);
     const startedChild = Object.assign(
-      childWithExit(child),
+      childWithExit(child, failureReportReader),
       observerBootLogDiagnostics(bootLogReader),
     );
     await bootLog.close();
@@ -46,6 +69,7 @@ export async function defaultSpawnObserver(
     child?.kill();
     await bootLog.close().catch(() => undefined);
     await bootLogReader?.close().catch(() => undefined);
+    failureReportReader?.dispose();
     if (!published) {
       await unlink(pendingBootLogPath).catch(() => undefined);
     }
@@ -63,6 +87,8 @@ export function observerSpawnEnvironment(
 ): NodeJS.ProcessEnv {
   const env = environmentWithoutGitLocals(inheritedEnvironment);
   delete env.STATION_OBSERVER_STARTUP_POLICY;
+  delete env[STATION_OBSERVER_STARTUP_FAILURE_FD];
+  env[STATION_OBSERVER_STARTUP_FAILURE_FD] = String(OBSERVER_STARTUP_FAILURE_FD);
   if (input.incumbentPolicy === "preserve") {
     env.STATION_OBSERVER_STARTUP_POLICY = "preserve-incumbent";
   }
@@ -92,21 +118,25 @@ export function observerSpawnArgv(input: DefaultSpawnObserverInput): [string, ..
   ];
 }
 
-function childWithExit(child: ChildProcess): ChildProcessLike {
+function childWithExit(
+  child: ChildProcess,
+  failureReportReader: ObserverStartupFailureReportReader,
+): ChildProcessLike {
   let disposeExitWait!: () => void;
   const exited = new Promise<ChildExitResult>((resolve) => {
     let settled = false;
-    const finish = (result: ChildExitResult) => {
+    const finish = async (result: ChildExitResult) => {
       if (settled) return;
       settled = true;
       disposeExitWait();
-      resolve(result);
+      const report = await failureReportReader.report.catch(() => undefined);
+      resolve(report === undefined ? result : { ...result, report });
     };
     const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
-      finish({ type: "exit", code, signal });
+      void finish({ type: "exit", code, signal });
     };
     const onError = (error: Error) => {
-      finish({ type: "spawn_error", error });
+      void finish({ type: "spawn_error", error });
     };
     disposeExitWait = () => {
       child.off("exit", onExit);
@@ -115,7 +145,11 @@ function childWithExit(child: ChildProcess): ChildProcessLike {
     child.once("exit", onExit);
     child.once("error", onError);
   });
-  return Object.assign(child, { exited, disposeExitWait });
+  return Object.assign(child, {
+    exited,
+    disposeExitWait,
+    disposeFailureReport: failureReportReader.dispose,
+  });
 }
 
 export async function readObserverBootLogTail(path: string): Promise<string | undefined> {
@@ -154,10 +188,9 @@ function observerBootLogDiagnostics(bootLog: FileHandle): {
 }
 
 async function readObserverBootLogTailFromHandle(bootLog: FileHandle): Promise<string | undefined> {
-  const maxBytes = 64 * 1024;
   const { size } = await bootLog.stat();
   if (size === 0) return undefined;
-  const length = Math.min(size, maxBytes);
+  const length = Math.min(size, OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_BYTES);
   const buffer = Buffer.alloc(length);
   const { bytesRead } = await bootLog.read(buffer, 0, length, size - length);
   let content = buffer.subarray(0, bytesRead).toString("utf8");
@@ -167,5 +200,5 @@ async function readObserverBootLogTailFromHandle(bootLog: FileHandle): Promise<s
   }
   content = content.trimEnd();
   if (content.trim().length === 0) return undefined;
-  return content.split(/\r?\n/).slice(-15).join("\n");
+  return content.split(/\r?\n/).slice(-OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_LINES).join("\n");
 }

--- a/apps/cli/src/observerProcess/startup.ts
+++ b/apps/cli/src/observerProcess/startup.ts
@@ -1,17 +1,21 @@
 import { mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
-import type { ObserverHealth, SafeError } from "@station/contracts";
+import {
+  OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_BYTES,
+  OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_LINES,
+  type ObserverHealth,
+  type ObserverStartupEvidence,
+  type SafeError,
+} from "@station/contracts";
 import { redactString } from "@station/observability";
 import {
   Effect,
-  isSafeError,
   publicSafeErrorFromUnknown,
-  type RuntimeBoundaryResult,
   type RuntimeClock,
-  type RuntimeSafeError,
   type RuntimeTraceContext,
   runRuntimeBoundaryWithTimeout,
 } from "@station/runtime";
+import { normalizeObserverStartupFailure } from "./failureReport.js";
 import {
   observerHandoffRefusedError,
   observerHealthWaitCancelledError,
@@ -23,15 +27,17 @@ import type {
   ChildProcessLike,
   ObserverProcessDeps,
   ObserverProcessOptions,
+  ObserverStartupProcessResult,
   SpawnObserverInput,
 } from "./types.js";
 
 const incumbentHealthGraceMs = 1_000;
 
 /**
- * Starts the Observer child and waits for exact-build health inside one timed runtime boundary.
- * Startup failures are enriched with the redacted boot reason and the child-owned boot-log tail
- * before the boot-log handle is disposed.
+ * ADAPTER
+ *
+ * Starts the Observer child and waits for exact-build health inside one timed runtime boundary,
+ * retaining a separate typed cause and bounded boot evidence before diagnostic handles close.
  */
 export async function startObserverProcess(
   input: {
@@ -46,10 +52,11 @@ export async function startObserverProcess(
     onStartupProgress?: ObserverProcessOptions["onStartupProgress"];
   },
   deps: ObserverProcessDeps,
-): Promise<RuntimeBoundaryResult<ObserverHealth>> {
+): Promise<ObserverStartupProcessResult> {
   const startupProgress = scheduleObserverStartupProgress(input.onStartupProgress, input.paths);
   let child: ChildProcessLike | undefined;
-  let startupFailureReason: string | undefined;
+  let startupCause: SafeError | undefined;
+  let startupEvidence: ObserverStartupEvidence | undefined;
   const result = await runRuntimeBoundaryWithTimeout(
     {
       operation: "cli.observer.start",
@@ -59,14 +66,14 @@ export async function startObserverProcess(
         tag: "ObserverStartupError",
         code: "OBSERVER_START_FAILED",
         message: "Observer startup failed.",
-        hint: `Run station debug trace ${input.trace.traceId}.`,
+        hint: `Run stn debug trace ${input.trace.traceId}.`,
         traceId: input.trace.traceId,
       },
       timeoutError: {
         tag: "ObserverStartupError",
         code: "OBSERVER_START_FAILED",
         message: "Observer did not become healthy before the startup timeout.",
-        hint: `Run station debug trace ${input.trace.traceId}.`,
+        hint: `Run stn debug trace ${input.trace.traceId}.`,
         traceId: input.trace.traceId,
       },
       trace: input.trace,
@@ -106,11 +113,18 @@ export async function startObserverProcess(
             buildVersion: input.buildVersion,
             trace: input.trace,
             signal,
+            onFailureEvidence: (evidence) => {
+              if (evidence.cause !== undefined) startupCause = evidence.cause;
+              startupEvidence = evidence.startupEvidence;
+            },
           },
           deps,
         );
       } catch (error) {
-        startupFailureReason = redactedStartupFailureReason(error);
+        if (startupCause === undefined) {
+          const report = normalizeObserverStartupFailure(error);
+          startupCause = report.cause ?? report.error;
+        }
         throw error;
       }
     },
@@ -124,17 +138,18 @@ export async function startObserverProcess(
     child?.kill?.();
   }
   if (result.ok) {
+    child?.disposeFailureReport?.();
     await disposeObserverBootLog(child);
     return result;
   }
-  const error = await enrichStartupFailureEvidence({
-    error: result.error,
-    reason: startupFailureReason,
-    paths: input.paths,
-    child,
-  });
+  startupEvidence ??= await readObserverStartupEvidence(input.paths, child);
+  child?.disposeFailureReport?.();
   await disposeObserverBootLog(child);
-  return { ...result, error };
+  return {
+    ...result,
+    ...(startupCause === undefined ? {} : { cause: startupCause }),
+    ...(startupEvidence === undefined ? {} : { startupEvidence }),
+  };
 }
 
 async function waitForStartedObserver(
@@ -145,6 +160,10 @@ async function waitForStartedObserver(
     buildVersion: string;
     trace: RuntimeTraceContext;
     signal: AbortSignal;
+    onFailureEvidence: (evidence: {
+      cause?: SafeError;
+      startupEvidence: ObserverStartupEvidence;
+    }) => void;
   },
   deps: ObserverProcessDeps,
 ): Promise<ObserverHealth> {
@@ -226,7 +245,7 @@ async function waitForStartedObserver(
       convergenceError = error;
     }
     if (replaceableIncumbent !== undefined) {
-      throw await observerReplacementExitedError(
+      const failure = await observerReplacementExitedFailure(
         replaceableIncumbent,
         input.buildVersion,
         input.paths,
@@ -235,8 +254,17 @@ async function waitForStartedObserver(
         convergenceError,
         input.trace,
       );
+      input.onFailureEvidence(failure);
+      throw failure.error;
     }
-    throw await observerExitedOnStartError(input.paths, input.child, outcome.exit, input.trace);
+    const failure = await observerExitedOnStartFailure(
+      input.paths,
+      input.child,
+      outcome.exit,
+      input.trace,
+    );
+    input.onFailureEvidence(failure);
+    throw failure.error;
   } finally {
     input.signal.removeEventListener("abort", cancelHealth);
     healthController.abort();
@@ -245,62 +273,71 @@ async function waitForStartedObserver(
   }
 }
 
-async function observerReplacementExitedError(
-  incumbent: ObserverHealth,
-  requestedVersion: string,
+async function observerReplacementExitedFailure(
+  _incumbent: ObserverHealth,
+  _requestedVersion: string,
   paths: SpawnObserverInput["paths"],
   child: ChildProcessLike,
   exit: ChildExitResult,
   convergenceFailure: unknown,
   trace: RuntimeTraceContext,
-): Promise<SafeError> {
+): Promise<{
+  error: SafeError;
+  cause?: SafeError;
+  startupEvidence: ObserverStartupEvidence;
+}> {
   const convergence = publicSafeErrorFromUnknown(convergenceFailure, {
     tag: "ObserverStartupError",
     code: "OBSERVER_HEALTH_FAILED",
     message: "Observer health check failed during startup convergence.",
   });
-  const convergenceDescription =
-    convergence.code === "OBSERVER_INCUMBENT_HEALTH_TIMEOUT"
-      ? `${convergence.code} after ${incumbentHealthGraceMs} ms`
-      : convergence.code;
-  const bootLogHint = await observerBootLogHint(paths, child);
-  const traceHint =
-    trace.traceId === undefined ? "" : `\nRun station debug trace ${trace.traceId}.`;
-  const error = observerHandoffRefusedError(
-    incumbent,
-    requestedVersion,
-    `Replacement child: ${childExitDescription(exit)}. Health convergence: ${convergenceDescription}.\n${bootLogHint}${traceHint}`,
-  );
-  if (trace.traceId !== undefined) {
-    error.traceId = trace.traceId;
-  }
-  return error;
+  const cause = startupCauseFromExit(exit) ?? convergence;
+  return observerExitedFailure(paths, child, exit, trace, cause);
 }
 
-async function observerExitedOnStartError(
+async function observerExitedOnStartFailure(
   paths: SpawnObserverInput["paths"],
   child: ChildProcessLike,
   exit: ChildExitResult,
   trace: RuntimeTraceContext,
-): Promise<SafeError> {
-  const bootLogHint = await observerBootLogHint(paths, child);
-  const traceHint =
-    trace.traceId === undefined ? "" : `\nRun station debug trace ${trace.traceId}.`;
+): Promise<{
+  error: SafeError;
+  cause?: SafeError;
+  startupEvidence: ObserverStartupEvidence;
+}> {
+  return observerExitedFailure(paths, child, exit, trace, startupCauseFromExit(exit));
+}
+
+async function observerExitedFailure(
+  paths: SpawnObserverInput["paths"],
+  child: ChildProcessLike,
+  exit: ChildExitResult,
+  trace: RuntimeTraceContext,
+  cause: SafeError | undefined,
+): Promise<{
+  error: SafeError;
+  cause?: SafeError;
+  startupEvidence: ObserverStartupEvidence;
+}> {
   const error: SafeError = {
     tag: "ObserverStartupError",
     code: "OBSERVER_EXITED_ON_START",
     message: `Observer exited before becoming healthy (${childExitDescription(exit)}).`,
-    hint: `${bootLogHint}${traceHint}`,
   };
   if (trace.traceId !== undefined) {
     error.traceId = trace.traceId;
+    error.hint = `Run stn debug trace ${trace.traceId}.`;
   }
-  return error;
+  return {
+    error,
+    ...(cause === undefined ? {} : { cause }),
+    startupEvidence: await readObserverStartupEvidence(paths, child),
+  };
 }
 
 function childExitDescription(exit: ChildExitResult): string {
   if (exit.type === "spawn_error") {
-    return `spawn error: ${redactString(exit.error.message)}`;
+    return "spawn error";
   }
   if (exit.signal !== null) {
     return `signal ${exit.signal}`;
@@ -311,33 +348,55 @@ function childExitDescription(exit: ChildExitResult): string {
   return "unknown exit status";
 }
 
-async function observerBootLogHint(
+function startupCauseFromExit(exit: ChildExitResult): SafeError | undefined {
+  if (exit.report !== undefined) {
+    return exit.report.cause ?? exit.report.error;
+  }
+  if (exit.type === "spawn_error") {
+    const report = normalizeObserverStartupFailure(exit.error);
+    return report.cause ?? report.error;
+  }
+  return undefined;
+}
+
+async function readObserverStartupEvidence(
   paths: SpawnObserverInput["paths"],
   child: ChildProcessLike | undefined,
-): Promise<string> {
-  const path = observerBootLogPath(paths);
+): Promise<ObserverStartupEvidence> {
+  const evidence: ObserverStartupEvidence = { bootLogPath: observerBootLogPath(paths) };
   if (child?.readBootLogTail !== undefined) {
-    const pathHint = `Latest observer boot log: ${path}`;
     try {
       const tail = await child.readBootLogTail();
-      if (tail === undefined) {
-        return `${pathHint}\nBoot-log tail unavailable (missing, empty, or unreadable).`;
-      }
-      return `${pathHint}\nThis attempt's last 15 lines (redacted):\n${redactString(tail)}`;
+      const boundedTail = boundedRedactedBootLogTail(tail);
+      if (boundedTail !== undefined) evidence.bootLogTail = boundedTail;
     } catch {
-      return `${pathHint}\nBoot-log tail unavailable (missing, empty, or unreadable).`;
+      // The path remains useful when the attempt-owned handle cannot be read.
     }
+    return evidence;
   }
-  const pathHint = `Observer boot log: ${path}`;
   try {
-    const tail = await readObserverBootLogTail(path);
-    if (tail === undefined) {
-      return `${pathHint}\nBoot-log tail unavailable (missing, empty, or unreadable).`;
-    }
-    return `${pathHint}\nLast 15 lines (redacted):\n${redactString(tail)}`;
+    const tail = await readObserverBootLogTail(evidence.bootLogPath);
+    const boundedTail = boundedRedactedBootLogTail(tail);
+    if (boundedTail !== undefined) evidence.bootLogTail = boundedTail;
   } catch {
-    return `${pathHint}\nBoot-log tail unavailable (missing, empty, or unreadable).`;
+    // An absent or unreadable tail is represented by the optional field being absent.
   }
+  return evidence;
+}
+
+function boundedRedactedBootLogTail(tail: string | undefined): string | undefined {
+  if (tail === undefined) return undefined;
+  const redacted = redactString(tail)
+    .split(/\r?\n/u)
+    .slice(-OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_LINES)
+    .join("\n")
+    .trimEnd();
+  if (redacted.length === 0) return undefined;
+  const encoded = Buffer.from(redacted, "utf8");
+  if (encoded.byteLength <= OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_BYTES) return redacted;
+  let start = encoded.byteLength - OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_BYTES;
+  while (start < encoded.byteLength && (encoded[start] ?? 0) >> 6 === 2) start += 1;
+  return encoded.subarray(start).toString("utf8");
 }
 
 function waitForIncumbentHealth(
@@ -365,40 +424,6 @@ function waitForIncumbentHealth(
       },
     );
   });
-}
-
-/**
- * Appends the redacted spawn reason and the child-owned boot-log tail to a flattened or timed-out
- * startup error. Runs after the runtime boundary so one path covers both the timeout failure and
- * non-SafeError flattening, neither of which reaches the early-exit error builders that already
- * carry this evidence.
- */
-async function enrichStartupFailureEvidence(input: {
-  error: RuntimeSafeError;
-  reason: string | undefined;
-  paths: SpawnObserverInput["paths"];
-  child: ChildProcessLike | undefined;
-}): Promise<RuntimeSafeError> {
-  if (input.error.hint?.includes(observerBootLogPath(input.paths)) === true) {
-    return input.error;
-  }
-  const evidence = [
-    ...(input.reason === undefined ? [] : [`Startup failure: ${input.reason}`]),
-    await observerBootLogHint(input.paths, input.child),
-  ].join("\n");
-  const hint = input.error.hint === undefined ? evidence : `${input.error.hint}\n${evidence}`;
-  return { ...input.error, hint };
-}
-
-/**
- * Reduces a non-SafeError startup escape to its first redacted line; typed SafeErrors already
- * carry their own sanitized shape and pass through the boundary untouched.
- */
-function redactedStartupFailureReason(error: unknown): string | undefined {
-  if (isSafeError(error)) return undefined;
-  const message = error instanceof Error ? error.message : String(error);
-  const [firstLine] = redactString(message).split("\n");
-  return firstLine === undefined || firstLine.length === 0 ? undefined : firstLine;
 }
 
 async function disposeObserverBootLog(child: ChildProcessLike | undefined): Promise<void> {

--- a/apps/cli/src/observerProcess/startup.ts
+++ b/apps/cli/src/observerProcess/startup.ts
@@ -6,6 +6,7 @@ import {
   type ObserverHealth,
   type ObserverStartupEvidence,
   type SafeError,
+  textLineTerminatorPattern,
 } from "@station/contracts";
 import { redactString } from "@station/observability";
 import {
@@ -54,6 +55,7 @@ export async function startObserverProcess(
     paths: SpawnObserverInput["paths"];
     timeoutMs: number;
     buildVersion: string;
+    replaceableIncumbent?: ObserverHealth;
     trace: RuntimeTraceContext;
     clock: RuntimeClock;
     configPath?: string;
@@ -121,6 +123,9 @@ export async function startObserverProcess(
             paths: input.paths,
             timeoutMs: input.timeoutMs,
             buildVersion: input.buildVersion,
+            ...(input.replaceableIncumbent === undefined
+              ? {}
+              : { replaceableIncumbent: input.replaceableIncumbent }),
             trace: input.trace,
             signal,
           },
@@ -170,13 +175,14 @@ async function waitForStartedObserver(
     paths: SpawnObserverInput["paths"];
     timeoutMs: number;
     buildVersion: string;
+    replaceableIncumbent?: ObserverHealth;
     trace: RuntimeTraceContext;
     signal: AbortSignal;
   },
   deps: ObserverProcessDeps,
 ): Promise<StartedObserverResult> {
   const healthController = new AbortController();
-  let replaceableIncumbent: ObserverHealth | undefined;
+  let replaceableIncumbent = input.replaceableIncumbent;
   const cancelHealth = () => healthController.abort();
   input.signal.addEventListener("abort", cancelHealth, { once: true });
   const healthPromise = waitForObserverHealth(
@@ -252,22 +258,39 @@ async function waitForStartedObserver(
       }
       convergenceError = error;
     }
-    let cause = startupCauseFromExit(outcome.exit);
-    if (cause === undefined && replaceableIncumbent !== undefined) {
-      cause = publicSafeErrorFromUnknown(convergenceError, {
-        tag: "ObserverStartupError",
-        code: "OBSERVER_HEALTH_FAILED",
-        message: "Observer health check failed during startup convergence.",
-      });
+    const reportedCause = startupCauseFromExit(outcome.exit);
+    if (replaceableIncumbent !== undefined) {
+      const cause =
+        reportedCause ??
+        publicSafeErrorFromUnknown(convergenceError, {
+          tag: "ObserverStartupError",
+          code: "OBSERVER_HEALTH_FAILED",
+          message: "Observer health check failed during startup convergence.",
+        });
+      const handoffError = observerHandoffRefusedError(
+        replaceableIncumbent,
+        input.buildVersion,
+        "The replacement process exited before publishing compatible health.",
+      );
+      handoffError.traceId = input.trace.traceId;
+      return {
+        ok: false,
+        failure: await observerExitedFailure(input.paths, input.child, handoffError, cause),
+      };
     }
     return {
       ok: false,
       failure: await observerExitedFailure(
         input.paths,
         input.child,
-        outcome.exit,
-        input.trace,
-        cause,
+        {
+          tag: "ObserverStartupError",
+          code: "OBSERVER_EXITED_ON_START",
+          message: `Observer exited before becoming healthy (${childExitDescription(outcome.exit)}).`,
+          hint: `Run stn debug trace ${input.trace.traceId}.`,
+          traceId: input.trace.traceId,
+        },
+        reportedCause,
       ),
     };
   } finally {
@@ -281,19 +304,9 @@ async function waitForStartedObserver(
 async function observerExitedFailure(
   paths: SpawnObserverInput["paths"],
   child: ChildProcessLike,
-  exit: ChildExitResult,
-  trace: RuntimeTraceContext,
+  error: SafeError,
   cause: SafeError | undefined,
 ): Promise<ObserverStartupFailureEvidence> {
-  const error: SafeError = {
-    tag: "ObserverStartupError",
-    code: "OBSERVER_EXITED_ON_START",
-    message: `Observer exited before becoming healthy (${childExitDescription(exit)}).`,
-  };
-  if (trace.traceId !== undefined) {
-    error.traceId = trace.traceId;
-    error.hint = `Run stn debug trace ${trace.traceId}.`;
-  }
   return {
     error,
     ...(cause === undefined ? {} : { cause }),
@@ -346,7 +359,7 @@ async function readObserverStartupEvidence(
 function boundedRedactedBootLogTail(tail: string | undefined): string | undefined {
   if (tail === undefined) return undefined;
   const redacted = redactString(tail)
-    .split(/\r?\n/u)
+    .split(textLineTerminatorPattern)
     .slice(-OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_LINES)
     .join("\n")
     .trimEnd();

--- a/apps/cli/src/observerProcess/startup.ts
+++ b/apps/cli/src/observerProcess/startup.ts
@@ -33,6 +33,16 @@ import type {
 
 const incumbentHealthGraceMs = 1_000;
 
+type ObserverStartupFailureEvidence = {
+  error: SafeError;
+  cause?: SafeError;
+  startupEvidence: ObserverStartupEvidence;
+};
+
+type StartedObserverResult =
+  | { ok: true; health: ObserverHealth }
+  | { ok: false; failure: ObserverStartupFailureEvidence };
+
 /**
  * ADAPTER
  *
@@ -105,7 +115,7 @@ export async function startObserverProcess(
           throw observerHealthWaitCancelledError();
         }
         child.unref?.();
-        return await waitForStartedObserver(
+        const started = await waitForStartedObserver(
           {
             child,
             paths: input.paths,
@@ -113,13 +123,15 @@ export async function startObserverProcess(
             buildVersion: input.buildVersion,
             trace: input.trace,
             signal,
-            onFailureEvidence: (evidence) => {
-              if (evidence.cause !== undefined) startupCause = evidence.cause;
-              startupEvidence = evidence.startupEvidence;
-            },
           },
           deps,
         );
+        if (!started.ok) {
+          startupCause = started.failure.cause;
+          startupEvidence = started.failure.startupEvidence;
+          throw started.failure.error;
+        }
+        return started.health;
       } catch (error) {
         if (startupCause === undefined) {
           const report = normalizeObserverStartupFailure(error);
@@ -160,13 +172,9 @@ async function waitForStartedObserver(
     buildVersion: string;
     trace: RuntimeTraceContext;
     signal: AbortSignal;
-    onFailureEvidence: (evidence: {
-      cause?: SafeError;
-      startupEvidence: ObserverStartupEvidence;
-    }) => void;
   },
   deps: ObserverProcessDeps,
-): Promise<ObserverHealth> {
+): Promise<StartedObserverResult> {
   const healthController = new AbortController();
   let replaceableIncumbent: ObserverHealth | undefined;
   const cancelHealth = () => healthController.abort();
@@ -191,7 +199,7 @@ async function waitForStartedObserver(
     const childExit = input.child.exited;
     if (childExit === undefined) {
       try {
-        return await healthPromise;
+        return { ok: true, health: await healthPromise };
       } catch (error) {
         if (replaceableIncumbent !== undefined) {
           throw observerHandoffRefusedError(
@@ -231,40 +239,37 @@ async function waitForStartedObserver(
       throw outcome.error;
     }
     if (outcome.type === "healthy") {
-      return outcome.health;
+      return { ok: true, health: outcome.health };
     }
 
     let convergenceError: unknown;
     try {
       // A losing child can exit just before the winning observer becomes healthy, so preserve its retry loop briefly.
-      return await waitForIncumbentHealth(healthPromise, healthController);
+      return { ok: true, health: await waitForIncumbentHealth(healthPromise, healthController) };
     } catch (error) {
       if (input.signal.aborted) {
         throw observerHealthWaitCancelledError();
       }
       convergenceError = error;
     }
-    if (replaceableIncumbent !== undefined) {
-      const failure = await observerReplacementExitedFailure(
-        replaceableIncumbent,
-        input.buildVersion,
+    let cause = startupCauseFromExit(outcome.exit);
+    if (cause === undefined && replaceableIncumbent !== undefined) {
+      cause = publicSafeErrorFromUnknown(convergenceError, {
+        tag: "ObserverStartupError",
+        code: "OBSERVER_HEALTH_FAILED",
+        message: "Observer health check failed during startup convergence.",
+      });
+    }
+    return {
+      ok: false,
+      failure: await observerExitedFailure(
         input.paths,
         input.child,
         outcome.exit,
-        convergenceError,
         input.trace,
-      );
-      input.onFailureEvidence(failure);
-      throw failure.error;
-    }
-    const failure = await observerExitedOnStartFailure(
-      input.paths,
-      input.child,
-      outcome.exit,
-      input.trace,
-    );
-    input.onFailureEvidence(failure);
-    throw failure.error;
+        cause,
+      ),
+    };
   } finally {
     input.signal.removeEventListener("abort", cancelHealth);
     healthController.abort();
@@ -273,52 +278,13 @@ async function waitForStartedObserver(
   }
 }
 
-async function observerReplacementExitedFailure(
-  _incumbent: ObserverHealth,
-  _requestedVersion: string,
-  paths: SpawnObserverInput["paths"],
-  child: ChildProcessLike,
-  exit: ChildExitResult,
-  convergenceFailure: unknown,
-  trace: RuntimeTraceContext,
-): Promise<{
-  error: SafeError;
-  cause?: SafeError;
-  startupEvidence: ObserverStartupEvidence;
-}> {
-  const convergence = publicSafeErrorFromUnknown(convergenceFailure, {
-    tag: "ObserverStartupError",
-    code: "OBSERVER_HEALTH_FAILED",
-    message: "Observer health check failed during startup convergence.",
-  });
-  const cause = startupCauseFromExit(exit) ?? convergence;
-  return observerExitedFailure(paths, child, exit, trace, cause);
-}
-
-async function observerExitedOnStartFailure(
-  paths: SpawnObserverInput["paths"],
-  child: ChildProcessLike,
-  exit: ChildExitResult,
-  trace: RuntimeTraceContext,
-): Promise<{
-  error: SafeError;
-  cause?: SafeError;
-  startupEvidence: ObserverStartupEvidence;
-}> {
-  return observerExitedFailure(paths, child, exit, trace, startupCauseFromExit(exit));
-}
-
 async function observerExitedFailure(
   paths: SpawnObserverInput["paths"],
   child: ChildProcessLike,
   exit: ChildExitResult,
   trace: RuntimeTraceContext,
   cause: SafeError | undefined,
-): Promise<{
-  error: SafeError;
-  cause?: SafeError;
-  startupEvidence: ObserverStartupEvidence;
-}> {
+): Promise<ObserverStartupFailureEvidence> {
   const error: SafeError = {
     tag: "ObserverStartupError",
     code: "OBSERVER_EXITED_ON_START",
@@ -364,22 +330,15 @@ async function readObserverStartupEvidence(
   child: ChildProcessLike | undefined,
 ): Promise<ObserverStartupEvidence> {
   const evidence: ObserverStartupEvidence = { bootLogPath: observerBootLogPath(paths) };
-  if (child?.readBootLogTail !== undefined) {
-    try {
-      const tail = await child.readBootLogTail();
-      const boundedTail = boundedRedactedBootLogTail(tail);
-      if (boundedTail !== undefined) evidence.bootLogTail = boundedTail;
-    } catch {
-      // The path remains useful when the attempt-owned handle cannot be read.
-    }
-    return evidence;
-  }
   try {
-    const tail = await readObserverBootLogTail(evidence.bootLogPath);
+    const tail =
+      child?.readBootLogTail === undefined
+        ? await readObserverBootLogTail(evidence.bootLogPath)
+        : await child.readBootLogTail();
     const boundedTail = boundedRedactedBootLogTail(tail);
     if (boundedTail !== undefined) evidence.bootLogTail = boundedTail;
   } catch {
-    // An absent or unreadable tail is represented by the optional field being absent.
+    // The boot log path remains useful when the optional tail cannot be read.
   }
   return evidence;
 }

--- a/apps/cli/src/observerProcess/types.ts
+++ b/apps/cli/src/observerProcess/types.ts
@@ -1,13 +1,18 @@
 import type { ChildProcess } from "node:child_process";
 import type { StationConfig } from "@station/config";
-import type { ObserverHealth, SafeError } from "@station/contracts";
+import type {
+  ObserverHealth,
+  ObserverStartupEvidence,
+  ObserverStartupFailureReport,
+  SafeError,
+} from "@station/contracts";
 import type { JsonlLogger } from "@station/observability";
 import type {
   CreateObserverClientOptions,
   createObserverClient,
   probeUnixSocket,
 } from "@station/protocol";
-import type { RuntimeClock } from "@station/runtime";
+import type { RuntimeBoundaryResult, RuntimeClock } from "@station/runtime";
 import type { ObserverPaths } from "../paths.js";
 import type { ExecutableArgv } from "../selfExec.js";
 
@@ -22,6 +27,10 @@ export type ObserverStatus =
       status: "stopped" | "stale" | "unhealthy";
       paths: ObserverPaths;
       error?: SafeError;
+      /** Deepest typed child failure retained separately from the lifecycle classification. */
+      cause?: SafeError;
+      /** Bounded, redacted evidence from this startup attempt. */
+      startupEvidence?: ObserverStartupEvidence;
     };
 
 export type ExactObserverActivationPhase = "inspection" | "stop" | "start" | "verification";
@@ -43,6 +52,10 @@ export type ExactObserverBuildStatus =
       status: "unhealthy";
       paths: ObserverPaths;
       error: SafeError;
+      /** Underlying typed lifecycle failure without changing the exact-activation code. */
+      cause?: SafeError;
+      /** Bounded, redacted evidence from the attempted successor startup. */
+      startupEvidence?: ObserverStartupEvidence;
       phase: ExactObserverActivationPhase;
       incumbentDisposition: ExactObserverIncumbentDisposition;
     };
@@ -78,11 +91,15 @@ export type ChildProcessExit = {
   type: "exit";
   code: number | null;
   signal: NodeJS.Signals | null;
+  /** Strict report fully consumed from the inherited pipe before exit resolution. */
+  report?: ObserverStartupFailureReport;
 };
 
 export type ChildProcessSpawnError = {
   type: "spawn_error";
   error: Error;
+  /** Strict report fully consumed from the inherited pipe before exit resolution. */
+  report?: ObserverStartupFailureReport;
 };
 
 export type ChildExitResult = ChildProcessExit | ChildProcessSpawnError;
@@ -91,6 +108,7 @@ export type ChildProcessLike = Pick<ChildProcess, "pid" | "unref"> & {
   kill?: ChildProcess["kill"];
   exited?: Promise<ChildExitResult>;
   disposeExitWait?: () => void;
+  disposeFailureReport?: () => void;
   readBootLogTail?: () => Promise<string | undefined>;
   disposeBootLog?: () => Promise<void>;
 };
@@ -104,4 +122,10 @@ export type ObserverProcessOptions = {
   startupDeadlineMs?: number;
   observerCommand?: ExecutableArgv;
   onStartupProgress?: (message: string) => void;
+};
+
+/** Timed child-start result with causal and bounded evidence kept outside the outer SafeError. */
+export type ObserverStartupProcessResult = RuntimeBoundaryResult<ObserverHealth> & {
+  cause?: SafeError;
+  startupEvidence?: ObserverStartupEvidence;
 };

--- a/apps/cli/test/fixtures/observer-startup-failure-child.mjs
+++ b/apps/cli/test/fixtures/observer-startup-failure-child.mjs
@@ -1,0 +1,30 @@
+import { runCliObserverProcess } from "../../dist/observerMain.js";
+
+const failure = (() => {
+  switch (process.argv[2]) {
+    case "error":
+      return new Error(
+        "ordinary failure with API_TOKEN=super-secret-value\n    at /private/ordinary-frame.ts",
+      );
+    case "typed":
+      return Object.assign(new Error("typed failure"), {
+        tag: "ObserverProcessEvidenceError",
+        code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH",
+        message: "Typed failure with API_TOKEN=super-secret-value",
+        hint: "Inspect the exact process evidence.",
+      });
+    case "plain-object":
+      return {
+        message: "plain-object failure with API_TOKEN=super-secret-value",
+        stack: "plain-object failure\n    at /private/plain-object-frame.ts",
+      };
+    case "unknown":
+      return "unknown failure with API_TOKEN=super-secret-value\n    at /private/unknown-frame.ts";
+    default:
+      throw new Error(`Unknown startup failure fixture: ${String(process.argv[2])}`);
+  }
+})();
+
+process.exitCode = await runCliObserverProcess(async () => {
+  throw failure;
+});

--- a/apps/cli/test/integration/command-command.test.ts
+++ b/apps/cli/test/integration/command-command.test.ts
@@ -206,7 +206,7 @@ describe("CLI command dispatch/get", () => {
           sleep: async () => undefined,
         },
       ),
-    ).rejects.toThrow("Observer did not become healthy before the startup timeout.");
+    ).rejects.toMatchObject({ error: { code: "OBSERVER_START_FAILED" } });
   });
 
   it("never dispatches a mutation through a losing same-version Observer", async () => {
@@ -245,7 +245,7 @@ describe("CLI command dispatch/get", () => {
             }) as never,
         },
       ),
-    ).rejects.toThrow(/OBSERVER_HANDOFF_REFUSED/u);
+    ).rejects.toMatchObject({ error: { code: "OBSERVER_HANDOFF_REFUSED" } });
 
     expect(spawned).toBe(true);
     expect(dispatches).toBe(0);

--- a/apps/cli/test/integration/diagnostic-commands.test.ts
+++ b/apps/cli/test/integration/diagnostic-commands.test.ts
@@ -508,12 +508,14 @@ describe("CLI diagnostic commands", () => {
             tag: "ObserverStartupError",
             code: "OBSERVER_START_FAILED",
             message: "Observer did not become healthy before the startup timeout.",
+            hint: "Run stn debug trace trc_lifecycle.",
             traceId: "trc_lifecycle",
           },
           cause: {
             tag: "ObserverProcessEvidenceError",
             code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH",
             message: "Observer process evidence did not match the exact executable and argv.",
+            hint: "Use the launcher that owns the incumbent build.",
           },
           startupEvidence: {
             bootLogPath: join(fixture.stateDir, "logs", "observer-boot.log"),
@@ -539,10 +541,14 @@ describe("CLI diagnostic commands", () => {
         traceId: "trc_lifecycle",
         spanId: "spn_lifecycle",
         error: {
+          tag: "ObserverStartupError",
           code: "OBSERVER_START_FAILED",
+          hint: "Run stn debug trace trc_lifecycle.",
         },
         cause: {
+          tag: "ObserverProcessEvidenceError",
           code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH",
+          hint: "Use the launcher that owns the incumbent build.",
         },
         startupEvidence: {
           bootLogPath: join(fixture.stateDir, "logs", "observer-boot.log"),
@@ -592,8 +598,16 @@ describe("CLI diagnostic commands", () => {
         },
         records: [
           {
-            error: { code: "OBSERVER_START_FAILED" },
-            cause: { code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH" },
+            error: {
+              tag: "ObserverStartupError",
+              code: "OBSERVER_START_FAILED",
+              hint: "Run stn debug trace trc_lifecycle.",
+            },
+            cause: {
+              tag: "ObserverProcessEvidenceError",
+              code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH",
+              hint: "Use the launcher that owns the incumbent build.",
+            },
             startupEvidence: {
               bootLogTail: "startup evidence API_TOKEN=[REDACTED]",
             },

--- a/apps/cli/test/integration/diagnostic-commands.test.ts
+++ b/apps/cli/test/integration/diagnostic-commands.test.ts
@@ -510,6 +510,15 @@ describe("CLI diagnostic commands", () => {
             message: "Observer did not become healthy before the startup timeout.",
             traceId: "trc_lifecycle",
           },
+          cause: {
+            tag: "ObserverProcessEvidenceError",
+            code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH",
+            message: "Observer process evidence did not match the exact executable and argv.",
+          },
+          startupEvidence: {
+            bootLogPath: join(fixture.stateDir, "logs", "observer-boot.log"),
+            bootLogTail: "startup evidence API_TOKEN=[REDACTED]",
+          },
         },
       })}\n`,
     );
@@ -532,11 +541,22 @@ describe("CLI diagnostic commands", () => {
         error: {
           code: "OBSERVER_START_FAILED",
         },
+        cause: {
+          code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH",
+        },
+        startupEvidence: {
+          bootLogPath: join(fixture.stateDir, "logs", "observer-boot.log"),
+          bootLogTail: "startup evidence API_TOKEN=[REDACTED]",
+        },
+        rootCauseCodes: expect.arrayContaining([
+          "OBSERVER_START_FAILED",
+          "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH",
+        ]),
         causeAssessment: {
-          status: "observed_failure",
-          explicitRootCauseCodes: [],
+          status: "explicit_root_cause",
+          explicitRootCauseCodes: ["OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH"],
           observedFailureCodes: ["OBSERVER_START_FAILED"],
-          limitations: ["no_explicit_root_cause", "reporting_boundary_only"],
+          limitations: ["reporting_boundary_only"],
         },
         evidenceRoles: {
           operationalBoundaryEvidence: "failure_and_ownership_evidence",
@@ -551,6 +571,37 @@ describe("CLI diagnostic commands", () => {
         suggestedCommands: expect.arrayContaining(["stn debug bundle --trace trc_lifecycle"]),
       },
     });
+
+    const logs = await runCli(
+      ["--config", configPath, "debug", "logs", "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH"],
+      {
+        observerDeps: {
+          clientFactory: () => {
+            throw new Error("debug logs should not contact observer");
+          },
+        },
+      },
+    );
+    expect(logs).toMatchObject({
+      code: 0,
+      output: {
+        matched: 1,
+        causeAssessment: {
+          status: "explicit_root_cause",
+          explicitRootCauseCodes: ["OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH"],
+        },
+        records: [
+          {
+            error: { code: "OBSERVER_START_FAILED" },
+            cause: { code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH" },
+            startupEvidence: {
+              bootLogTail: "startup evidence API_TOKEN=[REDACTED]",
+            },
+          },
+        ],
+      },
+    });
+    expect(JSON.stringify({ traced, logs })).not.toContain("super-secret-value");
   });
 
   it("filters runtime logs without searching hook logs by default", async () => {

--- a/apps/cli/test/integration/observe-command.test.ts
+++ b/apps/cli/test/integration/observe-command.test.ts
@@ -243,7 +243,7 @@ describe("CLI observe command", () => {
     expect(returned).toBe(true);
   });
 
-  it("surfaces observer socket schema errors with hint and code", async () => {
+  it("surfaces observer socket schema errors with a concise code and next step", async () => {
     const fixture = await createTempState();
     const server = await listenUnixSocket({
       socketPath: fixture.socketPath,
@@ -280,9 +280,8 @@ describe("CLI observe command", () => {
         ),
       ).rejects.toThrow(
         [
-          "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.11.0.",
-          "Hint: A different STATION checkout may own the observer socket.",
-          "Code: PROTOCOL_SCHEMA_MISMATCH",
+          "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.11.0. (PROTOCOL_SCHEMA_MISMATCH)",
+          "Next: stn observer status",
         ].join("\n"),
       );
     } finally {

--- a/apps/cli/test/integration/observe-command.test.ts
+++ b/apps/cli/test/integration/observe-command.test.ts
@@ -278,12 +278,7 @@ describe("CLI observe command", () => {
             },
           },
         ),
-      ).rejects.toThrow(
-        [
-          "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.11.0. (PROTOCOL_SCHEMA_MISMATCH)",
-          "Next: stn observer status",
-        ].join("\n"),
-      );
+      ).rejects.toMatchObject({ error: { code: "PROTOCOL_SCHEMA_MISMATCH" } });
     } finally {
       await server.close();
     }

--- a/apps/cli/test/integration/observer-commands.test.ts
+++ b/apps/cli/test/integration/observer-commands.test.ts
@@ -261,6 +261,84 @@ describe("CLI observer commands", () => {
     expect(JSON.stringify(result)).not.toContain("[object Object]");
   });
 
+  it.each([
+    { label: "snapshot", args: ["snapshot", "--json"] },
+    { label: "doctor", args: ["doctor"] },
+    { label: "reconcile", args: ["reconcile"] },
+    { label: "command", args: ["command", "dispatch", "--stdin"] },
+    { label: "observe", args: ["observe", "--json", "--duration", "1ms"] },
+    { label: "debug bundle", args: ["debug", "bundle"] },
+  ])("retains lifecycle fields across the $label auto-start boundary", async ({ args }) => {
+    const fixture = await createTempState();
+    const configPath = await writeConfigToml(fixture.root, fixture.config);
+    let healthCalls = 0;
+    const lifecycleAttempt = runCli(["--config", configPath, ...args], {
+      stdin: JSON.stringify({
+        type: "observer.reconcile",
+        payload: { reason: "lifecycle-boundary" },
+      }),
+      observerDeps: {
+        buildVersion: requestedBuildVersion,
+        spawnObserver: async () => ({
+          pid: 4321,
+          unref: () => undefined,
+          exited: Promise.resolve({
+            type: "exit" as const,
+            code: 1,
+            signal: null,
+            report: {
+              kind: "observer-startup-failure" as const,
+              version: 1 as const,
+              error: {
+                tag: "ObserverHandoffError",
+                code: "OBSERVER_HANDOFF_REFUSED",
+                message: "The incumbent Observer could not be replaced safely.",
+              },
+              cause: {
+                tag: "ObserverProcessEvidenceError",
+                code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH",
+                message: "Observer process evidence did not match the exact executable and argv.",
+              },
+            },
+          }),
+          readBootLogTail: async () => "replacement refused",
+        }),
+        clientFactory: () =>
+          ({
+            health: async () => {
+              healthCalls += 1;
+              return healthCalls <= 2
+                ? {
+                    schemaVersion: "0.11.0",
+                    status: "healthy",
+                    pid: 1234,
+                    startedAt: now,
+                    version: zeroBuildVersion,
+                    socketPath: fixture.socketPath,
+                  }
+                : {
+                    schemaVersion: "0.11.0",
+                    status: "healthy",
+                    pid: 9876,
+                    startedAt: now,
+                    version: `1.2.3+station.${"f".repeat(64)}`,
+                    socketPath: fixture.socketPath,
+                  };
+            },
+          }) as never,
+      },
+    });
+
+    await expect(lifecycleAttempt).rejects.toMatchObject({
+      error: { code: "OBSERVER_HANDOFF_REFUSED" },
+      cause: { code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH" },
+      startupEvidence: {
+        bootLogPath: join(fixture.stateDir, "logs", "observer-boot.log"),
+        bootLogTail: "replacement refused",
+      },
+    });
+  });
+
   it("reports inaccessible ownership and fails start, restart, and doctor without mutation", async () => {
     const fixture = await createTempState();
     const configPath = await writeConfigToml(fixture.root, fixture.config);
@@ -308,9 +386,9 @@ describe("CLI observer commands", () => {
           });
         }
       }
-      await expect(runCli(["--config", configPath, "doctor"], { observerDeps })).rejects.toThrow(
-        /OBSERVER_SOCKET_INACCESSIBLE/u,
-      );
+      await expect(
+        runCli(["--config", configPath, "doctor"], { observerDeps }),
+      ).rejects.toMatchObject({ error: { code: "OBSERVER_SOCKET_INACCESSIBLE" } });
       const after = await lstat(fixture.socketPath, { bigint: true });
       expect({ ino: after.ino, birthtimeNs: after.birthtimeNs }).toEqual({
         ino: before.ino,

--- a/apps/cli/test/integration/observer-commands.test.ts
+++ b/apps/cli/test/integration/observer-commands.test.ts
@@ -1,4 +1,5 @@
 import { chmod, lstat } from "node:fs/promises";
+import { join } from "node:path";
 import { runCli } from "@station/cli";
 import { runObserverCommand } from "@station/cli/internal";
 import { listenUnixSocket } from "@station/protocol";
@@ -202,6 +203,64 @@ describe("CLI observer commands", () => {
     ).resolves.toMatchObject({ code: 0, output: { status: "running" } });
   });
 
+  it("projects distinct outer, causal, and startup evidence fields in JSON", async () => {
+    const fixture = await createTempState();
+    const configPath = await writeConfigToml(fixture.root, fixture.config);
+    const result = await runCli(
+      ["--config", configPath, "observer", "start", "--timeout-ms", "1500"],
+      {
+        observerDeps: {
+          buildVersion: requestedBuildVersion,
+          spawnObserver: async () => ({
+            pid: 4321,
+            unref: () => undefined,
+            exited: Promise.resolve({
+              type: "exit" as const,
+              code: 1,
+              signal: null,
+              report: {
+                kind: "observer-startup-failure" as const,
+                version: 1 as const,
+                error: {
+                  tag: "ObserverHandoffError",
+                  code: "OBSERVER_HANDOFF_REFUSED",
+                  message: "The incumbent Observer could not be replaced safely.",
+                },
+                cause: {
+                  tag: "ObserverProcessEvidenceError",
+                  code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH",
+                  message: "Observer process evidence did not match the exact executable and argv.",
+                },
+              },
+            }),
+            readBootLogTail: async () => "boot line API_TOKEN=super-secret-value",
+          }),
+          clientFactory: () =>
+            ({
+              health: async () => {
+                throw new Error("not running");
+              },
+            }) as never,
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      code: 1,
+      output: {
+        status: "unhealthy",
+        error: { code: "OBSERVER_EXITED_ON_START" },
+        cause: { code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH" },
+        startupEvidence: {
+          bootLogPath: join(fixture.stateDir, "logs", "observer-boot.log"),
+          bootLogTail: "boot line API_TOKEN=[REDACTED]",
+        },
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain("super-secret-value");
+    expect(JSON.stringify(result)).not.toContain("[object Object]");
+  });
+
   it("reports inaccessible ownership and fails start, restart, and doctor without mutation", async () => {
     const fixture = await createTempState();
     const configPath = await writeConfigToml(fixture.root, fixture.config);
@@ -244,7 +303,7 @@ describe("CLI observer commands", () => {
             output: {
               phase: "inspection",
               incumbentDisposition: "preserved",
-              error: { hint: expect.stringContaining("OBSERVER_SOCKET_INACCESSIBLE") },
+              cause: { code: "OBSERVER_SOCKET_INACCESSIBLE" },
             },
           });
         }

--- a/apps/cli/test/integration/snapshot-command.test.ts
+++ b/apps/cli/test/integration/snapshot-command.test.ts
@@ -32,7 +32,7 @@ describe("snapshot command", () => {
               }) as never,
           },
         ),
-      ).rejects.toThrow("not running");
+      ).rejects.toMatchObject({ error: { code: "OBSERVER_NOT_RUNNING" } });
       expect(spawnObserver).not.toHaveBeenCalled();
     } finally {
       await rm(root, { recursive: true, force: true });

--- a/apps/cli/test/unit/entrypoints.test.ts
+++ b/apps/cli/test/unit/entrypoints.test.ts
@@ -17,6 +17,7 @@ describe("process entrypoints", () => {
     expect(cli.runCliMain).toBeTypeOf("function");
     expect(cli.runCli).toBeTypeOf("function");
     expect(observer.runCliObserverMain).toBeTypeOf("function");
+    expect(observer.runCliObserverProcess).toBeTypeOf("function");
     expect(ingress.runCliIngressMain).toBeTypeOf("function");
     expect(observerRuntime.runObserverMain).toBeTypeOf("function");
     expect(process.listenerCount("SIGINT")).toBe(signalListeners.sigint);

--- a/apps/cli/test/unit/ingress-delivery-policy.test.ts
+++ b/apps/cli/test/unit/ingress-delivery-policy.test.ts
@@ -317,7 +317,29 @@ describe("provider hook delivery policy", () => {
         }) as never,
       spawnObserver: async () => {
         state.spawnCount += 1;
-        return { pid: 5678, unref: () => undefined };
+        return {
+          pid: 5678,
+          unref: () => undefined,
+          exited: Promise.resolve({
+            type: "exit" as const,
+            code: 1,
+            signal: null,
+            report: {
+              kind: "observer-startup-failure" as const,
+              version: 1 as const,
+              error: {
+                tag: "ObserverStartupError",
+                code: "OBSERVER_HANDOFF_REFUSED",
+                message: "Observer handoff was refused.",
+              },
+              cause: {
+                tag: "ObserverProcessIdentityError",
+                code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH",
+                message: "Observer executable arguments did not match.",
+              },
+            },
+          }),
+        };
       },
     };
     const input = deliveryInput(fixture, "hook_handoff_refused", state, deps);

--- a/apps/cli/test/unit/observer-main.test.ts
+++ b/apps/cli/test/unit/observer-main.test.ts
@@ -11,7 +11,7 @@ vi.mock("../../src/observerProviders.js", () => ({
   createProviderRegistry: mocks.createProviderRegistry,
 }));
 
-import { runCliObserverMain } from "../../src/observerMain.js";
+import { runCliObserverMain, runCliObserverProcess } from "../../src/observerMain.js";
 
 const ingressLauncher = "/source/bin/stn-ingress";
 const artifactOwner = {
@@ -82,5 +82,52 @@ describe("runCliObserverMain", () => {
       providerHookIngressLauncher: ingressLauncher,
       providerHookArtifactOwner: artifactOwner,
     });
+  });
+
+  it("reports source-process failures with redacted stderr and exit status", async () => {
+    mocks.runObserverMain.mockRejectedValue(
+      new Error("startup failed with API_TOKEN=super-secret-value\n    at private-frame"),
+    );
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      await expect(
+        runCliObserverProcess((startupReadinessSink) =>
+          runCliObserverMain([], {
+            providerHookIngressLauncher: ingressLauncher,
+            providerHookArtifactOwner: artifactOwner,
+            startupReadinessSink,
+          }),
+        ),
+      ).resolves.toBe(1);
+      expect(stderr).toHaveBeenCalledWith(
+        "startup failed with API_TOKEN=[REDACTED] (OBSERVER_STARTUP_CAUSE_ERROR)\n",
+      );
+      expect(stderr).not.toHaveBeenCalledWith(expect.stringContaining("private-frame"));
+      expect(stderr).not.toHaveBeenCalledWith(expect.stringContaining("super-secret-value"));
+    } finally {
+      stderr.mockRestore();
+    }
+  });
+
+  it("closes the common process reporter after a successful run", async () => {
+    const startupFailureReporter = {
+      ready: vi.fn(),
+      failure: vi.fn(),
+    };
+
+    await expect(
+      runCliObserverProcess(
+        async (startupReadinessSink) => {
+          startupReadinessSink.ready();
+          return 0;
+        },
+        {
+          startupFailureReporter,
+        },
+      ),
+    ).resolves.toBe(0);
+
+    expect(startupFailureReporter.ready).toHaveBeenCalledOnce();
+    expect(startupFailureReporter.failure).not.toHaveBeenCalled();
   });
 });

--- a/apps/cli/test/unit/observer-process/activation-surfacing.test.ts
+++ b/apps/cli/test/unit/observer-process/activation-surfacing.test.ts
@@ -8,8 +8,8 @@ import { createTempState } from "../../../../../tests/support/temp-projects";
  * Surfacing guarantees for Observer-activation failures when a foreign-build Observer owns the
  * socket during `stn setup`:
  *
- *  1. A flattened or timed-out startup failure surfaces the redacted boot reason and the
- *     child-owned boot-log tail instead of a bare "Observer startup failed."
+ *  1. A flattened or timed-out startup failure surfaces a separate typed cause and bounded,
+ *     redacted child-owned boot evidence instead of interpolating either into the hint.
  *  2. A failed cross-build restart retains the incumbent build identity it tried to replace.
  *  3. The setup activation adapter wires the startup progress callback that startObserver
  *     supports (proven in setup-observer-activation.test.ts).
@@ -47,7 +47,7 @@ function unavailableClientFactory(message = "connect ENOENT observer.sock") {
 }
 
 describe("startup failures surface the boot failure evidence", () => {
-  it("keeps the redacted spawn failure reason in the flattened error hint", async () => {
+  it("keeps the redacted spawn failure reason as a structured cause", async () => {
     const fixture = await createTempState();
 
     const result = await startObserver(
@@ -64,8 +64,13 @@ describe("startup failures surface the boot failure evidence", () => {
     const error = unhealthyError(result);
     expect(error.code).toBe("OBSERVER_START_FAILED");
     expect(error.message).toBe("Observer startup failed.");
-    expect(error.hint).toContain(`Startup failure: spawn aborted: ${bootReason}`);
-    expect(JSON.stringify(error)).toContain("dbf7f368");
+    expect(error.hint).not.toContain(bootReason);
+    expect(result).toMatchObject({
+      cause: {
+        code: "OBSERVER_STARTUP_CAUSE_ERROR",
+        message: `spawn aborted: ${bootReason}`,
+      },
+    });
   });
 
   it("reads the child boot log when the boot wait fails without early exit", async () => {
@@ -95,8 +100,8 @@ describe("startup failures surface the boot failure evidence", () => {
     const error = unhealthyError(result);
     expect(killed).toBe(true);
     expect(readBootLogTail).toHaveBeenCalled();
-    expect(error.hint).toContain(bootReason);
-    expect(JSON.stringify(error)).toContain("dbf7f368");
+    expect(error.hint).not.toContain(bootReason);
+    expect(result).toMatchObject({ startupEvidence: { bootLogTail: bootReason } });
   });
 
   it("control: reads the same boot log when the child exits early", async () => {
@@ -123,7 +128,8 @@ describe("startup failures surface the boot failure evidence", () => {
     const error = unhealthyError(result);
     expect(error.code).toBe("OBSERVER_EXITED_ON_START");
     expect(readBootLogTail).toHaveBeenCalled();
-    expect(error.hint).toContain(bootReason);
+    expect(error.hint).not.toContain(bootReason);
+    expect(result).toMatchObject({ startupEvidence: { bootLogTail: bootReason } });
   });
 });
 
@@ -170,7 +176,10 @@ describe("a failed cross-build restart retains the incumbent build context", () 
     // owned the socket plus the redacted reason the replacement never booted.
     expect(error.hint).toContain("Restart was replacing incumbent 0.0.0-pre-alpha.4");
     expect(error.hint).toContain("pid 4321");
-    expect(JSON.stringify(error)).toContain(bootReason);
+    expect(JSON.stringify(error)).not.toContain(bootReason);
+    expect(result).toMatchObject({
+      cause: { code: "OBSERVER_STARTUP_CAUSE_ERROR", message: `boot aborted: ${bootReason}` },
+    });
   });
 
   it("control: the upfront refusal path surfaces both builds without attempting a start", async () => {

--- a/apps/cli/test/unit/observer-process/failure-report.test.ts
+++ b/apps/cli/test/unit/observer-process/failure-report.test.ts
@@ -57,9 +57,16 @@ describe("Observer startup failure reports", () => {
     });
   });
 
-  it("normalizes ordinary Errors to one redacted line without stacks", () => {
+  it.each([
+    "\n",
+    "\r",
+    "\u2028",
+    "\u2029",
+  ])("normalizes ordinary Errors to one redacted line at %j", (terminator) => {
     const report = normalizeObserverStartupFailure(
-      new Error("startup failed with API_TOKEN=super-secret-value\n    at private-frame"),
+      new Error(
+        `startup failed with API_TOKEN=super-secret-value${terminator}    at /private/frame`,
+      ),
     );
 
     expect(report.error).toEqual({
@@ -67,7 +74,7 @@ describe("Observer startup failure reports", () => {
       code: "OBSERVER_STARTUP_CAUSE_ERROR",
       message: "startup failed with API_TOKEN=[REDACTED]",
     });
-    expect(JSON.stringify(report)).not.toContain("private-frame");
+    expect(JSON.stringify(report)).not.toContain("/private/frame");
     expect(JSON.stringify(report)).not.toContain("super-secret-value");
   });
 

--- a/apps/cli/test/unit/observer-process/failure-report.test.ts
+++ b/apps/cli/test/unit/observer-process/failure-report.test.ts
@@ -1,0 +1,185 @@
+import { PassThrough } from "node:stream";
+import { OBSERVER_STARTUP_FAILURE_REPORT_MAX_BYTES, type SafeError } from "@station/contracts";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createObserverStartupFailureReporter,
+  normalizeObserverStartupFailure,
+  OBSERVER_STARTUP_FAILURE_FD,
+  parseObserverStartupFailureReport,
+  readObserverStartupFailureReport,
+  STATION_OBSERVER_STARTUP_FAILURE_FD,
+  serializeObserverStartupFailureReport,
+} from "../../../src/observerProcess/failureReport.js";
+
+const typedCause: SafeError = {
+  tag: "ObserverProcessEvidenceError",
+  code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH",
+  message: "Observer process evidence did not match the exact executable and argv.",
+};
+
+describe("Observer startup failure reports", () => {
+  it("preserves SafeErrors and selects the deepest typed cause", () => {
+    const inner = Object.assign(new Error(typedCause.message), typedCause);
+    const outer = Object.assign(new Error("handoff refused", { cause: inner }), {
+      tag: "ObserverHandoffError",
+      code: "OBSERVER_HANDOFF_REFUSED",
+      message: "The incumbent Observer could not be replaced safely.",
+      hint: "Inspect ownership.",
+    });
+
+    expect(normalizeObserverStartupFailure(outer)).toEqual({
+      kind: "observer-startup-failure",
+      version: 1,
+      error: {
+        tag: "ObserverHandoffError",
+        code: "OBSERVER_HANDOFF_REFUSED",
+        message: "The incumbent Observer could not be replaced safely.",
+        hint: "Inspect ownership.",
+      },
+      cause: typedCause,
+    });
+  });
+
+  it("retains typed fields from a SafeError-shaped plain object and redacts them", () => {
+    expect(
+      normalizeObserverStartupFailure({
+        ...typedCause,
+        message: "Mismatch with API_TOKEN=super-secret-value",
+        raw: { password: "do-not-copy" },
+      }),
+    ).toEqual({
+      kind: "observer-startup-failure",
+      version: 1,
+      error: {
+        ...typedCause,
+        message: "Mismatch with API_TOKEN=[REDACTED]",
+      },
+    });
+  });
+
+  it("normalizes ordinary Errors to one redacted line without stacks", () => {
+    const report = normalizeObserverStartupFailure(
+      new Error("startup failed with API_TOKEN=super-secret-value\n    at private-frame"),
+    );
+
+    expect(report.error).toEqual({
+      tag: "ObserverStartupCauseError",
+      code: "OBSERVER_STARTUP_CAUSE_ERROR",
+      message: "startup failed with API_TOKEN=[REDACTED]",
+    });
+    expect(JSON.stringify(report)).not.toContain("private-frame");
+    expect(JSON.stringify(report)).not.toContain("super-secret-value");
+  });
+
+  it.each([
+    undefined,
+    null,
+    false,
+    42,
+    "raw private value",
+    { private: "value" },
+  ])("normalizes arbitrary value %# without interpolation", (value) => {
+    expect(normalizeObserverStartupFailure(value).error).toEqual({
+      tag: "ObserverStartupCauseError",
+      code: "OBSERVER_STARTUP_CAUSE_UNKNOWN",
+      message: "Observer startup failed for an unknown reason.",
+    });
+  });
+
+  it("terminates cyclic cause traversal", () => {
+    const cyclic = new Error("cyclic");
+    Object.defineProperty(cyclic, "cause", { value: cyclic });
+    expect(normalizeObserverStartupFailure(cyclic).error.code).toBe("OBSERVER_STARTUP_CAUSE_ERROR");
+  });
+
+  it("normalizes objects whose cause cannot be inspected", () => {
+    const inaccessibleCause = {};
+    Object.defineProperty(inaccessibleCause, "cause", {
+      get: () => {
+        throw new Error("private getter failure");
+      },
+    });
+
+    expect(normalizeObserverStartupFailure(inaccessibleCause).error).toEqual({
+      tag: "ObserverStartupCauseError",
+      code: "OBSERVER_STARTUP_CAUSE_UNKNOWN",
+      message: "Observer startup failed for an unknown reason.",
+    });
+  });
+
+  it("strictly serializes and parses exactly one bounded report", () => {
+    const report = normalizeObserverStartupFailure(typedCause);
+    const payload = serializeObserverStartupFailureReport(report);
+    expect(parseObserverStartupFailureReport(payload)).toEqual(report);
+
+    expect(() =>
+      parseObserverStartupFailureReport(Buffer.from(`${payload.toString()}{}\n`)),
+    ).toThrow("one complete JSON value");
+    expect(() => parseObserverStartupFailureReport(Buffer.from('{"kind":'))).toThrow(
+      "one complete JSON value",
+    );
+    expect(() =>
+      parseObserverStartupFailureReport(
+        Buffer.from(
+          JSON.stringify({
+            ...report,
+            extra: true,
+          }),
+        ),
+      ),
+    ).toThrow("strict contract");
+    expect(() =>
+      parseObserverStartupFailureReport(
+        Buffer.alloc(OBSERVER_STARTUP_FAILURE_REPORT_MAX_BYTES + 1),
+      ),
+    ).toThrow("byte limit");
+  });
+
+  it("reads one report and treats readiness EOF as absence", async () => {
+    const failureStream = new PassThrough();
+    const failureReader = readObserverStartupFailureReport(failureStream);
+    failureStream.end(
+      serializeObserverStartupFailureReport(normalizeObserverStartupFailure(typedCause)),
+    );
+    await expect(failureReader.report).resolves.toMatchObject({ error: typedCause });
+
+    const readyStream = new PassThrough();
+    const readyReader = readObserverStartupFailureReport(readyStream);
+    readyStream.end();
+    await expect(readyReader.report).resolves.toBeUndefined();
+  });
+
+  it("writes and closes once, including after a readiness notification", () => {
+    const chunks: Buffer[] = [];
+    const close = vi.fn();
+    const env = {
+      [STATION_OBSERVER_STARTUP_FAILURE_FD]: String(OBSERVER_STARTUP_FAILURE_FD),
+    };
+    const reporter = createObserverStartupFailureReporter(env, {
+      write: (_fd, buffer, offset) => {
+        const length = Math.min(7, buffer.byteLength - offset);
+        chunks.push(Buffer.from(buffer.subarray(offset, offset + length)));
+        return length;
+      },
+      close,
+    });
+
+    const report = reporter.failure(typedCause);
+    reporter.failure(new Error("later failure"));
+    reporter.ready();
+
+    expect(env).not.toHaveProperty(STATION_OBSERVER_STARTUP_FAILURE_FD);
+    expect(close).toHaveBeenCalledOnce();
+    expect(parseObserverStartupFailureReport(Buffer.concat(chunks))).toEqual(report);
+
+    const readyClose = vi.fn();
+    const readyReporter = createObserverStartupFailureReporter(
+      { [STATION_OBSERVER_STARTUP_FAILURE_FD]: String(OBSERVER_STARTUP_FAILURE_FD) },
+      { write: vi.fn(() => 0), close: readyClose },
+    );
+    readyReporter.ready();
+    readyReporter.ready();
+    readyReporter.failure(typedCause);
+    expect(readyClose).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/cli/test/unit/observer-process/lifecycle.test.ts
+++ b/apps/cli/test/unit/observer-process/lifecycle.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createRealStaleSocket } from "../../../../../tests/support/sockets";
 import { fileExists } from "../../../../../tests/support/spool";
 import { createTempState } from "../../../../../tests/support/temp-projects";
+import { observerStatusErrorMessage } from "../../../src/observerProcess.js";
 
 const now = "2026-05-20T12:00:00.000Z";
 const zeroBuildVersion = `0.0.0+station.${"a".repeat(64)}`;
@@ -22,6 +23,37 @@ const exactOneBuildVersion = `1.0.0+station.${"a".repeat(64)}`;
 const exactTwoBuildVersion = `2.0.0+station.${"a".repeat(64)}`;
 
 describe("CLI observer process lifecycle", () => {
+  it("renders the outer failure, separate cause, and one executable next step", async () => {
+    const fixture = await createTempState();
+    expect(
+      observerStatusErrorMessage({
+        status: "unhealthy",
+        paths: fixture,
+        error: {
+          tag: "ObserverStartupError",
+          code: "OBSERVER_EXITED_ON_START",
+          message: "Observer exited before becoming healthy (exit code 1).",
+          traceId: "trc_lifecycle",
+        },
+        cause: {
+          tag: "ObserverProcessEvidenceError",
+          code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH",
+          message: "Observer process evidence did not match the exact executable and argv.",
+        },
+      }),
+    ).toBe(
+      [
+        "Observer exited before becoming healthy (exit code 1). (OBSERVER_EXITED_ON_START)",
+        "Cause: Observer process evidence did not match the exact executable and argv. (OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH)",
+        "Next: stn debug trace trc_lifecycle",
+      ].join("\n"),
+    );
+
+    expect(observerStatusErrorMessage({ status: "stopped", paths: fixture })).toBe(
+      "Observer is not running.",
+    );
+  });
+
   it("reports an absent socket as stopped without spending the remaining deadline on health", async () => {
     const fixture = await createTempState();
     let healthRequested = false;
@@ -201,7 +233,10 @@ describe("CLI observer process lifecycle", () => {
       error: {
         tag: "ObserverStartupError",
         traceId: expect.stringMatching(/^trc_/),
-        hint: expect.stringMatching(/^Run station debug trace trc_/),
+        hint: expect.stringMatching(/^Run stn debug trace trc_/),
+      },
+      startupEvidence: {
+        bootLogPath: join(fixture.stateDir, "logs", "observer-boot.log"),
       },
     });
     if (result.status === "running") {
@@ -225,6 +260,7 @@ describe("CLI observer process lifecycle", () => {
         error: {
           traceId: result.error?.traceId,
         },
+        startupEvidence: result.startupEvidence,
       },
     });
   });
@@ -320,7 +356,7 @@ describe("CLI observer process lifecycle", () => {
           expect(result).toMatchObject({
             phase: "inspection",
             incumbentDisposition: "preserved",
-            error: { hint: expect.stringContaining("OBSERVER_SOCKET_INACCESSIBLE") },
+            cause: { code: "OBSERVER_SOCKET_INACCESSIBLE" },
           });
         }
       }
@@ -593,6 +629,9 @@ describe("CLI observer process lifecycle", () => {
     expect(result).toMatchObject({
       status: "unhealthy",
       error: {
+        code: "OBSERVER_EXACT_BUILD_ACTIVATION_FAILED",
+      },
+      cause: {
         code: "OBSERVER_EXACT_BUILD_ACTIVATION_FAILED",
         hint: expect.stringContaining("configured socket changed owners"),
       },
@@ -1050,7 +1089,13 @@ describe("CLI observer process lifecycle", () => {
     expect(result.error?.hint).toContain(
       "Restart was replacing incumbent 1.0.0 (build aaaaaaaaaaaa) (pid 1234).",
     );
-    expect(result.error?.hint).toContain("Startup failure: boot aborted: socket claim refused");
+    expect(result.error?.hint).not.toContain("boot aborted");
+    expect(result).toMatchObject({
+      cause: {
+        code: "OBSERVER_STARTUP_CAUSE_ERROR",
+        message: "boot aborted: socket claim refused",
+      },
+    });
   });
 
   it("spawns a higher build and ignores the lower incumbent until its child is healthy", async () => {

--- a/apps/cli/test/unit/observer-process/lifecycle.test.ts
+++ b/apps/cli/test/unit/observer-process/lifecycle.test.ts
@@ -52,6 +52,24 @@ describe("CLI observer process lifecycle", () => {
     expect(observerStatusErrorMessage({ status: "stopped", paths: fixture })).toBe(
       "Observer is not running.",
     );
+
+    expect(
+      observerStatusErrorMessage({
+        status: "unhealthy",
+        paths: fixture,
+        error: {
+          tag: "ObserverStartupError",
+          code: "OBSERVER_HANDOFF_REFUSED",
+          message: "Observer build handoff was refused.",
+          hint: "Running build: 1.2.3 (build bbbbbbbbbbbb).\nRequested build: 1.2.3 (build aaaaaaaaaaaa). Run `stn observer stop` and retry.",
+        },
+      }),
+    ).toBe(
+      [
+        "Observer build handoff was refused. (OBSERVER_HANDOFF_REFUSED)",
+        "Next: Running build: 1.2.3 (build bbbbbbbbbbbb). Requested build: 1.2.3 (build aaaaaaaaaaaa). Run `stn observer stop` and retry.",
+      ].join("\n"),
+    );
   });
 
   it("reports an absent socket as stopped without spending the remaining deadline on health", async () => {

--- a/apps/cli/test/unit/observer-process/setup-observer-activation.test.ts
+++ b/apps/cli/test/unit/observer-process/setup-observer-activation.test.ts
@@ -140,4 +140,62 @@ describe("setup activation wires observer startup progress", () => {
     expect(received).toHaveLength(1);
     expect(Object.hasOwn(received[0] ?? {}, "onStartupProgress")).toBe(false);
   });
+
+  it("retains restart cause and startup evidence in the failed setup operation", async () => {
+    const fixture = await createTempState();
+    const configPath = join(fixture.root, "config.toml");
+    await writeFile(
+      configPath,
+      [
+        "schema_version = 1",
+        "projects = []",
+        "",
+        "[observer]",
+        `socket_path = ${JSON.stringify(fixture.socketPath)}`,
+        `state_dir = ${JSON.stringify(fixture.stateDir)}`,
+        "",
+        "[defaults]",
+        'worktree_provider = "worktrunk"',
+        'terminal = "tmux"',
+        'harness = "codex"',
+        'layout = "agent-build-shell"',
+      ].join("\n"),
+      "utf8",
+    );
+    restartObserverSpy.mockResolvedValueOnce({
+      status: "unhealthy",
+      paths: fixture,
+      error: {
+        tag: "ObserverStartupError",
+        code: "OBSERVER_HANDOFF_REFUSED",
+        message: "Observer handoff was refused.",
+      },
+      cause: {
+        tag: "ObserverProcessEvidenceError",
+        code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH",
+        message: "Observer executable arguments did not match.",
+      },
+      startupEvidence: {
+        bootLogPath: join(fixture.stateDir, "logs", "observer-boot.log"),
+        bootLogTail: "replacement refused",
+      },
+    });
+
+    const outcome = await createObserverActivationAdapter({
+      configPath: () => configPath,
+      homeDir: fixture.root,
+    })({
+      id: "activate-observer-config",
+      kind: "activate-observer-config",
+      tier: "required",
+      selected: true,
+    });
+
+    expect(outcome).toMatchObject({
+      status: "failed",
+      error: { code: "OBSERVER_HANDOFF_REFUSED" },
+      cause: { code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH" },
+      startupEvidence: { bootLogTail: "replacement refused" },
+    });
+  });
 });

--- a/apps/cli/test/unit/observer-process/spawn.test.ts
+++ b/apps/cli/test/unit/observer-process/spawn.test.ts
@@ -2,11 +2,16 @@ import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { createTempState } from "../../../../../tests/support/temp-projects";
 import {
   OBSERVER_STARTUP_FAILURE_FD,
   STATION_OBSERVER_STARTUP_FAILURE_FD,
 } from "../../../src/observerProcess/failureReport.js";
-import { observerSpawnArgv, observerSpawnEnvironment } from "../../../src/observerProcess/spawn.js";
+import {
+  defaultSpawnObserver,
+  observerSpawnArgv,
+  observerSpawnEnvironment,
+} from "../../../src/observerProcess/spawn.js";
 import { selfExecArgv } from "../../../src/selfExec.js";
 
 const paths = {
@@ -100,5 +105,45 @@ describe("observer spawn argv", () => {
     );
 
     expect(source).toContain('join(env.repoRoot, "apps", "cli", "dist", "observerMain.js")');
+  });
+
+  it.each([
+    { label: "malformed", payloadExpression: JSON.stringify("not-json") },
+    { label: "partial", payloadExpression: JSON.stringify('{"kind":') },
+    { label: "multiple", payloadExpression: JSON.stringify("{}{}") },
+    {
+      label: "oversized",
+      payloadExpression: `"x".repeat(${64 * 1024 + 1})`,
+    },
+  ])("handles a delayed child exit after $label report input", async ({ payloadExpression }) => {
+    const fixture = await createTempState();
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+    let child: Awaited<ReturnType<typeof defaultSpawnObserver>> | undefined;
+    try {
+      const script = [
+        'const { closeSync, writeSync } = require("node:fs");',
+        `writeSync(3, Buffer.from(${payloadExpression}));`,
+        "closeSync(3);",
+        "setTimeout(() => process.exit(1), 25);",
+      ].join("");
+      child = await defaultSpawnObserver({
+        paths: fixture,
+        startupTimeoutMs: 500,
+        buildVersion,
+        processToken,
+        observerCommand: [process.execPath, "-e", script, "--"],
+      });
+
+      await expect(child.exited).resolves.toMatchObject({ type: "exit", code: 1 });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+      child?.disposeFailureReport?.();
+      await child?.disposeBootLog?.();
+      child?.kill?.();
+    }
   });
 });

--- a/apps/cli/test/unit/observer-process/spawn.test.ts
+++ b/apps/cli/test/unit/observer-process/spawn.test.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { ObserverStartupFailureReportSchema, type SafeError } from "@station/contracts";
 import { describe, expect, it } from "vitest";
 import { createTempState } from "../../../../../tests/support/temp-projects";
 import {
@@ -24,6 +25,11 @@ const paths = {
 };
 const buildVersion = `1.2.3+station.${"a".repeat(64)}`;
 const processToken = ["a47ac10b", "58cc", "4372", "a567", "0e02b2c3d479"].join("-");
+const unknownStartupError: SafeError = {
+  tag: "ObserverStartupCauseError",
+  code: "OBSERVER_STARTUP_CAUSE_UNKNOWN",
+  message: "Observer startup failed for an unknown reason.",
+};
 
 describe("observer spawn argv", () => {
   it("keeps the source entry prefix and observer flag order", () => {
@@ -105,6 +111,80 @@ describe("observer spawn argv", () => {
     );
 
     expect(source).toContain('join(env.repoRoot, "apps", "cli", "dist", "observerMain.js")');
+  });
+
+  it.each([
+    {
+      label: "Error",
+      fixture: "error",
+      expectedError: {
+        tag: "ObserverStartupCauseError",
+        code: "OBSERVER_STARTUP_CAUSE_ERROR",
+        message: "ordinary failure with API_TOKEN=[REDACTED]",
+      } satisfies SafeError,
+    },
+    {
+      label: "typed error",
+      fixture: "typed",
+      expectedError: {
+        tag: "ObserverProcessEvidenceError",
+        code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH",
+        message: "Typed failure with API_TOKEN=[REDACTED]",
+        hint: "Inspect the exact process evidence.",
+      } satisfies SafeError,
+    },
+    {
+      label: "plain object",
+      fixture: "plain-object",
+      expectedError: unknownStartupError,
+    },
+    {
+      label: "unknown primitive",
+      fixture: "unknown",
+      expectedError: unknownStartupError,
+    },
+  ])("reports a real child process $label failure through the strict inherited pipe", async ({
+    fixture: failureFixture,
+    expectedError,
+  }) => {
+    const fixture = await createTempState();
+    const childEntry = fileURLToPath(
+      new URL("../../fixtures/observer-startup-failure-child.mjs", import.meta.url),
+    );
+    let child: Awaited<ReturnType<typeof defaultSpawnObserver>> | undefined;
+    try {
+      child = await defaultSpawnObserver({
+        paths: fixture,
+        startupTimeoutMs: 500,
+        buildVersion,
+        processToken,
+        observerCommand: [process.execPath, childEntry, failureFixture, "--"],
+      });
+
+      const exit = await child.exited;
+      expect(exit).toMatchObject({ type: "exit", code: 1, signal: null });
+      if (exit?.report === undefined) throw new Error("Child failure report was absent.");
+      expect(ObserverStartupFailureReportSchema.parse(exit.report)).toEqual({
+        kind: "observer-startup-failure",
+        version: 1,
+        error: expectedError,
+      });
+
+      const bootLogTail = await child.readBootLogTail?.();
+      expect(bootLogTail).toBeDefined();
+      const [, ...stderrLines] = bootLogTail?.split("\n") ?? [];
+      expect(stderrLines).toEqual([`${expectedError.message} (${expectedError.code})`]);
+
+      const serializedEvidence = JSON.stringify({ report: exit.report, stderrLines });
+      expect(serializedEvidence).not.toContain("super-secret-value");
+      expect(serializedEvidence).not.toContain("/private/");
+      expect(serializedEvidence).not.toContain("    at ");
+    } finally {
+      child?.disposeFailureReport?.();
+      await child?.disposeBootLog?.();
+      child?.kill?.();
+      await fixture.cleanup();
+    }
   });
 
   it.each([

--- a/apps/cli/test/unit/observer-process/spawn.test.ts
+++ b/apps/cli/test/unit/observer-process/spawn.test.ts
@@ -2,6 +2,10 @@ import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import {
+  OBSERVER_STARTUP_FAILURE_FD,
+  STATION_OBSERVER_STARTUP_FAILURE_FD,
+} from "../../../src/observerProcess/failureReport.js";
 import { observerSpawnArgv, observerSpawnEnvironment } from "../../../src/observerProcess/spawn.js";
 import { selfExecArgv } from "../../../src/selfExec.js";
 
@@ -75,12 +79,17 @@ describe("observer spawn argv", () => {
     const inherited = {
       PATH: "/usr/bin",
       STATION_OBSERVER_STARTUP_POLICY: "preserve-incumbent",
+      [STATION_OBSERVER_STARTUP_FAILURE_FD]: "99",
     };
 
-    expect(observerSpawnEnvironment({}, inherited)).toEqual({ PATH: "/usr/bin" });
+    expect(observerSpawnEnvironment({}, inherited)).toEqual({
+      PATH: "/usr/bin",
+      [STATION_OBSERVER_STARTUP_FAILURE_FD]: String(OBSERVER_STARTUP_FAILURE_FD),
+    });
     expect(observerSpawnEnvironment({ incumbentPolicy: "preserve" }, inherited)).toEqual({
       PATH: "/usr/bin",
       STATION_OBSERVER_STARTUP_POLICY: "preserve-incumbent",
+      [STATION_OBSERVER_STARTUP_FAILURE_FD]: String(OBSERVER_STARTUP_FAILURE_FD),
     });
   });
 

--- a/apps/cli/test/unit/observer-process/startup.test.ts
+++ b/apps/cli/test/unit/observer-process/startup.test.ts
@@ -3,6 +3,10 @@ import { join } from "node:path";
 import { startObserver } from "@station/cli";
 import type { ChildProcessLike } from "@station/cli/internal";
 import type { ObserverHealth, SafeError } from "@station/contracts";
+import {
+  OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_BYTES,
+  OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_LINES,
+} from "@station/contracts";
 import { stationObserverBuildVersion } from "@station/runtime";
 import { describe, expect, it, vi } from "vitest";
 import { createTempState } from "../../../../../tests/support/temp-projects";
@@ -157,15 +161,17 @@ describe("CLI observer process startup", () => {
         error: {
           code: "OBSERVER_EXITED_ON_START",
           message: expect.stringContaining("exit code 17"),
-          hint: expect.stringContaining(`Latest observer boot log: ${bootLogPath}`),
+        },
+        startupEvidence: {
+          bootLogPath,
+          bootLogTail: expect.stringContaining("boot-line-6"),
         },
       });
-      expect(statusError(result)?.hint).toContain("This attempt's last 15 lines (redacted):");
-      expect(statusError(result)?.hint).toContain("boot-line-6");
-      expect(statusError(result)?.hint).not.toContain("boot-line-5\n");
-      expect(statusError(result)?.hint).toContain("API_TOKEN=[REDACTED]");
-      expect(statusError(result)?.hint).not.toContain("super-secret-value");
-      expect(statusError(result)?.hint).not.toContain("winning-attempt");
+      if (result.status === "running") throw new Error("Expected startup failure.");
+      expect(result.startupEvidence?.bootLogTail).not.toContain("boot-line-5\n");
+      expect(result.startupEvidence?.bootLogTail).toContain("API_TOKEN=[REDACTED]");
+      expect(result.startupEvidence?.bootLogTail).not.toContain("super-secret-value");
+      expect(result.startupEvidence?.bootLogTail).not.toContain("winning-attempt");
       await expect(readFile(bootLogPath, "utf8")).resolves.toBe("winning-attempt\n");
       expect(bootLogDisposals).toBe(1);
       const healthCallsAtExit = healthCalls;
@@ -288,12 +294,12 @@ describe("CLI observer process startup", () => {
     {
       label: "exit code",
       exit: { type: "exit" as const, code: 17, signal: null },
-      expected: "Replacement child: exit code 17",
+      expected: "exit code 17",
     },
     {
       label: "signal",
       exit: { type: "exit" as const, code: null, signal: "SIGTERM" as const },
-      expected: "Replacement child: signal SIGTERM",
+      expected: "signal SIGTERM",
     },
     {
       label: "spawn error",
@@ -301,14 +307,17 @@ describe("CLI observer process startup", () => {
         type: "spawn_error" as const,
         error: new Error("launch failed with API_TOKEN=super-secret-value"),
       },
-      expected: "Replacement child: spawn error: launch failed with API_TOKEN=[REDACTED]",
+      expected: "spawn error",
     },
     {
       label: "unknown status",
       exit: { type: "exit" as const, code: null, signal: null },
-      expected: "Replacement child: unknown exit status",
+      expected: "unknown exit status",
     },
-  ])("retains a replacement child's $label under handoff refusal", async ({ exit, expected }) => {
+  ])("retains a replacement child's $label under early-exit classification", async ({
+    exit,
+    expected,
+  }) => {
     const fixture = await createTempState();
     let healthCalls = 0;
 
@@ -330,18 +339,23 @@ describe("CLI observer process startup", () => {
 
     expect(result).toMatchObject({
       status: "unhealthy",
-      error: { code: "OBSERVER_HANDOFF_REFUSED", traceId: expect.any(String) },
+      error: {
+        code: "OBSERVER_EXITED_ON_START",
+        message: expect.stringContaining(expected),
+        traceId: expect.any(String),
+      },
+      startupEvidence: { bootLogPath: observerBootLogPath(fixture.stateDir) },
     });
-    expect(statusError(result)?.hint).toContain(expected);
-    expect(statusError(result)?.hint).toContain(
-      "Health convergence: OBSERVER_INCUMBENT_HEALTH_TIMEOUT after 1000 ms",
-    );
-    expect(statusError(result)?.hint).toContain("Boot-log tail unavailable");
-    expect(statusError(result)?.hint).toContain("1.0.0 (build bbbbbbbbbbbb)");
-    expect(statusError(result)?.hint).toContain("2.0.0 (build aaaaaaaaaaaa)");
-    expect(statusError(result)?.hint).toContain(
-      `station debug trace ${statusError(result)?.traceId}`,
-    );
+    expect(statusError(result)?.hint).not.toContain(expected);
+    expect(result).toMatchObject({
+      cause:
+        exit.type === "spawn_error"
+          ? {
+              code: "OBSERVER_STARTUP_CAUSE_ERROR",
+              message: "launch failed with API_TOKEN=[REDACTED]",
+            }
+          : { code: "OBSERVER_INCUMBENT_HEALTH_TIMEOUT" },
+    });
     expect(statusError(result)?.hint).not.toContain("super-secret-value");
     expect(healthCalls).toBeGreaterThan(1);
   });
@@ -351,7 +365,7 @@ describe("CLI observer process startup", () => {
     {
       delayMs: 1_001,
       expectedStatus: "unhealthy",
-      expectedCode: "OBSERVER_HANDOFF_REFUSED",
+      expectedCode: "OBSERVER_EXITED_ON_START",
     },
   ])("keeps the one-second convergence boundary at $delayMs ms", async ({
     delayMs,
@@ -397,9 +411,7 @@ describe("CLI observer process startup", () => {
       expect(result.status).toBe(expectedStatus);
       expect(statusError(result)?.code).toBe(expectedCode);
       if (delayMs === 1_001) {
-        expect(statusError(result)?.hint).toContain(
-          "Health convergence: OBSERVER_INCUMBENT_HEALTH_TIMEOUT after 1000 ms",
-        );
+        expect(result).toMatchObject({ cause: { code: "OBSERVER_INCUMBENT_HEALTH_TIMEOUT" } });
       }
     } finally {
       vi.useRealTimers();
@@ -428,11 +440,12 @@ describe("CLI observer process startup", () => {
       },
     );
 
-    expect(statusError(result)?.code).toBe("OBSERVER_HANDOFF_REFUSED");
-    expect(statusError(result)?.hint).toContain("Health convergence: OBSERVER_HANDOFF_REFUSED");
-    expect(statusError(result)?.hint).toContain("This attempt's last 15 lines (redacted):");
-    expect(statusError(result)?.hint).toContain("API_TOKEN=[REDACTED]");
-    expect(statusError(result)?.hint).not.toContain("super-secret-value");
+    expect(statusError(result)?.code).toBe("OBSERVER_EXITED_ON_START");
+    expect(result).toMatchObject({
+      cause: { code: "OBSERVER_HANDOFF_REFUSED" },
+      startupEvidence: { bootLogTail: "startup failed with API_TOKEN=[REDACTED]" },
+    });
+    expect(JSON.stringify(result)).not.toContain("super-secret-value");
   });
 
   it("lets the outer startup timeout preempt incumbent convergence", async () => {
@@ -506,9 +519,13 @@ describe("CLI observer process startup", () => {
       status: "unhealthy",
       error: {
         code: "OBSERVER_EXITED_ON_START",
-        message: expect.stringContaining("spawn error: spawn failed with API_TOKEN=[REDACTED]"),
-        hint: expect.stringContaining(observerBootLogPath(fixture.stateDir)),
+        message: expect.stringContaining("spawn error"),
       },
+      cause: {
+        code: "OBSERVER_STARTUP_CAUSE_ERROR",
+        message: "spawn failed with API_TOKEN=[REDACTED]",
+      },
+      startupEvidence: { bootLogPath: observerBootLogPath(fixture.stateDir) },
     });
     expect(statusError(result)?.message).not.toContain("super-secret-value");
   });
@@ -560,9 +577,9 @@ describe("CLI observer process startup", () => {
       },
     );
 
-    expect(statusError(result)?.hint).toContain(`Observer boot log: ${bootLogPath}`);
-    expect(statusError(result)?.hint).toContain("Boot-log tail unavailable");
-    expect(statusError(result)?.hint).not.toContain("Last 15 lines");
+    expect(result).toMatchObject({ startupEvidence: { bootLogPath } });
+    if (result.status === "running") throw new Error("Expected startup failure.");
+    expect(result.startupEvidence?.bootLogTail).toBeUndefined();
   });
 
   it("emits delayed startup progress at 1.5s and 5s, then clears its timers", async () => {
@@ -686,7 +703,7 @@ describe("CLI observer process startup", () => {
     }
   });
 
-  it("includes the redacted boot-log tail in a startup timeout hint", async () => {
+  it("includes the redacted boot-log tail as structured startup evidence", async () => {
     const fixture = await createTempState();
     const readBootLogTail = vi.fn(async () => "boot crashed after API_TOKEN=super-secret-value");
     let killed = false;
@@ -709,16 +726,49 @@ describe("CLI observer process startup", () => {
 
     expect(killed).toBe(true);
     expect(statusError(result)?.code).toBe("OBSERVER_START_FAILED");
-    expect(statusError(result)?.hint).toMatch(/^Run station debug trace trc_/);
+    expect(statusError(result)?.hint).toMatch(/^Run stn debug trace trc_/);
     expect(readBootLogTail).toHaveBeenCalled();
-    expect(statusError(result)?.hint).toContain(
-      `Latest observer boot log: ${observerBootLogPath(fixture.stateDir)}`,
-    );
-    expect(statusError(result)?.hint).toContain("boot crashed after API_TOKEN=[REDACTED]");
+    expect(result).toMatchObject({
+      startupEvidence: {
+        bootLogPath: observerBootLogPath(fixture.stateDir),
+        bootLogTail: "boot crashed after API_TOKEN=[REDACTED]",
+      },
+    });
     expect(statusError(result)?.hint).not.toContain("super-secret-value");
   });
 
-  it("includes the redacted one-line spawn failure reason in a flattened startup error hint", async () => {
+  it("bounds injected boot evidence after redaction expands it", async () => {
+    const fixture = await createTempState();
+    const readBootLogTail = vi.fn(async () =>
+      Array.from({ length: 20 }, () => `${"ordinary-prefix ".repeat(6_000)}API_TOKEN=x`).join("\n"),
+    );
+
+    const result = await startObserver(
+      { config: fixture.config, timeoutMs: 60 },
+      {
+        spawnObserver: async (): Promise<ChildProcessLike> =>
+          fakeChild({
+            exited: new Promise<never>(() => undefined),
+            readBootLogTail,
+            kill: () => true,
+          }),
+        clientFactory: unavailableClientFactory(),
+      },
+    );
+
+    if (result.status === "running" || result.startupEvidence?.bootLogTail === undefined) {
+      throw new Error("Startup did not retain bounded boot evidence.");
+    }
+    expect(Buffer.byteLength(result.startupEvidence.bootLogTail, "utf8")).toBeLessThanOrEqual(
+      OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_BYTES,
+    );
+    expect(result.startupEvidence.bootLogTail.split("\n").length).toBeLessThanOrEqual(
+      OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_LINES,
+    );
+    expect(result.startupEvidence.bootLogTail).not.toContain("API_TOKEN=x");
+  });
+
+  it("includes the redacted one-line spawn failure reason as a cause", async () => {
     const fixture = await createTempState();
 
     const result = await startObserver(
@@ -735,13 +785,14 @@ describe("CLI observer process startup", () => {
 
     expect(statusError(result)?.code).toBe("OBSERVER_START_FAILED");
     expect(statusError(result)?.message).toBe("Observer startup failed.");
-    expect(statusError(result)?.hint).toMatch(/^Run station debug trace trc_/);
-    expect(statusError(result)?.hint).toContain(
-      "Startup failure: spawn aborted: listener failed with API_TOKEN=[REDACTED]",
-    );
-    expect(statusError(result)?.hint).toContain(
-      `Observer boot log: ${observerBootLogPath(fixture.stateDir)}`,
-    );
+    expect(statusError(result)?.hint).toMatch(/^Run stn debug trace trc_/);
+    expect(result).toMatchObject({
+      cause: {
+        code: "OBSERVER_STARTUP_CAUSE_ERROR",
+        message: "spawn aborted: listener failed with API_TOKEN=[REDACTED]",
+      },
+      startupEvidence: { bootLogPath: observerBootLogPath(fixture.stateDir) },
+    });
     expect(statusError(result)?.hint).not.toContain("super-secret-value");
     expect(statusError(result)?.hint).not.toContain("internal-frame");
   });
@@ -764,7 +815,7 @@ describe("CLI observer process startup", () => {
     );
 
     expect(statusError(result)?.code).toBe("OBSERVER_START_FAILED");
-    expect(statusError(result)?.hint).toMatch(/^Run station debug trace trc_/);
+    expect(statusError(result)?.hint).toMatch(/^Run stn debug trace trc_/);
     expect(statusError(result)?.hint).not.toContain("Startup failure:");
     expect(JSON.stringify(statusError(result))).not.toContain("internal-frame");
   });

--- a/apps/cli/test/unit/observer-process/startup.test.ts
+++ b/apps/cli/test/unit/observer-process/startup.test.ts
@@ -119,7 +119,7 @@ describe("CLI observer process startup", () => {
     const fixture = await createTempState();
     const lines = Array.from({ length: 20 }, (_, index) => `boot-line-${index + 1}`);
     lines[19] = "API_TOKEN=super-secret-value";
-    const attemptTail = lines.slice(-15).join("\n");
+    const attemptTail = lines.join("\u2028");
     let healthCalls = 0;
     let bootLogDisposals = 0;
     let settled = false;
@@ -168,7 +168,8 @@ describe("CLI observer process startup", () => {
         },
       });
       if (result.status === "running") throw new Error("Expected startup failure.");
-      expect(result.startupEvidence?.bootLogTail).not.toContain("boot-line-5\n");
+      expect(result.startupEvidence?.bootLogTail).not.toContain("boot-line-5");
+      expect(result.startupEvidence?.bootLogTail?.split("\n")).toHaveLength(15);
       expect(result.startupEvidence?.bootLogTail).toContain("API_TOKEN=[REDACTED]");
       expect(result.startupEvidence?.bootLogTail).not.toContain("super-secret-value");
       expect(result.startupEvidence?.bootLogTail).not.toContain("winning-attempt");
@@ -314,7 +315,7 @@ describe("CLI observer process startup", () => {
       exit: { type: "exit" as const, code: null, signal: null },
       expected: "unknown exit status",
     },
-  ])("retains a replacement child's $label under early-exit classification", async ({
+  ])("keeps parent handoff refusal for a replacement child's $label", async ({
     exit,
     expected,
   }) => {
@@ -340,12 +341,12 @@ describe("CLI observer process startup", () => {
     expect(result).toMatchObject({
       status: "unhealthy",
       error: {
-        code: "OBSERVER_EXITED_ON_START",
-        message: expect.stringContaining(expected),
-        traceId: expect.any(String),
+        code: "OBSERVER_HANDOFF_REFUSED",
       },
       startupEvidence: { bootLogPath: observerBootLogPath(fixture.stateDir) },
     });
+    expect(statusError(result)?.hint).toContain("Running build:");
+    expect(statusError(result)?.hint).toContain("Requested build:");
     expect(statusError(result)?.hint).not.toContain(expected);
     expect(result).toMatchObject({
       cause:
@@ -365,7 +366,7 @@ describe("CLI observer process startup", () => {
     {
       delayMs: 1_001,
       expectedStatus: "unhealthy",
-      expectedCode: "OBSERVER_EXITED_ON_START",
+      expectedCode: "OBSERVER_HANDOFF_REFUSED",
     },
   ])("keeps the one-second convergence boundary at $delayMs ms", async ({
     delayMs,
@@ -440,7 +441,7 @@ describe("CLI observer process startup", () => {
       },
     );
 
-    expect(statusError(result)?.code).toBe("OBSERVER_EXITED_ON_START");
+    expect(statusError(result)?.code).toBe("OBSERVER_HANDOFF_REFUSED");
     expect(result).toMatchObject({
       cause: { code: "OBSERVER_HANDOFF_REFUSED" },
       startupEvidence: { bootLogTail: "startup failed with API_TOKEN=[REDACTED]" },

--- a/apps/cli/test/unit/update-command.test.ts
+++ b/apps/cli/test/unit/update-command.test.ts
@@ -1,4 +1,5 @@
 import { type StationConfig, stationHostSocketPath } from "@station/config";
+import { type ObserverLifecycleFailure, STATION_SCHEMA_VERSION } from "@station/contracts";
 import { HOST_PROTOCOL_VERSION } from "@station/host";
 import { listenUnixSocket } from "@station/protocol";
 import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
@@ -270,6 +271,51 @@ describe("stn update command", () => {
           "20000",
         ],
       ],
+    });
+  });
+
+  it("strictly retains a successor Observer lifecycle cause and startup evidence", async () => {
+    const fixture = probeFixture("installer-binary");
+    const lifecycleFailure: ObserverLifecycleFailure = {
+      error: {
+        tag: "ObserverStartupError",
+        code: "OBSERVER_HANDOFF_REFUSED",
+        message: "Observer build handoff was refused.",
+      },
+      cause: {
+        tag: "ObserverProcessIdentityError",
+        code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH",
+        message: "Observer executable arguments did not match.",
+      },
+      startupEvidence: {
+        bootLogPath: "/tmp/station/logs/observer-boot.log",
+        bootLogTail: "replacement refused",
+      },
+    };
+    const result = await runUpdateCommand(["--json"], commandOptions(), {
+      probes: [fixture.probe],
+      buildInfo: testBuildInfo,
+      commandRunner: async (input) => ({
+        command: input.command,
+        args: input.args ?? [],
+        stdout: JSON.stringify({
+          status: "unhealthy",
+          paths: observerCommandPaths(),
+          ...lifecycleFailure,
+        }),
+        stderr: "",
+        exitCode: 1,
+      }),
+    });
+
+    expect(result).toMatchObject({
+      code: 1,
+      output: {
+        status: "failed",
+        error: { code: "UPDATE_RUNTIME_CROSSOVER_FAILED" },
+        cause: { code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH" },
+        startupEvidence: lifecycleFailure.startupEvidence,
+      },
     });
   });
 
@@ -570,12 +616,35 @@ function missingProbe(channel: UpdateChannelId): UpdateChannelProbe {
 }
 
 function commandResult(input: ExternalCommandInput): ExternalCommandResult {
+  const observerRestart =
+    input.args?.includes("observer") === true && input.args.includes("restart");
   return {
     command: input.command,
     args: input.args ?? [],
-    stdout: "",
+    stdout: observerRestart
+      ? JSON.stringify({
+          status: "running",
+          socketPath: config.observer.socketPath,
+          health: {
+            schemaVersion: STATION_SCHEMA_VERSION,
+            status: "healthy",
+          },
+        })
+      : "",
     stderr: "",
     exitCode: 0,
+  };
+}
+
+function observerCommandPaths() {
+  const stateDir = "/tmp/station";
+  return {
+    stateDir,
+    socketPath: `${stateDir}/run/observer.sock`,
+    dbPath: `${stateDir}/observer.sqlite`,
+    logDir: `${stateDir}/logs`,
+    diagnosticsDir: `${stateDir}/diagnostics`,
+    hookSpoolDir: `${stateDir}/spool/hooks`,
   };
 }
 

--- a/apps/observer/src/runtime/main.ts
+++ b/apps/observer/src/runtime/main.ts
@@ -101,6 +101,16 @@ export type ObserverProviderRegistryFactory = (
   options: ObserverProviderRegistryFactoryOptions,
 ) => ProviderRegistry | Promise<ProviderRegistry>;
 
+/**
+ * DRIVEN PORT
+ *
+ * Notifies the spawning process that startup publication completed so its
+ * private failure-report channel can close without waiting for process exit.
+ */
+export interface ObserverStartupReadinessSink {
+  ready(): void;
+}
+
 export type RunObserverMainDeps = {
   providerRegistryFactory: ObserverProviderRegistryFactory;
   /** Exact Observer build selector; defaults to the running artifact selector. */
@@ -112,6 +122,7 @@ export type RunObserverMainDeps = {
   handoffSleep?: (ms: number) => Promise<void>;
   /** Test/composition override for the child-side incumbent admission policy. */
   startupPolicy?: "generic" | "preserve-incumbent";
+  startupReadinessSink?: ObserverStartupReadinessSink;
   exit?: (code: number) => void;
 };
 
@@ -121,7 +132,8 @@ export type RunObserverMainDeps = {
  * Claims boot ownership, branches on four-state socket evidence, selects
  * Observer-private infrastructure from resolved runtime identity, and owns bind,
  * pidfile, read-only duplicate inspection, ownership-aware shutdown, and exact build
- * health publication.
+ * health publication. Successful publication notifies the injected readiness sink;
+ * startup rejection retains the original failure after best-effort cleanup.
  */
 export async function runObserverMain(
   argv = process.argv.slice(2),
@@ -186,7 +198,10 @@ export async function runObserverMain(
         const incumbent = await lifecycle.health(socketPath, {
           timeoutMs: remainingStartupMs,
         });
-        if (incumbent.version === buildVersion) return 0;
+        if (incumbent.version === buildVersion) {
+          notifyObserverStartupReady(deps.startupReadinessSink);
+          return 0;
+        }
         throw preserveIncumbentRefusal(
           socketPath,
           incumbent.version ?? "legacy/unknown build",
@@ -228,7 +243,10 @@ export async function runObserverMain(
           ...(deps.handoffSleep === undefined ? {} : { sleep: deps.handoffSleep }),
         },
       );
-      if (result.action === "attach") return 0;
+      if (result.action === "attach") {
+        notifyObserverStartupReady(deps.startupReadinessSink);
+        return 0;
+      }
     }
     return await runClaimedObserverRuntime({
       options,
@@ -540,6 +558,9 @@ async function runClaimedObserverRuntime(input: {
     await api.reconcile("observer.startup");
     const startupCommit = startupGate.settleReady(() => claim.release());
     shouldReconcile = startupCommit.status === "ready";
+    if (startupCommit.status === "ready") {
+      notifyObserverStartupReady(deps.startupReadinessSink);
+    }
     if (startupCommit.status === "ready" && startupCommit.claimRelease.status === "failed") {
       // Readiness is already committed; cleanup after a partial SQLite release
       // could race a successor, so the live Observer remains the socket owner.
@@ -555,10 +576,12 @@ async function runClaimedObserverRuntime(input: {
     process.off("SIGTERM", stopFromSignal);
     startupGate.settleFailed();
     shutdownExitCode = 1;
-    await logger.error("Observer startup failed; shutting down runtime services.", {
-      socketPath,
-      error,
-    });
+    await logger
+      .error("Observer startup failed; shutting down runtime services.", {
+        socketPath,
+        error,
+      })
+      .catch(() => undefined);
     try {
       await stopObserver(1);
     } catch (shutdownError) {
@@ -569,10 +592,13 @@ async function runClaimedObserverRuntime(input: {
         })
         .catch(() => undefined);
     } finally {
-      sqlite.close();
+      try {
+        sqlite.close();
+      } catch {
+        // Cleanup failure must not replace the original startup rejection.
+      }
     }
-    setTimeout(() => process.exit(1), 2000).unref();
-    return 1;
+    throw error;
   }
   if (shouldReconcile) {
     duplicateInspectionFlight = inspectObserverDuplicates(socketPath, {
@@ -604,6 +630,14 @@ async function runClaimedObserverRuntime(input: {
   // Stray unref-less timers must not keep a stopped observer alive.
   setTimeout(() => process.exit(0), 2000).unref();
   return 0;
+}
+
+function notifyObserverStartupReady(sink: ObserverStartupReadinessSink | undefined): void {
+  try {
+    sink?.ready();
+  } catch {
+    // Readiness is already committed; process-report transport failure cannot revoke it.
+  }
 }
 
 async function logDuplicateInspection(

--- a/apps/observer/src/runtime/observerHandoff.ts
+++ b/apps/observer/src/runtime/observerHandoff.ts
@@ -105,7 +105,8 @@ export type ObserverStopRequest = ObserverLifecycleRequest & {
  * DRIVEN PORT
  *
  * Supplies exact incumbent-process evidence without exposing operating-system
- * commands; unavailable socket-holder evidence throws and never means zero.
+ * commands; typed evidence failures remain available as causes, while unavailable
+ * socket-holder evidence throws and never means zero.
  */
 export interface ObserverProcessEvidenceSource {
   readObserverProcess(pid: number): ObserverProcessEntry | undefined;
@@ -270,7 +271,8 @@ function comparePublicVersionLineReset(candidate: string, incumbent: string): -1
  * USE CASE
  *
  * Replaces an older incumbent only after corroborating its socket and process
- * identity; probe or evidence failure refuses before any signal.
+ * identity; probe or evidence failure refuses before any signal, preserving a
+ * typed evidence failure as the handoff refusal's cause.
  */
 export async function negotiateObserverIncumbent(
   input: {

--- a/apps/observer/src/runtime/observerProcessEvidence.ts
+++ b/apps/observer/src/runtime/observerProcessEvidence.ts
@@ -2,7 +2,7 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { readFileSync, readlinkSync, realpathSync, statSync } from "node:fs";
 import { basename, isAbsolute } from "node:path";
 import { resolveObserverSocketForProcessArgs } from "@station/config";
-import { ObserverProcessTokenSchema } from "@station/contracts";
+import { ObserverProcessTokenSchema, type SafeError } from "@station/contracts";
 import { z } from "zod";
 import {
   type ObserverProcessEntry,
@@ -49,6 +49,8 @@ type LocalObserverProcessEvidenceDeps = {
  * Translates targeted and global exact argv, executable provenance, launch nonce,
  * OS start time, strict socket-holder and complete file-descriptor evidence,
  * pidfiles, socket identities, and signals into conservative ownership evidence.
+ * Exact executable/argv mismatch throws a stable typed refusal without weakening
+ * the fail-closed ownership decision.
  */
 export function createLocalObserverProcessEvidence(
   deps: LocalObserverProcessEvidenceDeps = {},
@@ -315,7 +317,7 @@ function requireExactLocalObserverProcess(
         exactArgv.some((value, index) => value !== entry.argv[index]))) ||
     !processExecutableMatches(entry.pid, entry.executablePath)
   ) {
-    throw new Error(`Observer process ${entry.pid} did not match its exact executable and argv.`);
+    throw observerProcessExecutableArgvMismatch();
   }
   const scriptPath = entry.argv[1];
   if (scriptPath !== "__observer") {
@@ -324,6 +326,15 @@ function requireExactLocalObserverProcess(
     }
   }
   return { ...entry, executablePath: realpathSync(entry.executablePath) };
+}
+
+function observerProcessExecutableArgvMismatch(): Error & SafeError {
+  const safeError: SafeError = {
+    tag: "ObserverProcessEvidenceError",
+    code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH",
+    message: "Observer process evidence did not match the exact executable and argv.",
+  };
+  return Object.assign(new Error(safeError.message), safeError);
 }
 
 function processListArgs(): string[] {

--- a/apps/observer/test/integration/protocol-server.test.ts
+++ b/apps/observer/test/integration/protocol-server.test.ts
@@ -1,4 +1,4 @@
-import { access, chmod, mkdtemp, rm } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
@@ -143,6 +143,29 @@ describe("observer protocol server", () => {
       await server.close();
       fixture.sqlite.close();
     }
+  });
+
+  it("rejects a post-bind publication failure with its original cause after cleanup", async () => {
+    const { dir, socketPath } = await createTempSocketPath();
+    const stateDir = join(dir, "publication-failure-state");
+    await mkdir(`${socketPath}.pid`);
+
+    const failure = await runObserverMain(
+      ["--socket", socketPath, "--state-dir", stateDir, "--startup-timeout-ms", "1000"],
+      {
+        providerRegistryFactory: () =>
+          new ProviderRegistry({
+            worktree: new FakeWorktreeProvider({ now }),
+            terminal: new FakeTerminalProvider({ now }),
+            harnesses: [new FakeHarnessProvider({ now })],
+          }),
+        buildVersion: observerBuildVersion,
+      },
+    ).catch((error: unknown) => error);
+
+    expect(failure).toMatchObject({ code: expect.stringMatching(/EISDIR|ENOTDIR/u) });
+    await expect(access(socketPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await rm(dir, { recursive: true, force: true });
   });
 
   it("captures canonical runtime paths in the local diagnostic adapter", async () => {
@@ -305,6 +328,7 @@ describe("observer protocol server", () => {
     const providerReadStarted = deferred();
     const releaseProviderRead = deferred();
     const terminal = new FakeTerminalProvider({ now });
+    const startupReadinessSink = { ready: vi.fn() };
     vi.spyOn(terminal, "listTargets").mockImplementation(async () => {
       providerReadStarted.resolve();
       await releaseProviderRead.promise;
@@ -320,6 +344,7 @@ describe("observer protocol server", () => {
             harnesses: [new FakeHarnessProvider({ now })],
           }),
         buildVersion: observerBuildVersion,
+        startupReadinessSink,
       },
     );
     const client = createObserverClient({ socketPath, requestId: ids("startup-context") });
@@ -331,6 +356,7 @@ describe("observer protocol server", () => {
       await expect(client.health()).resolves.toMatchObject({
         lastReconcile: { reason: "observer.startup" },
       });
+      expect(startupReadinessSink.ready).toHaveBeenCalledOnce();
       await expect(client.getSnapshot()).resolves.toMatchObject({ observer: { healthy: true } });
     } finally {
       releaseProviderRead.resolve();

--- a/apps/observer/test/unit/observerHandoff.test.ts
+++ b/apps/observer/test/unit/observerHandoff.test.ts
@@ -316,6 +316,30 @@ describe("negotiateObserverIncumbent", () => {
     expect(fixture.signal).not.toHaveBeenCalled();
   });
 
+  it("preserves a typed process-evidence failure as the handoff refusal cause", async () => {
+    const fixture = handoffFixture();
+    const evidenceFailure = Object.assign(
+      new Error("Observer process evidence did not match the exact executable and argv."),
+      {
+        tag: "ObserverProcessEvidenceError",
+        code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH",
+        message: "Observer process evidence did not match the exact executable and argv.",
+      },
+    );
+    fixture.evidence.readObserverProcess = () => {
+      throw evidenceFailure;
+    };
+
+    const failure = await runNegotiation(fixture).catch((error: unknown) => error);
+
+    expect(failure).toMatchObject({
+      code: "OBSERVER_HANDOFF_REFUSED",
+      cause: evidenceFailure,
+    });
+    expect(fixture.stop).not.toHaveBeenCalled();
+    expect(fixture.signal).not.toHaveBeenCalled();
+  });
+
   it("treats a stop receipt as acknowledgement and waits for socket closure and exact death", async () => {
     const fixture = handoffFixture();
     let sleeps = 0;

--- a/apps/observer/test/unit/observerProcessEvidence.test.ts
+++ b/apps/observer/test/unit/observerProcessEvidence.test.ts
@@ -63,7 +63,13 @@ describe("local Observer process evidence", () => {
       processExecutableMatches: () => false,
     });
 
-    expect(() => evidence.listObserverProcesses()).toThrow("exact executable and argv");
+    expect(() => evidence.listObserverProcesses()).toThrow(
+      expect.objectContaining({
+        tag: "ObserverProcessEvidenceError",
+        code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH",
+        message: "Observer process evidence did not match the exact executable and argv.",
+      }),
+    );
     expect(() =>
       parseObserverProcessList(
         wrapper.replace(" --state-dir /tmp/state", " --socket /spoof --state-dir /tmp/state"),

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -228,8 +228,10 @@ version (`0.7.0` in this example).
 `OBSERVER_HANDOFF_REFUSED` means automatic build or cross-version replacement
 could not proceed safely. Read the running/requested display versions and build
 IDs in the error. When a replacement child exits, the result keeps its outer
-lifecycle `error` separate from the child report's typed, redacted `cause` and
-structured `startupEvidence`. Use the outer trace ID against the same state
+lifecycle `error` as `OBSERVER_HANDOFF_REFUSED` once the parent has classified a
+replaceable incumbent; the child report remains diagnostic and contributes only
+the typed, redacted `cause` and structured `startupEvidence`. Provider ingress
+rejects this outcome without creating a retry spool record. Use the outer trace ID against the same state
 directory; `stn debug trace <traceId>` projects the causal code separately. A
 same-version legacy or losing
 identified build with stable PID/start-time health can be stopped explicitly;
@@ -237,6 +239,14 @@ missing process identity refuses rather than risking a successor. It must not
 attach to different code. Compare `lsof -t <socket>` with the strict pidfile and
 `ps -ww -p <pid> -o lstart=,command=`, then retry only after resolving missing
 or conflicting evidence. Automatic handoff never uses SIGKILL.
+
+Auto-starting `snapshot`, `doctor`, `command`, `reconcile`, `observe`, and
+`debug bundle` boundaries preserve failures as the strict `{ error, cause?,
+startupEvidence? }` lifecycle envelope instead of flattening them into prose.
+Setup activation retains the same fields in its failed operation/session
+outcome. `stn update --json` keeps `UPDATE_RUNTIME_CROSSOVER_FAILED` as its outer
+`error` and publishes the strictly parsed successor lifecycle `cause` and
+`startupEvidence` separately.
 
 `OBSERVER_EXACT_BUILD_ACTIVATION_FAILED` means an explicit configured-runtime
 activation could not finish with the caller's exact immutable selector. The
@@ -382,7 +392,7 @@ the client; a scoped `tsc` output is not an identified whole-repository build.
 
 ## Reading Evidence
 
-- `logs/observer-boot.log` is the raw, local-only record of the latest observer startup attempt. Each attempt atomically replaces it at mode `0600` with a JSON-encoded command header followed by that child's stdout/stderr. It sits outside ordinary lifecycle text. A failed start can expose its path and a redacted final 15-line, 64-KiB-bounded tail as structured `startupEvidence`; `debug logs` and `debug trace` keep that evidence separate from the outer error and typed cause.
+- `logs/observer-boot.log` is the raw, local-only record of the latest observer startup attempt. Each attempt atomically replaces it at mode `0600` with a JSON-encoded command header followed by that child's stdout/stderr. It sits outside ordinary lifecycle text. A failed start can expose its path and a redacted final 15-line, 64-KiB-bounded tail as structured `startupEvidence`; CRLF, lone CR/LF, U+2028, and U+2029 all count as line terminators. `debug logs` and `debug trace` keep that evidence separate from the outer error and typed cause, including each SafeError's `tag` and optional `hint`.
 - A failed hosted binary smoke can upload `binary-smoke-evidence-<run-id>-<attempt>` for three days. Download it with `gh run download <run-id> --name binary-smoke-evidence-<run-id>-<attempt> --dir /tmp/station-binary-smoke-evidence-<run-id>`, then read `manifest.json` before the round's `failure.json`, bounded logs, and runtime summary. The bundle is redacted, allowlisted, and capped at 1 MiB, but collaborators with Actions access can download it. Do not run `stn debug trace` against unrelated live state and treat it as evidence for the downloaded CI run.
 - Binary-smoke runtime ownership is recorded in `rounds/*/runtime/lifecycle.jsonl`. Read the owner registration and process-start events first, then the shutdown signal, any bounded escalation, refusal or rescue event, and `runtime.cleanup.completed` counts. The manifest's per-run ID must match the invocation that finalized it. A complete disposable cleanup has zero group members, private roots, Observer or Host sockets, Observer pidfiles, or active owner records; an incomplete or ambiguous cleanup retains the relevant root identity for the next ordinary start or manual inspection. Do not remove a retained root or signal a listed PID unless its executable, process group, start identity, and disposable role still match.
 - `observer.claim.sqlite` is boot-exclusion evidence only. Inspect it with

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -94,12 +94,13 @@ stn command get <commandId>
 error envelope includes diagnostics, the trace summary can include redacted
 external-command details: command, cwd, exit code, duration, bounded
 stdout/stderr snippets, and the effective `PATH` when executable lookup fails with
-`ENOENT`. The compatibility `rootCauseCodes` field retains command, envelope, index, and
-matching-log codes. Use `causeAssessment` for causal interpretation: only a
-correlated diagnostic-index root-cause declaration produces
-`explicit_root_cause`; an error code, retained signal, or exactly matched
-warning/error record produces `observed_failure` and does not establish the
-deeper mechanism. Trace output uses the same `evidenceRoles` and
+`ENOENT`. The compatibility `rootCauseCodes` field retains command, envelope, index,
+typed lifecycle-cause, and matching-log codes. Use `causeAssessment` for causal
+interpretation: a correlated diagnostic-index root-cause declaration or a strict
+lifecycle `cause` produces `explicit_root_cause`; a generic outer error code,
+retained signal, or exactly matched warning/error record produces
+`observed_failure` and does not establish the deeper mechanism. Trace output uses
+the same `evidenceRoles` and
 `operationalBoundaryEvidence` semantics as `debug logs`.
 
 `stn command get <commandId>` asks the live observer for the command lifecycle
@@ -226,11 +227,11 @@ version (`0.7.0` in this example).
 
 `OBSERVER_HANDOFF_REFUSED` means automatic build or cross-version replacement
 could not proceed safely. Read the running/requested display versions and build
-IDs in the error. When a replacement child exits, the error also reports its
-exit code, signal, redacted spawn error, or unknown status; the health rejection
-code or unchanged one-second convergence expiry; and that child's bounded,
-redacted boot-log tail or an explicit unavailable marker. Use the included
-trace ID against the same state directory. A same-version legacy or losing
+IDs in the error. When a replacement child exits, the result keeps its outer
+lifecycle `error` separate from the child report's typed, redacted `cause` and
+structured `startupEvidence`. Use the outer trace ID against the same state
+directory; `stn debug trace <traceId>` projects the causal code separately. A
+same-version legacy or losing
 identified build with stable PID/start-time health can be stopped explicitly;
 missing process identity refuses rather than risking a successor. It must not
 attach to different code. Compare `lsof -t <socket>` with the strict pidfile and
@@ -241,8 +242,10 @@ or conflicting evidence. Automatic handoff never uses SIGKILL.
 activation could not finish with the caller's exact immutable selector. The
 result's `phase` is `inspection`, `stop`, `start`, or `verification`, and
 `incumbentDisposition` reports `none`, `preserved`, `stopped`, or `unknown` for
-the Observer admitted at operation start. The hint retains the underlying safe
-cause code. In a checkout devbox, exact activation does not target the Station
+the Observer admitted at operation start. The result's separate `cause` retains
+the underlying safe code, while `startupEvidence` retains only bounded,
+redacted child boot evidence when one was spawned. In a checkout devbox, exact
+activation does not target the Station
 Host or hosted agents and does not reset `.dev-state`. Resolve inaccessible
 ownership before retrying a `preserved` result. Inspect status first for
 `unknown`. For `stopped`, the isolated Observer may be down while Host-owned
@@ -379,7 +382,7 @@ the client; a scoped `tsc` output is not an identified whole-repository build.
 
 ## Reading Evidence
 
-- `logs/observer-boot.log` is the raw, local-only record of the latest observer startup attempt. Each attempt atomically replaces it at mode `0600` with a JSON-encoded command header followed by that child's stdout/stderr. It sits outside structured `stn debug logs`; an `OBSERVER_EXITED_ON_START` error includes the latest path and, when available, a redacted final 15-line tail captured from its own failed child.
+- `logs/observer-boot.log` is the raw, local-only record of the latest observer startup attempt. Each attempt atomically replaces it at mode `0600` with a JSON-encoded command header followed by that child's stdout/stderr. It sits outside ordinary lifecycle text. A failed start can expose its path and a redacted final 15-line, 64-KiB-bounded tail as structured `startupEvidence`; `debug logs` and `debug trace` keep that evidence separate from the outer error and typed cause.
 - A failed hosted binary smoke can upload `binary-smoke-evidence-<run-id>-<attempt>` for three days. Download it with `gh run download <run-id> --name binary-smoke-evidence-<run-id>-<attempt> --dir /tmp/station-binary-smoke-evidence-<run-id>`, then read `manifest.json` before the round's `failure.json`, bounded logs, and runtime summary. The bundle is redacted, allowlisted, and capped at 1 MiB, but collaborators with Actions access can download it. Do not run `stn debug trace` against unrelated live state and treat it as evidence for the downloaded CI run.
 - Binary-smoke runtime ownership is recorded in `rounds/*/runtime/lifecycle.jsonl`. Read the owner registration and process-start events first, then the shutdown signal, any bounded escalation, refusal or rescue event, and `runtime.cleanup.completed` counts. The manifest's per-run ID must match the invocation that finalized it. A complete disposable cleanup has zero group members, private roots, Observer or Host sockets, Observer pidfiles, or active owner records; an incomplete or ambiguous cleanup retains the relevant root identity for the next ordinary start or manual inspection. Do not remove a retained root or signal a listed PID unless its executable, process group, start identity, and disposable role still match.
 - `observer.claim.sqlite` is boot-exclusion evidence only. Inspect it with

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -58,10 +58,13 @@ command diagnostics, and suggested next commands without contacting the observer
 When a command error envelope includes external-command diagnostics, trace output
 can show the command, cwd, exit code, duration, bounded stdout/stderr snippets,
 and the effective `PATH` for an `ENOENT` executable lookup failure, after
-redaction. `causeAssessment` distinguishes a correlated,
-diagnostic-index-declared root cause from an observed command/error failure or
-insufficient evidence. A generic error code is failure evidence, not proof of
-the mechanism beneath it.
+redaction. Observer lifecycle records preserve the outer `error`, a separately
+normalized `cause`, and bounded `startupEvidence`; `debug logs` and `debug trace`
+parse those fields through strict shared schemas instead of reconstructing them
+from hint text. `causeAssessment` distinguishes a correlated diagnostic-index
+root cause or strict lifecycle cause from an observed generic command/error
+failure or insufficient evidence. A generic outer error code is failure evidence,
+not proof of the mechanism beneath it.
 
 Trace and log results expose `evidenceRoles` so consumers do not confuse the
 record's logging component with failure ownership. `operationalBoundaryEvidence`
@@ -80,6 +83,12 @@ and detach reasons. Each record marks `componentRole` as
 `context` for direct citation. An exactly matched warning or error record can
 establish the retained event as an observed proximate failure without
 establishing a deeper cause.
+
+Lifecycle child reports and boot tails are redacted before they cross the process
+boundary. Ordinary JavaScript errors retain only their redacted first message
+line; arbitrary, cyclic, primitive, or malformed values become a stable unknown
+startup cause without interpolation or raw serialization. Stacks and untrusted
+object fields are not persisted.
 
 `stn observer status` checks the configured observer process/socket state. It is
 non-mutating, but it is still a live status check rather than an existing-state

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -3942,10 +3942,16 @@
           "purpose": null
         },
         {
+          "name": "ObserverStartupReadinessSink",
+          "kind": "interface",
+          "role": "DRIVEN PORT",
+          "purpose": "Notifies the spawning process that startup publication completed so its private failure-report channel can close without waiting for process exit."
+        },
+        {
           "name": "runObserverMain",
           "kind": "function",
           "role": "COMPOSITION ROOT",
-          "purpose": "Claims boot ownership, branches on four-state socket evidence, selects Observer-private infrastructure from resolved runtime identity, and owns bind, pidfile, read-only duplicate inspection, ownership-aware shutdown, and exact build health publication."
+          "purpose": "Claims boot ownership, branches on four-state socket evidence, selects Observer-private infrastructure from resolved runtime identity, and owns bind, pidfile, read-only duplicate inspection, ownership-aware shutdown, and exact build health publication. Successful publication notifies the injected readiness sink; startup rejection retains the original failure after best-effort cleanup."
         },
         {
           "name": "RunObserverMainDeps",
@@ -4168,7 +4174,7 @@
           "name": "createLocalObserverProcessEvidence",
           "kind": "function",
           "role": "ADAPTER",
-          "purpose": "Translates targeted and global exact argv, executable provenance, launch nonce, OS start time, strict socket-holder and complete file-descriptor evidence, pidfiles, socket identities, and signals into conservative ownership evidence."
+          "purpose": "Translates targeted and global exact argv, executable provenance, launch nonce, OS start time, strict socket-holder and complete file-descriptor evidence, pidfiles, socket identities, and signals into conservative ownership evidence. Exact executable/argv mismatch throws a stable typed refusal without weakening the fail-closed ownership decision."
         },
         {
           "name": "createObserverApi",
@@ -4498,7 +4504,7 @@
           "name": "negotiateObserverIncumbent",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Replaces an older incumbent only after corroborating its socket and process identity; probe or evidence failure refuses before any signal."
+          "purpose": "Replaces an older incumbent only after corroborating its socket and process identity; probe or evidence failure refuses before any signal, preserving a typed evidence failure as the handoff refusal's cause."
         },
         {
           "name": "ObservationStore",
@@ -4666,7 +4672,7 @@
           "name": "ObserverProcessEvidenceSource",
           "kind": "interface",
           "role": "DRIVEN PORT",
-          "purpose": "Supplies exact incumbent-process evidence without exposing operating-system commands; unavailable socket-holder evidence throws and never means zero."
+          "purpose": "Supplies exact incumbent-process evidence without exposing operating-system commands; typed evidence failures remain available as causes, while unavailable socket-holder evidence throws and never means zero."
         },
         {
           "name": "ObserverProcessSignalResult",
@@ -4781,6 +4787,12 @@
           "kind": "type",
           "role": null,
           "purpose": null
+        },
+        {
+          "name": "ObserverStartupReadinessSink",
+          "kind": "interface",
+          "role": "DRIVEN PORT",
+          "purpose": "Notifies the spawning process that startup publication completed so its private failure-report channel can close without waiting for process exit."
         },
         {
           "name": "ObserverStopRequest",
@@ -5200,7 +5212,7 @@
           "name": "runObserverMain",
           "kind": "function",
           "role": "COMPOSITION ROOT",
-          "purpose": "Claims boot ownership, branches on four-state socket evidence, selects Observer-private infrastructure from resolved runtime identity, and owns bind, pidfile, read-only duplicate inspection, ownership-aware shutdown, and exact build health publication."
+          "purpose": "Claims boot ownership, branches on four-state socket evidence, selects Observer-private infrastructure from resolved runtime identity, and owns bind, pidfile, read-only duplicate inspection, ownership-aware shutdown, and exact build health publication. Successful publication notifies the injected readiness sink; startup rejection retains the original failure after best-effort cleanup."
         },
         {
           "name": "RunObserverMainDeps",
@@ -10684,10 +10696,16 @@
           "purpose": null
         },
         {
+          "name": "ObserverStartupReadinessSink",
+          "kind": "interface",
+          "role": "DRIVEN PORT",
+          "purpose": "Notifies the spawning process that startup publication completed so its private failure-report channel can close without waiting for process exit."
+        },
+        {
           "name": "runObserverMain",
           "kind": "function",
           "role": "COMPOSITION ROOT",
-          "purpose": "Claims boot ownership, branches on four-state socket evidence, selects Observer-private infrastructure from resolved runtime identity, and owns bind, pidfile, read-only duplicate inspection, ownership-aware shutdown, and exact build health publication."
+          "purpose": "Claims boot ownership, branches on four-state socket evidence, selects Observer-private infrastructure from resolved runtime identity, and owns bind, pidfile, read-only duplicate inspection, ownership-aware shutdown, and exact build health publication. Successful publication notifies the injected readiness sink; startup rejection retains the original failure after best-effort cleanup."
         },
         {
           "name": "RunObserverMainDeps",
@@ -11081,7 +11099,7 @@
           "name": "negotiateObserverIncumbent",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Replaces an older incumbent only after corroborating its socket and process identity; probe or evidence failure refuses before any signal."
+          "purpose": "Replaces an older incumbent only after corroborating its socket and process identity; probe or evidence failure refuses before any signal, preserving a typed evidence failure as the handoff refusal's cause."
         },
         {
           "name": "observerBuildSelectorIsValid",
@@ -11147,7 +11165,7 @@
           "name": "ObserverProcessEvidenceSource",
           "kind": "interface",
           "role": "DRIVEN PORT",
-          "purpose": "Supplies exact incumbent-process evidence without exposing operating-system commands; unavailable socket-holder evidence throws and never means zero."
+          "purpose": "Supplies exact incumbent-process evidence without exposing operating-system commands; typed evidence failures remain available as causes, while unavailable socket-holder evidence throws and never means zero."
         },
         {
           "name": "ObserverProcessSignalResult",
@@ -11302,7 +11320,7 @@
           "name": "createLocalObserverProcessEvidence",
           "kind": "function",
           "role": "ADAPTER",
-          "purpose": "Translates targeted and global exact argv, executable provenance, launch nonce, OS start time, strict socket-holder and complete file-descriptor evidence, pidfiles, socket identities, and signals into conservative ownership evidence."
+          "purpose": "Translates targeted and global exact argv, executable provenance, launch nonce, OS start time, strict socket-holder and complete file-descriptor evidence, pidfiles, socket identities, and signals into conservative ownership evidence. Exact executable/argv mismatch throws a stable typed refusal without weakening the fail-closed ownership decision."
         },
         {
           "name": "parseObserverProcessList",
@@ -11383,6 +11401,12 @@
           "resolvedPath": "packages/contracts/src/index.ts",
           "edgeKind": "runtime",
           "bindings": ["ObserverProcessTokenSchema"]
+        },
+        {
+          "specifier": "@station/contracts",
+          "resolvedPath": "packages/contracts/src/index.ts",
+          "edgeKind": "type-only",
+          "bindings": ["SafeError"]
         },
         {
           "specifier": "zod",
@@ -12441,6 +12465,22 @@
   ],
   "controlledDeclarations": [
     {
+      "path": "apps/cli/src/commands/debugLogs.ts",
+      "declaration": "runDebugLogsCommand",
+      "kind": "function",
+      "role": "ADAPTER",
+      "purpose": "Reads redacted lifecycle logs and projects strict outer, causal, and startup evidence fields without treating the logging component as failure ownership.",
+      "dependencies": []
+    },
+    {
+      "path": "apps/cli/src/commands/debugTrace.ts",
+      "declaration": "runDebugTraceCommand",
+      "kind": "function",
+      "role": "ADAPTER",
+      "purpose": "Correlates existing bundle and log evidence, projecting a strict lifecycle cause as explicit causal evidence while retaining its outer reporting boundary.",
+      "dependencies": []
+    },
+    {
       "path": "apps/cli/src/commands/doctor.ts",
       "declaration": "runDoctorCommand",
       "kind": "function",
@@ -12862,6 +12902,13 @@
         },
         {
           "path": "apps/cli/src/observerProcess.ts",
+          "declaration": "logObserverLifecycleFailure",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/cli/src/observerProcess.ts",
           "declaration": "startObserver",
           "kind": "function",
           "role": "ADAPTER",
@@ -13123,7 +13170,7 @@
       "declaration": "runCliObserverMain",
       "kind": "function",
       "role": "COMPOSITION ROOT",
-      "purpose": "Chooses CLI-owned provider composition and joins it to the Observer runtime lifecycle.",
+      "purpose": "Chooses CLI-owned provider composition and joins it to the Observer runtime lifecycle, including private startup-readiness notification for the spawning CLI.",
       "dependencies": [
         {
           "path": "apps/cli/src/observerProviders.ts",
@@ -13142,15 +13189,52 @@
       ]
     },
     {
+      "path": "apps/cli/src/observerMain.ts",
+      "declaration": "runCliObserverProcess",
+      "kind": "function",
+      "role": "ADAPTER",
+      "purpose": "Applies one shared source/compiled Observer process boundary: typed startup reporting, redacted stderr, readiness closure, and exit-code translation.",
+      "dependencies": [
+        {
+          "path": "apps/cli/src/observerProcess/failureReport.ts",
+          "declaration": "createObserverStartupFailureReporter",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/observer/src/runtime/main.ts",
+          "declaration": "ObserverStartupReadinessSink",
+          "kind": "interface",
+          "role": "DRIVEN PORT",
+          "edgeKind": "type-only"
+        }
+      ]
+    },
+    {
       "path": "apps/cli/src/observerProcess.ts",
       "declaration": "ensureExactObserverBuild",
       "kind": "function",
       "role": "ADAPTER",
-      "purpose": "Converges one configured Observer socket to this caller's exact immutable build within one deadline. At most the admitted identity-pinned incumbent is stopped cooperatively; the child preserves any later non-exact owner. Failures report their phase and the admitted incumbent's last proven disposition without changing generic singleton ordering.",
+      "purpose": "Converges one configured Observer socket to this caller's exact immutable build within one deadline. At most the admitted identity-pinned incumbent is stopped cooperatively; the child preserves any later non-exact owner. Failures report their phase and the admitted incumbent's last proven disposition while retaining a separate typed cause and startup evidence, without changing generic singleton ordering.",
       "dependencies": [
         {
           "path": "apps/cli/src/observerProcess.ts",
           "declaration": "getObserverStatus",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/cli/src/observerProcess.ts",
+          "declaration": "logObserverLifecycleFailure",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/cli/src/observerProcess/startup.ts",
+          "declaration": "startObserverProcess",
           "kind": "function",
           "role": "ADAPTER",
           "edgeKind": "runtime"
@@ -13189,10 +13273,18 @@
     },
     {
       "path": "apps/cli/src/observerProcess.ts",
+      "declaration": "logObserverLifecycleFailure",
+      "kind": "function",
+      "role": "ADAPTER",
+      "purpose": "Persists one redacted CLI lifecycle boundary with distinct outer error, causal failure, and bounded startup evidence fields.",
+      "dependencies": []
+    },
+    {
+      "path": "apps/cli/src/observerProcess.ts",
       "declaration": "restartObserver",
       "kind": "function",
       "role": "ADAPTER",
-      "purpose": "Translates a CLI restart request while preserving a newer winning Observer build. An explicit higher-build restart cooperatively stops the identity-pinned incumbent before spawn. A failed replacement annotates the error hint with the incumbent build identity it tried to replace.",
+      "purpose": "Translates a CLI restart request while preserving a newer winning Observer build. An explicit higher-build restart cooperatively stops the identity-pinned incumbent before spawn. A failed replacement retains its typed cause and startup evidence while annotating only the outer error hint with the incumbent build identity it tried to replace.",
       "dependencies": [
         {
           "path": "apps/cli/src/observerProcess.ts",
@@ -13222,11 +13314,25 @@
       "declaration": "startObserver",
       "kind": "function",
       "role": "ADAPTER",
-      "purpose": "Translates CLI startup intent into exact-build Observer attachment or child startup while leaving socket ownership mutation to the child's boot lifecycle.",
+      "purpose": "Translates CLI startup intent into exact-build Observer attachment or child startup while leaving socket ownership mutation to the child's boot lifecycle. Startup failures retain their typed child cause and bounded boot evidence.",
       "dependencies": [
         {
           "path": "apps/cli/src/observerProcess.ts",
           "declaration": "getObserverStatus",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/cli/src/observerProcess.ts",
+          "declaration": "logObserverLifecycleFailure",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/cli/src/observerProcess/startup.ts",
+          "declaration": "startObserverProcess",
           "kind": "function",
           "role": "ADAPTER",
           "edgeKind": "runtime"
@@ -13250,6 +13356,54 @@
         {
           "path": "packages/protocol/src/client.ts",
           "declaration": "createObserverClient",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        }
+      ]
+    },
+    {
+      "path": "apps/cli/src/observerProcess/failureReport.ts",
+      "declaration": "createObserverStartupFailureReporter",
+      "kind": "function",
+      "role": "ADAPTER",
+      "purpose": "Writes at most one strict, redacted Observer startup failure to the inherited report descriptor and closes the descriptor on either readiness or failure.",
+      "dependencies": []
+    },
+    {
+      "path": "apps/cli/src/observerProcess/failureReport.ts",
+      "declaration": "readObserverStartupFailureReport",
+      "kind": "function",
+      "role": "ADAPTER",
+      "purpose": "Consumes one bounded inherited-pipe payload and validates the strict private child report before exposing typed failure evidence to lifecycle orchestration.",
+      "dependencies": []
+    },
+    {
+      "path": "apps/cli/src/observerProcess/spawn.ts",
+      "declaration": "defaultSpawnObserver",
+      "kind": "function",
+      "role": "ADAPTER",
+      "purpose": "Spawns one detached Observer with a private failure-report descriptor and child-owned boot log, then exposes bounded exit and diagnostic cleanup.",
+      "dependencies": [
+        {
+          "path": "apps/cli/src/observerProcess/failureReport.ts",
+          "declaration": "readObserverStartupFailureReport",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        }
+      ]
+    },
+    {
+      "path": "apps/cli/src/observerProcess/startup.ts",
+      "declaration": "startObserverProcess",
+      "kind": "function",
+      "role": "ADAPTER",
+      "purpose": "Starts the Observer child and waits for exact-build health inside one timed runtime boundary, retaining a separate typed cause and bounded boot evidence before diagnostic handles close.",
+      "dependencies": [
+        {
+          "path": "apps/cli/src/observerProcess/spawn.ts",
+          "declaration": "defaultSpawnObserver",
           "kind": "function",
           "role": "ADAPTER",
           "edgeKind": "runtime"
@@ -14488,10 +14642,18 @@
     },
     {
       "path": "apps/observer/src/runtime/main.ts",
+      "declaration": "ObserverStartupReadinessSink",
+      "kind": "interface",
+      "role": "DRIVEN PORT",
+      "purpose": "Notifies the spawning process that startup publication completed so its private failure-report channel can close without waiting for process exit.",
+      "dependencies": []
+    },
+    {
+      "path": "apps/observer/src/runtime/main.ts",
       "declaration": "runObserverMain",
       "kind": "function",
       "role": "COMPOSITION ROOT",
-      "purpose": "Claims boot ownership, branches on four-state socket evidence, selects Observer-private infrastructure from resolved runtime identity, and owns bind, pidfile, read-only duplicate inspection, ownership-aware shutdown, and exact build health publication.",
+      "purpose": "Claims boot ownership, branches on four-state socket evidence, selects Observer-private infrastructure from resolved runtime identity, and owns bind, pidfile, read-only duplicate inspection, ownership-aware shutdown, and exact build health publication. Successful publication notifies the injected readiness sink; startup rejection retains the original failure after best-effort cleanup.",
       "dependencies": [
         {
           "path": "apps/observer/src/commands/harnessLaunchPreflight.ts",
@@ -14534,6 +14696,13 @@
           "kind": "function",
           "role": "ADAPTER",
           "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/observer/src/runtime/main.ts",
+          "declaration": "ObserverStartupReadinessSink",
+          "kind": "interface",
+          "role": "DRIVEN PORT",
+          "edgeKind": "type-only"
         },
         {
           "path": "apps/observer/src/runtime/observerBootClaim.ts",
@@ -14651,7 +14820,7 @@
       "declaration": "negotiateObserverIncumbent",
       "kind": "function",
       "role": "USE CASE",
-      "purpose": "Replaces an older incumbent only after corroborating its socket and process identity; probe or evidence failure refuses before any signal.",
+      "purpose": "Replaces an older incumbent only after corroborating its socket and process identity; probe or evidence failure refuses before any signal, preserving a typed evidence failure as the handoff refusal's cause.",
       "dependencies": [
         {
           "path": "apps/observer/src/runtime/observerHandoff.ts",
@@ -14689,7 +14858,7 @@
       "declaration": "ObserverProcessEvidenceSource",
       "kind": "interface",
       "role": "DRIVEN PORT",
-      "purpose": "Supplies exact incumbent-process evidence without exposing operating-system commands; unavailable socket-holder evidence throws and never means zero.",
+      "purpose": "Supplies exact incumbent-process evidence without exposing operating-system commands; typed evidence failures remain available as causes, while unavailable socket-holder evidence throws and never means zero.",
       "dependencies": []
     },
     {
@@ -14697,7 +14866,7 @@
       "declaration": "createLocalObserverProcessEvidence",
       "kind": "function",
       "role": "ADAPTER",
-      "purpose": "Translates targeted and global exact argv, executable provenance, launch nonce, OS start time, strict socket-holder and complete file-descriptor evidence, pidfiles, socket identities, and signals into conservative ownership evidence.",
+      "purpose": "Translates targeted and global exact argv, executable provenance, launch nonce, OS start time, strict socket-holder and complete file-descriptor evidence, pidfiles, socket identities, and signals into conservative ownership evidence. Exact executable/argv mismatch throws a stable typed refusal without weakening the fail-closed ownership decision.",
       "dependencies": [
         {
           "path": "apps/observer/src/runtime/observerReap.ts",

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -12681,7 +12681,7 @@
       "declaration": "createObserverActivationAdapter",
       "kind": "function",
       "role": "ADAPTER",
-      "purpose": "Translates setup activation into config loading, Observer path resolution, restart, and health confirmation. Forwards Observer startup progress to the caller-supplied callback without interpreting it.",
+      "purpose": "Translates setup activation into config loading, Observer path resolution, restart, and health confirmation. Forwards startup progress and retains lifecycle cause/evidence without interpreting either.",
       "dependencies": [
         {
           "path": "apps/cli/src/observerProcess.ts",
@@ -15744,7 +15744,7 @@
       "declaration": "SetupObserverActivationPort",
       "kind": "type",
       "role": "DRIVEN PORT",
-      "purpose": "Activates a committed setup configuration and confirms Observer health.",
+      "purpose": "Activates a committed setup configuration and confirms Observer health while retaining typed lifecycle cause and startup evidence in failed operation outcomes.",
       "dependencies": []
     },
     {

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -199,6 +199,7 @@ ownership even where current ownership is still a deviation.
 | Diagnostic evidence | Driven | `DiagnosticEvidenceSource` | `createLocalDiagnosticEvidenceSource` | Conforming read-only role: the adapter captures resolved local state, log, diagnostics, socket, and hook-spool locations while only typed measurements and bounded evidence cross the port; command/event journals, providers, core, and SQLite remain separate inputs. |
 | Observer incumbent lifecycle | Driven | `ObserverIncumbentLifecycle` | local protocol client adapter | Handoff may read health and request controlled stop without importing transport mechanics into policy or orchestration. |
 | Observer process evidence | Driven | `ObserverProcessEvidenceSource` | local `lsof`/`ps`/`/proc`/pidfile/signal adapter | `lsof` is primary socket ownership; health, strict pidfile, executable provenance, exact argv, per-launch token, build selector, and second-resolution OS start token must corroborate before replacement or signaling. Handoff reads only the requested incumbent PID. |
+| Observer startup readiness | Driven | `ObserverStartupReadinessSink` | CLI private failure-report pipe adapter | The Observer publishes only the readiness transition. CLI composition owns pipe creation, strict bounded report translation, redaction, and closure; no filesystem descriptor or child-process representation enters Observer application code. |
 | Duplicate-process evidence | Driven | `ObserverDuplicateProcessEvidenceSource` | local process-evidence adapter | Extends targeted handoff evidence with fail-closed global process inventory, bound-socket identity, and strict per-process Unix-socket-FD counts; unavailable evidence always refuses. |
 | Observer-reap exclusion | Driven | `ObserverReapExclusion` | boot-claim reap exclusion adapter | Explicit force runs under a fail-fast boot claim and releases it after every callback outcome; read-only inspection never acquires the claim. |
 
@@ -287,6 +288,14 @@ ports plus local socket, pidfile, boot-claim, and ownership-watcher adapters. Th
 complete ownership, four-state probe, handoff, bind, readiness, displacement,
 and refusal mechanics are defined only in
 [Observer singleton lifecycle](observer-singleton.md).
+
+CLI composition also owns a private child-process failure-report adapter. It supplies the
+Observer with the provider-neutral `ObserverStartupReadinessSink`; success closes the inherited
+pipe at readiness, while a pre-readiness rejection is normalized once into the shared strict,
+redacted startup-failure contract. The parent carries the outer lifecycle error, its distinct
+causal `SafeError`, and bounded startup evidence. This diagnostic dependency points inward from
+the CLI adapter to contracts and the Observer port and does not add a protocol method or expose
+provider-specific data to Observer/core.
 
 Application composition proceeds around that boundary in this order:
 

--- a/docs/observer-singleton.md
+++ b/docs/observer-singleton.md
@@ -137,6 +137,15 @@ Publication, OS-start-token, bind, or pre-ready lifecycle failure keeps health c
 retains the claim through socket and pidfile cleanup. A stop requested before readiness is
 terminal.
 
+The spawning CLI gives the child one private inherited pipe for startup outcome reporting.
+Before readiness, the child may write one strict, redacted, versioned failure report and then
+close the pipe; readiness closes it without a report. The parent preserves the lifecycle
+classification separately from the report's typed causal error and bounded boot-log evidence.
+The channel is diagnostic transport only: malformed, missing, or oversized reports authorize
+no retry, repair, unlink, stop, or signal. In particular, an exact executable/argv mismatch is
+reported as `OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH` while the existing fail-closed handoff
+decision continues to preserve the incumbent.
+
 ## Ownership-loss shutdown
 
 The ownership watcher compares the bound socket's inode and birth time with the identity
@@ -226,7 +235,8 @@ Station fails closed for singleton mutation:
 - an inaccessible socket is preserved for operator diagnosis.
 
 The actionable operator surfaces are `stn doctor`, `stn observer status`,
-`stn observer reap`, existing structured logs, and redacted debug bundles.
+`stn observer reap`, typed lifecycle results, existing structured logs, and redacted debug
+traces and bundles.
 
 ## Non-goals
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -19,6 +19,7 @@ export * from "./recoveryBreadcrumbs.js";
 export * from "./recoveryInventory.js";
 export * from "./sessionRecovery.js";
 export * from "./setupTypes.js";
+export { textLineTerminatorPattern } from "./shared.js";
 export * from "./snapshot.js";
 export * from "./terminalTargets.js";
 export * from "./tuiConfig.js";

--- a/packages/contracts/src/observer.ts
+++ b/packages/contracts/src/observer.ts
@@ -33,7 +33,11 @@ import {
 } from "./providers.js";
 import type { ObserverRecoveryInventory } from "./recoveryInventory.js";
 import type { SessionRecoveryReadiness } from "./sessionRecovery.js";
-import { nonEmptyStringSchema, userFacingTitleSchema } from "./shared.js";
+import {
+  nonEmptyStringSchema,
+  textLineTerminatorPattern,
+  userFacingTitleSchema,
+} from "./shared.js";
 import { type StationSnapshot, StationSnapshotSchema } from "./snapshot.js";
 
 /** Maximum encoded size of one child-to-parent Observer startup failure report. */
@@ -54,7 +58,8 @@ const ObserverStartupBootLogTailSchema = z
     "Observer boot-log tail exceeded its byte limit.",
   )
   .refine(
-    (value) => value.split(/\r?\n/u).length <= OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_LINES,
+    (value) =>
+      value.split(textLineTerminatorPattern).length <= OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_LINES,
     "Observer boot-log tail exceeded its line limit.",
   );
 
@@ -179,6 +184,35 @@ export const ObserverHealthSchema = z
   .strict();
 
 export type ObserverHealth = z.infer<typeof ObserverHealthSchema>;
+
+/** Concrete local paths emitted with a non-running Observer command result. */
+export const ObserverCommandPathsSchema = z
+  .object({
+    stateDir: nonEmptyStringSchema,
+    socketPath: nonEmptyStringSchema,
+    dbPath: nonEmptyStringSchema,
+    logDir: nonEmptyStringSchema,
+    diagnosticsDir: nonEmptyStringSchema,
+    hookSpoolDir: nonEmptyStringSchema,
+  })
+  .strict();
+
+/** Strict JSON result consumed when an update asks its successor launcher to restart Observer. */
+export const ObserverRestartCommandResultSchema = z.discriminatedUnion("status", [
+  z
+    .object({
+      status: z.literal("running"),
+      socketPath: nonEmptyStringSchema,
+      health: ObserverHealthSchema,
+    })
+    .strict(),
+  ObserverLifecycleFailureSchema.extend({
+    status: z.enum(["stopped", "stale", "unhealthy"]),
+    paths: ObserverCommandPathsSchema,
+  }).strict(),
+]);
+
+export type ObserverRestartCommandResult = z.infer<typeof ObserverRestartCommandResultSchema>;
 
 export const ObserverStopReceiptSchema = z
   .object({

--- a/packages/contracts/src/observer.ts
+++ b/packages/contracts/src/observer.ts
@@ -36,6 +36,61 @@ import type { SessionRecoveryReadiness } from "./sessionRecovery.js";
 import { nonEmptyStringSchema, userFacingTitleSchema } from "./shared.js";
 import { type StationSnapshot, StationSnapshotSchema } from "./snapshot.js";
 
+/** Maximum encoded size of one child-to-parent Observer startup failure report. */
+export const OBSERVER_STARTUP_FAILURE_REPORT_MAX_BYTES = 64 * 1024;
+
+/** Maximum encoded size retained from the end of one Observer boot log. */
+export const OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_BYTES = 64 * 1024;
+
+/** Maximum number of boot-log lines retained as startup evidence. */
+export const OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_LINES = 15;
+
+const ObserverStartupBootLogTailSchema = z
+  .string()
+  .min(1)
+  .refine(
+    (value) =>
+      new TextEncoder().encode(value).byteLength <= OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_BYTES,
+    "Observer boot-log tail exceeded its byte limit.",
+  )
+  .refine(
+    (value) => value.split(/\r?\n/u).length <= OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_LINES,
+    "Observer boot-log tail exceeded its line limit.",
+  );
+
+/** Bounded, redacted local evidence retained for one Observer startup attempt. */
+export const ObserverStartupEvidenceSchema = z
+  .object({
+    bootLogPath: nonEmptyStringSchema,
+    bootLogTail: ObserverStartupBootLogTailSchema.optional(),
+  })
+  .strict();
+
+export type ObserverStartupEvidence = z.infer<typeof ObserverStartupEvidenceSchema>;
+
+/** Public lifecycle failure fields shared by CLI results and diagnostic records. */
+export const ObserverLifecycleFailureSchema = z
+  .object({
+    error: SafeErrorSchema,
+    cause: SafeErrorSchema.optional(),
+    startupEvidence: ObserverStartupEvidenceSchema.optional(),
+  })
+  .strict();
+
+export type ObserverLifecycleFailure = z.infer<typeof ObserverLifecycleFailureSchema>;
+
+/** Strict private report written once by an Observer child before an unsuccessful exit. */
+export const ObserverStartupFailureReportSchema = z
+  .object({
+    kind: z.literal("observer-startup-failure"),
+    version: z.literal(1),
+    error: SafeErrorSchema,
+    cause: SafeErrorSchema.optional(),
+  })
+  .strict();
+
+export type ObserverStartupFailureReport = z.infer<typeof ObserverStartupFailureReportSchema>;
+
 export const ObserverHealthStatusSchema = z.enum(["healthy", "degraded", "unavailable"]);
 
 /** Opaque UUID v4 minted for one Observer launch and published in argv and its pidfile. */

--- a/packages/contracts/src/shared.ts
+++ b/packages/contracts/src/shared.ts
@@ -1,9 +1,12 @@
 import { z } from "zod";
 
+/** JavaScript line terminators used by bounded and user-safe text contracts. */
+export const textLineTerminatorPattern = /\r\n|[\n\r\u2028\u2029]/u;
+
 export const nonEmptyStringSchema = z.string().min(1);
 export const userFacingTitleSchema = z.string().trim().min(1);
 export const safeTextSchema = nonEmptyStringSchema.refine(
-  (value) => !/\n\s*at\s+\S+/.test(value),
+  (value) => !/(?:\r\n|[\n\r\u2028\u2029])\s*at\s+\S+/u.test(value),
   "must not contain stack trace frames",
 );
 export const optionalProviderDataSchema = z.unknown().optional();

--- a/packages/contracts/src/update.ts
+++ b/packages/contracts/src/update.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { type SafeError, SafeErrorSchema } from "./errors.js";
+import { type ObserverStartupEvidence, ObserverStartupEvidenceSchema } from "./observer.js";
 import { nonEmptyStringSchema, safeTextSchema } from "./shared.js";
 
 export const UpdateChannelIdSchema = z.enum([
@@ -74,7 +75,8 @@ const UpdateArtifactSchema = z
 
 /**
  * Strict machine-readable schema-version-1 contract emitted by `stn update --json`.
- * Consumers must parse this shared contract before interpreting update outcomes.
+ * Consumers must parse this shared contract before interpreting update outcomes; runtime
+ * crossover failures keep the update error outermost and child cause/evidence separate.
  */
 export type UpdateCommandReport = {
   schemaVersion: 1;
@@ -86,6 +88,8 @@ export type UpdateCommandReport = {
   warnings: SafeError[];
   recoveryCommands: UpdateCommandArgv[];
   error?: SafeError;
+  cause?: SafeError;
+  startupEvidence?: ObserverStartupEvidence;
 };
 
 export const UpdateCommandReportSchema: z.ZodType<UpdateCommandReport> = z
@@ -99,6 +103,8 @@ export const UpdateCommandReportSchema: z.ZodType<UpdateCommandReport> = z
     warnings: z.array(SafeErrorSchema),
     recoveryCommands: z.array(UpdateCommandArgvSchema),
     error: SafeErrorSchema.optional(),
+    cause: SafeErrorSchema.optional(),
+    startupEvidence: ObserverStartupEvidenceSchema.optional(),
   })
   .strict()
   .transform(
@@ -112,5 +118,7 @@ export const UpdateCommandReportSchema: z.ZodType<UpdateCommandReport> = z
       warnings: report.warnings,
       recoveryCommands: report.recoveryCommands,
       ...(report.error === undefined ? {} : { error: report.error }),
+      ...(report.cause === undefined ? {} : { cause: report.cause }),
+      ...(report.startupEvidence === undefined ? {} : { startupEvidence: report.startupEvidence }),
     }),
   );

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -28,8 +28,11 @@ import {
   ObserverEventHookConfigSchema,
   ObserverEventHookInvocationSchema,
   ObserverHealthSchema,
+  ObserverLifecycleFailureSchema,
   type ObserverProcessIdentity,
   ObserverProcessIdentitySchema,
+  ObserverStartupEvidenceSchema,
+  ObserverStartupFailureReportSchema,
   ObserverStopReceiptSchema,
   type ProjectId,
   ProjectIdSchema,
@@ -2148,6 +2151,66 @@ describe("contract schemas", () => {
         message: "External command failed.\n    at run (/tmp/internal.ts:10:1)",
       },
       "stack-like SafeError message",
+    );
+  });
+
+  it("strictly parses Observer lifecycle failures and private startup reports", () => {
+    const error = {
+      tag: "ObserverStartupError",
+      code: "OBSERVER_EXITED_ON_START",
+      message: "Observer exited before becoming healthy (exit code 1).",
+      traceId: "trc_observer_start",
+    };
+    const cause = {
+      tag: "ObserverProcessEvidenceError",
+      code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH",
+      message: "Observer process evidence did not match the exact executable and argv.",
+    };
+    const startupEvidence = {
+      bootLogPath: "/tmp/station/logs/observer-boot.log",
+      bootLogTail: "line one\nline two",
+    };
+
+    expect(ObserverStartupEvidenceSchema.parse(startupEvidence)).toEqual(startupEvidence);
+    expect(ObserverLifecycleFailureSchema.parse({ error, cause, startupEvidence })).toEqual({
+      error,
+      cause,
+      startupEvidence,
+    });
+    expect(ObserverLifecycleFailureSchema.parse({ error })).toEqual({ error });
+    expect(
+      ObserverStartupFailureReportSchema.parse({
+        kind: "observer-startup-failure",
+        version: 1,
+        error,
+        cause,
+      }),
+    ).toMatchObject({ version: 1, cause });
+
+    expectFails(
+      ObserverStartupEvidenceSchema,
+      { ...startupEvidence, bootLogTail: Array.from({ length: 16 }, () => "line").join("\n") },
+      "startup evidence over the line bound",
+    );
+    expectFails(
+      ObserverStartupEvidenceSchema,
+      { ...startupEvidence, extra: true },
+      "startup evidence with an extra field",
+    );
+    expectFails(
+      ObserverLifecycleFailureSchema,
+      { error, cause: { code: cause.code, message: cause.message } },
+      "lifecycle failure with a malformed cause",
+    );
+    expectFails(
+      ObserverStartupFailureReportSchema,
+      { kind: "observer-startup-failure", version: 2, error },
+      "startup report with an unsupported version",
+    );
+    expectFails(
+      ObserverStartupFailureReportSchema,
+      { kind: "observer-startup-failure", version: 1, error, extra: true },
+      "startup report with an extra field",
     );
   });
 

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -31,6 +31,7 @@ import {
   ObserverLifecycleFailureSchema,
   type ObserverProcessIdentity,
   ObserverProcessIdentitySchema,
+  ObserverRestartCommandResultSchema,
   ObserverStartupEvidenceSchema,
   ObserverStartupFailureReportSchema,
   ObserverStopReceiptSchema,
@@ -2179,6 +2180,22 @@ describe("contract schemas", () => {
     });
     expect(ObserverLifecycleFailureSchema.parse({ error })).toEqual({ error });
     expect(
+      ObserverRestartCommandResultSchema.parse({
+        status: "unhealthy",
+        paths: {
+          stateDir: "/tmp/station",
+          socketPath: "/tmp/station/run/observer.sock",
+          dbPath: "/tmp/station/observer.sqlite",
+          logDir: "/tmp/station/logs",
+          diagnosticsDir: "/tmp/station/diagnostics",
+          hookSpoolDir: "/tmp/station/spool/hooks",
+        },
+        error,
+        cause,
+        startupEvidence,
+      }),
+    ).toMatchObject({ status: "unhealthy", cause, startupEvidence });
+    expect(
       ObserverStartupFailureReportSchema.parse({
         kind: "observer-startup-failure",
         version: 1,
@@ -2192,6 +2209,26 @@ describe("contract schemas", () => {
       { ...startupEvidence, bootLogTail: Array.from({ length: 16 }, () => "line").join("\n") },
       "startup evidence over the line bound",
     );
+    for (const terminator of ["\r", "\u2028", "\u2029"]) {
+      expectFails(
+        ObserverStartupEvidenceSchema,
+        {
+          ...startupEvidence,
+          bootLogTail: Array.from({ length: 16 }, () => "line").join(terminator),
+        },
+        `startup evidence over the line bound with ${JSON.stringify(terminator)}`,
+      );
+      expectFails(
+        ObserverLifecycleFailureSchema,
+        {
+          error: {
+            ...error,
+            message: `failed${terminator}    at /private/secret.ts`,
+          },
+        },
+        `lifecycle stack disclosure with ${JSON.stringify(terminator)}`,
+      );
+    }
     expectFails(
       ObserverStartupEvidenceSchema,
       { ...startupEvidence, extra: true },

--- a/packages/contracts/test/schema/update-schema.test.ts
+++ b/packages/contracts/test/schema/update-schema.test.ts
@@ -26,6 +26,18 @@ const report = {
 describe("update command schemas", () => {
   it("parses the strict schema-version-1 report contract", () => {
     expect(UpdateCommandReportSchema.parse(report)).toEqual(report);
+    const failed = {
+      ...report,
+      status: "failed" as const,
+      error: { tag: "UpdateError", code: "UPDATE_RUNTIME_CROSSOVER_FAILED", message: "Failed." },
+      cause: {
+        tag: "ObserverProcessIdentityError",
+        code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH",
+        message: "Mismatch.",
+      },
+      startupEvidence: { bootLogPath: "/tmp/station/logs/observer-boot.log" },
+    };
+    expect(UpdateCommandReportSchema.parse(failed)).toEqual(failed);
   });
 
   it("rejects unknown report and step fields", () => {

--- a/packages/setup-core/src/model/operations.ts
+++ b/packages/setup-core/src/model/operations.ts
@@ -1,4 +1,4 @@
-import type { CliSetupHarnessId, SafeError } from "@station/contracts";
+import type { CliSetupHarnessId, ObserverStartupEvidence, SafeError } from "@station/contracts";
 import type { SetupToolId } from "./facts.js";
 
 type SetupOperationBase<
@@ -204,6 +204,8 @@ export type SetupOperationFailedOutcome = {
   readonly status: "failed";
   readonly operationId: SetupOperation["id"];
   readonly error: SafeError;
+  readonly cause?: SafeError;
+  readonly startupEvidence?: ObserverStartupEvidence;
 };
 
 /** Boundary result for one requested semantic operation, correlated by operation identity. */

--- a/packages/setup-core/src/model/session.ts
+++ b/packages/setup-core/src/model/session.ts
@@ -1,4 +1,4 @@
-import type { SafeError } from "@station/contracts";
+import type { ObserverStartupEvidence, SafeError } from "@station/contracts";
 import type { SetupPlanningIntent } from "./intent.js";
 import type { SetupIssue } from "./issues.js";
 import type {
@@ -99,6 +99,8 @@ export type SetupSessionBlockedState = SetupSessionBase & {
   readonly reason: SetupSessionBlockReason;
   readonly plan?: SetupPlan;
   readonly error?: SafeError;
+  readonly cause?: SafeError;
+  readonly startupEvidence?: ObserverStartupEvidence;
 };
 
 export type SetupSessionCompletedState = SetupSessionWithPlan & {

--- a/packages/setup-core/src/ports.ts
+++ b/packages/setup-core/src/ports.ts
@@ -47,7 +47,8 @@ export type SetupConfigMutationPort = (
 /**
  * DRIVEN PORT
  *
- * Activates a committed setup configuration and confirms Observer health.
+ * Activates a committed setup configuration and confirms Observer health while retaining typed
+ * lifecycle cause and startup evidence in failed operation outcomes.
  */
 export type SetupObserverActivationPort = (
   operation: SetupObserverActivationOperation,

--- a/packages/setup-core/src/session/application.ts
+++ b/packages/setup-core/src/session/application.ts
@@ -413,6 +413,10 @@ class SetupSessionRuntime implements SetupSessionApplication {
         status: "blocked",
         reason: blockReasonForPhase(applying.applyPhase),
         error: outcome.error,
+        ...(outcome.cause === undefined ? {} : { cause: outcome.cause }),
+        ...(outcome.startupEvidence === undefined
+          ? {}
+          : { startupEvidence: outcome.startupEvidence }),
       };
     } else {
       this.#state = withOutcome;

--- a/packages/setup-core/test/unit/setup-application.test.ts
+++ b/packages/setup-core/test/unit/setup-application.test.ts
@@ -60,6 +60,58 @@ describe("createSetupSessionApplication", () => {
     ]);
   });
 
+  it("retains Observer lifecycle evidence when activation blocks the session", async () => {
+    const inspections = [missingConfigFacts(), missingConfigFacts()];
+    const application = createSetupSessionApplication({
+      intent: intent(),
+      inspection: async () => {
+        const facts = inspections.shift();
+        if (facts === undefined) throw new Error("unexpected inspection");
+        return { status: "completed", facts };
+      },
+      executeOperation: async (operation) => {
+        if (operation.kind === "write-config") {
+          return {
+            status: "completed",
+            operationId: operation.id,
+            commit: { kind: "config", configPath: "/tmp/config.toml", change: "created" },
+          };
+        }
+        return {
+          status: "failed",
+          operationId: operation.id,
+          error: {
+            tag: "ObserverStartupError",
+            code: "OBSERVER_HANDOFF_REFUSED",
+            message: "Observer handoff was refused.",
+          },
+          cause: {
+            tag: "ObserverProcessEvidenceError",
+            code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH",
+            message: "Observer executable arguments did not match.",
+          },
+          startupEvidence: { bootLogPath: "/tmp/station/logs/observer-boot.log" },
+        };
+      },
+    });
+
+    await expect(application.apply()).resolves.toMatchObject({
+      status: "blocked",
+      reason: "observer-activation-failed",
+      error: { code: "OBSERVER_HANDOFF_REFUSED" },
+      cause: { code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH" },
+      startupEvidence: { bootLogPath: "/tmp/station/logs/observer-boot.log" },
+      operationOutcomes: [
+        { status: "completed", operationId: "write-config" },
+        {
+          status: "failed",
+          operationId: "activate-observer-config",
+          cause: { code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH" },
+        },
+      ],
+    });
+  });
+
   it("keeps the session mode fixed, passes replaced intent to inspection, and does not replay preparation", async () => {
     const inspections = [
       missingWorktrunkFacts(),

--- a/station/src/bin/stnMain.ts
+++ b/station/src/bin/stnMain.ts
@@ -34,11 +34,16 @@ function compiledRunners(installedRoot: string): SelfExecRunners {
   return {
     cli: async (argv) => (await import("@station/cli/main")).runCliMain(argv, cliOptions),
     observer: async (argv) => {
-      const { runCliObserverMain } = await import("@station/cli/observer-main");
-      process.exitCode = await runCliObserverMain(argv, {
-        preparePiExtension: prepareCompiledPiExtension,
-        providerHookIngressLauncher,
-      });
+      const { runCliObserverMain, runCliObserverProcess } = await import(
+        "@station/cli/observer-main"
+      );
+      process.exitCode = await runCliObserverProcess((startupReadinessSink) =>
+        runCliObserverMain(argv, {
+          preparePiExtension: prepareCompiledPiExtension,
+          providerHookIngressLauncher,
+          startupReadinessSink,
+        }),
+      );
     },
     ingress: async (argv) => (await import("@station/cli/ingress-main")).runCliIngressMain(argv),
     tui: async () =>
@@ -59,7 +64,8 @@ function compiledRunners(installedRoot: string): SelfExecRunners {
  * COMPOSITION ROOT
  *
  * Binds compiled raw arguments to lazy process entries, packaged runtime assets,
- * installed launcher identity, popup ownership, and setup wiring.
+ * installed launcher identity, the shared Observer process failure boundary,
+ * popup ownership, and setup wiring.
  */
 export async function runStationBinaryMain(): Promise<void> {
   // The OpenCode plugin body is embedded as an asset; expose its path so the

--- a/tests/e2e/observer-lifecycle.test.ts
+++ b/tests/e2e/observer-lifecycle.test.ts
@@ -11,6 +11,7 @@ import {
   readlink,
   rm,
   stat,
+  symlink,
   unlink,
   writeFile,
 } from "node:fs/promises";
@@ -30,6 +31,7 @@ import { acquireObserverBootClaim, observerBootClaimPath } from "@station/observ
 import { createObserverClient, listenUnixSocket, probeUnixSocket } from "@station/protocol";
 import { stationBuildInfo, stationObserverBuildVersion } from "@station/runtime";
 import { describe, expect, it, vi } from "vitest";
+import { observerStatusErrorMessage } from "../../apps/cli/src/observerProcess.js";
 import { createRealStaleSocket, waitForSocketClosed } from "../support/sockets";
 import { createTempState, writeConfigToml } from "../support/temp-projects";
 
@@ -342,6 +344,120 @@ describe("observer lifecycle e2e", () => {
     }
   });
 
+  it("preserves a typed executable mismatch when a live incumbent symlink is retargeted", async () => {
+    const fixture = await createTempState();
+    const config = observerConfig(fixture.stateDir, fixture.socketPath);
+    const configPath = await writeConfigToml(fixture.root, config);
+    const nodeImagesRoot = join(fixture.root, "node-images");
+    const firstNode = join(nodeImagesRoot, "first", "bin", "node");
+    const secondNode = join(nodeImagesRoot, "second", "bin", "node");
+    const nodeLink = join(nodeImagesRoot, "node");
+    await copyNodeExecutableImage(firstNode);
+    await copyNodeExecutableImage(secondNode);
+    await symlink(firstNode, nodeLink);
+
+    const build = stationBuildInfo();
+    const incumbentVersion = stationObserverBuildVersion({
+      ...build,
+      buildIdentity: "0".repeat(64),
+    });
+    const candidateVersion = stationObserverBuildVersion(build);
+    const incumbent = await startIncumbentFixture({
+      stateDir: fixture.stateDir,
+      socketPath: fixture.socketPath,
+      version: incumbentVersion,
+      executablePath: nodeLink,
+    });
+    const pidfilePath = `${fixture.socketPath}.pid`;
+    const originalSocket = await stat(fixture.socketPath);
+    const originalPidfile = await stat(pidfilePath);
+    const originalPidfileBytes = await readFile(pidfilePath);
+
+    try {
+      await unlink(nodeLink);
+      await symlink(secondNode, nodeLink);
+      const status = await startObserver(
+        {
+          config,
+          configPath,
+          timeoutMs: 10_000,
+          observerCommand: [
+            nodeLink,
+            join(process.cwd(), "apps", "cli", "dist", "observerMain.js"),
+          ],
+        },
+        { buildVersion: candidateVersion },
+      );
+
+      expect(status, JSON.stringify(status)).toMatchObject({
+        status: "unhealthy",
+        error: {
+          code: "OBSERVER_EXITED_ON_START",
+          traceId: expect.any(String),
+        },
+        cause: {
+          tag: "ObserverProcessEvidenceError",
+          code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH",
+          message: "Observer process evidence did not match the exact executable and argv.",
+        },
+        startupEvidence: {
+          bootLogPath: join(fixture.stateDir, "logs", "observer-boot.log"),
+        },
+      });
+      if (status.status === "running" || status.error === undefined) {
+        throw new Error("Executable mismatch unexpectedly started an Observer.");
+      }
+
+      const serialized = JSON.stringify(status);
+      expect(serialized).not.toContain("[object Object]");
+      const rendered = observerStatusErrorMessage(status);
+      expect(rendered).toContain("Observer exited before becoming healthy");
+      expect(rendered).toContain(
+        "Cause: Observer process evidence did not match the exact executable and argv. (OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH)",
+      );
+      expect(rendered).toContain(`Next: stn debug trace ${status.error.traceId}`);
+      expect(rendered).not.toContain("observer-boot.log");
+
+      const trace = await runCli([
+        "--config",
+        configPath,
+        "debug",
+        "trace",
+        status.error.traceId ?? "",
+      ]);
+      expect(trace).toMatchObject({
+        code: 0,
+        output: {
+          cause: { code: "OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH" },
+          causeAssessment: {
+            status: "explicit_root_cause",
+            explicitRootCauseCodes: ["OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH"],
+          },
+        },
+      });
+
+      expect(processIsAlive(incumbent.child.pid)).toBe(true);
+      await expect(incumbent.client.health()).resolves.toMatchObject({
+        pid: incumbent.child.pid,
+        version: incumbentVersion,
+      });
+      const currentSocket = await stat(fixture.socketPath);
+      const currentPidfile = await stat(pidfilePath);
+      expect({ ino: currentSocket.ino, birthtimeMs: currentSocket.birthtimeMs }).toEqual({
+        ino: originalSocket.ino,
+        birthtimeMs: originalSocket.birthtimeMs,
+      });
+      expect({ ino: currentPidfile.ino, birthtimeMs: currentPidfile.birthtimeMs }).toEqual({
+        ino: originalPidfile.ino,
+        birthtimeMs: originalPidfile.birthtimeMs,
+      });
+      await expect(readFile(pidfilePath)).resolves.toEqual(originalPidfileBytes);
+    } finally {
+      await terminateFixture(incumbent.child);
+      await waitForSocketClosed(fixture.socketPath).catch(() => undefined);
+    }
+  });
+
   it("keeps ordinary losing-build refusal but explicitly activates an exact build", async () => {
     const fixture = await createTempState();
     const build = stationBuildInfo();
@@ -421,10 +537,12 @@ describe("observer lifecycle e2e", () => {
         { config: observerConfig(fixture.stateDir, fixture.socketPath), timeoutMs: 10_000 },
         { buildVersion: stationObserverBuildVersion() },
       );
-      expect(status).toMatchObject({
-        status: "unhealthy",
-        error: { code: "OBSERVER_HANDOFF_REFUSED" },
-      });
+      expect(status.status).toBe("unhealthy");
+      if (status.status === "running") throw new Error("Wedged incumbent was replaced.");
+      expect(["OBSERVER_START_FAILED", "OBSERVER_EXITED_ON_START"]).toContain(status.error?.code);
+      if (status.error?.code === "OBSERVER_EXITED_ON_START") {
+        expect(status.cause?.code).toBe("OBSERVER_HANDOFF_REFUSED");
+      }
       expect(processIsAlive(incumbent.child.pid)).toBe(true);
       await expect(incumbent.client.health()).resolves.toMatchObject({
         pid: incumbent.child.pid,
@@ -457,7 +575,8 @@ describe("observer lifecycle e2e", () => {
       );
       expect(status).toMatchObject({
         status: "unhealthy",
-        error: { code: "OBSERVER_HANDOFF_REFUSED" },
+        error: { code: "OBSERVER_EXITED_ON_START" },
+        cause: { code: "OBSERVER_HANDOFF_REFUSED" },
       });
       expect(processIsAlive(incumbent.child.pid)).toBe(true);
       await expect(incumbent.client.health()).resolves.toMatchObject({ pid: incumbent.child.pid });
@@ -788,10 +907,14 @@ describe("observer lifecycle e2e", () => {
       error: {
         code: "OBSERVER_EXITED_ON_START",
         message: expect.stringContaining("exit code 1"),
-        hint: expect.stringContaining(`Latest observer boot log: ${bootLogPath}`),
+      },
+      cause: { message: "Invalid TOML document: cannot find end of structure" },
+      startupEvidence: {
+        bootLogPath,
+        bootLogTail: expect.stringContaining("Station config file is not valid TOML."),
       },
     });
-    expect(status.error?.hint).toContain("Station config file is not valid TOML.");
+    expect(status.error?.hint ?? "").not.toContain("Station config file is not valid TOML.");
     await expect(readFile(bootLogPath, "utf8")).resolves.toContain(
       "Station config file is not valid TOML.",
     );
@@ -820,15 +943,26 @@ describe("observer lifecycle e2e", () => {
     expect(malformedStatus).toMatchObject({
       status: "unhealthy",
       error: { code: "OBSERVER_EXITED_ON_START" },
+      cause: { message: "Invalid TOML document: cannot find end of structure" },
+      startupEvidence: {
+        bootLogTail: expect.stringContaining("Station config file is not valid TOML."),
+      },
     });
-    expect(malformedStatus.error?.hint).toContain("Station config file is not valid TOML.");
-    expect(malformedStatus.error?.hint).not.toContain("Station config file was not found.");
+    expect(malformedStatus.error?.hint ?? "").not.toContain(
+      "Station config file is not valid TOML.",
+    );
     expect(missingStatus).toMatchObject({
       status: "unhealthy",
       error: { code: "OBSERVER_EXITED_ON_START" },
+      cause: {
+        code: "OBSERVER_STARTUP_CAUSE_ERROR",
+        message: expect.stringContaining("ENOENT: no such file or directory"),
+      },
+      startupEvidence: {
+        bootLogTail: expect.stringContaining("Station config file was not found."),
+      },
     });
-    expect(missingStatus.error?.hint).toContain("Station config file was not found.");
-    expect(missingStatus.error?.hint).not.toContain("Station config file is not valid TOML.");
+    expect(missingStatus.error?.hint ?? "").not.toContain("Station config file was not found.");
 
     const bootLog = await readFile(bootLogPath, "utf8");
     const [header = "", ...bodyLines] = bootLog.split(/\r?\n/);
@@ -902,10 +1036,31 @@ function observerConfig(stateDir: string, socketPath: string) {
   };
 }
 
+async function copyNodeExecutableImage(targetPath: string): Promise<void> {
+  await mkdir(dirname(targetPath), { recursive: true });
+  await copyFile(process.execPath, targetPath);
+  await chmod(targetPath, 0o755);
+  if (process.platform !== "darwin") return;
+
+  const sourceLibDir = join(dirname(process.execPath), "..", "lib");
+  const targetLibDir = join(dirname(targetPath), "..", "lib");
+  const nodeLibraries = (await readdir(sourceLibDir)).filter((name) =>
+    /^libnode\..+\.dylib$/u.test(name),
+  );
+  if (nodeLibraries.length === 0) {
+    throw new Error(`Node runtime libraries were unavailable under ${sourceLibDir}.`);
+  }
+  await mkdir(targetLibDir, { recursive: true });
+  await Promise.all(
+    nodeLibraries.map((name) => copyFile(join(sourceLibDir, name), join(targetLibDir, name))),
+  );
+}
+
 async function startIncumbentFixture(input: {
   stateDir: string;
   socketPath: string;
   version: string;
+  executablePath?: string;
   pidfileVersion?: string;
   mode?: "graceful" | "wedged";
   stopDelayMs?: number;
@@ -931,7 +1086,7 @@ async function startIncumbentFixture(input: {
     "--process-token",
     randomUUID(),
   ];
-  const child = spawn(process.execPath, args, {
+  const child = spawn(input.executablePath ?? process.execPath, args, {
     cwd: process.cwd(),
     env: {
       ...process.env,

--- a/tests/e2e/observer-lifecycle.test.ts
+++ b/tests/e2e/observer-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { type ChildProcess, execFile, spawn } from "node:child_process";
+import { type ChildProcess, execFile, spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import {
   access,
@@ -224,7 +224,7 @@ describe("observer lifecycle e2e", () => {
       });
       await expect(
         runCli(["--config", configPath, "doctor"], { observerDeps: deps }),
-      ).rejects.toThrow(/OBSERVER_SOCKET_INACCESSIBLE/u);
+      ).rejects.toMatchObject({ error: { code: "OBSERVER_SOCKET_INACCESSIBLE" } });
       await sleep(5500);
 
       expect(processIsAlive(originalPid)).toBe(true);
@@ -392,7 +392,7 @@ describe("observer lifecycle e2e", () => {
       expect(status, JSON.stringify(status)).toMatchObject({
         status: "unhealthy",
         error: {
-          code: "OBSERVER_EXITED_ON_START",
+          code: "OBSERVER_HANDOFF_REFUSED",
           traceId: expect.any(String),
         },
         cause: {
@@ -411,7 +411,7 @@ describe("observer lifecycle e2e", () => {
       const serialized = JSON.stringify(status);
       expect(serialized).not.toContain("[object Object]");
       const rendered = observerStatusErrorMessage(status);
-      expect(rendered).toContain("Observer exited before becoming healthy");
+      expect(rendered).toContain("Observer build handoff was refused");
       expect(rendered).toContain(
         "Cause: Observer process evidence did not match the exact executable and argv. (OBSERVER_PROCESS_EXECUTABLE_ARGV_MISMATCH)",
       );
@@ -435,6 +435,30 @@ describe("observer lifecycle e2e", () => {
           },
         },
       });
+
+      const ingress = spawnSync(
+        join(process.cwd(), "bin", "stn-ingress"),
+        [
+          "--socket",
+          fixture.socketPath,
+          "--state-dir",
+          fixture.stateDir,
+          "--startup-timeout-ms",
+          "10000",
+          "worktrunk",
+          "post-create",
+        ],
+        {
+          cwd: process.cwd(),
+          encoding: "utf8",
+          input: JSON.stringify({ branch: "station/executable-mismatch" }),
+          timeout: 20_000,
+        },
+      );
+      if (ingress.error !== undefined) throw ingress.error;
+      expect(ingress.status).toBe(1);
+      expect(ingress.stderr).toContain("OBSERVER_HANDOFF_REFUSED");
+      await expect(directoryFileCount(fixture.hookSpoolDir)).resolves.toBe(0);
 
       expect(processIsAlive(incumbent.child.pid)).toBe(true);
       await expect(incumbent.client.health()).resolves.toMatchObject({
@@ -539,8 +563,8 @@ describe("observer lifecycle e2e", () => {
       );
       expect(status.status).toBe("unhealthy");
       if (status.status === "running") throw new Error("Wedged incumbent was replaced.");
-      expect(["OBSERVER_START_FAILED", "OBSERVER_EXITED_ON_START"]).toContain(status.error?.code);
-      if (status.error?.code === "OBSERVER_EXITED_ON_START") {
+      expect(["OBSERVER_START_FAILED", "OBSERVER_HANDOFF_REFUSED"]).toContain(status.error?.code);
+      if (status.error?.code === "OBSERVER_HANDOFF_REFUSED") {
         expect(status.cause?.code).toBe("OBSERVER_HANDOFF_REFUSED");
       }
       expect(processIsAlive(incumbent.child.pid)).toBe(true);
@@ -575,7 +599,7 @@ describe("observer lifecycle e2e", () => {
       );
       expect(status).toMatchObject({
         status: "unhealthy",
-        error: { code: "OBSERVER_EXITED_ON_START" },
+        error: { code: "OBSERVER_HANDOFF_REFUSED" },
         cause: { code: "OBSERVER_HANDOFF_REFUSED" },
       });
       expect(processIsAlive(incumbent.child.pid)).toBe(true);
@@ -1240,6 +1264,15 @@ async function observerProcessesForSocket(socketPath: string): Promise<number[]>
     .map((line) => Number.parseInt(line.trimStart().split(/\s+/, 1)[0] ?? "", 10))
     .filter(Number.isFinite)
     .sort((left, right) => left - right);
+}
+
+async function directoryFileCount(path: string): Promise<number> {
+  try {
+    return (await readdir(path)).length;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return 0;
+    throw error;
+  }
 }
 
 async function waitFor(condition: () => Promise<boolean>, timeoutMs: number): Promise<void> {


### PR DESCRIPTION
## What this fixes

Observer lifecycle failures were still losing meaning at several process and automation boundaries. A real replacement-child handoff refusal could be reclassified as a generic startup exit and spooled for retry; malformed startup reports could terminate the parent through an unhandled rejection; and setup, update, diagnostic, and auto-starting commands discarded structured causes or startup evidence.

The same path also had line-terminator redaction gaps, omitted same-version build identity from operator output, and dropped SafeError tags and hints from debug projections.

Closes #635.

## What changed

- Preserve the parent-observed `OBSERVER_HANDOFF_REFUSED` classification for replacement children, keeping the executable/argv mismatch as its cause so provider hooks reject without spooling.
- Attach startup-report rejection handling synchronously and bound malformed, partial, multiple, and oversized child reports without exposing parser stacks or abandoning a detached child.
- Treat CR, LF, U+2028, and U+2029 consistently in safe-text validation, normalization, boot-tail truncation, and line counting.
- Carry lifecycle `error`, `cause`, and `startupEvidence` through setup, update crossover, snapshot, doctor, command, reconcile, observe, and debug-bundle results; successor update output is now strictly parsed.
- Restore actionable handoff context in text output and retain required `tag` plus optional `hint` in debug log and trace summaries.
- Extend the shared contracts, setup-core outcomes, debugging documentation, and generated Observer architecture manifest for the resulting boundary shapes.

## Testing

Published head: `25b006253b1a4d61958e60deefbfece5f33cc48f`, rebased directly onto `d04427d5` (#646, including #659).

The new regression launches a real OS child through the production spawn adapter and inherited fd3 report pipe:

| Child throw shape | Expected strict result |
| --- | --- |
| ordinary `Error` | explicit `OBSERVER_STARTUP_CAUSE_ERROR` |
| typed `SafeError`/`Error` | typed tag, code, message, and hint preserved |
| plain object | explicit `OBSERVER_STARTUP_CAUSE_UNKNOWN` fallback |
| unknown primitive | explicit `OBSERVER_STARTUP_CAUSE_UNKNOWN` fallback |

Every matrix case asserts child exit 1, strict `ObserverStartupFailureReportSchema` parsing, one-line safe stderr, secret redaction, and absence of stack frames and private paths. The exact published head passed the five focused lifecycle suites (89 tests).

The complete deterministic lane set is green when run independently: unit (2,728), contracts (85), integration (706), diagnostics (161), scripted-agent (5), setup E2E (28), Observer E2E (22), and install smoke, plus build, typecheck, lint/architecture, and binary build. Two one-shot `test:all` attempts encountered unrelated fixed-time suite-load flakes; the affected tests passed in isolation and in the complete unit lane.

`pnpm test:ci:binary` passed on the exact published head: compiled binary smoke (including caller/incumbent immutable build identity) and all three update-crossover scenarios.

The real Codex lane is **not green** and is not counted as #648 validation: 0/2 probes failed because the session-create fixture did not observe its launch-shim argv and the direct app-server fixture rejects Codex's new top-level `emittedAtMs` field. Both fixtures bypass Observer process startup and reproduce independently of this lifecycle transport change.

An additional non-required handoff stress probe found an existing timing race; exact current `main` (`d04427d5`) reproduced the same socket-inaccessible handoff failure on its first round. It is not attributed to #648 and is not counted as a green lane.

## Safety and scope

Operational retry policy derives from parent-observed lifecycle state rather than child report contents. The change does not stop or signal an incumbent, repair ownership evidence, or relax strict parsing and redaction limits.

## User-visible behavior

Text output now distinguishes the outer lifecycle failure from its typed cause and gives one actionable recovery line. JSON, logs, debug trace, setup/update automation, and other auto-starting commands retain the same bounded redacted lifecycle envelope.