### PR TITLE
fix(session-recovery): resume newest eligible handle

### DIFF
--- a/apps/observer/src/reconcile/graph.ts
+++ b/apps/observer/src/reconcile/graph.ts
@@ -27,6 +27,7 @@ import {
 import { pathIsSameOrInside } from "@station/runtime";
 import { harnessRunCanActivateSession, terminalCanActivateSession } from "../sessionActivation.js";
 import { sessionRecoveryEligibility } from "../sessionRecoveryEligibility.js";
+import { selectNewestSessionRecoveryCandidate } from "../sessionRecoverySelection.js";
 import { countsForSnapshot } from "./snapshotCounts.js";
 
 export type ObserverGraphInput = {
@@ -388,16 +389,15 @@ function recoveryActionForRow(input: {
         canResume: capabilities.canResume,
       };
     }
-    return sessionRecoveryEligibility(eligibilityInput).kind === "eligible" ? [handle] : [];
+    return sessionRecoveryEligibility(eligibilityInput).kind === "eligible" ? [{ handle }] : [];
   });
-  if (eligible.length !== 1) {
+  // Snapshot actions and launch resolution share one total order so reconcile cannot advertise a
+  // different recovery target than the command will validate and launch.
+  const selected = selectNewestSessionRecoveryCandidate(eligible);
+  if (selected === undefined) {
     return undefined;
   }
-
-  const handle = eligible[0];
-  if (handle === undefined) {
-    return undefined;
-  }
+  const handle = selected.handle;
   const action: WorktreeRecoveryAction = {
     kind: "agent-resume",
     handleId: handle.id,

--- a/apps/observer/src/sessionRecovery.ts
+++ b/apps/observer/src/sessionRecovery.ts
@@ -13,6 +13,7 @@ import {
   type SessionRecoveryEligibilityInput,
   sessionRecoveryEligibility,
 } from "./sessionRecoveryEligibility.js";
+import { selectNewestSessionRecoveryCandidate } from "./sessionRecoverySelection.js";
 
 type SessionRecoveryExpectation = {
   sessionId: string;
@@ -29,10 +30,10 @@ type ResolvedSessionRecovery = {
 /**
  * USE CASE
  *
- * Filters durable handles through exact lifecycle and provider-neutral eligibility before applying
- * zero/one/many cardinality, then returns only typed resume authority for the selected provider.
- * Explicit selection retains imported-handle compatibility only when no contradictory local
- * Station lifecycle exists.
+ * Filters durable handles through exact lifecycle and provider-neutral eligibility before selecting
+ * the newest automatic candidate deterministically, then returns only typed resume authority for
+ * that provider. Explicit selection retains imported-handle compatibility only when no
+ * contradictory local Station lifecycle exists.
  */
 export async function resolveSessionRecovery(input: {
   persistence: SessionStore;
@@ -97,17 +98,9 @@ async function resolveRecoveryHandle(
     const eligibility = evaluateHandle(input, sessions, handle, false);
     return eligibility.kind === "eligible" ? [{ handle, eligibility }] : [];
   });
-  if (eligible.length === 1) {
-    return eligible[0] as (typeof eligible)[number];
-  }
-  if (eligible.length > 1) {
-    throw commandValidationError({
-      code: "SESSION_RECOVERY_HANDLE_AMBIGUOUS",
-      message: "More than one recovery handle is available for this worktree.",
-      hint: "Select a specific recovery handle and retry.",
-      projectId: input.projectId,
-      worktreeId: input.worktreeId,
-    });
+  const selected = selectNewestSessionRecoveryCandidate(eligible);
+  if (selected !== undefined) {
+    return selected;
   }
   throw commandValidationError({
     code: "SESSION_RECOVERY_HANDLE_NOT_FOUND",

--- a/apps/observer/src/sessionRecoverySelection.ts
+++ b/apps/observer/src/sessionRecoverySelection.ts
@@ -1,0 +1,44 @@
+import type { SessionRecoveryHandle } from "@station/contracts";
+
+type SessionRecoveryCandidate = {
+  handle: SessionRecoveryHandle;
+};
+
+/**
+ * POLICY
+ *
+ * Selects the newest already-eligible recovery candidate by last activity, observation recency,
+ * then opaque Station handle identity so automatic recovery is stable across input order and
+ * restart without exposing provider-native targets.
+ */
+export function selectNewestSessionRecoveryCandidate<TCandidate extends SessionRecoveryCandidate>(
+  candidates: readonly TCandidate[],
+): TCandidate | undefined {
+  let selected: TCandidate | undefined;
+  for (const candidate of candidates) {
+    if (
+      selected === undefined ||
+      compareSessionRecoveryHandles(candidate.handle, selected.handle) < 0
+    ) {
+      selected = candidate;
+    }
+  }
+  return selected;
+}
+
+function compareSessionRecoveryHandles(
+  left: SessionRecoveryHandle,
+  right: SessionRecoveryHandle,
+): number {
+  return (
+    Date.parse(right.lastSeenAt) - Date.parse(left.lastSeenAt) ||
+    Date.parse(right.observedAt) - Date.parse(left.observedAt) ||
+    compareHandleIds(left.id, right.id)
+  );
+}
+
+function compareHandleIds(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}

--- a/apps/observer/test/integration/session-commands.test.ts
+++ b/apps/observer/test/integration/session-commands.test.ts
@@ -1686,10 +1686,35 @@ describe("session command vertical slice", () => {
     await expect(fixture.persistence.getCommand(importReceipt.commandId)).resolves.toMatchObject({
       status: "succeeded",
     });
-    const [handle] = await fixture.persistence.listSessionRecoveryHandles({
+    const newerImportReceipt = await fixture.queue.dispatch({
+      type: "session.importRecoveryHandle",
+      payload: {
+        projectId: "web",
+        worktreeId: "wt_web_resume",
+        expectedPath: "/tmp/station/web/resume",
+        handle: {
+          id: "report_resume_newest",
+          provider: "fake-harness",
+          projectId: "web",
+          worktreeId: "wt_web_resume",
+          sessionId: "ses_previous",
+          target: { kind: "native-session", id: "native_session_newest" },
+          cwd: "/tmp/station/web/resume",
+          observedAt: "2026-05-21T12:01:00.000Z",
+          lastSeenAt: "2026-05-21T12:02:00.000Z",
+        },
+      },
+    });
+    await fixture.queue.drain();
+    await expect(
+      fixture.persistence.getCommand(newerImportReceipt.commandId),
+    ).resolves.toMatchObject({ status: "succeeded" });
+    const [handle, olderHandle] = await fixture.persistence.listSessionRecoveryHandles({
       worktreeId: "wt_web_resume",
     });
-    if (handle === undefined) throw new Error("Expected imported recovery handle.");
+    if (handle === undefined || olderHandle === undefined) {
+      throw new Error("Expected both imported recovery handles.");
+    }
 
     expect(fixture.core.getSnapshot().rows[0]?.recovery).toMatchObject({
       kind: "agent-resume",
@@ -1726,7 +1751,7 @@ describe("session command vertical slice", () => {
       initialPrompt: "Continue the recovered context.",
       mode: "interactive",
       resume: {
-        target: { kind: "native-session", id: "native_session_123" },
+        target: { kind: "native-session", id: "native_session_newest" },
         previousSessionId: "ses_previous",
         recoveryHandleId: handle.id,
       },
@@ -1737,6 +1762,9 @@ describe("session command vertical slice", () => {
     expect(
       (await fixture.persistence.listSessions()).find((session) => session.id === "ses_previous"),
     ).not.toHaveProperty("endedAt");
+    await expect(
+      fixture.persistence.listSessionRecoveryHandles({ worktreeId: "wt_web_resume" }),
+    ).resolves.toHaveLength(2);
     expect(fixture.core.getSnapshot().sessions).toEqual([
       expect.objectContaining({
         id: "ses_previous",

--- a/apps/observer/test/unit/external-launch.test.ts
+++ b/apps/observer/test/unit/external-launch.test.ts
@@ -888,7 +888,7 @@ describe("prepareExternalLaunch", () => {
     expect(retainedHandles).toEqual(expect.arrayContaining([persistedHandle, ineligibleHandle]));
   });
 
-  it("keeps multiple eligible recovery handles ambiguous before terminal mutation", async () => {
+  it("recovers the newest eligible handle deterministically", async () => {
     const persistence = createInMemoryObserverPersistence({
       clock: { now: () => new Date(now) },
     });
@@ -902,25 +902,44 @@ describe("prepareExternalLaunch", () => {
       createdAt: now,
       lastSeenAt: now,
     });
-    await persistence.upsertSessionRecoveryHandle(recoveryHandle());
     await persistence.upsertSessionRecoveryHandle(
       recoveryHandle({
-        id: "rec_other",
-        target: { kind: "native-session", id: "native_other" },
+        id: "rec_older",
+        target: { kind: "native-session", id: "native_older" },
+        observedAt: "2026-05-21T10:00:00.000Z",
+        lastSeenAt: "2026-05-21T11:00:00.000Z",
       }),
     );
+    const selected = await persistence.upsertSessionRecoveryHandle(
+      recoveryHandle({
+        id: "rec_newest",
+        target: { kind: "native-session", id: "native_newest" },
+        observedAt: "2026-05-21T11:30:00.000Z",
+        lastSeenAt: "2026-05-21T11:59:00.000Z",
+      }),
+    );
+    const harness = new CapturingHarness({ id: "fake-harness", now: () => new Date(now) });
     const station = new FakeManagedTerminalLifecycle();
 
     await expect(
       prepareExternalLaunch(
-        deps([row()], station, undefined, persistence, {
+        deps([row()], station, [harness], persistence, {
           sessions: [retainedSession()],
           sessionResumeAgentEnabled: true,
         }),
         prepareParams,
       ),
-    ).rejects.toMatchObject({ code: "SESSION_RECOVERY_HANDLE_AMBIGUOUS" });
-    expect(await station.listTargets()).toEqual([]);
+    ).resolves.toMatchObject({ outcome: { kind: "prepared" } });
+    expect(harness.requests).toEqual([
+      expect.objectContaining({
+        resume: {
+          target: { kind: "native-session", id: "native_newest" },
+          previousSessionId: "ses_recoverable",
+          recoveryHandleId: selected.id,
+        },
+      }),
+    ]);
+    expect(await station.listTargets()).toHaveLength(1);
   });
 
   it.each([

--- a/apps/observer/test/unit/graph.test.ts
+++ b/apps/observer/test/unit/graph.test.ts
@@ -236,17 +236,30 @@ function recoverySession(
 }
 
 describe("observer graph derivation", () => {
-  it("projects recovery only for one exact eligible open-session handle", () => {
+  it("projects the newest exact eligible open-session recovery handle", () => {
     const recoverable = worktree("wt_web_recoverable", "web", "recoverable");
-    const valid = recoveryHandle(recoverable);
-    const wrongSession = recoveryHandle(recoverable, {
-      id: "rec_wrong_session",
+    const older = recoveryHandle(recoverable, {
+      id: "rec_older",
+      target: { kind: "native-session", id: "native_older" },
+      observedAt: "2026-05-20T10:00:00.000Z",
+      lastSeenAt: "2026-05-20T11:00:00.000Z",
+    });
+    const selected = recoveryHandle(recoverable, {
+      id: "rec_selected",
+      target: { kind: "native-session", id: "native_selected" },
+      observedAt: "2026-05-20T11:30:00.000Z",
+      lastSeenAt: "2026-05-20T11:59:00.000Z",
+    });
+    const wrongSessionNewer = recoveryHandle(recoverable, {
+      id: "rec_wrong_session_newer",
       sessionId: "ses_other",
       target: { kind: "native-session", id: "native_wrong_session" },
+      observedAt: "2026-05-20T12:30:00.000Z",
+      lastSeenAt: "2026-05-20T13:00:00.000Z",
     });
     const snapshot = build({
       worktrees: [recoverable],
-      recoveryHandles: [valid, wrongSession],
+      recoveryHandles: [wrongSessionNewer, older, selected],
       sessionMetadata: [recoverySession(recoverable)],
       harnessCapabilities: { "fake-harness": resumableHarnessCapabilities },
       featureFlags: recoveryFeatureFlags,
@@ -254,11 +267,11 @@ describe("observer graph derivation", () => {
 
     expect(snapshot.rows[0]?.recovery).toEqual({
       kind: "agent-resume",
-      handleId: valid.id,
+      handleId: selected.id,
       provider: "fake-harness",
       targetKind: "native-session",
-      sessionId: valid.sessionId,
-      lastSeenAt: generatedAt,
+      sessionId: selected.sessionId,
+      lastSeenAt: selected.lastSeenAt,
     });
   });
 

--- a/apps/observer/test/unit/sessionRecovery.test.ts
+++ b/apps/observer/test/unit/sessionRecovery.test.ts
@@ -220,18 +220,36 @@ describe("resolveSessionRecovery", () => {
     });
   });
 
-  it("requires exactly one actionable automatic handle", async () => {
+  it("requires an actionable automatic handle and selects the newest eligible candidate", async () => {
     await expect(resolveRecovery()).rejects.toMatchObject({
       code: "SESSION_RECOVERY_HANDLE_NOT_FOUND",
     });
 
-    const first = recoveryHandle();
-    const second = recoveryHandle({
-      id: "rec_second",
-      target: { kind: "native-session", id: "native_second" },
+    const older = recoveryHandle({
+      id: "rec_older",
+      target: { kind: "native-session", id: "native_older" },
+      observedAt: "2026-08-08T10:00:00.000Z",
+      lastSeenAt: "2026-08-08T11:00:00.000Z",
     });
-    await expect(resolveRecovery({ handles: [first, second] })).rejects.toMatchObject({
-      code: "SESSION_RECOVERY_HANDLE_AMBIGUOUS",
+    const selected = recoveryHandle({
+      id: "rec_selected",
+      target: { kind: "native-session", id: "native_selected" },
+      observedAt: "2026-08-08T11:30:00.000Z",
+      lastSeenAt: "2026-08-08T11:59:00.000Z",
+    });
+    const ineligibleNewer = recoveryHandle({
+      id: "rec_ineligible_newer",
+      sessionId: "ses_other",
+      target: { kind: "native-session", id: "native_ineligible_newer" },
+      observedAt: "2026-08-08T12:30:00.000Z",
+      lastSeenAt: "2026-08-08T13:00:00.000Z",
+    });
+
+    await expect(
+      resolveRecovery({ handles: [ineligibleNewer, older, selected] }),
+    ).resolves.toMatchObject({
+      handle: { target: selected.target },
+      resume: { target: selected.target },
     });
   });
 

--- a/apps/observer/test/unit/sessionRecoverySelection.test.ts
+++ b/apps/observer/test/unit/sessionRecoverySelection.test.ts
@@ -1,0 +1,57 @@
+import type { SessionRecoveryHandle } from "@station/contracts";
+import { describe, expect, it } from "vitest";
+import { selectNewestSessionRecoveryCandidate } from "../../src/sessionRecoverySelection";
+
+const newest = "2026-08-20T12:00:00.000Z";
+const older = "2026-08-20T11:00:00.000Z";
+
+function candidate(
+  id: string,
+  overrides: Partial<SessionRecoveryHandle> = {},
+): { handle: SessionRecoveryHandle; marker: string } {
+  return {
+    marker: id,
+    handle: {
+      id,
+      provider: "fake-harness",
+      projectId: "web",
+      worktreeId: "wt_web_feature",
+      sessionId: "ses_feature",
+      target: { kind: "native-session", id: `native_${id}` },
+      cwd: "/tmp/station/web/feature",
+      observedAt: older,
+      lastSeenAt: older,
+      ...overrides,
+    },
+  };
+}
+
+describe("selectNewestSessionRecoveryCandidate", () => {
+  it("returns no selection for no eligible candidates", () => {
+    expect(selectNewestSessionRecoveryCandidate([])).toBeUndefined();
+  });
+
+  it("selects the most recently active candidate independent of input order", () => {
+    const first = candidate("rec_first");
+    const selected = candidate("rec_selected", { lastSeenAt: newest });
+
+    expect(selectNewestSessionRecoveryCandidate([first, selected])).toBe(selected);
+    expect(selectNewestSessionRecoveryCandidate([selected, first])).toBe(selected);
+  });
+
+  it("uses newest observation when last activity ties", () => {
+    const first = candidate("rec_first");
+    const selected = candidate("rec_selected", { observedAt: newest });
+
+    expect(selectNewestSessionRecoveryCandidate([first, selected])).toBe(selected);
+    expect(selectNewestSessionRecoveryCandidate([selected, first])).toBe(selected);
+  });
+
+  it("uses opaque Station handle identity as the final stable tie-breaker", () => {
+    const selected = candidate("rec_a");
+    const other = candidate("rec_b");
+
+    expect(selectNewestSessionRecoveryCandidate([other, selected])).toBe(selected);
+    expect(selectNewestSessionRecoveryCandidate([selected, other])).toBe(selected);
+  });
+});

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -9199,6 +9199,12 @@
           "bindings": ["sessionRecoveryEligibility"]
         },
         {
+          "specifier": "../sessionRecoverySelection.js",
+          "resolvedPath": "apps/observer/src/sessionRecoverySelection.ts",
+          "edgeKind": "runtime",
+          "bindings": ["selectNewestSessionRecoveryCandidate"]
+        },
+        {
           "specifier": "@station/contracts",
           "resolvedPath": "packages/contracts/src/index.ts",
           "edgeKind": "runtime",
@@ -11955,7 +11961,7 @@
           "name": "resolveSessionRecovery",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Filters durable handles through exact lifecycle and provider-neutral eligibility before applying zero/one/many cardinality, then returns only typed resume authority for the selected provider. Explicit selection retains imported-handle compatibility only when no contradictory local Station lifecycle exists."
+          "purpose": "Filters durable handles through exact lifecycle and provider-neutral eligibility before selecting the newest automatic candidate deterministically, then returns only typed resume authority for that provider. Explicit selection retains imported-handle compatibility only when no contradictory local Station lifecycle exists."
         }
       ],
       "imports": [
@@ -11994,6 +12000,12 @@
           "resolvedPath": "apps/observer/src/sessionRecoveryEligibility.ts",
           "edgeKind": "type-only",
           "bindings": ["SessionRecoveryEligibility", "SessionRecoveryEligibilityInput"]
+        },
+        {
+          "specifier": "./sessionRecoverySelection.js",
+          "resolvedPath": "apps/observer/src/sessionRecoverySelection.ts",
+          "edgeKind": "runtime",
+          "bindings": ["selectNewestSessionRecoveryCandidate"]
         },
         {
           "specifier": "@station/contracts",
@@ -12054,6 +12066,25 @@
           "resolvedPath": "packages/runtime/src/index.ts",
           "edgeKind": "runtime",
           "bindings": ["pathIsSameOrInside"]
+        }
+      ]
+    },
+    {
+      "path": "apps/observer/src/sessionRecoverySelection.ts",
+      "exports": [
+        {
+          "name": "selectNewestSessionRecoveryCandidate",
+          "kind": "function",
+          "role": "POLICY",
+          "purpose": "Selects the newest already-eligible recovery candidate by last activity, observation recency, then opaque Station handle identity so automatic recovery is stable across input order and restart without exposing provider-native targets."
+        }
+      ],
+      "imports": [
+        {
+          "specifier": "@station/contracts",
+          "resolvedPath": "packages/contracts/src/index.ts",
+          "edgeKind": "type-only",
+          "bindings": ["SessionRecoveryHandle"]
         }
       ]
     },
@@ -14053,6 +14084,13 @@
           "edgeKind": "runtime"
         },
         {
+          "path": "apps/observer/src/sessionRecoverySelection.ts",
+          "declaration": "selectNewestSessionRecoveryCandidate",
+          "kind": "function",
+          "role": "POLICY",
+          "edgeKind": "runtime"
+        },
+        {
           "path": "packages/contracts/src/agentStatus.ts",
           "declaration": "AGENT_STATUS",
           "kind": "const",
@@ -14773,7 +14811,7 @@
       "declaration": "resolveSessionRecovery",
       "kind": "function",
       "role": "USE CASE",
-      "purpose": "Filters durable handles through exact lifecycle and provider-neutral eligibility before applying zero/one/many cardinality, then returns only typed resume authority for the selected provider. Explicit selection retains imported-handle compatibility only when no contradictory local Station lifecycle exists.",
+      "purpose": "Filters durable handles through exact lifecycle and provider-neutral eligibility before selecting the newest automatic candidate deterministically, then returns only typed resume authority for that provider. Explicit selection retains imported-handle compatibility only when no contradictory local Station lifecycle exists.",
       "dependencies": [
         {
           "path": "apps/observer/src/persistence/ports.ts",
@@ -14785,6 +14823,13 @@
         {
           "path": "apps/observer/src/sessionRecoveryEligibility.ts",
           "declaration": "sessionRecoveryEligibility",
+          "kind": "function",
+          "role": "POLICY",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/observer/src/sessionRecoverySelection.ts",
+          "declaration": "selectNewestSessionRecoveryCandidate",
           "kind": "function",
           "role": "POLICY",
           "edgeKind": "runtime"
@@ -14804,6 +14849,14 @@
       "kind": "function",
       "role": "POLICY",
       "purpose": "Admits one opaque recovery handle only when its provider-neutral identity, open Station lifecycle, registered harness capability, and cwd evidence authorize the exact worktree. A deliberately selected imported handle may proceed without a local lifecycle row, but local legacy, ended, or contradictory identity always wins over that compatibility path.",
+      "dependencies": []
+    },
+    {
+      "path": "apps/observer/src/sessionRecoverySelection.ts",
+      "declaration": "selectNewestSessionRecoveryCandidate",
+      "kind": "function",
+      "role": "POLICY",
+      "purpose": "Selects the newest already-eligible recovery candidate by last activity, observation recency, then opaque Station handle identity so automatic recovery is stable across input order and restart without exposing provider-native targets.",
       "dependencies": []
     },
     {

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -424,6 +424,14 @@ trace-correlated diagnostic evidence.
 
 ### Session Recovery Cutover
 
+Automatic session recovery first applies the provider-neutral
+`sessionRecoveryEligibility` policy, then selects the newest eligible handle by
+`lastSeenAt`, `observedAt`, and opaque Station handle ID. Snapshot projection and
+managed or command launch share that total order, so input order, reconcile, and
+restart cannot change the chosen provider-native target. Explicit handle selection
+remains available through the existing command contract and is revalidated through
+the same eligibility policy.
+
 Session migration is an exclusive cutover, not a blue/green launch. Its
 read-only plan pins source and target Observer identities, compares the complete
 source Host PTY census, requires each canonical source row title to match its


### PR DESCRIPTION
## What this fixes

Interrupted Station sessions can retain multiple exact recovery handles. Automatic recovery previously rejected that state as ambiguous, while reconcile omitted the recovery action and could send the TUI into fresh-start UX.

## What changed

- Select the newest handle only after #647's exact session, provider, worktree, capability, cwd, and lifecycle eligibility checks.
- Order eligible handles by `lastSeenAt`, then `observedAt`, then hidden Station handle identity for deterministic ties.
- Share the same provider-neutral selection policy between automatic launch and snapshot reconciliation.
- Preserve explicit `recoveryHandleId` selection for repair tooling without adding a picker, provider-history enumeration, pruning, or persistence changes.
- Document the policy and regenerate Observer architecture evidence.

## Testing

- `pnpm build`
- `pnpm --filter @station/observer typecheck`
- `pnpm lint`
- Recovery-focused unit suite: 107 tests passed
- Session-command integration suite: 49 tests passed
- Build-identity-sensitive unit rerun: 241 tests passed

Closes #638