### PR TITLE
refactor(terminal): make attachment evidence and focus decisions observable

### DIFF
--- a/apps/cli/src/commands/debugLogs.ts
+++ b/apps/cli/src/commands/debugLogs.ts
@@ -1,6 +1,11 @@
 import { readFile } from "node:fs/promises";
 import type { StationConfig } from "@station/config";
-import type { LogRecord, ObserverStartupEvidence, SafeError } from "@station/contracts";
+import type {
+  LogRecord,
+  ObserverOperationalEvent,
+  ObserverStartupEvidence,
+  SafeError,
+} from "@station/contracts";
 import { LogRecordSchema } from "@station/contracts";
 import { componentLogPath } from "@station/observability";
 import { resolveObserverPaths } from "../paths.js";
@@ -60,6 +65,7 @@ type DebugLogRecordSummary = {
   worktreeId?: string;
   sessionId?: string;
   provider?: string;
+  operationalEvent?: ObserverOperationalEvent;
   operationalBoundaryEvidence?: OperationalBoundaryEvidence;
   context?: DiagnosticContextEntry[];
   matchEvidence?: DiagnosticMatchEvidence[];
@@ -313,6 +319,7 @@ function logSummary(
   if (record.worktreeId !== undefined) summary.worktreeId = record.worktreeId;
   if (record.sessionId !== undefined) summary.sessionId = record.sessionId;
   if (record.provider !== undefined) summary.provider = record.provider;
+  if (record.operationalEvent !== undefined) summary.operationalEvent = record.operationalEvent;
   if (context.length > 0) summary.context = context;
   if (query !== undefined) {
     const matchEvidence = extractDiagnosticMatchEvidence(record, query);

--- a/apps/cli/test/integration/command-command.test.ts
+++ b/apps/cli/test/integration/command-command.test.ts
@@ -229,9 +229,9 @@ describe("CLI command dispatch/get", () => {
             ({
               health: async () =>
                 spawned
-                  ? { schemaVersion: "0.11.0", status: "healthy" }
+                  ? { schemaVersion: "0.12.0", status: "healthy" }
                   : {
-                      schemaVersion: "0.11.0",
+                      schemaVersion: "0.12.0",
                       status: "healthy",
                       pid: 1234,
                       startedAt: now,
@@ -263,7 +263,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.11.0",
+          schemaVersion: "0.12.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,

--- a/apps/cli/test/integration/diagnostic-commands.test.ts
+++ b/apps/cli/test/integration/diagnostic-commands.test.ts
@@ -27,7 +27,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.11.0",
+            schemaVersion: "0.12.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -49,7 +49,7 @@ describe("CLI diagnostic commands", () => {
     ).resolves.toMatchObject({
       code: 0,
       output: {
-        schemaVersion: "0.11.0",
+        schemaVersion: "0.12.0",
         status: "healthy",
         debugBundle: {
           available: true,
@@ -166,7 +166,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.11.0",
+            schemaVersion: "0.12.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -201,7 +201,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.11.0",
+            schemaVersion: "0.12.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -238,7 +238,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.11.0",
+            schemaVersion: "0.12.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -301,7 +301,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.11.0",
+            schemaVersion: "0.12.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -342,7 +342,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.11.0",
+            schemaVersion: "0.12.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -737,6 +737,83 @@ describe("CLI diagnostic commands", () => {
     });
   });
 
+  it("returns strict operational decision payloads with envelope correlation", async () => {
+    const fixture = await createTempState();
+    const configPath = await writeConfigToml(fixture.root, fixture.config);
+    await mkdir(join(fixture.stateDir, "logs"), { recursive: true });
+    await writeFile(
+      join(fixture.stateDir, "logs", "observer.jsonl"),
+      `${JSON.stringify({
+        timestamp: "2026-05-20T12:03:00.000Z",
+        level: "info",
+        component: "observer",
+        message: "Terminal focus decision recorded.",
+        commandId: "cmd_focus",
+        traceId: "trc_focus",
+        projectId: "web",
+        worktreeId: "wt_web_feature",
+        sessionId: "ses_web_feature",
+        provider: "tmux",
+        operationalEvent: {
+          kind: "terminal.focus.decision",
+          decision: {
+            outcome: "focused",
+            hasOriginClientId: false,
+            resolution: {
+              kind: "selected",
+              totalTargetCount: 2,
+              matchingTargetCount: 1,
+              targetId: "tmux:station:@1:%2",
+              targetState: "open",
+              selectionBasis: "session-main-agent",
+            },
+          },
+        },
+      })}\n`,
+    );
+
+    await expect(
+      runCli(["--config", configPath, "debug", "logs", "terminal.focus.decision"]),
+    ).resolves.toMatchObject({
+      code: 0,
+      output: {
+        matched: 1,
+        records: [
+          {
+            level: "info",
+            commandId: "cmd_focus",
+            traceId: "trc_focus",
+            projectId: "web",
+            worktreeId: "wt_web_feature",
+            sessionId: "ses_web_feature",
+            provider: "tmux",
+            operationalEvent: {
+              kind: "terminal.focus.decision",
+              decision: {
+                outcome: "focused",
+                hasOriginClientId: false,
+                resolution: {
+                  kind: "selected",
+                  totalTargetCount: 2,
+                  matchingTargetCount: 1,
+                  targetId: "tmux:station:@1:%2",
+                  targetState: "open",
+                  selectionBasis: "session-main-agent",
+                },
+              },
+            },
+            matchEvidence: [
+              expect.objectContaining({
+                path: "/operationalEvent/kind",
+                excerpt: expect.stringContaining("terminal.focus.decision"),
+              }),
+            ],
+          },
+        ],
+      },
+    });
+  });
+
   it("returns doctor diagnostics for an invalid config without starting the observer", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-invalid-config-"));
     const configPath = join(root, "config.toml");
@@ -821,12 +898,12 @@ describe("CLI diagnostic commands", () => {
 
 function doctorReport(stateDir: string): DoctorReport {
   return {
-    schemaVersion: "0.11.0",
+    schemaVersion: "0.12.0",
     generatedAt: now,
     status: "healthy",
     checks: [{ name: "observer", status: "ok", message: "Observer is healthy." }],
     observer: {
-      schemaVersion: "0.11.0",
+      schemaVersion: "0.12.0",
       status: "healthy",
       pid: 1234,
       startedAt: now,
@@ -854,17 +931,17 @@ function doctorReport(stateDir: string): DoctorReport {
 
 function diagnosticSnapshot(): DiagnosticSnapshot {
   return {
-    schemaVersion: "0.11.0",
+    schemaVersion: "0.12.0",
     collectedAt: now,
     observerHealth: {
-      schemaVersion: "0.11.0",
+      schemaVersion: "0.12.0",
       status: "healthy",
       pid: 1234,
       startedAt: now,
       version: observerBuildVersion,
     },
     snapshot: {
-      schemaVersion: "0.11.0",
+      schemaVersion: "0.12.0",
       generatedAt: now,
       observer: { pid: 1234, startedAt: now, version: "0.7.0", healthy: true },
       providerHealth: {},

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -57,7 +57,7 @@ describe("CLI manual-smoke commands", () => {
     const configPath = await writeConfigToml(fixture.root, fixture.config);
     const reconciles: Array<string | undefined> = [];
     const receipt: ReconcileReceipt = {
-      schemaVersion: "0.11.0",
+      schemaVersion: "0.12.0",
       reason: "manual-smoke",
       reconciledAt: now,
       snapshot: snapshotFixture(),
@@ -317,7 +317,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.11.0",
+          schemaVersion: "0.12.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,
@@ -328,7 +328,7 @@ function runningObserverDeps(options: {
         reconcile:
           options.reconcile ??
           (async (reason?: string) => ({
-            schemaVersion: "0.11.0",
+            schemaVersion: "0.12.0",
             reason: reason ?? "manual",
             reconciledAt: now,
             snapshot: options.snapshot ?? snapshotFixture(),
@@ -340,7 +340,7 @@ function runningObserverDeps(options: {
 
 function snapshotFixture(): StationSnapshot {
   return {
-    schemaVersion: "0.11.0",
+    schemaVersion: "0.12.0",
     generatedAt: now,
     observer: { pid: 1234, startedAt: now, version: "0.7.0", healthy: true },
     providerHealth: {},

--- a/apps/cli/test/integration/observe-command.test.ts
+++ b/apps/cli/test/integration/observe-command.test.ts
@@ -265,7 +265,7 @@ describe("CLI observe command", () => {
                       tag: "ProtocolError",
                       code: "PROTOCOL_SCHEMA_MISMATCH",
                       message:
-                        "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.11.0.",
+                        "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.12.0.",
                       hint: "A different STATION checkout may own the observer socket.",
                     };
                   },
@@ -298,7 +298,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.11.0",
+          schemaVersion: "0.12.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,
@@ -311,7 +311,7 @@ function runningObserverDeps(options: {
           return options.events;
         },
         reconcile: async (reason?: string): Promise<ReconcileReceipt> => ({
-          schemaVersion: "0.11.0",
+          schemaVersion: "0.12.0",
           reason: reason ?? "manual",
           reconciledAt: now,
           snapshot: options.snapshot ?? snapshotFixture(),
@@ -385,7 +385,7 @@ async function sleep(ms: number): Promise<void> {
 
 function snapshotFixture(): StationSnapshot {
   return {
-    schemaVersion: "0.11.0",
+    schemaVersion: "0.12.0",
     generatedAt: now,
     observer: { pid: 1234, startedAt: now, version: "0.7.0", healthy: true },
     providerHealth: {},

--- a/apps/cli/test/integration/observer-commands.test.ts
+++ b/apps/cli/test/integration/observer-commands.test.ts
@@ -28,7 +28,7 @@ describe("CLI observer commands", () => {
               throw new Error("stopped");
             }
             return {
-              schemaVersion: "0.11.0",
+              schemaVersion: "0.12.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -38,7 +38,7 @@ describe("CLI observer commands", () => {
           },
           stop: async () => {
             running = false;
-            return { schemaVersion: "0.11.0", stopped: true, at: now };
+            return { schemaVersion: "0.12.0", stopped: true, at: now };
           },
         }) as never,
       sleep: async () => undefined,
@@ -78,7 +78,7 @@ describe("CLI observer commands", () => {
               throw new Error("stopped");
             }
             return {
-              schemaVersion: "0.11.0",
+              schemaVersion: "0.12.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -88,7 +88,7 @@ describe("CLI observer commands", () => {
           },
           stop: async () => {
             running = false;
-            return { schemaVersion: "0.11.0", stopped: true, at: now };
+            return { schemaVersion: "0.12.0", stopped: true, at: now };
           },
         }) as never,
       sleep: async () => undefined,
@@ -159,7 +159,7 @@ describe("CLI observer commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.11.0",
+            schemaVersion: "0.12.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,

--- a/apps/cli/test/integration/popup-command.test.ts
+++ b/apps/cli/test/integration/popup-command.test.ts
@@ -46,7 +46,7 @@ describe("CLI popup command", () => {
           health: async () => {
             if (!running) throw new Error("stopped");
             return {
-              schemaVersion: "0.11.0",
+              schemaVersion: "0.12.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -119,7 +119,7 @@ describe("CLI popup command", () => {
                   if (!spawned) throw new Error("stopped");
                   await healthReady;
                   return {
-                    schemaVersion: "0.11.0",
+                    schemaVersion: "0.12.0",
                     status: "healthy",
                     pid: 1234,
                     startedAt: now,
@@ -189,7 +189,7 @@ describe("CLI popup command", () => {
               clientFactory: () =>
                 ({
                   health: async () => ({
-                    schemaVersion: "0.11.0",
+                    schemaVersion: "0.12.0",
                     status: "healthy",
                     pid: 1234,
                     startedAt: now,
@@ -218,7 +218,7 @@ describe("CLI popup command", () => {
       () =>
         ({
           health: async () => ({
-            schemaVersion: "0.11.0",
+            schemaVersion: "0.12.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -702,7 +702,7 @@ function runningObserverDeps(reconciles: string[]): ObserverProcessDeps {
     clientFactory: () =>
       ({
         health: async () => ({
-          schemaVersion: "0.11.0",
+          schemaVersion: "0.12.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,
@@ -719,11 +719,11 @@ function runningObserverDeps(reconciles: string[]): ObserverProcessDeps {
 
 function emptySnapshot(reason: string) {
   return {
-    schemaVersion: "0.11.0",
+    schemaVersion: "0.12.0",
     reason,
     reconciledAt: now,
     snapshot: {
-      schemaVersion: "0.11.0",
+      schemaVersion: "0.12.0",
       generatedAt: now,
       observer: { pid: 1234, startedAt: now, version: "0.7.0", healthy: true },
       providerHealth: {},
@@ -767,7 +767,7 @@ function nonCompletingReconcileObserverDeps(reconciles: string[]): ObserverProce
     clientFactory: () =>
       ({
         health: async () => ({
-          schemaVersion: "0.11.0",
+          schemaVersion: "0.12.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,

--- a/apps/cli/test/integration/project-command.test.ts
+++ b/apps/cli/test/integration/project-command.test.ts
@@ -144,7 +144,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.11.0",
+          schemaVersion: "0.12.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,

--- a/apps/cli/test/integration/snapshot-command.test.ts
+++ b/apps/cli/test/integration/snapshot-command.test.ts
@@ -2,10 +2,43 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { emptyConfig } from "@station/config";
+import { STATION_SCHEMA_VERSION } from "@station/contracts";
 import { describe, expect, it, vi } from "vitest";
 import { runSnapshotCommand } from "../../src/commands/snapshot.js";
 
 describe("snapshot command", () => {
+  it("forwards --include-debug to the Observer snapshot query", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-snapshot-debug-"));
+    const config = {
+      ...emptyConfig(),
+      observer: {
+        stateDir: join(root, "state"),
+        socketPath: join(root, "observer.sock"),
+      },
+    };
+    const getSnapshot = vi.fn(async () => ({ debug: { terminalTargets: [] } }));
+
+    try {
+      await runSnapshotCommand(
+        ["--json", "--include-debug", "--require-running"],
+        { config, timeoutMs: 50 },
+        {
+          clientFactory: () =>
+            ({
+              health: async () => ({
+                schemaVersion: STATION_SCHEMA_VERSION,
+                status: "healthy",
+              }),
+              getSnapshot,
+            }) as never,
+        },
+      );
+      expect(getSnapshot).toHaveBeenCalledWith({ includeDebug: true });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("does not spawn an Observer when --require-running finds no runtime", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-snapshot-require-running-"));
     const spawnObserver = vi.fn();

--- a/apps/cli/test/integration/tui-command.test.ts
+++ b/apps/cli/test/integration/tui-command.test.ts
@@ -51,11 +51,11 @@ const tuiConfig: TuiConfig = {
 
 function emptySnapshot(reason: string) {
   return {
-    schemaVersion: "0.11.0",
+    schemaVersion: "0.12.0",
     reason,
     reconciledAt: now,
     snapshot: {
-      schemaVersion: "0.11.0",
+      schemaVersion: "0.12.0",
       generatedAt: now,
       observer: { pid: 1234, startedAt: now, version: "0.7.0", healthy: true },
       providerHealth: {},
@@ -104,7 +104,7 @@ function runningObserverDeps(
         health: async () => {
           if (!running) throw new Error("stopped");
           return {
-            schemaVersion: "0.11.0",
+            schemaVersion: "0.12.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -130,7 +130,7 @@ function warmObserverDeps(version: string): ObserverProcessDeps {
     clientFactory: () =>
       ({
         health: async () => ({
-          schemaVersion: "0.11.0",
+          schemaVersion: "0.12.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,
@@ -586,7 +586,7 @@ describe("CLI tui command", () => {
                   if (!spawned) throw new Error("stopped");
                   await healthReady;
                   return {
-                    schemaVersion: "0.11.0",
+                    schemaVersion: "0.12.0",
                     status: "healthy",
                     pid: 1234,
                     startedAt: now,
@@ -652,7 +652,7 @@ describe("CLI tui command", () => {
               clientFactory: () =>
                 ({
                   health: async () => ({
-                    schemaVersion: "0.11.0",
+                    schemaVersion: "0.12.0",
                     status: "healthy",
                     pid: 1234,
                     startedAt: now,
@@ -683,7 +683,7 @@ describe("CLI tui command", () => {
       () =>
         ({
           health: async () => ({
-            schemaVersion: "0.11.0",
+            schemaVersion: "0.12.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,

--- a/apps/cli/test/unit/ingress-command.test.ts
+++ b/apps/cli/test/unit/ingress-command.test.ts
@@ -51,7 +51,7 @@ describe("provider hook ingress command", () => {
             ingestProviderHookEvent: async (event: ProviderHookEvent) => {
               if (!running) throw new Error("offline");
               return {
-                schemaVersion: "0.11.0",
+                schemaVersion: "0.12.0",
                 hookId: event.hookId ?? "hook_final_command",
                 provider: event.provider,
                 event: event.event,
@@ -121,7 +121,7 @@ describe("provider hook ingress command", () => {
             ingestProviderHookEvent: async (event: ProviderHookEvent) => {
               if (!(await fileExists(argvPath))) throw new Error("offline");
               return {
-                schemaVersion: "0.11.0",
+                schemaVersion: "0.12.0",
                 hookId: event.hookId ?? "hook_child_timeout",
                 provider: event.provider,
                 event: event.event,
@@ -172,7 +172,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedPayload = event.payload;
             return {
-              schemaVersion: "0.11.0",
+              schemaVersion: "0.12.0",
               hookId: event.hookId ?? "hook_worktrunk_1",
               provider: event.provider,
               event: event.event,
@@ -216,7 +216,7 @@ describe("provider hook ingress command", () => {
             ingestProviderHookEvent: async (event: ProviderHookEvent) => {
               observedEvent = event;
               return {
-                schemaVersion: "0.11.0",
+                schemaVersion: "0.12.0",
                 hookId: event.hookId ?? "hook_worktrunk_empty",
                 provider: event.provider,
                 event: event.event,
@@ -262,7 +262,7 @@ describe("provider hook ingress command", () => {
         writeSpool: async ({ spoolDir, event, error, clock }) => {
           observedSpoolDir = spoolDir;
           return {
-            schemaVersion: "0.11.0",
+            schemaVersion: "0.12.0",
             hookId: event.hookId ?? "hook_worktrunk_config_only",
             provider: event.provider,
             event: event.event,
@@ -374,7 +374,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedEvent = event;
             return {
-              schemaVersion: "0.11.0",
+              schemaVersion: "0.12.0",
               hookId: event.hookId ?? "hook_1",
               provider: event.provider,
               event: event.event,
@@ -438,7 +438,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedEvent = event;
             return {
-              schemaVersion: "0.11.0",
+              schemaVersion: "0.12.0",
               hookId: event.hookId ?? "hook_1",
               provider: event.provider,
               event: event.event,
@@ -498,7 +498,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedEvent = event;
             return {
-              schemaVersion: "0.11.0",
+              schemaVersion: "0.12.0",
               hookId: event.hookId ?? "hook_1",
               provider: event.provider,
               event: event.event,
@@ -550,7 +550,7 @@ describe("provider hook ingress command", () => {
             ingestProviderHookEvent: async (event: ProviderHookEvent) => {
               observedEvent = event;
               return {
-                schemaVersion: "0.11.0",
+                schemaVersion: "0.12.0",
                 hookId: event.hookId ?? "hook_pi_1",
                 provider: event.provider,
                 event: event.event,
@@ -613,7 +613,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedEvent = event;
             return {
-              schemaVersion: "0.11.0",
+              schemaVersion: "0.12.0",
               hookId: event.hookId ?? "hook_opencode_1",
               provider: event.provider,
               event: event.event,
@@ -625,7 +625,7 @@ describe("provider hook ingress command", () => {
           };
           return {
             health: async () => ({
-              schemaVersion: "0.11.0",
+              schemaVersion: "0.12.0",
               status: "healthy",
               pid: 12345,
               startedAt: now,
@@ -681,7 +681,7 @@ describe("provider hook ingress command", () => {
             health: async () => {
               healthCalls += 1;
               return {
-                schemaVersion: "0.11.0",
+                schemaVersion: "0.12.0",
                 status: "healthy",
                 pid: 12345,
                 startedAt: now,
@@ -695,7 +695,7 @@ describe("provider hook ingress command", () => {
             ): Promise<ProviderHookReceipt> => {
               deliveryCalls += 1;
               return {
-                schemaVersion: "0.11.0",
+                schemaVersion: "0.12.0",
                 hookId: event.hookId ?? "hook_pi_invalid",
                 provider: event.provider,
                 event: event.event,
@@ -764,7 +764,7 @@ describe("provider hook ingress command", () => {
             observedBuildVersion = options.expectedBuildVersion;
           }
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => ({
-            schemaVersion: "0.11.0",
+            schemaVersion: "0.12.0",
             hookId: event.hookId ?? "hook_timeout_1",
             provider: event.provider,
             event: event.event,
@@ -944,7 +944,7 @@ function stationEnv(): Record<string, string> {
 
 function healthyObserver(paths: { socketPath: string; stateDir: string }): ObserverHealth {
   return {
-    schemaVersion: "0.11.0",
+    schemaVersion: "0.12.0",
     status: "healthy",
     pid: 12345,
     startedAt: now,

--- a/apps/cli/test/unit/ingress-correlation.test.ts
+++ b/apps/cli/test/unit/ingress-correlation.test.ts
@@ -238,7 +238,7 @@ describe("provider hook ingress correlation", () => {
     );
 
     expect(receipt).toEqual({
-      schemaVersion: "0.11.0",
+      schemaVersion: "0.12.0",
       hookId,
       provider,
       event: expectedEvent,
@@ -352,7 +352,7 @@ describe("provider hook ingress correlation", () => {
     );
 
     expect(receipt).toEqual({
-      schemaVersion: "0.11.0",
+      schemaVersion: "0.12.0",
       hookId: "hook_logging_failure",
       provider: "cursor",
       event: "beforeShellExecution",

--- a/apps/cli/test/unit/observe-formatters.test.ts
+++ b/apps/cli/test/unit/observe-formatters.test.ts
@@ -177,7 +177,7 @@ describe("observe snapshot context", () => {
 
 function snapshotFixture(): StationSnapshot {
   return {
-    schemaVersion: "0.11.0",
+    schemaVersion: "0.12.0",
     generatedAt: now,
     observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
     providerHealth: {},

--- a/apps/cli/test/unit/observer-process/activation-surfacing.test.ts
+++ b/apps/cli/test/unit/observer-process/activation-surfacing.test.ts
@@ -152,7 +152,7 @@ describe("a failed cross-build restart retains the incumbent build context", () 
             health: async () => {
               if (!running) throw new Error("stopped");
               return {
-                schemaVersion: "0.11.0",
+                schemaVersion: "0.12.0",
                 status: "healthy",
                 pid: 4321,
                 startedAt: now,
@@ -162,7 +162,7 @@ describe("a failed cross-build restart retains the incumbent build context", () 
             },
             stop: async () => {
               running = false;
-              return { schemaVersion: "0.11.0", stopped: true, at: now };
+              return { schemaVersion: "0.12.0", stopped: true, at: now };
             },
           }) as never,
       },
@@ -197,14 +197,14 @@ describe("a failed cross-build restart retains the incumbent build context", () 
         clientFactory: () =>
           ({
             health: async () => ({
-              schemaVersion: "0.11.0",
+              schemaVersion: "0.12.0",
               status: "healthy",
               pid: 4321,
               startedAt: now,
               version: compiledBuildVersion,
               socketPath: fixture.socketPath,
             }),
-            stop: async () => ({ schemaVersion: "0.11.0", stopped: true, at: now }),
+            stop: async () => ({ schemaVersion: "0.12.0", stopped: true, at: now }),
           }) as never,
       },
     );

--- a/apps/cli/test/unit/observer-process/lifecycle.test.ts
+++ b/apps/cli/test/unit/observer-process/lifecycle.test.ts
@@ -142,7 +142,7 @@ describe("CLI observer process lifecycle", () => {
                 throw new Error("not yet");
               }
               return {
-                schemaVersion: "0.11.0",
+                schemaVersion: "0.12.0",
                 status: "healthy",
                 pid: 1234,
                 startedAt: now,
@@ -192,7 +192,7 @@ describe("CLI observer process lifecycle", () => {
                 throw new Error("not running");
               }
               return {
-                schemaVersion: "0.11.0",
+                schemaVersion: "0.12.0",
                 status: "healthy",
                 pid: 1234,
                 startedAt: now,
@@ -311,7 +311,7 @@ describe("CLI observer process lifecycle", () => {
                   tag: "ProtocolError",
                   code: "PROTOCOL_SCHEMA_MISMATCH",
                   message:
-                    "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.11.0.",
+                    "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.12.0.",
                   hint: "A different STATION checkout may own the observer socket.",
                 };
               },
@@ -407,7 +407,7 @@ describe("CLI observer process lifecycle", () => {
           clientFactory: () =>
             ({
               health: async () => ({
-                schemaVersion: "0.11.0",
+                schemaVersion: "0.12.0",
                 status: "healthy",
                 pid: 1234,
                 startedAt: now,
@@ -671,7 +671,7 @@ describe("CLI observer process lifecycle", () => {
         clientFactory: () =>
           ({
             health: async () => ({
-              schemaVersion: "0.11.0",
+              schemaVersion: "0.12.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -709,7 +709,7 @@ describe("CLI observer process lifecycle", () => {
         clientFactory: () =>
           ({
             health: async () => ({
-              schemaVersion: "0.11.0",
+              schemaVersion: "0.12.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -718,7 +718,7 @@ describe("CLI observer process lifecycle", () => {
             }),
             stop: async () => {
               stops += 1;
-              return { schemaVersion: "0.11.0", stopped: true, at: now };
+              return { schemaVersion: "0.12.0", stopped: true, at: now };
             },
           }) as never,
       },
@@ -758,7 +758,7 @@ describe("CLI observer process lifecycle", () => {
             health: async () => {
               if (!running) throw new Error("stopped");
               return {
-                schemaVersion: "0.11.0",
+                schemaVersion: "0.12.0",
                 status: "healthy",
                 pid: 1234,
                 startedAt: now,
@@ -769,7 +769,7 @@ describe("CLI observer process lifecycle", () => {
             stop: async () => {
               stops += 1;
               running = false;
-              return { schemaVersion: "0.11.0", stopped: true, at: now };
+              return { schemaVersion: "0.12.0", stopped: true, at: now };
             },
           } as never;
         },
@@ -812,7 +812,7 @@ describe("CLI observer process lifecycle", () => {
             health: async () => {
               if (!stopping) {
                 return {
-                  schemaVersion: "0.11.0",
+                  schemaVersion: "0.12.0",
                   status: "healthy",
                   pid: 1234,
                   startedAt: now,
@@ -830,7 +830,7 @@ describe("CLI observer process lifecycle", () => {
             },
             stop: async () => {
               stopping = true;
-              return { schemaVersion: "0.11.0", stopped: true, at: now };
+              return { schemaVersion: "0.12.0", stopped: true, at: now };
             },
           }) as never,
       },
@@ -869,7 +869,7 @@ describe("CLI observer process lifecycle", () => {
               health: async () => {
                 if (!running) throw new Error("stopped");
                 return {
-                  schemaVersion: "0.11.0",
+                  schemaVersion: "0.12.0",
                   status: "healthy",
                   pid: 1234,
                   startedAt: now,
@@ -880,7 +880,7 @@ describe("CLI observer process lifecycle", () => {
               stop: async () => {
                 await new Promise((resolve) => setTimeout(resolve, 700));
                 running = false;
-                return { schemaVersion: "0.11.0", stopped: true, at: now };
+                return { schemaVersion: "0.12.0", stopped: true, at: now };
               },
             } as never;
           },
@@ -909,7 +909,7 @@ describe("CLI observer process lifecycle", () => {
               health: async () => {
                 if (!running) throw new Error("stopped");
                 return {
-                  schemaVersion: "0.11.0",
+                  schemaVersion: "0.12.0",
                   status: "healthy",
                   pid: 1234,
                   startedAt: now,
@@ -917,7 +917,7 @@ describe("CLI observer process lifecycle", () => {
               },
               stop: async () => {
                 running = false;
-                return { schemaVersion: "0.11.0", stopped: true, at: now };
+                return { schemaVersion: "0.12.0", stopped: true, at: now };
               },
             } as never;
           },
@@ -953,7 +953,7 @@ describe("CLI observer process lifecycle", () => {
             health: async () => {
               if (!running) throw new Error("stopped");
               return {
-                schemaVersion: "0.11.0",
+                schemaVersion: "0.12.0",
                 status: "healthy",
                 pid: version === exactOneBuildVersion ? 5678 : 1234,
                 startedAt: now,
@@ -963,7 +963,7 @@ describe("CLI observer process lifecycle", () => {
             stop: async () => {
               stops += 1;
               running = false;
-              return { schemaVersion: "0.11.0", stopped: true, at: now };
+              return { schemaVersion: "0.12.0", stopped: true, at: now };
             },
           }) as never,
       },
@@ -988,14 +988,14 @@ describe("CLI observer process lifecycle", () => {
           clientFactory: () =>
             ({
               health: async () => ({
-                schemaVersion: "0.11.0",
+                schemaVersion: "0.12.0",
                 status: "healthy",
                 startedAt: now,
                 version: "1.0.0",
               }),
               stop: async () => {
                 stops += 1;
-                return { schemaVersion: "0.11.0", stopped: true, at: now };
+                return { schemaVersion: "0.12.0", stopped: true, at: now };
               },
             }) as never,
         },
@@ -1032,7 +1032,7 @@ describe("CLI observer process lifecycle", () => {
             health: async () => {
               if (!running) throw new Error("stopped");
               return {
-                schemaVersion: "0.11.0",
+                schemaVersion: "0.12.0",
                 status: "healthy",
                 pid,
                 startedAt: now,
@@ -1044,7 +1044,7 @@ describe("CLI observer process lifecycle", () => {
               stops += 1;
               lifecycle.push("stop");
               running = false;
-              return { schemaVersion: "0.11.0", stopped: true, at: now };
+              return { schemaVersion: "0.12.0", stopped: true, at: now };
             },
           }) as never,
       },
@@ -1078,7 +1078,7 @@ describe("CLI observer process lifecycle", () => {
             health: async () => {
               if (!running) throw new Error("stopped");
               return {
-                schemaVersion: "0.11.0",
+                schemaVersion: "0.12.0",
                 status: "healthy",
                 pid: 1234,
                 startedAt: now,
@@ -1089,7 +1089,7 @@ describe("CLI observer process lifecycle", () => {
             stop: async () => {
               stops += 1;
               running = false;
-              return { schemaVersion: "0.11.0", stopped: true, at: now };
+              return { schemaVersion: "0.12.0", stopped: true, at: now };
             },
           }) as never,
       },
@@ -1135,7 +1135,7 @@ describe("CLI observer process lifecycle", () => {
               healthAttempts += 1;
               if (!spawned || healthAttempts < 3) {
                 return {
-                  schemaVersion: "0.11.0",
+                  schemaVersion: "0.12.0",
                   status: "healthy",
                   pid: 1234,
                   startedAt: now,
@@ -1144,7 +1144,7 @@ describe("CLI observer process lifecycle", () => {
                 };
               }
               return {
-                schemaVersion: "0.11.0",
+                schemaVersion: "0.12.0",
                 status: "healthy",
                 pid: 5678,
                 startedAt: now,
@@ -1186,7 +1186,7 @@ describe("CLI observer process lifecycle", () => {
         clientFactory: () =>
           ({
             health: async () => ({
-              schemaVersion: "0.11.0",
+              schemaVersion: "0.12.0",
               status: "healthy",
               ...identity,
             }),

--- a/apps/cli/test/unit/observer-process/setup-observer-activation.test.ts
+++ b/apps/cli/test/unit/observer-process/setup-observer-activation.test.ts
@@ -24,7 +24,7 @@ restartObserverSpy.mockImplementation(async () => ({
     stateDir: "unused",
   },
   health: {
-    schemaVersion: "0.11.0",
+    schemaVersion: "0.12.0",
     status: "healthy",
     pid: 1234,
     startedAt: now,

--- a/apps/cli/test/unit/observer-process/startup.test.ts
+++ b/apps/cli/test/unit/observer-process/startup.test.ts
@@ -17,7 +17,7 @@ const lowerBuildVersion = `1.0.0+station.${"b".repeat(64)}`;
 
 const healthyObserver = (pid = 1234, version = stationObserverBuildVersion()) =>
   ({
-    schemaVersion: "0.11.0",
+    schemaVersion: "0.12.0",
     status: "healthy",
     pid,
     startedAt: now,

--- a/apps/observer/src/commands/router.ts
+++ b/apps/observer/src/commands/router.ts
@@ -175,6 +175,7 @@ export function registerObserverCommandHandlers(
       core: options.core,
       providers: options.providers,
       clock: options.clock,
+      logger: options.logger,
     }),
     "terminal.close": createTerminalCloseHandler({
       providers: options.providers,

--- a/apps/observer/src/commands/terminal.ts
+++ b/apps/observer/src/commands/terminal.ts
@@ -9,6 +9,7 @@ import type { EventJournal, SessionStore } from "../persistence/index.js";
 import type { ProviderRegistry } from "../providers/registry.js";
 import type { ObserverCore } from "../reconcile/core.js";
 import type { ObserverEventBus } from "../runtime/eventBus.js";
+import type { StationLogger } from "../stationLogger.js";
 import { nowIso } from "../utils/time.js";
 import { assertCommandType } from "./assertCommand.js";
 import { throwIfAborted } from "./cancellation.js";
@@ -34,6 +35,7 @@ export type CreateTerminalFocusHandlerOptions = {
   core: ObserverCore;
   providers: ProviderRegistry;
   clock?: RuntimeClock | undefined;
+  logger?: StationLogger | undefined;
 };
 
 export type CreateTerminalCloseHandlerOptions = {
@@ -61,6 +63,7 @@ export function createTerminalFocusHandler(
       origin: context.command.payload.origin,
       context,
       clock: options.clock,
+      logger: options.logger,
     });
     throwIfAborted(context.signal);
   };

--- a/apps/observer/src/commands/terminalOperations.ts
+++ b/apps/observer/src/commands/terminalOperations.ts
@@ -5,7 +5,9 @@ import type {
   ProviderProjectConfig,
   SafeError,
   SessionView,
+  TerminalFocusOperationalEvent,
   TerminalFocusOrigin,
+  TerminalFocusResolutionEvidence,
   TerminalProvider,
   TerminalState,
   TerminalTargetObservation,
@@ -15,7 +17,7 @@ import type {
 import { terminalTargetObservationFromBinding } from "@station/contracts";
 import { type RuntimeClock, systemClock, toIsoTimestamp } from "@station/runtime";
 import { toSafeError } from "../diagnostics/errors.js";
-import type { StationLogger } from "../stationLogger.js";
+import type { StationLogger, StationOperationalEventRecord } from "../stationLogger.js";
 import { throwIfAborted } from "./cancellation.js";
 import type { HarnessLaunchPreflight } from "./harnessLaunchPreflight.js";
 import type { CommandHandlerContext } from "./queue.js";
@@ -142,7 +144,12 @@ export async function ensureAgentWorkspace(
   }
 }
 
-/** Resolves and focuses one provider-owned target from product session/worktree identity. */
+/**
+ * USE CASE
+ *
+ * Resolves fresh provider-owned target evidence from product identity, focuses the selected
+ * target with request-local origin context, and retains one bounded decision record.
+ */
 export async function focusTerminal(
   input: {
     terminal: TerminalProvider;
@@ -150,8 +157,13 @@ export async function focusTerminal(
     origin?: TerminalFocusOrigin | undefined;
   } & TerminalOperationRuntime,
 ): Promise<void> {
+  let resolution: TerminalTargetResolution | undefined;
   try {
-    const target = await resolveTerminalTarget(input);
+    resolution = await resolveTerminalTarget(input);
+    if (resolution.kind !== "selected") {
+      throw terminalTargetResolutionError(input.terminal.id, input.subject, resolution);
+    }
+    const selectedResolution = resolution;
     await runProviderMutation(
       {
         ...operationRuntime(input),
@@ -163,10 +175,14 @@ export async function focusTerminal(
           provider: input.terminal.id,
         },
       },
-      () => input.terminal.focusTarget(target.id, focusContext(input.origin)),
+      () => input.terminal.focusTarget(selectedResolution.target.id, focusContext(input.origin)),
     );
+    await recordTerminalFocusDecision(input, {
+      outcome: "focused",
+      resolution: selectedResolution,
+    });
   } catch (error) {
-    throw toSafeError(
+    const safeError = toSafeError(
       error,
       {
         tag: "TerminalProviderError",
@@ -174,8 +190,15 @@ export async function focusTerminal(
         message: "The terminal provider failed to focus the target.",
         provider: input.terminal.id,
       },
-      { commandId: input.context.commandId },
+      { commandId: input.context.commandId, traceId: input.context.trace.traceId },
     );
+    const failedDecision: TerminalFocusDecisionResult = {
+      outcome: "failed",
+      errorCode: safeError.code,
+    };
+    if (resolution !== undefined) failedDecision.resolution = resolution;
+    await recordTerminalFocusDecision(input, failedDecision);
+    throw safeError;
   }
 }
 
@@ -187,7 +210,10 @@ export async function closeTerminal(
   } & TerminalOperationRuntime,
 ): Promise<void> {
   try {
-    const target = await resolveTerminalTarget(input);
+    const resolution = await resolveTerminalTarget(input);
+    if (resolution.kind !== "selected") {
+      throw terminalTargetResolutionError(input.terminal.id, input.subject, resolution);
+    }
     await runProviderMutation(
       {
         ...operationRuntime(input),
@@ -199,7 +225,7 @@ export async function closeTerminal(
           provider: input.terminal.id,
         },
       },
-      () => input.terminal.closeTarget(target.id),
+      () => input.terminal.closeTarget(resolution.target.id),
     );
   } catch (error) {
     throw toSafeError(
@@ -247,7 +273,7 @@ async function resolveTerminalTarget(input: {
   subject: TerminalTargetSubject;
   context: CommandHandlerContext;
   clock?: RuntimeClock | undefined;
-}): Promise<TerminalTargetObservation> {
+}): Promise<TerminalTargetResolution> {
   const targets = await runProviderMutation(
     {
       ...operationRuntime(input),
@@ -277,12 +303,28 @@ async function resolveTerminalTarget(input: {
         ? left.stateRank - right.stateRank
         : left.identityRank - right.identityRank,
     );
-  const selected = ranked[0]?.target;
-  if (selected !== undefined) return selected;
-  if (matching.some((target) => target.state === "stale")) {
-    throw terminalTargetStaleError(input.terminal.id, input.subject);
+  const selected = ranked[0];
+  if (selected !== undefined) {
+    return {
+      kind: "selected",
+      target: selected.target,
+      selectionBasis: selected.selectionBasis,
+      totalTargetCount: targets.length,
+      matchingTargetCount: matching.length,
+    };
   }
-  throw terminalTargetMissingError(input.terminal.id, input.subject);
+  if (matching.some((target) => target.state === "stale")) {
+    return {
+      kind: "stale",
+      totalTargetCount: targets.length,
+      matchingTargetCount: matching.length,
+    };
+  }
+  return {
+    kind: "missing",
+    totalTargetCount: targets.length,
+    matchingTargetCount: matching.length,
+  };
 }
 
 async function closeOpenedTargetBestEffort(
@@ -403,7 +445,29 @@ type RankedTarget = {
   target: TerminalTargetObservation;
   identityRank: number;
   stateRank: number;
+  selectionBasis: TerminalTargetSelectionBasis;
 };
+
+type TerminalTargetSelectionBasis =
+  | "session-main-agent"
+  | "session"
+  | "worktree-main-agent"
+  | "worktree"
+  | "cwd-fallback";
+
+type TerminalTargetResolution =
+  | {
+      kind: "selected";
+      target: TerminalTargetObservation;
+      selectionBasis: TerminalTargetSelectionBasis;
+      totalTargetCount: number;
+      matchingTargetCount: number;
+    }
+  | {
+      kind: "stale" | "missing";
+      totalTargetCount: number;
+      matchingTargetCount: number;
+    };
 
 function targetMatchesSubject(input: {
   target: TerminalTargetObservation;
@@ -431,25 +495,35 @@ function rankedTarget(
   subject: TerminalTargetSubject,
 ): RankedTarget | undefined {
   const stateRank = targetStateRank(target.state);
-  const identityRank = targetIdentityRank(target, subject);
-  return stateRank === undefined || identityRank === undefined
+  const identity = targetIdentity(target, subject);
+  return stateRank === undefined || identity === undefined
     ? undefined
-    : { target, identityRank, stateRank };
+    : {
+        target,
+        identityRank: identity.rank,
+        stateRank,
+        selectionBasis: identity.basis,
+      };
 }
 
-function targetIdentityRank(
+function targetIdentity(
   target: TerminalTargetObservation,
   subject: TerminalTargetSubject,
-): number | undefined {
+): { rank: number; basis: TerminalTargetSelectionBasis } | undefined {
   const mainAgent = target.harnessBinding?.role === "main-agent";
-  if (subject.sessionId !== undefined && target.sessionId === subject.sessionId && mainAgent)
-    return 0;
-  if (subject.sessionId !== undefined && target.sessionId === subject.sessionId) return 1;
-  if (subject.worktreeId !== undefined && target.worktreeId === subject.worktreeId && mainAgent) {
-    return 2;
+  if (subject.sessionId !== undefined && target.sessionId === subject.sessionId && mainAgent) {
+    return { rank: 0, basis: "session-main-agent" };
   }
-  if (subject.worktreeId !== undefined && target.worktreeId === subject.worktreeId) return 3;
-  if (target.cwd !== undefined) return 4;
+  if (subject.sessionId !== undefined && target.sessionId === subject.sessionId) {
+    return { rank: 1, basis: "session" };
+  }
+  if (subject.worktreeId !== undefined && target.worktreeId === subject.worktreeId && mainAgent) {
+    return { rank: 2, basis: "worktree-main-agent" };
+  }
+  if (subject.worktreeId !== undefined && target.worktreeId === subject.worktreeId) {
+    return { rank: 3, basis: "worktree" };
+  }
+  if (target.cwd !== undefined) return { rank: 4, basis: "cwd-fallback" };
   return undefined;
 }
 
@@ -495,6 +569,100 @@ function terminalTargetStaleError(provider: string, subject: TerminalTargetSubje
   };
   assignSubject(error, subject);
   return error;
+}
+
+function terminalTargetResolutionError(
+  provider: string,
+  subject: TerminalTargetSubject,
+  resolution: Exclude<TerminalTargetResolution, { kind: "selected" }>,
+): SafeError {
+  return resolution.kind === "stale"
+    ? terminalTargetStaleError(provider, subject)
+    : terminalTargetMissingError(provider, subject);
+}
+
+type TerminalFocusDecisionResult =
+  | {
+      outcome: "focused";
+      resolution: Extract<TerminalTargetResolution, { kind: "selected" }>;
+    }
+  | {
+      outcome: "failed";
+      errorCode: string;
+      resolution?: TerminalTargetResolution | undefined;
+    };
+
+async function recordTerminalFocusDecision(
+  input: {
+    terminal: TerminalProvider;
+    subject: TerminalTargetSubject;
+    origin?: TerminalFocusOrigin | undefined;
+  } & TerminalOperationRuntime,
+  result: TerminalFocusDecisionResult,
+): Promise<void> {
+  if (input.logger === undefined) return;
+  let decision: TerminalFocusOperationalEvent["decision"];
+  if (result.outcome === "focused") {
+    decision = {
+      outcome: "focused",
+      hasOriginClientId: input.origin?.clientId !== undefined,
+      resolution: terminalFocusResolutionEvidence(result.resolution),
+    };
+  } else {
+    const failedDecision: Extract<
+      TerminalFocusOperationalEvent["decision"],
+      { outcome: "failed" }
+    > = {
+      outcome: "failed",
+      hasOriginClientId: input.origin?.clientId !== undefined,
+      errorCode: result.errorCode,
+    };
+    if (result.resolution !== undefined) {
+      failedDecision.resolution = terminalFocusResolutionEvidence(result.resolution);
+    }
+    decision = failedDecision;
+  }
+  if (input.origin?.provider !== undefined) decision.originProvider = input.origin.provider;
+  const record: StationOperationalEventRecord = {
+    level: "info",
+    commandId: input.context.commandId,
+    traceId: input.context.trace.traceId,
+    provider: input.terminal.id,
+    operationalEvent: {
+      kind: "terminal.focus.decision",
+      decision,
+    },
+  };
+  if (input.subject.projectId !== undefined) record.projectId = input.subject.projectId;
+  if (input.subject.worktreeId !== undefined) record.worktreeId = input.subject.worktreeId;
+  if (input.subject.sessionId !== undefined) record.sessionId = input.subject.sessionId;
+  await input.logger.recordOperationalEvent(record).catch(() => undefined);
+}
+
+function terminalFocusResolutionEvidence(
+  resolution: Extract<TerminalTargetResolution, { kind: "selected" }>,
+): Extract<TerminalFocusResolutionEvidence, { kind: "selected" }>;
+function terminalFocusResolutionEvidence(
+  resolution: TerminalTargetResolution,
+): TerminalFocusResolutionEvidence;
+function terminalFocusResolutionEvidence(
+  resolution: TerminalTargetResolution,
+): TerminalFocusResolutionEvidence {
+  if (resolution.kind !== "selected") {
+    return {
+      kind: resolution.kind,
+      totalTargetCount: resolution.totalTargetCount,
+      matchingTargetCount: resolution.matchingTargetCount,
+    };
+  }
+  return {
+    kind: "selected",
+    totalTargetCount: resolution.totalTargetCount,
+    matchingTargetCount: resolution.matchingTargetCount,
+    targetId: resolution.target.id,
+    targetState: resolution.target.state,
+    selectionBasis: resolution.selectionBasis,
+  };
 }
 
 function assignSubject(error: SafeError, subject: TerminalTargetSubject): void {

--- a/apps/observer/src/diagnostics/environmentCheck.ts
+++ b/apps/observer/src/diagnostics/environmentCheck.ts
@@ -6,32 +6,30 @@ import type {
 } from "@station/contracts";
 
 /**
- * Readable `stn doctor` summary of session terminal topology. Detached/stale
- * sessions or orphans warn; full per-session detail remains in the JSON snapshot.
+ * Readable `stn doctor` summary of session terminal topology and normalized
+ * capability evidence. Stale sessions or orphans warn; detached is lifecycle
+ * state rather than renderer-relative evidence of unreachability.
  */
 export function buildSessionEnvironmentCheck(
   snapshot: Pick<StationSnapshot, "sessions" | "orphans">,
 ): DoctorCheck {
   const sessions = snapshot.sessions;
   const orphans = snapshot.orphans ?? [];
-  const detached = sessions.filter(isDetachedOrStale);
+  const stale = sessions.filter((session) => session.terminal?.state === "stale");
 
   const parts = [`${sessions.length} session(s)${summarizeProviders(sessions)}.`];
-  if (detached.length > 0) {
-    parts.push(
-      `${detached.length} detached/stale (running, not attachable here): ${describeSessions(detached)}.`,
-    );
+  if (sessions.length > 0) {
+    parts.push(summarizeTerminalEvidence(sessions));
+  }
+  if (stale.length > 0) {
+    parts.push(`${stale.length} stale: ${describeSessions(stale)}.`);
   }
   if (orphans.length > 0) {
     parts.push(`${orphans.length} orphaned runtime state(s)${summarizeOrphans(orphans)}.`);
   }
 
-  const status: DoctorCheck["status"] = detached.length > 0 || orphans.length > 0 ? "warn" : "ok";
+  const status: DoctorCheck["status"] = stale.length > 0 || orphans.length > 0 ? "warn" : "ok";
   return { name: "sessions", status, message: parts.join(" ") };
-}
-
-function isDetachedOrStale(session: SessionView): boolean {
-  return session.terminal?.state === "detached" || session.terminal?.state === "stale";
 }
 
 /** ` — station: 4 open · tmux: 3 detached` (empty for zero sessions). */
@@ -57,6 +55,35 @@ function summarizeProviders(sessions: readonly SessionView[]): string {
     segments.push(`no terminal: ${withoutTerminal}`);
   }
   return ` — ${segments.join(" · ")}`;
+}
+
+function summarizeTerminalEvidence(sessions: readonly SessionView[]): string {
+  const focus = countEvidence(sessions, (session) => session.terminal?.focusable);
+  const managedAttachment = countEvidence(
+    sessions,
+    (session) => session.terminal?.hasManagedAttachment,
+  );
+  return `Terminal evidence — external focus: ${evidenceText(focus)} · managed attachment: ${evidenceText(managedAttachment)}.`;
+}
+
+type EvidenceCounts = { yes: number; no: number; unknown: number };
+
+function countEvidence(
+  sessions: readonly SessionView[],
+  select: (session: SessionView) => boolean | undefined,
+): EvidenceCounts {
+  const counts: EvidenceCounts = { yes: 0, no: 0, unknown: 0 };
+  for (const session of sessions) {
+    const evidence = select(session);
+    if (evidence === true) counts.yes += 1;
+    else if (evidence === false) counts.no += 1;
+    else counts.unknown += 1;
+  }
+  return counts;
+}
+
+function evidenceText(counts: EvidenceCounts): string {
+  return `${counts.yes} yes, ${counts.no} no, ${counts.unknown} unknown`;
 }
 
 const MAX_LISTED = 4;

--- a/apps/observer/src/reconcile/core.ts
+++ b/apps/observer/src/reconcile/core.ts
@@ -4,6 +4,7 @@ import type {
   ProviderHealth,
   ProviderProjectConfig,
   SessionGroupView,
+  SnapshotTerminalTargetDebug,
   StationEvent,
   StationSnapshot,
   WorktreeRow,
@@ -40,6 +41,7 @@ import {
   projectHarnessEventReportOntoSnapshot,
   type StatusProjectionResult,
 } from "./statusProjection.js";
+import { terminalTargetDebugFromObservations } from "./terminalTargetDebug.js";
 
 export type { ReconcileTiming } from "./reconcileResult.js";
 
@@ -61,7 +63,7 @@ export type ObserverCore = {
   clearTurnReadiness(input: { sessionId: string; token: string }): StationEvent | undefined;
   updateConfig(config: StationConfig): void;
   getProjects(): readonly ProviderProjectConfig[];
-  getSnapshot(): StationSnapshot;
+  getSnapshot(options?: { includeDebug?: boolean }): StationSnapshot;
   getHealth(): ObserverCoreHealth;
 };
 
@@ -97,6 +99,7 @@ export function createObserverCore(input: CreateObserverCoreInput): ObserverCore
   let snapshotWriterChain: Promise<void> = Promise.resolve();
   let providerHealth: Record<string, ProviderHealth> = {};
   let lastReconcile: ReconcileTiming | undefined;
+  let terminalTargetDebug: SnapshotTerminalTargetDebug[] = [];
   let snapshot = buildInitialSnapshot({
     generatedAt: startedAt,
     observer: { pid, startedAt, version },
@@ -141,6 +144,7 @@ export function createObserverCore(input: CreateObserverCoreInput): ObserverCore
         providerHealth = result.providerHealth;
         lastReconcile = result.lastReconcile;
         snapshot = result.snapshot;
+        terminalTargetDebug = terminalTargetDebugFromObservations(result.terminalTargets);
         return snapshot;
       };
 
@@ -316,7 +320,10 @@ export function createObserverCore(input: CreateObserverCoreInput): ObserverCore
       projects = providerProjectsFromConfig(nextConfig);
     },
     getProjects: () => projects,
-    getSnapshot: () => snapshot,
+    getSnapshot: (options) =>
+      options?.includeDebug === true
+        ? { ...snapshot, debug: { terminalTargets: terminalTargetDebug } }
+        : snapshot,
     getHealth: () => ({
       status: snapshot.observer.healthy ? "healthy" : "degraded",
       startedAt,

--- a/apps/observer/src/reconcile/graph.ts
+++ b/apps/observer/src/reconcile/graph.ts
@@ -438,6 +438,9 @@ function terminalAttachment(
   } else if (terminal.closeable === false || capabilities?.canCloseTarget === false) {
     attachment.closeable = false;
   }
+  if (terminal.hasManagedAttachment !== undefined) {
+    attachment.hasManagedAttachment = terminal.hasManagedAttachment;
+  }
   if (terminal.worktreeId !== undefined) attachment.hasWorkspace = true;
   if (hasPrimaryAgentEndpoint(terminal, harnessRun)) {
     attachment.hasPrimaryAgentEndpoint = true;

--- a/apps/observer/src/reconcile/run.ts
+++ b/apps/observer/src/reconcile/run.ts
@@ -55,6 +55,7 @@ type ReconcileOnceInput = {
 
 type ReconcileOnceResult = {
   snapshot: StationSnapshot;
+  terminalTargets: TerminalTargetObservation[];
   providerHealth: Record<string, ProviderHealth>;
   lastReconcile: ReconcileTiming;
 };
@@ -63,8 +64,8 @@ type ReconcileOnceResult = {
  * USE CASE
  *
  * Orchestrates provider reads, relationship correlation, durable harness-event repair and overlays,
- * cached metadata hydration, Group projection, snapshot assembly, and atomic session persistence.
- * The same resolved title records feed snapshot composition and atomic reconcile persistence.
+ * cached metadata hydration, Group projection, snapshot and sanitized-debug input assembly, and
+ * atomic session persistence. The same resolved title and terminal records feed every output.
  */
 export async function runReconcileOnce(input: ReconcileOnceInput): Promise<ReconcileOnceResult> {
   const started = toIsoTimestamp(input.read.clock.now());
@@ -158,6 +159,7 @@ export async function runReconcileOnce(input: ReconcileOnceInput): Promise<Recon
 
   return {
     snapshot,
+    terminalTargets: observations.terminalTargets,
     providerHealth,
     lastReconcile,
   };

--- a/apps/observer/src/reconcile/terminalTargetDebug.ts
+++ b/apps/observer/src/reconcile/terminalTargetDebug.ts
@@ -1,0 +1,30 @@
+import type { SnapshotTerminalTargetDebug, TerminalTargetObservation } from "@station/contracts";
+
+/** Builds the redaction-safe target evidence exposed only by opt-in debug snapshots. */
+export function terminalTargetDebugFromObservation(
+  target: TerminalTargetObservation,
+): SnapshotTerminalTargetDebug {
+  const debug: SnapshotTerminalTargetDebug = {
+    id: target.id,
+    provider: target.provider,
+    state: target.state,
+    confidence: target.confidence,
+    reason: target.reason,
+    observedAt: target.observedAt,
+  };
+  if (target.projectId !== undefined) debug.projectId = target.projectId;
+  if (target.worktreeId !== undefined) debug.worktreeId = target.worktreeId;
+  if (target.sessionId !== undefined) debug.sessionId = target.sessionId;
+  if (target.focusable !== undefined) debug.focusable = target.focusable;
+  if (target.closeable !== undefined) debug.closeable = target.closeable;
+  if (target.hasManagedAttachment !== undefined) {
+    debug.hasManagedAttachment = target.hasManagedAttachment;
+  }
+  return debug;
+}
+
+export function terminalTargetDebugFromObservations(
+  targets: readonly TerminalTargetObservation[],
+): SnapshotTerminalTargetDebug[] {
+  return targets.map(terminalTargetDebugFromObservation);
+}

--- a/apps/observer/src/runtime/api.ts
+++ b/apps/observer/src/runtime/api.ts
@@ -7,6 +7,7 @@ import type {
   DoctorOptions,
   DoctorReport,
   EventFilter,
+  ExternalLaunchPreparationOperationalEvent,
   HarnessEventReport,
   HarnessEventReportReceipt,
   ObserverApi,
@@ -68,7 +69,7 @@ import type { ObserverPersistenceBundle, PersistenceHealthSource } from "../pers
 import type { ProviderRegistry } from "../providers/registry.js";
 import { type ObserverCore, providerProjectsFromConfig } from "../reconcile/core.js";
 import { inspectObserverRecoveryInventory } from "../sessionRecoveryInventory.js";
-import type { StationLogger } from "../stationLogger.js";
+import type { StationLogger, StationOperationalEventRecord } from "../stationLogger.js";
 import {
   createWorktreeMutationCoordinator,
   type WorktreeMutationCoordinator,
@@ -277,7 +278,7 @@ export function createObserverApi(options: CreateObserverApiOptions): ObserverAp
         stopProviderHealthPublication,
         clock,
       ),
-    getSnapshot: async () => options.core.getSnapshot(),
+    getSnapshot: async (snapshotOptions) => options.core.getSnapshot(snapshotOptions),
     getSessionRecoveryReadiness: async () => sessionRecoveryReadiness(options),
     getSessionRecoveryInventory: (): Promise<ObserverRecoveryInventory> =>
       inspectObserverRecoveryInventory({
@@ -381,6 +382,10 @@ async function prepareExternalLaunchSafe(
       code: "EXTERNAL_LAUNCH_PREPARE_FAILED",
       message: "External agent launch preparation failed.",
     });
+    await recordExternalLaunchPreparationDecision(options.logger, params, {
+      outcome: "failed",
+      errorCode: error.code,
+    });
     if (error.code === "HARNESS_HOOKS_NOT_INSTALLED") {
       const attributes: Record<string, unknown> = {
         error,
@@ -396,11 +401,60 @@ async function prepareExternalLaunchSafe(
     }
     throw cause;
   }
-  const { outcome, reconcile } = result;
+  const { outcome, reconcile, decision } = result;
+  await recordExternalLaunchPreparationDecision(options.logger, params, {
+    outcome: "prepared",
+    decision,
+  });
   if (reconcile) {
     reconcileScheduler.request("agent.prepareExternalLaunch");
   }
   return outcome;
+}
+
+async function recordExternalLaunchPreparationDecision(
+  logger: StationLogger | undefined,
+  params: Parameters<ObserverApi["prepareExternalLaunch"]>[0],
+  result:
+    | {
+        outcome: "prepared";
+        decision: Awaited<ReturnType<typeof prepareExternalLaunch>>["decision"];
+      }
+    | { outcome: "failed"; errorCode: string },
+): Promise<void> {
+  if (logger === undefined) return;
+  let decision: ExternalLaunchPreparationOperationalEvent["decision"];
+  if (result.outcome === "prepared") {
+    const preparedDecision: Extract<
+      ExternalLaunchPreparationOperationalEvent["decision"],
+      { outcome: "prepared" }
+    > = {
+      outcome: "prepared",
+      route: result.decision.route,
+    };
+    if (result.decision.terminalTargetId !== undefined) {
+      preparedDecision.terminalTargetId = result.decision.terminalTargetId;
+    }
+    decision = preparedDecision;
+  } else {
+    decision = { outcome: "failed", errorCode: result.errorCode };
+  }
+  const record: StationOperationalEventRecord = {
+    level: "info",
+    projectId: params.projectId,
+    worktreeId: params.worktreeId,
+    operationalEvent: {
+      kind: "agent.prepareExternalLaunch.decision",
+      decision,
+    },
+  };
+  if (result.outcome === "prepared") {
+    record.sessionId = result.decision.sessionId;
+    if (result.decision.terminalProvider !== undefined) {
+      record.provider = result.decision.terminalProvider;
+    }
+  }
+  await logger.recordOperationalEvent(record).catch(() => undefined);
 }
 
 async function reportExternalExitSafe(

--- a/apps/observer/src/runtime/externalLaunch.ts
+++ b/apps/observer/src/runtime/externalLaunch.ts
@@ -3,6 +3,7 @@ import type {
   AgentPrepareExternalLaunchResult,
   AgentReportExternalExitParams,
   AgentReportExternalExitResult,
+  ExternalLaunchPreparationRoute,
   ManagedOpenWorkspaceResult,
   ManagedTerminalLifecycle,
   SafeError,
@@ -51,21 +52,35 @@ export type ExternalLaunchOutcome<T> = {
   reconcile: boolean;
 };
 
+export type ExternalLaunchPreparationDecision = {
+  route: ExternalLaunchPreparationRoute;
+  sessionId: string;
+  terminalProvider?: string | undefined;
+  terminalTargetId?: string | undefined;
+};
+
+export type PrepareExternalLaunchOutcome =
+  ExternalLaunchOutcome<AgentPrepareExternalLaunchResult> & {
+    decision: ExternalLaunchPreparationDecision;
+  };
+
 /**
  * USE CASE
  *
  * Returns a live or attachable managed identity first, then exactly recovers the canonical open
  * Station session unless explicit, identity-bound user consent requests a fresh provider execution.
  * Recovery retains that session's identity and durable state, passes only provider-neutral resume
- * options, and releases only its replacement target generation on failure. Both launch paths
- * preflight only the selected provider. A fresh Station identity is atomically seeded with explicit
- * root placement or the requested source session's current Group before target publication, and
- * confirmed failed launch cleanup removes only its membership and owned inline Group.
+ * options, and releases only its replacement target generation on failure. The provider-neutral
+ * preparation decision distinguishes attachment, live-session, managed-process, and caller-owned
+ * launch routes without claiming the client landed. Both launch paths preflight only the selected
+ * provider. A fresh Station identity is atomically seeded with explicit root placement or the
+ * requested source session's current Group before target publication, and confirmed failed launch
+ * cleanup removes only its membership and owned inline Group.
  */
 export async function prepareExternalLaunch(
   deps: ExternalLaunchDeps,
   params: AgentPrepareExternalLaunchParams,
-): Promise<ExternalLaunchOutcome<AgentPrepareExternalLaunchResult>> {
+): Promise<PrepareExternalLaunchOutcome> {
   return deps.worktreeMutations.run(params.projectId, params.worktreeId, () =>
     prepareExternalLaunchForWorktree(deps, params),
   );
@@ -74,7 +89,7 @@ export async function prepareExternalLaunch(
 async function prepareExternalLaunchForWorktree(
   deps: ExternalLaunchDeps,
   params: AgentPrepareExternalLaunchParams,
-): Promise<ExternalLaunchOutcome<AgentPrepareExternalLaunchResult>> {
+): Promise<PrepareExternalLaunchOutcome> {
   const project = findProjectOrThrow(deps.core.getProjects(), params.projectId);
   const snapshot = deps.core.getSnapshot();
   const row = snapshot.rows.find((candidate) => candidate.id === params.worktreeId);
@@ -115,6 +130,12 @@ async function prepareExternalLaunchForWorktree(
             attachment,
           },
           reconcile: false,
+          decision: {
+            route: "existing-managed-attachment",
+            sessionId: target.sessionId,
+            terminalProvider: managedTerminal.id,
+            terminalTargetId: target.id,
+          },
         };
       }
     }
@@ -127,6 +148,13 @@ async function prepareExternalLaunchForWorktree(
     if (agent?.sessionId === undefined) {
       throw sessionAlreadyHasAgentError(row.id);
     }
+    const decision: ExternalLaunchPreparationDecision = {
+      route: "existing-live-session-without-attachment",
+      sessionId: agent.sessionId,
+    };
+    if (row.terminal?.provider !== undefined) {
+      decision.terminalProvider = row.terminal.provider;
+    }
     return {
       outcome: {
         kind: "existing-session",
@@ -134,6 +162,7 @@ async function prepareExternalLaunchForWorktree(
         harnessProvider: agent.harness,
       },
       reconcile: false,
+      decision,
     };
   }
 
@@ -155,7 +184,7 @@ async function prepareExternalLaunchForWorktree(
             target.sessionId !== undefined,
         )
       : undefined;
-  if (concurrentManagedTarget?.sessionId !== undefined) {
+  if (managedTerminal !== undefined && concurrentManagedTarget?.sessionId !== undefined) {
     return {
       outcome: {
         kind: "existing-session",
@@ -164,6 +193,12 @@ async function prepareExternalLaunchForWorktree(
           concurrentManagedTarget.harnessBinding?.harnessProvider ?? project.defaults.harness,
       },
       reconcile: false,
+      decision: {
+        route: "existing-live-session-without-attachment",
+        sessionId: concurrentManagedTarget.sessionId,
+        terminalProvider: managedTerminal.id,
+        terminalTargetId: concurrentManagedTarget.id,
+      },
     };
   }
 
@@ -306,6 +341,12 @@ async function prepareExternalLaunchForWorktree(
     return {
       outcome,
       reconcile: true,
+      decision: {
+        route: launched.started ? "prepared-managed-attachment" : "prepared-caller-owned",
+        sessionId,
+        terminalProvider: managedTerminal.id,
+        terminalTargetId: opened.target.targetId,
+      },
     };
   } catch (error) {
     const targetReleaseConfirmed = await releaseOpenedTargetBestEffort({

--- a/apps/observer/src/runtime/logging.ts
+++ b/apps/observer/src/runtime/logging.ts
@@ -1,3 +1,4 @@
+import type { ObserverOperationalEvent } from "@station/contracts";
 import { componentLogPath, createJsonlLogger } from "@station/observability";
 import type { RuntimeClock } from "@station/runtime";
 import type { StationLogger } from "../stationLogger.js";
@@ -18,6 +19,12 @@ export function createObserverLogger(input: {
     ...(input.clock === undefined ? {} : { clock: input.clock }),
   });
   return {
+    async recordOperationalEvent(record) {
+      await logger.log({
+        ...record,
+        message: operationalEventMessage(record.operationalEvent),
+      });
+    },
     async info(message, attributes) {
       await logger.info(message, attributes);
     },
@@ -28,4 +35,13 @@ export function createObserverLogger(input: {
       await logger.error(message, attributes);
     },
   };
+}
+
+function operationalEventMessage(event: ObserverOperationalEvent): string {
+  switch (event.kind) {
+    case "terminal.focus.decision":
+      return "Terminal focus decision recorded.";
+    case "agent.prepareExternalLaunch.decision":
+      return "External launch preparation decision recorded.";
+  }
 }

--- a/apps/observer/src/stationLogger.ts
+++ b/apps/observer/src/stationLogger.ts
@@ -1,10 +1,23 @@
+import type { LogLevel, LogRecord, ObserverOperationalEvent } from "@station/contracts";
+
+export type StationOperationalEventRecord = {
+  level: LogLevel;
+  operationalEvent: ObserverOperationalEvent;
+} & Partial<
+  Pick<
+    LogRecord,
+    "traceId" | "spanId" | "commandId" | "projectId" | "worktreeId" | "sessionId" | "provider"
+  >
+>;
+
 /**
  * DRIVEN PORT
  *
- * Records Observer operational events without exposing their storage
- * representation or destination.
+ * Records typed operational evidence and narrative messages without exposing
+ * their storage representation or destination.
  */
 export interface StationLogger {
+  recordOperationalEvent(record: StationOperationalEventRecord): Promise<void>;
   info(message: string, attributes?: Record<string, unknown>): Promise<void>;
   warn(message: string, attributes?: Record<string, unknown>): Promise<void>;
   error(message: string, attributes?: Record<string, unknown>): Promise<void>;

--- a/apps/observer/test/integration/diagnostics-collector.test.ts
+++ b/apps/observer/test/integration/diagnostics-collector.test.ts
@@ -39,7 +39,7 @@ describe("observer diagnostics collector", () => {
       };
 
       await expect(collectDiagnosticSnapshot(deps)).resolves.toMatchObject({
-        schemaVersion: "0.11.0",
+        schemaVersion: "0.12.0",
         observerHealth: {
           stateDir: "memory://state",
           socketPath: "memory://observer-socket",

--- a/apps/observer/test/integration/external-launch-reconcile.test.ts
+++ b/apps/observer/test/integration/external-launch-reconcile.test.ts
@@ -30,7 +30,7 @@ import {
   ProviderRegistry,
   providerIngressSpoolDir,
 } from "../../src/internal";
-import type { StationLogger } from "../../src/stationLogger";
+import type { StationLogger, StationOperationalEventRecord } from "../../src/stationLogger";
 import { FakeDiagnosticEvidenceSource } from "../support/diagnosticEvidenceSources.js";
 
 const now = "2026-05-20T12:00:00.000Z";
@@ -222,7 +222,11 @@ describe("observer external-launch reconcile", () => {
   it("logs hook readiness rejections with their diagnostic code", async () => {
     const stateDir = await mkdtemp(join(tmpdir(), "station-observer-ext-"));
     const records: Array<{ message: string; attributes?: Record<string, unknown> }> = [];
+    const operationalRecords: StationOperationalEventRecord[] = [];
     const logger: StationLogger = {
+      recordOperationalEvent: async (record) => {
+        operationalRecords.push(record);
+      },
       info: async () => {},
       warn: async (message, attributes) => {
         records.push({ message, ...(attributes === undefined ? {} : { attributes }) });
@@ -238,6 +242,18 @@ describe("observer external-launch reconcile", () => {
     await expect(
       fixture.api.prepareExternalLaunch({ projectId: "web", worktreeId: "wt_web_feature" }),
     ).rejects.toMatchObject({ code: "HARNESS_HOOKS_NOT_INSTALLED" });
+    expect(operationalRecords).toContainEqual({
+      level: "info",
+      projectId: "web",
+      worktreeId: "wt_web_feature",
+      operationalEvent: {
+        kind: "agent.prepareExternalLaunch.decision",
+        decision: {
+          outcome: "failed",
+          errorCode: "HARNESS_HOOKS_NOT_INSTALLED",
+        },
+      },
+    });
     expect(records).toContainEqual({
       message: "External agent launch rejected because harness hooks are unavailable.",
       attributes: {
@@ -247,6 +263,49 @@ describe("observer external-launch reconcile", () => {
       },
     });
 
+    fixture.sqlite.close();
+  });
+
+  it("logs the provider-neutral external launch preparation route", async () => {
+    const stateDir = await mkdtemp(join(tmpdir(), "station-observer-ext-"));
+    const records: Array<{ message: string; attributes?: Record<string, unknown> }> = [];
+    const operationalRecords: StationOperationalEventRecord[] = [];
+    const logger: StationLogger = {
+      recordOperationalEvent: async (record) => {
+        operationalRecords.push(record);
+      },
+      info: async (message, attributes) => {
+        records.push({ message, ...(attributes === undefined ? {} : { attributes }) });
+      },
+      warn: async (message, attributes) => {
+        records.push({ message, ...(attributes === undefined ? {} : { attributes }) });
+      },
+      error: async () => {},
+    };
+    const fixture = createFixture(providerIngressSpoolDir(stateDir), { logger });
+    await fixture.api.reconcile("seed");
+
+    const result = await fixture.api.prepareExternalLaunch({
+      projectId: "web",
+      worktreeId: "wt_web_feature",
+    });
+    if (result.kind !== "prepared") throw new Error("expected prepared launch");
+
+    expect(operationalRecords).toContainEqual({
+      level: "info",
+      projectId: "web",
+      worktreeId: "wt_web_feature",
+      sessionId: result.sessionId,
+      provider: "native",
+      operationalEvent: {
+        kind: "agent.prepareExternalLaunch.decision",
+        decision: {
+          outcome: "prepared",
+          route: "prepared-caller-owned",
+          terminalTargetId: "native:wt_web_feature",
+        },
+      },
+    });
     fixture.sqlite.close();
   });
 

--- a/apps/observer/test/integration/in-memory-observer-api.test.ts
+++ b/apps/observer/test/integration/in-memory-observer-api.test.ts
@@ -134,6 +134,27 @@ describe("Observer API composition with in-memory persistence", () => {
         },
       ],
     });
+    expect(initial.snapshot).not.toHaveProperty("debug");
+    await expect(api.getSnapshot()).resolves.not.toHaveProperty("debug");
+    await expect(api.getSnapshot({ includeDebug: false })).resolves.not.toHaveProperty("debug");
+    const debugSnapshot = await api.getSnapshot({ includeDebug: true });
+    expect(debugSnapshot).toMatchObject({
+      debug: {
+        terminalTargets: [
+          {
+            id: "term_web_task",
+            provider: "fake-terminal",
+            projectId: "web",
+            worktreeId: "wt_web_task",
+            sessionId: "ses_web_task",
+            focusable: true,
+            closeable: true,
+            hasManagedAttachment: false,
+          },
+        ],
+      },
+    });
+    expect(debugSnapshot.debug?.terminalTargets[0]).not.toHaveProperty("providerData");
     await initialEvents.return?.();
     await waitFor(() => worktreeChangeSource.requests.length > 0);
     expect(worktreeChangeSource.requests[0]?.target).toMatchObject({
@@ -417,6 +438,10 @@ function fakeProviders(): ProviderRegistry {
           sessionId: "ses_web_task",
           harnessRunId: "run_web_task",
           cwd: "/tmp/station/web/task",
+          focusable: true,
+          closeable: true,
+          hasManagedAttachment: false,
+          providerData: { paneId: "%private" },
           harnessBinding: { role: "main-agent", harnessProvider: "fake-harness" },
           now,
         }),

--- a/apps/observer/test/integration/reconcile-persistence.test.ts
+++ b/apps/observer/test/integration/reconcile-persistence.test.ts
@@ -636,6 +636,7 @@ describe("observer reconcile persistence", () => {
       persistence,
       clock,
       logger: {
+        recordOperationalEvent: async () => undefined,
         info: async () => undefined,
         warn: async () => undefined,
         error: async (message, attributes) => {

--- a/apps/observer/test/integration/reconcile-station-terminal.test.ts
+++ b/apps/observer/test/integration/reconcile-station-terminal.test.ts
@@ -88,6 +88,7 @@ describe("observer reconcile with a station-hosted target", () => {
     // does not dispatch a focus/close the station provider can only reject.
     expect(stationRow?.terminal?.focusable).toBe(false);
     expect(stationRow?.terminal?.closeable).toBe(false);
+    expect(stationRow?.terminal?.hasManagedAttachment).toBe(false);
 
     // Reporting exit drops only the station target; the tmux session survives.
     await expect(
@@ -160,9 +161,19 @@ describe("observer reconcile with a station-hosted target", () => {
     const stationSession = snapshot.sessions.find((session) => session.id === "ses_station");
     expect(stationSession).toMatchObject({
       worktreeId: "wt_web_station",
-      terminal: { provider: "native", closeable: true },
+      terminal: { provider: "native", closeable: true, hasManagedAttachment: true },
     });
     expect(stationSession?.terminal?.focusable).toBe(false);
+    expect(core.getSnapshot({ includeDebug: true }).debug?.terminalTargets).toContainEqual(
+      expect.objectContaining({
+        id: stationTargetId("wt_web_station"),
+        provider: "native",
+        sessionId: "ses_station",
+        focusable: false,
+        closeable: true,
+        hasManagedAttachment: true,
+      }),
+    );
 
     // Observer-restart proxy: a fresh provider has no in-memory targets and must
     // rebuild the same non-focusable projection from host.list.
@@ -176,7 +187,7 @@ describe("observer reconcile with a station-hosted target", () => {
     const rebuiltSession = rebuiltSnapshot.sessions.find((session) => session.id === "ses_station");
     expect(rebuiltSession).toMatchObject({
       worktreeId: "wt_web_station",
-      terminal: { provider: "native", closeable: true },
+      terminal: { provider: "native", closeable: true, hasManagedAttachment: true },
     });
     expect(rebuiltSession?.terminal?.focusable).toBe(false);
   });
@@ -250,6 +261,7 @@ describe("observer reconcile with a station-hosted target", () => {
     expect(stationRow?.terminal?.provider).toBe("native");
     expect(stationRow?.terminal?.focusable).toBe(false);
     expect(stationRow?.terminal?.closeable).toBe(false);
+    expect(stationRow?.terminal?.hasManagedAttachment).toBe(false);
   });
 
   it("re-derives multiple station sessions from distinct host PTYs", async () => {

--- a/apps/observer/test/unit/environmentCheck.test.ts
+++ b/apps/observer/test/unit/environmentCheck.test.ts
@@ -2,9 +2,14 @@ import type { OrphanedRuntimeState, SessionView } from "@station/contracts";
 import { describe, expect, it } from "vitest";
 import { buildSessionEnvironmentCheck } from "../../src/diagnostics/environmentCheck";
 
-function session(title: string, provider: string, state: string): SessionView {
+function session(
+  title: string,
+  provider: string,
+  state: string,
+  evidence: Partial<NonNullable<SessionView["terminal"]>> = {},
+): SessionView {
   // Only `title` and `terminal.{provider,state}` are read by the check.
-  return { title, terminal: { provider, state } } as unknown as SessionView;
+  return { title, terminal: { provider, state, ...evidence } } as unknown as SessionView;
 }
 
 function sessionWithoutTerminal(title: string): SessionView {
@@ -29,7 +34,9 @@ describe("buildSessionEnvironmentCheck", () => {
       orphans: [],
     });
     expect(check.status).toBe("ok");
-    expect(check.message).toBe("2 session(s) — native: 2 open.");
+    expect(check.message).toBe(
+      "2 session(s) — native: 2 open. Terminal evidence — external focus: 0 yes, 0 no, 2 unknown · managed attachment: 0 yes, 0 no, 2 unknown.",
+    );
   });
 
   it("reports canonical sessions that have no observed terminal", () => {
@@ -39,32 +46,37 @@ describe("buildSessionEnvironmentCheck", () => {
     });
 
     expect(check.status).toBe("ok");
-    expect(check.message).toBe("1 session(s) — no terminal: 1.");
+    expect(check.message).toBe(
+      "1 session(s) — no terminal: 1. Terminal evidence — external focus: 0 yes, 0 no, 1 unknown · managed attachment: 0 yes, 0 no, 1 unknown.",
+    );
   });
 
-  it("warns and names detached sessions with their provider (the silent-click case)", () => {
+  it("reports detached sessions without claiming they are unreachable", () => {
     const check = buildSessionEnvironmentCheck({
       sessions: [
-        session("adc0a0", "native", "open"),
-        session("b83b75", "tmux", "detached"),
-        session("ui-explore", "tmux", "detached"),
+        session("adc0a0", "native", "open", {
+          focusable: false,
+          hasManagedAttachment: true,
+        }),
+        session("b83b75", "tmux", "detached", { focusable: true }),
+        session("ui-explore", "tmux", "detached", { focusable: true }),
       ],
       orphans: [],
     });
-    expect(check.status).toBe("warn");
+    expect(check.status).toBe("ok");
     expect(check.message).toContain("native: 1 open · tmux: 2 detached");
-    expect(check.message).toContain("2 detached/stale (running, not attachable here):");
-    expect(check.message).toContain("b83b75 [tmux]");
-    expect(check.message).toContain("ui-explore [tmux]");
+    expect(check.message).toContain("external focus: 2 yes, 1 no, 0 unknown");
+    expect(check.message).toContain("managed attachment: 1 yes, 0 no, 2 unknown");
+    expect(check.message).not.toContain("not attachable here");
   });
 
-  it("treats stale terminals as detached/stale too", () => {
+  it("warns and names stale terminals", () => {
     const check = buildSessionEnvironmentCheck({
       sessions: [session("x", "native", "stale")],
       orphans: [],
     });
     expect(check.status).toBe("warn");
-    expect(check.message).toContain("1 detached/stale");
+    expect(check.message).toContain("1 stale: x [native]");
   });
 
   it("warns on orphaned runtime states and counts them by kind", () => {
@@ -76,10 +88,10 @@ describe("buildSessionEnvironmentCheck", () => {
     expect(check.message).toContain("2 orphaned runtime state(s) (1 session, 1 terminal_target).");
   });
 
-  it("truncates the detached list past four with a +N more suffix", () => {
-    const detached = ["a", "b", "c", "d", "e", "f"].map((t) => session(t, "tmux", "detached"));
-    const check = buildSessionEnvironmentCheck({ sessions: detached, orphans: [] });
-    expect(check.message).toContain("6 detached/stale");
+  it("truncates the stale list past four with a +N more suffix", () => {
+    const stale = ["a", "b", "c", "d", "e", "f"].map((title) => session(title, "tmux", "stale"));
+    const check = buildSessionEnvironmentCheck({ sessions: stale, orphans: [] });
+    expect(check.message).toContain("6 stale");
     expect(check.message).toContain("+2 more");
   });
 });

--- a/apps/observer/test/unit/external-launch.test.ts
+++ b/apps/observer/test/unit/external-launch.test.ts
@@ -510,6 +510,12 @@ describe("prepareExternalLaunch", () => {
     expect(result.outcome.launchPlan.provider).toBe("fake-harness");
     expect(result.outcome.launchPlan.env?.STATION_SESSION_ID).toBe(result.outcome.sessionId);
     expect(result.outcome).not.toHaveProperty("outputCompatibility");
+    expect(result.decision).toEqual({
+      route: "prepared-caller-owned",
+      sessionId: result.outcome.sessionId,
+      terminalProvider: "managed-test",
+      terminalTargetId: managedTargetId("wt_web_feature"),
+    });
 
     // Exactly one station target was registered for the worktree.
     const targets = await station.listTargets();
@@ -725,6 +731,12 @@ describe("prepareExternalLaunch", () => {
         attachment,
       },
       reconcile: false,
+      decision: {
+        route: "existing-managed-attachment",
+        sessionId: first.outcome.sessionId,
+        terminalProvider: "managed-test",
+        terminalTargetId: managedTargetId("wt_web_feature"),
+      },
     });
     expect(await station.listTargets()).toHaveLength(1);
     await expect(secondDeps.persistence.listWorktreeDisplayTitles()).resolves.toEqual([]);
@@ -749,6 +761,10 @@ describe("prepareExternalLaunch", () => {
         harnessProvider: "fake-harness",
       },
       reconcile: false,
+      decision: {
+        route: "existing-live-session-without-attachment",
+        sessionId: "ses_existing",
+      },
     });
     // No title or target is created when an agent already exists.
     expect(persistence.seeded).toEqual([]);
@@ -1192,6 +1208,10 @@ describe("prepareExternalLaunch", () => {
         harnessProvider: "fake-harness",
       },
       reconcile: false,
+      decision: {
+        route: "existing-live-session-without-attachment",
+        sessionId: "ses_replacement",
+      },
     });
     await expect(persistence.listSessionRecoveryHandles()).resolves.toEqual([persistedHandle]);
     expect(harness.healthCalls).toBe(0);
@@ -1229,6 +1249,12 @@ describe("prepareExternalLaunch", () => {
         attachment,
       },
       reconcile: false,
+      decision: {
+        route: "existing-managed-attachment",
+        sessionId: "ses_replacement",
+        terminalProvider: "managed-test",
+        terminalTargetId: managedTargetId("wt_web_feature"),
+      },
     });
     expect(harness.healthCalls).toBe(0);
     expect(harness.hooksCalls).toBe(0);
@@ -1482,6 +1508,10 @@ describe("prepareExternalLaunch", () => {
         harnessProvider: "fake-harness",
       },
       reconcile: false,
+      decision: {
+        route: "existing-live-session-without-attachment",
+        sessionId: "ses_existing",
+      },
     });
   });
 
@@ -1966,6 +1996,12 @@ describe("prepareExternalLaunch managed attachments", () => {
     if (result.outcome.kind !== "prepared") throw new Error("expected prepared");
     expect(result.outcome.attachment).toBe(attachment);
     expect(result.outcome).not.toHaveProperty("outputCompatibility");
+    expect(result.decision).toEqual({
+      route: "prepared-managed-attachment",
+      sessionId: result.outcome.sessionId,
+      terminalProvider: "managed-test",
+      terminalTargetId: managedTargetId("wt_web_feature"),
+    });
   });
 
   it("passes the adapter's opaque attachment through to an existing-session result", async () => {
@@ -2009,6 +2045,12 @@ describe("prepareExternalLaunch managed attachments", () => {
         },
       },
       reconcile: false,
+      decision: {
+        route: "existing-managed-attachment",
+        sessionId: "ses_replacement",
+        terminalProvider: "managed-test",
+        terminalTargetId: managedTargetId("wt_web_feature"),
+      },
     });
   });
 

--- a/apps/observer/test/unit/git-ref-invalidation.test.ts
+++ b/apps/observer/test/unit/git-ref-invalidation.test.ts
@@ -295,6 +295,7 @@ async function createWatchFixture(
 
 function testLogger(warn: StationLogger["warn"]): StationLogger {
   return {
+    recordOperationalEvent: async () => undefined,
     info: async () => undefined,
     warn,
     error: async () => undefined,

--- a/apps/observer/test/unit/graph.test.ts
+++ b/apps/observer/test/unit/graph.test.ts
@@ -984,6 +984,7 @@ describe("observer graph derivation", () => {
     const target = terminal("term_idle", "wt_web_idle", "run_idle");
     target.focusable = false;
     target.closeable = false;
+    target.hasManagedAttachment = true;
 
     const snapshot = build({
       worktrees: [worktree("wt_web_idle", "web", "idle")],
@@ -995,6 +996,7 @@ describe("observer graph derivation", () => {
     expect(terminalAttachment?.provider).toBe("fake-terminal");
     expect(terminalAttachment?.focusable).toBe(false);
     expect(terminalAttachment?.closeable).toBe(false);
+    expect(terminalAttachment?.hasManagedAttachment).toBe(true);
     expect(StationSnapshotSchema.parse(snapshot)).toEqual(snapshot);
   });
 

--- a/apps/observer/test/unit/harnessReportProcessor.test.ts
+++ b/apps/observer/test/unit/harnessReportProcessor.test.ts
@@ -23,6 +23,7 @@ describe("harness report processor logging", () => {
     const records: LogRecord[] = [];
     const snapshot = emptyStationSnapshot(now);
     const logger: StationLogger = {
+      recordOperationalEvent: () => Promise.resolve(),
       info: (message, attributes) => {
         records.push({ message, attributes });
         return Promise.resolve();

--- a/apps/observer/test/unit/logging.test.ts
+++ b/apps/observer/test/unit/logging.test.ts
@@ -13,7 +13,31 @@ describe("Observer logging adapter", () => {
       clock: { now: () => new Date("2026-05-20T12:00:00.000Z") },
     });
 
-    expect(Object.keys(logger).sort()).toEqual(["error", "info", "warn"]);
+    expect(Object.keys(logger).sort()).toEqual(["error", "info", "recordOperationalEvent", "warn"]);
+    await expect(
+      logger.recordOperationalEvent({
+        level: "info",
+        commandId: "cmd_focus",
+        traceId: "trace_focus",
+        projectId: "web",
+        worktreeId: "wt_web_feature",
+        sessionId: "ses_web_feature",
+        provider: "tmux",
+        operationalEvent: {
+          kind: "terminal.focus.decision",
+          decision: {
+            outcome: "failed",
+            hasOriginClientId: false,
+            errorCode: "TERMINAL_TARGET_MISSING",
+            resolution: {
+              kind: "missing",
+              totalTargetCount: 1,
+              matchingTargetCount: 0,
+            },
+          },
+        },
+      }),
+    ).resolves.toBeUndefined();
     await expect(
       logger.info("Observer ready.", { token: "sk-secret000000000000" }),
     ).resolves.toBeUndefined();
@@ -21,6 +45,23 @@ describe("Observer logging adapter", () => {
     await expect(logger.error("Observer failed.")).resolves.toBeUndefined();
 
     await expect(readJsonlLog(componentLogPath(stateDir, "observer"))).resolves.toEqual([
+      expect.objectContaining({
+        level: "info",
+        message: "Terminal focus decision recorded.",
+        commandId: "cmd_focus",
+        traceId: "trace_focus",
+        projectId: "web",
+        worktreeId: "wt_web_feature",
+        sessionId: "ses_web_feature",
+        provider: "tmux",
+        operationalEvent: expect.objectContaining({
+          kind: "terminal.focus.decision",
+          decision: expect.objectContaining({
+            outcome: "failed",
+            errorCode: "TERMINAL_TARGET_MISSING",
+          }),
+        }),
+      }),
       expect.objectContaining({
         level: "info",
         message: "Observer ready.",

--- a/apps/observer/test/unit/observerHandoff.test.ts
+++ b/apps/observer/test/unit/observerHandoff.test.ts
@@ -211,7 +211,7 @@ describe("negotiateObserverIncumbent", () => {
       fixture.listening = false;
       fixture.startToken = undefined;
       return {
-        schemaVersion: "0.11.0" as const,
+        schemaVersion: "0.12.0" as const,
         stopped: true,
         at: "2026-07-12T12:00:00.000Z",
       };
@@ -395,7 +395,7 @@ describe("negotiateObserverIncumbent", () => {
     fixture.stop.mockImplementation(async () => {
       fixture.listening = false;
       return {
-        schemaVersion: "0.11.0" as const,
+        schemaVersion: "0.12.0" as const,
         stopped: true,
         at: "2026-07-12T12:00:00.000Z",
       };
@@ -419,7 +419,7 @@ describe("negotiateObserverIncumbent", () => {
     fixture.stop.mockImplementation(async () => {
       fixture.listening = false;
       return {
-        schemaVersion: "0.11.0" as const,
+        schemaVersion: "0.12.0" as const,
         stopped: true,
         at: "2026-07-12T12:00:00.000Z",
       };
@@ -438,7 +438,7 @@ describe("negotiateObserverIncumbent", () => {
     fixture.stop.mockImplementation(async () => {
       fixture.startToken = undefined;
       return {
-        schemaVersion: "0.11.0" as const,
+        schemaVersion: "0.12.0" as const,
         stopped: true,
         at: "2026-07-12T12:00:00.000Z",
       };
@@ -471,7 +471,7 @@ describe("negotiateObserverIncumbent", () => {
         throw new Error("successor process evidence is unavailable");
       };
       return {
-        schemaVersion: "0.11.0" as const,
+        schemaVersion: "0.12.0" as const,
         stopped: true,
         at: "2026-07-12T12:00:00.000Z",
       };
@@ -488,7 +488,7 @@ describe("negotiateObserverIncumbent", () => {
       fixture.listening = false;
       fixture.startToken = undefined;
       return {
-        schemaVersion: "0.11.0" as const,
+        schemaVersion: "0.12.0" as const,
         stopped: true,
         at: "2026-07-12T12:00:00.000Z",
       };
@@ -530,7 +530,7 @@ function observerBuildVersion(version: string, buildIdentity: string): string {
 
 function handoffFixture() {
   const incumbentHealth: ObserverHealth = {
-    schemaVersion: "0.11.0",
+    schemaVersion: "0.12.0",
     status: "healthy",
     pid: 100,
     startedAt: "2026-07-12T11:00:00.000Z",
@@ -552,7 +552,7 @@ function handoffFixture() {
     incumbentHealth,
     health: vi.fn(async (_socketPath: string, _request: { timeoutMs: number }) => incumbentHealth),
     stop: vi.fn(async (_socketPath: string, _request: { timeoutMs: number }) => ({
-      schemaVersion: "0.11.0" as const,
+      schemaVersion: "0.12.0" as const,
       stopped: true,
       at: "2026-07-12T12:00:00.000Z",
     })),

--- a/apps/observer/test/unit/reconcileProfiling.test.ts
+++ b/apps/observer/test/unit/reconcileProfiling.test.ts
@@ -176,6 +176,7 @@ function fakeLogger(): StationLogger & { records: LogRecord[] } {
   };
   return {
     records,
+    recordOperationalEvent: async () => undefined,
     info: (message, attributes) => record("info", message, attributes),
     warn: (message, attributes) => record("warn", message, attributes),
     error: (message, attributes) => record("error", message, attributes),

--- a/apps/observer/test/unit/terminal-commands.test.ts
+++ b/apps/observer/test/unit/terminal-commands.test.ts
@@ -6,7 +6,7 @@ import {
   FakeTerminalProvider,
   FakeWorktreeProvider,
 } from "@station/testing";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   createObserverCore,
   createTerminalCloseHandler,
@@ -20,6 +20,7 @@ describe("observer terminal commands", () => {
   it("focuses a target resolved from worktreeId without exposing tmux details", async () => {
     const focused: string[] = [];
     const focusContexts: Array<TerminalFocusContext | undefined> = [];
+    const recordOperationalEvent = vi.fn(async () => undefined);
     const terminal = new RecordingTerminalProvider({
       id: "tmux",
       now,
@@ -80,6 +81,12 @@ describe("observer terminal commands", () => {
     const handler = createTerminalFocusHandler({
       core,
       providers,
+      logger: {
+        recordOperationalEvent,
+        info: async () => undefined,
+        warn: async () => undefined,
+        error: async () => undefined,
+      },
     });
 
     await handler({
@@ -107,6 +114,20 @@ describe("observer terminal commands", () => {
         },
       },
     ]);
+    expect(recordOperationalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: "info",
+        commandId: "cmd_1",
+        traceId: "trc_1",
+        operationalEvent: expect.objectContaining({
+          kind: "terminal.focus.decision",
+          decision: expect.objectContaining({
+            outcome: "focused",
+            resolution: expect.objectContaining({ targetId: "tmux:station:@1:%2" }),
+          }),
+        }),
+      }),
+    );
   });
 
   it("throws a safe terminal provider error when the target cannot be resolved", async () => {

--- a/apps/observer/test/unit/terminal-operations.test.ts
+++ b/apps/observer/test/unit/terminal-operations.test.ts
@@ -119,6 +119,7 @@ describe("terminal operations", () => {
 
   it("focuses a listed target by session subject and preserves focus origin", async () => {
     const order: string[] = [];
+    const logger = new CapturingLogger();
     const terminal = new RecordingTerminalProvider({
       order,
       targets: [
@@ -158,6 +159,7 @@ describe("terminal operations", () => {
       origin: { provider: "tmux", clientId: "client_1" },
       context: commandContext("cmd_focus"),
       clock,
+      logger,
     });
 
     expect(order).toEqual(["listTargets", "focusTarget"]);
@@ -165,6 +167,114 @@ describe("terminal operations", () => {
     expect(terminal.snapshot().focusContexts).toEqual([
       { origin: { provider: "tmux", clientId: "client_1" } },
     ]);
+    expect(logger.records).toEqual([
+      expect.objectContaining({
+        level: "info",
+        commandId: "cmd_focus",
+        traceId: "trace_cmd_focus",
+        projectId: "web",
+        worktreeId: "wt_web_feature",
+        sessionId: "ses_web_feature",
+        provider: "fake-terminal",
+        operationalEvent: {
+          kind: "terminal.focus.decision",
+          decision: {
+            outcome: "focused",
+            originProvider: "tmux",
+            hasOriginClientId: true,
+            resolution: {
+              kind: "selected",
+              totalTargetCount: 2,
+              matchingTargetCount: 2,
+              targetId: "term_agent",
+              targetState: "open",
+              selectionBasis: "session-main-agent",
+            },
+          },
+        },
+      }),
+    ]);
+    expect(JSON.stringify(logger.records)).not.toContain("client_1");
+    expect(JSON.stringify(logger.records)).not.toContain("%ignored");
+  });
+
+  it("logs normalized provider focus failure against the selected target", async () => {
+    const logger = new CapturingLogger();
+    const terminal = new RecordingTerminalProvider({
+      targets: [
+        createFakeTerminalTarget({
+          id: "term_agent",
+          provider: "fake-terminal",
+          worktreeId: "wt_web_feature",
+          sessionId: "ses_web_feature",
+          now,
+        }),
+      ],
+      failures: {
+        focusTarget: {
+          tag: "TerminalProviderError",
+          code: "FAKE_FOCUS_FAILED",
+          message: "The fake terminal failed to focus.",
+          provider: "fake-terminal",
+        },
+      },
+    });
+
+    await expect(
+      focusTerminal({
+        terminal,
+        subject: { worktreeId: "wt_web_feature", sessionId: "ses_web_feature" },
+        context: commandContext("cmd_focus_failed"),
+        clock,
+        logger,
+      }),
+    ).rejects.toMatchObject({ code: "FAKE_FOCUS_FAILED" });
+    expect(logger.records).toEqual([
+      expect.objectContaining({
+        level: "info",
+        operationalEvent: {
+          kind: "terminal.focus.decision",
+          decision: expect.objectContaining({
+            outcome: "failed",
+            errorCode: "FAKE_FOCUS_FAILED",
+            resolution: expect.objectContaining({
+              kind: "selected",
+              targetId: "term_agent",
+              selectionBasis: "session",
+            }),
+          }),
+        },
+      }),
+    ]);
+  });
+
+  it("does not let decision logger failure change successful focus", async () => {
+    const terminal = new RecordingTerminalProvider({
+      targets: [
+        createFakeTerminalTarget({
+          id: "term_agent",
+          provider: "fake-terminal",
+          worktreeId: "wt_web_feature",
+          now,
+        }),
+      ],
+    });
+    const logger: StationLogger = {
+      recordOperationalEvent: async () => Promise.reject(new Error("log unavailable")),
+      info: async () => Promise.reject(new Error("log unavailable")),
+      warn: async () => undefined,
+      error: async () => undefined,
+    };
+
+    await expect(
+      focusTerminal({
+        terminal,
+        subject: { worktreeId: "wt_web_feature" },
+        context: commandContext("cmd_focus_log_failure"),
+        clock,
+        logger,
+      }),
+    ).resolves.toBeUndefined();
   });
 
   it("closes the main-agent target before workspace targets for worktree subjects", async () => {
@@ -205,6 +315,7 @@ describe("terminal operations", () => {
   });
 
   it("rejects stale-only and missing focus or close subjects without provider mutation", async () => {
+    const logger = new CapturingLogger();
     const staleTerminal = new RecordingTerminalProvider({
       targets: [
         createFakeTerminalTarget({
@@ -223,6 +334,7 @@ describe("terminal operations", () => {
         subject: { projectId: "web", worktreeId: "wt_web_feature" },
         context: commandContext("cmd_stale_focus"),
         clock,
+        logger,
       }),
     ).rejects.toMatchObject({
       tag: "TerminalProviderError",
@@ -231,6 +343,23 @@ describe("terminal operations", () => {
       worktreeId: "wt_web_feature",
     });
     expect(staleTerminal.snapshot().focused).toEqual([]);
+    expect(logger.records).toEqual([
+      expect.objectContaining({
+        level: "info",
+        operationalEvent: {
+          kind: "terminal.focus.decision",
+          decision: expect.objectContaining({
+            outcome: "failed",
+            errorCode: "TERMINAL_TARGET_STALE",
+            resolution: {
+              kind: "stale",
+              totalTargetCount: 1,
+              matchingTargetCount: 1,
+            },
+          }),
+        },
+      }),
+    ]);
 
     const missingTerminal = new RecordingTerminalProvider();
     await expect(
@@ -499,6 +628,17 @@ class CapturingHarnessProvider extends FakeHarnessProvider {
 
 class CapturingLogger implements StationLogger {
   readonly records: LogRecord[] = [];
+
+  async recordOperationalEvent(
+    record: Parameters<StationLogger["recordOperationalEvent"]>[0],
+  ): Promise<void> {
+    this.records.push({
+      component: "observer",
+      timestamp: now,
+      message: "Captured operational event.",
+      ...record,
+    });
+  }
 
   async info(message: string, attributes?: Record<string, unknown>): Promise<void> {
     this.record("info", message, attributes);

--- a/apps/observer/test/unit/terminalTargetDebug.test.ts
+++ b/apps/observer/test/unit/terminalTargetDebug.test.ts
@@ -1,0 +1,71 @@
+import type { TerminalTargetObservation } from "@station/contracts";
+import { describe, expect, it } from "vitest";
+import { terminalTargetDebugFromObservations } from "../../src/reconcile/terminalTargetDebug";
+
+const observedAt = "2026-08-20T12:00:00.000Z";
+
+describe("terminal target debug projection", () => {
+  it("preserves normalized correlations and explicit false while removing provider mechanics", () => {
+    const target: TerminalTargetObservation = {
+      id: "tmux:station:@1:%2",
+      provider: "tmux",
+      projectId: "web",
+      worktreeId: "wt_web_feature",
+      sessionId: "ses_web_feature",
+      harnessRunId: "run_web_feature",
+      state: "detached",
+      focusable: true,
+      closeable: false,
+      hasManagedAttachment: false,
+      cwd: "/private/worktree",
+      pid: 1234,
+      title: "private pane title",
+      confidence: "high",
+      reason: "Normalized tmux target evidence.",
+      observedAt,
+      providerData: {
+        paneId: "%2",
+        socketPath: "/private/tmux.sock",
+      },
+    };
+
+    expect(terminalTargetDebugFromObservations([target])).toEqual([
+      {
+        id: "tmux:station:@1:%2",
+        provider: "tmux",
+        projectId: "web",
+        worktreeId: "wt_web_feature",
+        sessionId: "ses_web_feature",
+        state: "detached",
+        focusable: true,
+        closeable: false,
+        hasManagedAttachment: false,
+        confidence: "high",
+        reason: "Normalized tmux target evidence.",
+        observedAt,
+      },
+    ]);
+  });
+
+  it("omits optional evidence that the provider did not establish", () => {
+    const target: TerminalTargetObservation = {
+      id: "term_unknown",
+      provider: "terminal",
+      state: "unknown",
+      confidence: "low",
+      reason: "Target identity is incomplete.",
+      observedAt,
+    };
+
+    expect(terminalTargetDebugFromObservations([target])).toEqual([
+      {
+        id: "term_unknown",
+        provider: "terminal",
+        state: "unknown",
+        confidence: "low",
+        reason: "Target identity is incomplete.",
+        observedAt,
+      },
+    ]);
+  });
+});

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,7 +53,10 @@ No single layer owns all truth.
 - Config is authoritative for the projects station manages, project defaults, provider choices, and safe local policy.
 - Fresh worktree-provider reads are authoritative for external worktree existence and metadata they can prove;
   adapters do not retain list results as a second inventory.
-- Terminal providers are authoritative for terminal topology and provider-owned target identity.
+- Terminal providers are authoritative for terminal topology, provider-owned target identity,
+  external-focus capability, and current Station-managed attachment evidence. A managed
+  attachment proves that Station advertised an attachment route; it does not prove that a
+  renderer has opened or revealed a native pane.
 - Harness providers are authoritative for agent launch, present-tense run discovery observations,
   persisted-event compatibility, status signals, and provider-native recovery artifacts they can prove. Each
   discovered run carries its normalized current status; Observer overlays newer admitted event
@@ -68,10 +71,16 @@ No single layer owns all truth.
   deterministic parent-before-child order. `WorktreeRow.title` is the
   display authority, while `SessionView.title` is its lifecycle projection. Session and activity
   counts derive from `sessions`, while worktree counts derive from `rows`.
+- Snapshot debug evidence is opt-in and non-canonical. Its terminal-target list is sanitized from
+  the latest successful reconcile and matches the target input used to produce that reconcile's
+  canonical graph, so operators can explain target selection without exposing provider-private
+  payloads. Ordinary clients receive no debug block.
 - Session start and resume resolve only from current snapshot `rows`; absence is not repaired from
   provider-process memory. Mutating providers receive configured project context explicitly and may
   perform a final fresh read when the operation requires race-safe identity revalidation.
-- JSONL logs and debug bundles are diagnostic evidence, not runtime truth.
+- JSONL logs and debug bundles are diagnostic evidence, not runtime truth. Durable Observer
+  decision records use strict operational-event payloads and first-class envelope correlation;
+  their presentation messages do not define event identity or severity.
 - Observer recovery inventories are point-in-time retained-session and redacted recovery-handle evidence, never recovery eligibility or persistence-mutation authority.
 
 When these disagree, reconcile from config, providers, and current observer state first. Treat stale logs, old bundles, and historical plans as evidence to inspect, not as authority.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -44,6 +44,43 @@ Use the narrowest tool that can answer the question:
 | Observer event hook setup | `stn event-hooks doctor` |
 | Setup and tool readiness | `stn setup check --json`, `stn setup system --check`, or `pnpm setup:system:check` |
 
+## Terminal Evidence
+
+Use `stn snapshot --json --include-debug` when a canonical session or attachment does
+not explain which terminal target Observer saw. The optional `debug.terminalTargets`
+array comes from the latest successful reconcile and matches the target input used to
+produce that reconcile's canonical graph. It contains only provider-neutral identity,
+correlation, state, capability, confidence, reason, and observation-time fields. It
+intentionally excludes provider-private payloads, cwd, process ids, and titles. Without
+`--include-debug`, the block is absent.
+
+Interpret the terminal facts separately:
+
+- `focusable: true` means the terminal provider advertised an external focus action.
+- `hasManagedAttachment: true` means Station currently advertised a managed attachment
+  route for that target.
+- Neither field proves that the native renderer has opened or revealed a local pane.
+
+`stn doctor` summarizes terminal providers and states, then tallies external-focus and
+managed-attachment evidence as yes, no, or unknown. Detached targets are normal
+topology and do not warn by themselves; stale targets and orphaned sessions do.
+
+For historical decisions, query the one-record operation summaries:
+
+```bash
+stn debug logs "terminal.focus.decision"
+stn debug logs "agent.prepareExternalLaunch.decision"
+```
+
+These stable event kinds identify strict `operationalEvent` payloads; the human-readable
+log message is presentation only. Focus records put command, trace, subject, and provider
+correlation in the log envelope, while their event payload contains candidate counts,
+selection basis, selected target, and normalized outcome. External-launch records put the
+resulting session and provider in the envelope, while their event payload contains the
+chosen route and target when available. Both are informational, best-effort historical
+evidence even when their domain outcome is `failed`; failure outcome alone does not make a
+record a warning. They exclude provider-private payloads.
+
 Use `stn debug logs [query]` for bounded historical log inspection when there is no
 trace, command, or diagnostic ID yet. It reads structured JSONL logs from the
 configured state directory without contacting the observer. By default it searches

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -2469,6 +2469,12 @@
           "bindings": ["ObserverEventBus"]
         },
         {
+          "specifier": "../stationLogger.js",
+          "resolvedPath": "apps/observer/src/stationLogger.ts",
+          "edgeKind": "type-only",
+          "bindings": ["StationLogger"]
+        },
+        {
           "specifier": "../utils/time.js",
           "resolvedPath": "apps/observer/src/utils/time.ts",
           "edgeKind": "runtime",
@@ -2511,8 +2517,8 @@
         {
           "name": "focusTerminal",
           "kind": "function",
-          "role": null,
-          "purpose": null
+          "role": "USE CASE",
+          "purpose": "Resolves fresh provider-owned target evidence from product identity, focuses the selected target with request-local origin context, and retains one bounded decision record."
         },
         {
           "name": "hasCloseableTerminalAttachment",
@@ -2574,7 +2580,7 @@
           "specifier": "../stationLogger.js",
           "resolvedPath": "apps/observer/src/stationLogger.ts",
           "edgeKind": "type-only",
-          "bindings": ["StationLogger"]
+          "bindings": ["StationLogger", "StationOperationalEventRecord"]
         },
         {
           "specifier": "@station/contracts",
@@ -2593,7 +2599,9 @@
             "ProviderProjectConfig",
             "SafeError",
             "SessionView",
+            "TerminalFocusOperationalEvent",
             "TerminalFocusOrigin",
+            "TerminalFocusResolutionEvidence",
             "TerminalProvider",
             "TerminalState",
             "TerminalTargetObservation",
@@ -4419,8 +4427,8 @@
         {
           "name": "focusTerminal",
           "kind": "function",
-          "role": null,
-          "purpose": null
+          "role": "USE CASE",
+          "purpose": "Resolves fresh provider-owned target evidence from product identity, focuses the selected target with request-local origin context, and retains one bounded decision record."
         },
         {
           "name": "GitRefInvalidationTarget",
@@ -9119,6 +9127,12 @@
           "bindings": ["StatusProjectionResult"]
         },
         {
+          "specifier": "./terminalTargetDebug.js",
+          "resolvedPath": "apps/observer/src/reconcile/terminalTargetDebug.ts",
+          "edgeKind": "runtime",
+          "bindings": ["terminalTargetDebugFromObservations"]
+        },
+        {
           "specifier": "../stationLogger.js",
           "resolvedPath": "apps/observer/src/stationLogger.ts",
           "edgeKind": "type-only",
@@ -9145,6 +9159,7 @@
             "ProviderHealth",
             "ProviderProjectConfig",
             "SessionGroupView",
+            "SnapshotTerminalTargetDebug",
             "StationEvent",
             "StationSnapshot",
             "WorktreeRow"
@@ -9580,7 +9595,7 @@
           "name": "runReconcileOnce",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Orchestrates provider reads, relationship correlation, durable harness-event repair and overlays, cached metadata hydration, Group projection, snapshot assembly, and atomic session persistence. The same resolved title records feed snapshot composition and atomic reconcile persistence."
+          "purpose": "Orchestrates provider reads, relationship correlation, durable harness-event repair and overlays, cached metadata hydration, Group projection, snapshot and sanitized-debug input assembly, and atomic session persistence. The same resolved title and terminal records feed every output."
         }
       ],
       "imports": [
@@ -10006,6 +10021,31 @@
       ]
     },
     {
+      "path": "apps/observer/src/reconcile/terminalTargetDebug.ts",
+      "exports": [
+        {
+          "name": "terminalTargetDebugFromObservation",
+          "kind": "function",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "terminalTargetDebugFromObservations",
+          "kind": "function",
+          "role": null,
+          "purpose": null
+        }
+      ],
+      "imports": [
+        {
+          "specifier": "@station/contracts",
+          "resolvedPath": "packages/contracts/src/index.ts",
+          "edgeKind": "type-only",
+          "bindings": ["SnapshotTerminalTargetDebug", "TerminalTargetObservation"]
+        }
+      ]
+    },
+    {
       "path": "apps/observer/src/reconcile/worktreeMetadataOverlay.ts",
       "exports": [
         {
@@ -10292,7 +10332,7 @@
           "specifier": "../stationLogger.js",
           "resolvedPath": "apps/observer/src/stationLogger.ts",
           "edgeKind": "type-only",
-          "bindings": ["StationLogger"]
+          "bindings": ["StationLogger", "StationOperationalEventRecord"]
         },
         {
           "specifier": "../worktreeMutationCoordinator.js",
@@ -10336,6 +10376,7 @@
             "DoctorOptions",
             "DoctorReport",
             "EventFilter",
+            "ExternalLaunchPreparationOperationalEvent",
             "HarnessEventReport",
             "HarnessEventReportReceipt",
             "ObserverApi",
@@ -10424,10 +10465,22 @@
           "purpose": null
         },
         {
+          "name": "ExternalLaunchPreparationDecision",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
           "name": "prepareExternalLaunch",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Returns a live or attachable managed identity first, then exactly recovers the canonical open Station session unless explicit, identity-bound user consent requests a fresh provider execution. Recovery retains that session's identity and durable state, passes only provider-neutral resume options, and releases only its replacement target generation on failure. Both launch paths preflight only the selected provider. A fresh Station identity is atomically seeded with explicit root placement or the requested source session's current Group before target publication, and confirmed failed launch cleanup removes only its membership and owned inline Group."
+          "purpose": "Returns a live or attachable managed identity first, then exactly recovers the canonical open Station session unless explicit, identity-bound user consent requests a fresh provider execution. Recovery retains that session's identity and durable state, passes only provider-neutral resume options, and releases only its replacement target generation on failure. The provider-neutral preparation decision distinguishes attachment, live-session, managed-process, and caller-owned launch routes without claiming the client landed. Both launch paths preflight only the selected provider. A fresh Station identity is atomically seeded with explicit root placement or the requested source session's current Group before target publication, and confirmed failed launch cleanup removes only its membership and owned inline Group."
+        },
+        {
+          "name": "PrepareExternalLaunchOutcome",
+          "kind": "type",
+          "role": null,
+          "purpose": null
         },
         {
           "name": "reportExternalExit",
@@ -10532,6 +10585,7 @@
             "AgentPrepareExternalLaunchResult",
             "AgentReportExternalExitParams",
             "AgentReportExternalExitResult",
+            "ExternalLaunchPreparationRoute",
             "ManagedOpenWorkspaceResult",
             "ManagedTerminalLifecycle",
             "SafeError",
@@ -10659,6 +10713,12 @@
           "resolvedPath": "apps/observer/src/stationLogger.ts",
           "edgeKind": "type-only",
           "bindings": ["StationLogger"]
+        },
+        {
+          "specifier": "@station/contracts",
+          "resolvedPath": "packages/contracts/src/index.ts",
+          "edgeKind": "type-only",
+          "bindings": ["ObserverOperationalEvent"]
         },
         {
           "specifier": "@station/observability",
@@ -12333,10 +12393,23 @@
           "name": "StationLogger",
           "kind": "interface",
           "role": "DRIVEN PORT",
-          "purpose": "Records Observer operational events without exposing their storage representation or destination."
+          "purpose": "Records typed operational evidence and narrative messages without exposing their storage representation or destination."
+        },
+        {
+          "name": "StationOperationalEventRecord",
+          "kind": "type",
+          "role": null,
+          "purpose": null
         }
       ],
-      "imports": []
+      "imports": [
+        {
+          "specifier": "@station/contracts",
+          "resolvedPath": "packages/contracts/src/index.ts",
+          "edgeKind": "type-only",
+          "bindings": ["LogLevel", "LogRecord", "ObserverOperationalEvent"]
+        }
+      ]
     },
     {
       "path": "apps/observer/src/utils/guards.ts",
@@ -13944,6 +14017,29 @@
       ]
     },
     {
+      "path": "apps/observer/src/commands/terminalOperations.ts",
+      "declaration": "focusTerminal",
+      "kind": "function",
+      "role": "USE CASE",
+      "purpose": "Resolves fresh provider-owned target evidence from product identity, focuses the selected target with request-local origin context, and retains one bounded decision record.",
+      "dependencies": [
+        {
+          "path": "apps/observer/src/stationLogger.ts",
+          "declaration": "StationLogger",
+          "kind": "interface",
+          "role": "DRIVEN PORT",
+          "edgeKind": "type-only"
+        },
+        {
+          "path": "packages/contracts/src/providers.ts",
+          "declaration": "TerminalProvider",
+          "kind": "interface",
+          "role": "DRIVEN PORT",
+          "edgeKind": "type-only"
+        }
+      ]
+    },
+    {
       "path": "apps/observer/src/commands/worktree/create.ts",
       "declaration": "createWorktreeCreateHandler",
       "kind": "function",
@@ -14326,7 +14422,7 @@
       "declaration": "runReconcileOnce",
       "kind": "function",
       "role": "USE CASE",
-      "purpose": "Orchestrates provider reads, relationship correlation, durable harness-event repair and overlays, cached metadata hydration, Group projection, snapshot assembly, and atomic session persistence. The same resolved title records feed snapshot composition and atomic reconcile persistence.",
+      "purpose": "Orchestrates provider reads, relationship correlation, durable harness-event repair and overlays, cached metadata hydration, Group projection, snapshot and sanitized-debug input assembly, and atomic session persistence. The same resolved title and terminal records feed every output.",
       "dependencies": [
         {
           "path": "apps/observer/src/persistence/ports.ts",
@@ -14555,6 +14651,13 @@
           "edgeKind": "runtime"
         },
         {
+          "path": "apps/observer/src/stationLogger.ts",
+          "declaration": "StationLogger",
+          "kind": "interface",
+          "role": "DRIVEN PORT",
+          "edgeKind": "type-only"
+        },
+        {
           "path": "packages/contracts/src/observer.ts",
           "declaration": "ObserverApi",
           "kind": "type",
@@ -14568,7 +14671,7 @@
       "declaration": "prepareExternalLaunch",
       "kind": "function",
       "role": "USE CASE",
-      "purpose": "Returns a live or attachable managed identity first, then exactly recovers the canonical open Station session unless explicit, identity-bound user consent requests a fresh provider execution. Recovery retains that session's identity and durable state, passes only provider-neutral resume options, and releases only its replacement target generation on failure. Both launch paths preflight only the selected provider. A fresh Station identity is atomically seeded with explicit root placement or the requested source session's current Group before target publication, and confirmed failed launch cleanup removes only its membership and owned inline Group.",
+      "purpose": "Returns a live or attachable managed identity first, then exactly recovers the canonical open Station session unless explicit, identity-bound user consent requests a fresh provider execution. Recovery retains that session's identity and durable state, passes only provider-neutral resume options, and releases only its replacement target generation on failure. The provider-neutral preparation decision distinguishes attachment, live-session, managed-process, and caller-owned launch routes without claiming the client landed. Both launch paths preflight only the selected provider. A fresh Station identity is atomically seeded with explicit root placement or the requested source session's current Group before target publication, and confirmed failed launch cleanup removes only its membership and owned inline Group.",
       "dependencies": [
         {
           "path": "apps/observer/src/commands/harnessLaunchPreflight.ts",
@@ -15124,7 +15227,7 @@
       "declaration": "StationLogger",
       "kind": "interface",
       "role": "DRIVEN PORT",
-      "purpose": "Records Observer operational events without exposing their storage representation or destination.",
+      "purpose": "Records typed operational evidence and narrative messages without exposing their storage representation or destination.",
       "dependencies": []
     },
     {
@@ -15387,7 +15490,7 @@
       "declaration": "StationTerminalProvider",
       "kind": "class",
       "role": "ADAPTER",
-      "purpose": "Station terminal provider: UI-hosted mode is a registration shim; host-backed mode supplies process lifecycle and opaque attachment identity. Native presentation remains locally owned by Station and is never externally focusable. Deterministic targets are released only when their current Station session and, for managed launch attempts, opaque binding generation match.",
+      "purpose": "Station terminal provider: UI-hosted mode is a registration shim; host-backed mode supplies process lifecycle, opaque attachment identity, and normalized current attachment evidence. Native presentation remains locally owned by Station and is never externally focusable. Deterministic targets are released only when their current Station session and, for managed launch attempts, opaque binding generation match.",
       "dependencies": [
         {
           "path": "packages/contracts/src/providers.ts",
@@ -15498,7 +15601,7 @@
       "declaration": "ObserverApi",
       "kind": "type",
       "role": "DRIVING PORT",
-      "purpose": "Exposes Observer state, recovery-readiness, and coherent recovery-inventory queries, plus handshakes, ingress reports, maintenance, and lifecycle operations to external actors.",
+      "purpose": "Exposes Observer state, recovery-readiness, and coherent recovery-inventory queries, plus handshakes, ingress reports, maintenance, and lifecycle operations to external actors. Snapshot debug evidence is opt-in and explanatory; ordinary snapshots remain the canonical client graph.",
       "dependencies": []
     },
     {
@@ -15514,7 +15617,7 @@
       "declaration": "ManagedTerminalLifecycle",
       "kind": "interface",
       "role": "DRIVEN PORT",
-      "purpose": "Owns the single managed terminal target used for an external Station launch. Its capabilities state whether process ownership survives the launching client; attachments expose only adapter-owned target identity, and at most one target may exist per worktree. A local fallback may instead carry a provider-neutral output policy for the caller-owned process. `openManagedWorkspace` returns opaque binding authority so launch and cleanup cannot mutate a superseding same-session attempt. Release never terminates a process: `false` proves the qualified binding was absent or superseded, while rejection leaves release uncertain.",
+      "purpose": "Owns the single managed terminal target used for an external Station launch. Its capabilities state whether process ownership survives the launching client; attachments expose only adapter-owned target identity, and at most one target may exist per worktree. A local fallback may instead carry a provider-neutral output policy for the caller-owned process. `openManagedWorkspace` returns opaque binding authority so launch and cleanup cannot mutate a superseding same-session attempt. Release never terminates a process: `false` proves the qualified binding was absent or superseded, while rejection leaves release uncertain. Target observations distinguish a currently issuable managed attachment from renderer-local pane state.",
       "dependencies": [
         {
           "path": "packages/contracts/src/providers.ts",
@@ -15538,7 +15641,7 @@
       "declaration": "TerminalProvider",
       "kind": "interface",
       "role": "DRIVEN PORT",
-      "purpose": "Supplies terminal topology and lifecycle through provider-owned target identities without exposing provider mechanics.",
+      "purpose": "Supplies terminal topology and lifecycle through provider-owned target identities without exposing provider mechanics. Target focusability describes external provider control, not whether a particular renderer can reveal, attach, or otherwise land in the target.",
       "dependencies": []
     },
     {

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -169,11 +169,13 @@ The split is allowed because both pieces are outer wiring. Application modules
 must not compensate for it by selecting concrete adapters at runtime.
 
 The Station terminal adapter may use Station Host when CLI composition enables
-host-backed terminals. Host backing supplies process lifecycle, close, and opaque
-attachment identity, but not external presentation control: native targets remain
-non-focusable from dashboards. Observer application code knows only the injected
-`ManagedTerminalLifecycle`; Station resolves its attachment to host socket and PTY
-mechanics at its own boundary and selects or reveals the session locally.
+host-backed terminals. Host backing supplies process lifecycle, close, opaque
+attachment identity, and current managed-attachment evidence, but not external
+presentation control: native targets remain non-focusable from dashboards. Observer
+application code knows only the injected `ManagedTerminalLifecycle`; Station resolves
+its attachment to host socket and PTY mechanics at its own boundary and selects or
+reveals the session locally. Observer evidence cannot prove that this renderer-local
+step has opened or revealed a pane.
 
 ## Port, Actor, And Adapter Map
 
@@ -188,13 +190,13 @@ ownership even where current ownership is still a deviation.
 | Provider hook delivery | Driving | provider hook ingress | `stn-ingress`, protocol method, offline spool, provider hook adapters | Raw input is validated and persisted once. Adapter-backed harness hooks normalize into reports; other hooks schedule reconcile without invoking provider operations. |
 | Harness status delivery | Driving | harness event report ingress | harness hooks, provider hook adapters, protocol clients | Reports are deduplicated, queued, projected, persisted, and followed by reconcile. |
 | Worktree operations | Driven | `WorktreeProvider` | Worktrunk and test adapters | Fresh list evidence and mutations only; Observer snapshots own current session selection, callers supply project context for mutation, and adapters retain no second worktree inventory. |
-| Terminal operations | Driven | `TerminalProvider` | tmux, Station terminal, and test adapters | General topology and operations are provider-owned. |
-| Managed terminal lifecycle | Driven | `ManagedTerminalLifecycle` | Station terminal adapter, optionally backed by Station Host | Explicit injected role returning only an opaque target identity and declaring whether launched processes persist beyond the caller; Host backing may add spawn/list/close/attachment lifecycle, while Station retains native presentation and host-backed targets remain externally non-focusable. |
+| Terminal operations | Driven | `TerminalProvider` | tmux, Station terminal, and test adapters | General topology and operations are provider-owned. Target observations distinguish external-focus support from current Station-managed attachment evidence. |
+| Managed terminal lifecycle | Driven | `ManagedTerminalLifecycle` | Station terminal adapter, optionally backed by Station Host | Explicit injected role returning only an opaque target identity and declaring whether launched processes persist beyond the caller; Host backing may add spawn/list/close/attachment lifecycle and managed-attachment evidence, while Station retains native presentation and host-backed targets remain externally non-focusable. |
 | Harness operations | Driven | `HarnessProvider`, `SessionRecoveryArtifactLocator` | Claude, Codex, Cursor, OpenCode, Pi, scripted, and test adapters | Strong purpose-owned ports: discovery returns provider-normalized current run status, while separate hook adapters own event parsing and harness providers retain compatibility admission and exact recovery-artifact location; unsupported artifact providers make migration ineligible. |
 | Repository metadata | Driven | `RepositoryProvider` | GitHub and test repository adapters | Adapters declare deterministic remote support; provider-neutral metadata policy selects zero or one match and rejects overlaps. |
 | Durable observer memory | Driven | `CommandJournal`, `EventJournal`, `IngressJournal`, `ObservationStore`, `ReconcileStore`, `SessionStore`, `SessionGroupStore`, `WorktreeMetadataStore` | Production SQLite adapter and test-only in-memory adapter | Observer-private, application-purpose ports separate current conversations from storage representation. `SessionStore.readRecoveryInventory` returns retained sessions and recovery handles from one coherent read transaction without classifying their eligibility. Consumers receive only the named ports they use; the unmarked `ObserverPersistenceBundle` intersection exists only at adapter and composition seams. |
 | Persistence health | Driven | `PersistenceHealthSource` | SQLite adapter created by `createSqliteObserverPersistence` | Runtime health and diagnostics read the public SQLite health projection without receiving the concrete database handle. |
-| Logging and config mutation | Driven | `StationLogger` and `ProjectConfigWriter` | `runtime/logging.ts` JSONL adapter and `runtime/projectConfigWriter.ts` config adapter | Conforming ports expose only operational logging and the three project mutations; paths and representations remain adapter-owned. |
+| Logging and config mutation | Driven | `StationLogger` and `ProjectConfigWriter` | `runtime/logging.ts` JSONL adapter and `runtime/projectConfigWriter.ts` config adapter | Conforming ports expose typed operational-event recording, narrative logging, and the three project mutations; paths and representations remain adapter-owned. |
 | Worktree metadata evidence | Driven | `WorktreeChangeSource` and `WorktreeMetadataInvalidationSource` | local Git reader and ref-watcher adapters | Conforming path-free roles: one reads typed checkout-local change evidence; the other owns full-set watcher replacement and terminal shutdown. |
 | Diagnostic evidence | Driven | `DiagnosticEvidenceSource` | `createLocalDiagnosticEvidenceSource` | Conforming read-only role: the adapter captures resolved local state, log, diagnostics, socket, and hook-spool locations while only typed measurements and bounded evidence cross the port; command/event journals, providers, core, and SQLite remain separate inputs. |
 | Observer incumbent lifecycle | Driven | `ObserverIncumbentLifecycle` | local protocol client adapter | Handoff may read health and request controlled stop without importing transport mechanics into policy or orchestration. |
@@ -743,6 +745,19 @@ remains read-only with respect to product state. Provider doctor calls receive a
 Observer-owned total timeout and cancellation signal; adapters that fan out
 checks must bound concurrency and return completed evidence before that budget
 expires.
+
+Terminal diagnostics report provider/state totals plus separate external-focus and
+managed-attachment tallies. Detached targets remain current topology and are not
+warnings by themselves; stale targets and orphaned sessions remain warnings. An
+opt-in snapshot debug block exposes the sanitized terminal targets from the latest
+successful reconcile and the canonical graph input produced at that time. Terminal
+focus and external-launch preparation each emit one strict, best-effort operational
+decision event containing the selected route or target and normalized outcome, with
+correlation stored in the JSONL envelope when the operation owns those identifiers.
+Stable event kinds, not presentation messages, identify these records. Decision events
+remain informational when their domain outcome fails; warnings are reserved for separate
+evidence of operational degradation. These records exclude provider-private payloads and
+are diagnostic evidence rather than runtime truth.
 
 ## Concurrency, Failure, And Backpressure
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -377,9 +377,11 @@ reattach; pane borders and neighboring panes must remain unlinked.
   source Group until canonical membership replaces it. Deliberate grouped creation first appears
   from a canonical snapshot with membership.
 - `terminal.focusable` describes external dashboard control, not native Station
-  interaction. Native row activation resolves an advertised managed attachment
-  and creates or reveals the local pane without dispatching `terminal.focus`;
-  no attachment leaves the overlay open with an actionable notice.
+  interaction. `terminal.hasManagedAttachment` records whether Observer
+  saw a Station-managed attachment route; it does not prove a pane is visible. Native
+  row activation resolves an advertised attachment and creates or reveals the local
+  pane without dispatching `terminal.focus`; no attachment leaves the overlay open
+  with an actionable notice.
 - Dashboard row click, focused Enter, and `1-9/a-z` row jump are the explicit
   authorization to relaunch a proven-exited managed pane. Pane clicks, pane
   cycling, overlay close, PTY exit, reconcile, restore, and HMR never relaunch;

--- a/integrations/terminal/station/src/provider.ts
+++ b/integrations/terminal/station/src/provider.ts
@@ -60,8 +60,9 @@ type PreviousTargetBinding = {
  * ADAPTER
  *
  * Station terminal provider: UI-hosted mode is a registration shim; host-backed
- * mode supplies process lifecycle and opaque attachment identity. Native
- * presentation remains locally owned by Station and is never externally focusable.
+ * mode supplies process lifecycle, opaque attachment identity, and normalized
+ * current attachment evidence. Native presentation remains locally owned by
+ * Station and is never externally focusable.
  * Deterministic targets are released only when their current Station session and,
  * for managed launch attempts, opaque binding generation match.
  */
@@ -155,7 +156,7 @@ export class StationTerminalProvider implements ManagedTerminalLifecycle {
    */
   async listTargets(): Promise<TerminalTargetObservation[]> {
     if (this.#host === undefined) {
-      return [...this.#targets.values()];
+      return this.#listedTargets();
     }
     this.#listRequestSequence += 1;
     const requestSequence = this.#listRequestSequence;
@@ -178,12 +179,12 @@ export class StationTerminalProvider implements ManagedTerminalLifecycle {
       if (recoveredOrphans) {
         throw error;
       }
-      return [...this.#targets.values()];
+      return this.#listedTargets();
     }
     // A response cannot overwrite a target rebound, released, or host-backed
     // after this request began; a newer list request also supersedes this view.
     if (requestSequence !== this.#listRequestSequence || targetRevision !== this.#targetRevision) {
-      return [...this.#targets.values()];
+      return this.#listedTargets();
     }
     const aliveById = new Map<string, HostListEntry>();
     for (const entry of live) {
@@ -216,7 +217,15 @@ export class StationTerminalProvider implements ManagedTerminalLifecycle {
         this.#previousBindings.delete(targetId);
       }
     }
-    return [...this.#targets.values()];
+    return this.#listedTargets();
+  }
+
+  #listedTargets(): TerminalTargetObservation[] {
+    return [...this.#targets.values()].map((target) => {
+      const observation: TerminalTargetObservation = { ...target };
+      observation.hasManagedAttachment = this.#hostBackedTargets.has(target.id);
+      return observation;
+    });
   }
 
   /**

--- a/integrations/terminal/station/test/unit/provider.test.ts
+++ b/integrations/terminal/station/test/unit/provider.test.ts
@@ -164,6 +164,7 @@ describe("StationTerminalProvider", () => {
       state: "open",
       focusable: false,
       closeable: false,
+      hasManagedAttachment: false,
       projectId: "web",
       worktreeId: "wt_web_feature",
       sessionId: "ses_web_feature",
@@ -363,7 +364,11 @@ describe("StationTerminalProvider (host-backed)", () => {
     const provider = new StationTerminalProvider({ clock, host });
 
     await expect(provider.listTargets()).resolves.toMatchObject([
-      { id: stationTargetId(worktree.id), sessionId: "ses_web_feature" },
+      {
+        id: stationTargetId(worktree.id),
+        sessionId: "ses_web_feature",
+        hasManagedAttachment: true,
+      },
     ]);
     expect(recoverOrphanedTargets).toHaveBeenCalledOnce();
   });
@@ -403,7 +408,7 @@ describe("StationTerminalProvider (host-backed)", () => {
       ptyId: "pty-1",
       pid: 99,
     }));
-    const provider = hostBackedProvider(fakeHostClient({ spawn }));
+    const provider = hostBackedProvider(fakeHostClient({ spawn, list: async () => [liveEntry()] }));
     const opened = await provider.openManagedWorkspace(openRequest());
     const result = await provider.launchManagedProcess({
       project,
@@ -422,6 +427,9 @@ describe("StationTerminalProvider (host-backed)", () => {
         terminalTargetId: stationTargetId(worktree.id),
       },
     });
+    await expect(provider.listTargets()).resolves.toMatchObject([
+      { id: stationTargetId(worktree.id), hasManagedAttachment: true },
+    ]);
     expect(spawn).toHaveBeenCalledTimes(1);
     expect(spawn.mock.calls[0]?.[0]).toMatchObject({
       terminalTargetId: stationTargetId(worktree.id),
@@ -496,6 +504,9 @@ describe("StationTerminalProvider (host-backed)", () => {
       started: false,
       outputCompatibility: "top-region-scrollback",
     });
+    await expect(provider.listTargets()).resolves.toMatchObject([
+      { id: stationTargetId(worktree.id), hasManagedAttachment: false },
+    ]);
   });
 
   it("leaves managed cleanup to the caller when a live-PTY upgrade blocks launch", async () => {

--- a/packages/contracts/src/diagnostics.ts
+++ b/packages/contracts/src/diagnostics.ts
@@ -15,6 +15,7 @@ import {
 } from "./ids.js";
 import { LogComponentSchema, LogLevelSchema } from "./logging.js";
 import { ObserverHealthSchema, ObserverSqliteHealthSummarySchema } from "./observer.js";
+import { ObserverOperationalEventSchema } from "./operationalEvents.js";
 import { ProviderHealthSchema, ProviderHookRuntimeSchema } from "./providers.js";
 import { nonEmptyStringSchema } from "./shared.js";
 import { StationSnapshotSchema } from "./snapshot.js";
@@ -48,6 +49,7 @@ export const LogRecordSchema = z
     sessionId: nonEmptyStringSchema.optional(),
     provider: ProviderIdSchema.optional(),
     lifecycle: UiLifecycleEventSchema.optional(),
+    operationalEvent: ObserverOperationalEventSchema.optional(),
     attributes: z.record(nonEmptyStringSchema, z.unknown()).optional(),
   })
   .strict();

--- a/packages/contracts/src/ids.ts
+++ b/packages/contracts/src/ids.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { nonEmptyStringSchema } from "./shared.js";
 
-export const STATION_SCHEMA_VERSION = "0.11.0" as const;
+export const STATION_SCHEMA_VERSION = "0.12.0" as const;
 
 const timestampSchema = z.string().datetime({ offset: true });
 declare const stationIdKind: unique symbol;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -13,6 +13,7 @@ export * from "./liveness.js";
 export * from "./logging.js";
 export * from "./observations.js";
 export * from "./observer.js";
+export * from "./operationalEvents.js";
 export * from "./providers.js";
 export * from "./recovery.js";
 export * from "./recoveryBreadcrumbs.js";

--- a/packages/contracts/src/observations.ts
+++ b/packages/contracts/src/observations.ts
@@ -193,8 +193,11 @@ export const TerminalTargetObservationSchema = z
     sessionId: SessionIdSchema.optional(),
     harnessRunId: HarnessRunIdSchema.optional(),
     state: TerminalStateSchema,
+    /** External provider-focus evidence; renderer-local opening routes are separate. */
     focusable: z.boolean().optional(),
     closeable: z.boolean().optional(),
+    /** Whether the provider can currently issue an opaque managed attachment. */
+    hasManagedAttachment: z.boolean().optional(),
     cwd: nonEmptyStringSchema.optional(),
     pid: z.number().int().positive().optional(),
     title: nonEmptyStringSchema.optional(),

--- a/packages/contracts/src/observer.ts
+++ b/packages/contracts/src/observer.ts
@@ -338,10 +338,13 @@ export type WorktreeCancelRemovalResult = z.infer<typeof WorktreeCancelRemovalRe
  *
  * Exposes Observer state, recovery-readiness, and coherent recovery-inventory queries,
  * plus handshakes, ingress reports, maintenance, and lifecycle operations to external actors.
+ * Snapshot debug evidence is opt-in and explanatory; ordinary snapshots remain the canonical
+ * client graph.
  */
 export type ObserverApi = {
   health(): Promise<ObserverHealth>;
   stop(): Promise<ObserverStopReceipt>;
+  /** Includes sanitized terminal-target evidence only when `includeDebug` is true. */
   getSnapshot(options?: { includeDebug?: boolean }): Promise<StationSnapshot>;
   getSessionRecoveryReadiness(): Promise<SessionRecoveryReadiness>;
   getSessionRecoveryInventory(): Promise<ObserverRecoveryInventory>;

--- a/packages/contracts/src/operationalEvents.ts
+++ b/packages/contracts/src/operationalEvents.ts
@@ -1,0 +1,104 @@
+import { z } from "zod";
+import { ProviderIdSchema, TerminalTargetIdSchema } from "./ids.js";
+import { TerminalStateSchema } from "./observations.js";
+import { nonEmptyStringSchema } from "./shared.js";
+
+export const TerminalFocusSelectionBasisSchema = z.enum([
+  "session-main-agent",
+  "session",
+  "worktree-main-agent",
+  "worktree",
+  "cwd-fallback",
+]);
+export type TerminalFocusSelectionBasis = z.infer<typeof TerminalFocusSelectionBasisSchema>;
+
+const TerminalFocusSelectedResolutionSchema = z
+  .object({
+    kind: z.literal("selected"),
+    totalTargetCount: z.number().int().nonnegative(),
+    matchingTargetCount: z.number().int().nonnegative(),
+    targetId: TerminalTargetIdSchema,
+    targetState: TerminalStateSchema,
+    selectionBasis: TerminalFocusSelectionBasisSchema,
+  })
+  .strict();
+
+export const TerminalFocusResolutionEvidenceSchema = z.discriminatedUnion("kind", [
+  TerminalFocusSelectedResolutionSchema,
+  z
+    .object({
+      kind: z.literal("missing"),
+      totalTargetCount: z.number().int().nonnegative(),
+      matchingTargetCount: z.number().int().nonnegative(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("stale"),
+      totalTargetCount: z.number().int().nonnegative(),
+      matchingTargetCount: z.number().int().nonnegative(),
+    })
+    .strict(),
+]);
+export type TerminalFocusResolutionEvidence = z.infer<typeof TerminalFocusResolutionEvidenceSchema>;
+
+const TerminalFocusDecisionBaseSchema = z.object({
+  hasOriginClientId: z.boolean(),
+  originProvider: ProviderIdSchema.optional(),
+});
+
+export const TerminalFocusOperationalEventSchema = z
+  .object({
+    kind: z.literal("terminal.focus.decision"),
+    decision: z.discriminatedUnion("outcome", [
+      TerminalFocusDecisionBaseSchema.extend({
+        outcome: z.literal("focused"),
+        resolution: TerminalFocusSelectedResolutionSchema,
+      }).strict(),
+      TerminalFocusDecisionBaseSchema.extend({
+        outcome: z.literal("failed"),
+        errorCode: nonEmptyStringSchema,
+        resolution: TerminalFocusResolutionEvidenceSchema.optional(),
+      }).strict(),
+    ]),
+  })
+  .strict();
+export type TerminalFocusOperationalEvent = z.infer<typeof TerminalFocusOperationalEventSchema>;
+
+export const ExternalLaunchPreparationRouteSchema = z.enum([
+  "existing-managed-attachment",
+  "existing-live-session-without-attachment",
+  "prepared-managed-attachment",
+  "prepared-caller-owned",
+]);
+export type ExternalLaunchPreparationRoute = z.infer<typeof ExternalLaunchPreparationRouteSchema>;
+
+export const ExternalLaunchPreparationOperationalEventSchema = z
+  .object({
+    kind: z.literal("agent.prepareExternalLaunch.decision"),
+    decision: z.discriminatedUnion("outcome", [
+      z
+        .object({
+          outcome: z.literal("prepared"),
+          route: ExternalLaunchPreparationRouteSchema,
+          terminalTargetId: TerminalTargetIdSchema.optional(),
+        })
+        .strict(),
+      z
+        .object({
+          outcome: z.literal("failed"),
+          errorCode: nonEmptyStringSchema,
+        })
+        .strict(),
+    ]),
+  })
+  .strict();
+export type ExternalLaunchPreparationOperationalEvent = z.infer<
+  typeof ExternalLaunchPreparationOperationalEventSchema
+>;
+
+export const ObserverOperationalEventSchema = z.discriminatedUnion("kind", [
+  TerminalFocusOperationalEventSchema,
+  ExternalLaunchPreparationOperationalEventSchema,
+]);
+export type ObserverOperationalEvent = z.infer<typeof ObserverOperationalEventSchema>;

--- a/packages/contracts/src/providers.ts
+++ b/packages/contracts/src/providers.ts
@@ -417,7 +417,9 @@ export interface WorktreeProvider {
 /**
  * DRIVEN PORT
  *
- * Supplies terminal topology and lifecycle through provider-owned target identities without exposing provider mechanics.
+ * Supplies terminal topology and lifecycle through provider-owned target identities without exposing
+ * provider mechanics. Target focusability describes external provider control, not whether a
+ * particular renderer can reveal, attach, or otherwise land in the target.
  */
 export interface TerminalProvider {
   id: ProviderId;
@@ -472,7 +474,8 @@ export type ReleaseManagedTerminalTargetRequest = {
  * output policy for the caller-owned process. `openManagedWorkspace` returns opaque
  * binding authority so launch and cleanup cannot mutate a superseding same-session attempt.
  * Release never terminates a process: `false` proves the qualified binding was
- * absent or superseded, while rejection leaves release uncertain.
+ * absent or superseded, while rejection leaves release uncertain. Target observations
+ * distinguish a currently issuable managed attachment from renderer-local pane state.
  */
 export interface ManagedTerminalLifecycle extends TerminalProvider {
   /** Opens a provisional binding whose token qualifies its launch and rollback. */

--- a/packages/contracts/src/snapshot.ts
+++ b/packages/contracts/src/snapshot.ts
@@ -78,8 +78,11 @@ export const TerminalAttachmentSchema = z
   .object({
     provider: ProviderIdSchema,
     state: TerminalStateSchema,
+    /** External provider-focus evidence; renderer-local opening routes are separate. */
     focusable: z.boolean().optional(),
     closeable: z.boolean().optional(),
+    /** Whether the provider can currently issue an opaque managed attachment. */
+    hasManagedAttachment: z.boolean().optional(),
     hasWorkspace: z.boolean().optional(),
     hasPrimaryAgentEndpoint: z.boolean().optional(),
     confidence: ConfidenceSchema.optional(),
@@ -273,6 +276,33 @@ export const OrphanedRuntimeStateSchema = z
 
 export type OrphanedRuntimeState = z.infer<typeof OrphanedRuntimeStateSchema>;
 
+export const SnapshotTerminalTargetDebugSchema = z
+  .object({
+    id: TerminalTargetIdSchema,
+    provider: ProviderIdSchema,
+    projectId: ProjectIdSchema.optional(),
+    worktreeId: WorktreeIdSchema.optional(),
+    sessionId: SessionIdSchema.optional(),
+    state: TerminalStateSchema,
+    focusable: z.boolean().optional(),
+    closeable: z.boolean().optional(),
+    hasManagedAttachment: z.boolean().optional(),
+    confidence: ConfidenceSchema,
+    reason: nonEmptyStringSchema,
+    observedAt: TimestampSchema,
+  })
+  .strict();
+
+export type SnapshotTerminalTargetDebug = z.infer<typeof SnapshotTerminalTargetDebugSchema>;
+
+export const StationSnapshotDebugSchema = z
+  .object({
+    terminalTargets: z.array(SnapshotTerminalTargetDebugSchema),
+  })
+  .strict();
+
+export type StationSnapshotDebug = z.infer<typeof StationSnapshotDebugSchema>;
+
 export const StationSnapshotSchema = z
   .object({
     schemaVersion: SchemaVersionSchema,
@@ -306,6 +336,8 @@ export const StationSnapshotSchema = z
     alerts: z.array(StationAlertSchema),
     featureFlags: ClientFeatureFlagsSchema.optional(),
     orphans: z.array(OrphanedRuntimeStateSchema).optional(),
+    /** Opt-in, redaction-safe evidence derived from the same reconcile as this snapshot. */
+    debug: StationSnapshotDebugSchema.optional(),
   })
   .strict()
   .superRefine((snapshot, context) => {

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -168,7 +168,7 @@ describe("contract schemas", () => {
   });
 
   it("exports the shared schema version used by snapshot fixtures", async () => {
-    expect(STATION_SCHEMA_VERSION).toBe("0.11.0");
+    expect(STATION_SCHEMA_VERSION).toBe("0.12.0");
 
     const snapshots = (await loadJson("snapshots/snapshot-scenarios.json")) as Record<
       string,
@@ -556,6 +556,7 @@ describe("contract schemas", () => {
       state: "open",
       focusable: true,
       closeable: true,
+      hasManagedAttachment: false,
       hasWorkspace: true,
       hasPrimaryAgentEndpoint: true,
       confidence: "high",
@@ -574,6 +575,39 @@ describe("contract schemas", () => {
       StationSnapshotSchema,
       providerNeutralTerminalSnapshot,
       "snapshot with provider-neutral terminal attachment",
+    );
+
+    const debugSnapshot = structuredClone(snapshots.idleAgent) as Record<string, unknown>;
+    const debugTarget = {
+      id: "native:wt_web_feature_auth",
+      provider: "native",
+      projectId: "web",
+      worktreeId: "wt_web_feature_auth",
+      sessionId: "ses_web_feature_auth",
+      state: "open",
+      focusable: false,
+      closeable: true,
+      hasManagedAttachment: true,
+      confidence: "high",
+      reason: "Reconciled from Station Host liveness.",
+      observedAt: "2026-05-20T12:00:00.000Z",
+    };
+    debugSnapshot.debug = { terminalTargets: [debugTarget] };
+    expectParses(StationSnapshotSchema, debugSnapshot, "snapshot with terminal debug evidence");
+    expectFails(
+      StationSnapshotSchema,
+      {
+        ...debugSnapshot,
+        debug: {
+          terminalTargets: [
+            {
+              ...debugTarget,
+              providerData: { ptyId: "pty-secret" },
+            },
+          ],
+        },
+      },
+      "snapshot debug target with provider data",
     );
 
     const externalSessionSnapshot = structuredClone(snapshots.idleAgent) as {
@@ -635,6 +669,7 @@ describe("contract schemas", () => {
       state: "open",
       focusable: true,
       closeable: true,
+      hasManagedAttachment: false,
       hasWorkspace: true,
       hasPrimaryAgentEndpoint: true,
       confidence: "high",
@@ -2434,6 +2469,8 @@ describe("contract schemas", () => {
         worktreeId: "wt_web_task",
         sessionId: "ses_web_task",
         state: "open",
+        focusable: false,
+        hasManagedAttachment: false,
         cwd: "/tmp/station/web/task",
         confidence: "high",
         reason: "tmux pane has station identity binding.",

--- a/packages/contracts/test/schema/diagnostics-schema.test.ts
+++ b/packages/contracts/test/schema/diagnostics-schema.test.ts
@@ -7,6 +7,7 @@ import {
   DoctorOptionsSchema,
   DoctorReportSchema,
   LogRecordSchema,
+  ObserverOperationalEventSchema,
   RedactionReportSchema,
   RetentionPolicySchema,
   STATION_SCHEMA_VERSION,
@@ -123,6 +124,51 @@ describe("diagnostics schemas", () => {
       rendererPid: rendererExit.rendererPid,
       clientKind: "native_renderer",
     });
+  });
+
+  it("parses strict Observer operational decision events", () => {
+    const focusDecision = {
+      kind: "terminal.focus.decision",
+      decision: {
+        outcome: "focused",
+        hasOriginClientId: true,
+        originProvider: "tmux",
+        resolution: {
+          kind: "selected",
+          totalTargetCount: 2,
+          matchingTargetCount: 1,
+          targetId: "term_1",
+          targetState: "open",
+          selectionBasis: "session-main-agent",
+        },
+      },
+    };
+    expect(ObserverOperationalEventSchema.parse(focusDecision)).toEqual(focusDecision);
+    expect(
+      ObserverOperationalEventSchema.safeParse({
+        ...focusDecision,
+        decision: { ...focusDecision.decision, extra: true },
+      }).success,
+    ).toBe(false);
+    expect(
+      ObserverOperationalEventSchema.safeParse({
+        kind: "terminal.focus.decision",
+        decision: {
+          outcome: "focused",
+          hasOriginClientId: false,
+          errorCode: "TERMINAL_TARGET_MISSING",
+        },
+      }).success,
+    ).toBe(false);
+
+    const failedPreparation = {
+      kind: "agent.prepareExternalLaunch.decision",
+      decision: {
+        outcome: "failed",
+        errorCode: "HARNESS_HOOKS_NOT_INSTALLED",
+      },
+    };
+    expect(ObserverOperationalEventSchema.parse(failedPreparation)).toEqual(failedPreparation);
   });
 
   it("parses a minimal diagnostic snapshot with trace-aware command and event records", () => {

--- a/packages/observability/test/unit/diagnostic-evidence.test.ts
+++ b/packages/observability/test/unit/diagnostic-evidence.test.ts
@@ -75,7 +75,7 @@ describe("diagnostic evidence index", () => {
     const index = buildDiagnosticEvidenceIndex(
       baseDiagnosticSnapshot({
         observerHealth: {
-          schemaVersion: "0.11.0",
+          schemaVersion: "0.12.0",
           status: "degraded",
           pid: 1234,
           startedAt: diagnosticNow,

--- a/packages/observability/test/unit/observability.test.ts
+++ b/packages/observability/test/unit/observability.test.ts
@@ -262,17 +262,17 @@ describe("observability helpers", () => {
 
 function minimalSnapshot(): DiagnosticSnapshot {
   return {
-    schemaVersion: "0.11.0",
+    schemaVersion: "0.12.0",
     collectedAt: now,
     observerHealth: {
-      schemaVersion: "0.11.0",
+      schemaVersion: "0.12.0",
       status: "healthy",
       pid: 1234,
       startedAt: now,
       version: "0.0.0",
     },
     snapshot: {
-      schemaVersion: "0.11.0",
+      schemaVersion: "0.12.0",
       generatedAt: now,
       observer: {
         pid: 1234,

--- a/packages/protocol/src/client.ts
+++ b/packages/protocol/src/client.ts
@@ -74,7 +74,7 @@ type OpenSubscription = {
 };
 
 const defaultRequestId = () => `req_${Date.now()}_${Math.random().toString(36).slice(2)}`;
-const PREVIOUS_LIFECYCLE_SCHEMA_VERSION = "0.10.0";
+const PREVIOUS_LIFECYCLE_SCHEMA_VERSION = "0.11.0";
 const PREVIOUS_LIFECYCLE_SCHEMA_REQUIRED = "PROTOCOL_PREVIOUS_LIFECYCLE_SCHEMA_REQUIRED";
 const ProtocolSchemaVersionProbeSchema = z
   .object({

--- a/packages/protocol/test/fixtures/protocol-messages.json
+++ b/packages/protocol/test/fixtures/protocol-messages.json
@@ -1,16 +1,16 @@
 {
   "request": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "jsonrpc": "2.0",
     "id": "req_1",
     "method": "observer.health"
   },
   "successResponse": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "jsonrpc": "2.0",
     "id": "req_1",
     "result": {
-      "schemaVersion": "0.11.0",
+      "schemaVersion": "0.12.0",
       "status": "healthy",
       "pid": 1234,
       "startedAt": "2026-05-20T12:00:00.000Z",
@@ -18,7 +18,7 @@
     }
   },
   "errorResponse": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "jsonrpc": "2.0",
     "id": "req_1",
     "error": {
@@ -28,7 +28,7 @@
     }
   },
   "eventEnvelope": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "event": {
       "type": "providerHook.ingested",
       "at": "2026-05-20T12:02:00.000Z",
@@ -38,7 +38,7 @@
     }
   },
   "doctorRequest": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "jsonrpc": "2.0",
     "id": "req_doctor",
     "method": "doctor.run",
@@ -47,7 +47,7 @@
     }
   },
   "diagnosticsRequest": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "jsonrpc": "2.0",
     "id": "req_diag",
     "method": "diagnostics.collect",

--- a/packages/protocol/test/integration/client-server.test.ts
+++ b/packages/protocol/test/integration/client-server.test.ts
@@ -168,6 +168,60 @@ describe("protocol client/server", () => {
     await server.close();
   });
 
+  it("round-trips opt-in snapshot debug evidence without adding it to ordinary snapshots", async () => {
+    const { socketPath } = await createTempSocketPath();
+    const requested: Array<{ includeDebug?: boolean } | undefined> = [];
+    const snapshot = emptySnapshot();
+    const api = createFakeObserverApi({
+      getSnapshot: async (options) => {
+        requested.push(options);
+        return options?.includeDebug === true
+          ? {
+              ...snapshot,
+              debug: {
+                terminalTargets: [
+                  {
+                    id: "native:wt_web_task",
+                    provider: "native",
+                    projectId: "web",
+                    worktreeId: "wt_web_task",
+                    sessionId: "ses_web_task",
+                    state: "open",
+                    focusable: false,
+                    closeable: true,
+                    hasManagedAttachment: true,
+                    confidence: "high",
+                    reason: "Reconciled from Station Host liveness.",
+                    observedAt: protocolTestNow,
+                  },
+                ],
+              },
+            }
+          : snapshot;
+      },
+    });
+    const server = await startProtocolServer({ socketPath, api });
+    const client = createObserverClient({ socketPath, requestId: ids("snapshot_debug") });
+
+    try {
+      await expect(client.getSnapshot()).resolves.not.toHaveProperty("debug");
+      await expect(client.getSnapshot({ includeDebug: true })).resolves.toMatchObject({
+        debug: {
+          terminalTargets: [
+            {
+              id: "native:wt_web_task",
+              focusable: false,
+              hasManagedAttachment: true,
+            },
+          ],
+        },
+      });
+      expect(requested).toEqual([undefined, { includeDebug: true }]);
+    } finally {
+      await server.close();
+    }
+  });
+
   it.each([
     ["another build", `0.0.0+station.${"a".repeat(64)}`],
     ["a legacy Observer", undefined],
@@ -317,7 +371,7 @@ describe("protocol client/server", () => {
     };
     const previousLifecycleRequestSchema = z
       .object({
-        schemaVersion: z.literal("0.10.0"),
+        schemaVersion: z.literal("0.11.0"),
         jsonrpc: z.literal("2.0"),
         id: z.string().min(1),
         method: z.enum(["observer.health", "observer.stop"]),
@@ -333,7 +387,7 @@ describe("protocol client/server", () => {
         if (connectionCount === 1) {
           const currentRequest = ProtocolRequestSchema.parse(firstRequest);
           connection.send({
-            schemaVersion: "0.10.0",
+            schemaVersion: "0.11.0",
             jsonrpc: "2.0",
             id: currentRequest.id,
             error: {
@@ -348,11 +402,11 @@ describe("protocol client/server", () => {
         const healthRequest = previousLifecycleRequestSchema.parse(firstRequest);
         expect(healthRequest.method).toBe("observer.health");
         connection.send({
-          schemaVersion: "0.10.0",
+          schemaVersion: "0.11.0",
           jsonrpc: "2.0",
           id: healthRequest.id,
           result: {
-            schemaVersion: "0.10.0",
+            schemaVersion: "0.11.0",
             status: "healthy",
             ...expectedObserverIdentity,
           },
@@ -361,10 +415,10 @@ describe("protocol client/server", () => {
         const stopRequest = previousLifecycleRequestSchema.parse((await iterator.next()).value);
         expect(stopRequest.method).toBe("observer.stop");
         connection.send({
-          schemaVersion: "0.10.0",
+          schemaVersion: "0.11.0",
           jsonrpc: "2.0",
           id: stopRequest.id,
-          result: { schemaVersion: "0.10.0", stopped: true, at: protocolTestNow },
+          result: { schemaVersion: "0.11.0", stopped: true, at: protocolTestNow },
         });
       },
     });
@@ -815,7 +869,7 @@ describe("protocol client/server", () => {
         tag: "ProtocolError",
         code: "PROTOCOL_SCHEMA_MISMATCH",
         message:
-          "Observer protocol schema mismatch: the observer responded with schema 9.9.9, but this CLI expects schema 0.11.0.",
+          "Observer protocol schema mismatch: the observer responded with schema 9.9.9, but this CLI expects schema 0.12.0.",
         hint: expect.stringContaining("A different STATION checkout"),
       });
     } finally {

--- a/packages/protocol/test/unit/messages.test.ts
+++ b/packages/protocol/test/unit/messages.test.ts
@@ -41,7 +41,7 @@ describe("protocol message envelopes", () => {
   it("rejects unknown protocol methods", () => {
     expect(
       ProtocolRequestSchema.safeParse({
-        schemaVersion: "0.11.0",
+        schemaVersion: "0.12.0",
         jsonrpc: "2.0",
         id: "req_bad",
         method: "provider.rawCall",

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -84,6 +84,7 @@ export type CreateFakeTerminalTargetInput = {
   state?: TerminalState;
   focusable?: boolean;
   closeable?: boolean;
+  hasManagedAttachment?: boolean;
   confidence?: Confidence;
   reason?: string;
   now?: FakeProviderClock;
@@ -256,6 +257,9 @@ export function createFakeTerminalTarget(
     state,
     ...(input.focusable === undefined ? {} : { focusable: input.focusable }),
     ...(input.closeable === undefined ? {} : { closeable: input.closeable }),
+    ...(input.hasManagedAttachment === undefined
+      ? {}
+      : { hasManagedAttachment: input.hasManagedAttachment }),
     confidence: input.confidence ?? (state === "unknown" ? "low" : "high"),
     reason: input.reason ?? "Fake provider listed the terminal target.",
     observedAt: resolveNow(input.now),

--- a/packages/testing/test/unit/fake-providers.test.ts
+++ b/packages/testing/test/unit/fake-providers.test.ts
@@ -58,6 +58,7 @@ describe("fake providers", () => {
           projectId: "web",
           worktreeId: "wt_web_main",
           harnessRunId: "run_web_main",
+          hasManagedAttachment: false,
           now,
         }),
       ],
@@ -80,6 +81,7 @@ describe("fake providers", () => {
         id: "term_web_main",
         provider: "fake-terminal",
         observedAt: now,
+        hasManagedAttachment: false,
       }),
     ]);
     await expect(

--- a/station/src/sources/fixtures/mockObserverSnapshot.ts
+++ b/station/src/sources/fixtures/mockObserverSnapshot.ts
@@ -15,7 +15,7 @@ const harnessCapabilities = {
 };
 
 export const mockObserverSnapshot = {
-  schemaVersion: "0.11.0",
+  schemaVersion: "0.12.0",
   generatedAt: fixtureNow,
   observer: {
     pid: 4242,

--- a/tests/agent/scenarios/diagnosis/harness-unexpected-exit.json
+++ b/tests/agent/scenarios/diagnosis/harness-unexpected-exit.json
@@ -2,7 +2,7 @@
   "name": "harness-unexpected-exit",
   "expectedRootCause": "HARNESS_UNEXPECTED_EXIT",
   "evidenceIndex": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/hook-spool-fallback.json
+++ b/tests/agent/scenarios/diagnosis/hook-spool-fallback.json
@@ -2,7 +2,7 @@
   "name": "hook-spool-fallback",
   "expectedRootCause": "HOOK_SPOOL_FALLBACK",
   "evidenceIndex": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/invalid-config.json
+++ b/tests/agent/scenarios/diagnosis/invalid-config.json
@@ -2,7 +2,7 @@
   "name": "invalid-config",
   "expectedRootCause": "INVALID_CONFIG",
   "evidenceIndex": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "unavailable",

--- a/tests/agent/scenarios/diagnosis/missing-worktrunk-binary.json
+++ b/tests/agent/scenarios/diagnosis/missing-worktrunk-binary.json
@@ -2,7 +2,7 @@
   "name": "missing-worktrunk-binary",
   "expectedRootCause": "MISSING_WORKTRUNK_BINARY",
   "evidenceIndex": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/provider-timeout.json
+++ b/tests/agent/scenarios/diagnosis/provider-timeout.json
@@ -2,7 +2,7 @@
   "name": "provider-timeout",
   "expectedRootCause": "PROVIDER_TIMEOUT",
   "evidenceIndex": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/sqlite-write-failure.json
+++ b/tests/agent/scenarios/diagnosis/sqlite-write-failure.json
@@ -2,7 +2,7 @@
   "name": "sqlite-write-failure",
   "expectedRootCause": "SQLITE_WRITE_FAILURE",
   "evidenceIndex": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/stale-terminal-target.json
+++ b/tests/agent/scenarios/diagnosis/stale-terminal-target.json
@@ -2,7 +2,7 @@
   "name": "stale-terminal-target",
   "expectedRootCause": "STALE_TERMINAL_TARGET",
   "evidenceIndex": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/contract-fixtures/diagnostics/debug-bundle-manifest.json
+++ b/tests/contract-fixtures/diagnostics/debug-bundle-manifest.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.11.0",
+  "schemaVersion": "0.12.0",
   "bundleId": "diag_2026-05-20T120000Z",
   "createdAt": "2026-05-20T12:00:00.000Z",
   "bundlePath": "/tmp/station/diagnostics/diag_2026-05-20T120000Z",

--- a/tests/contract-fixtures/diagnostics/diagnostic-evidence-index.json
+++ b/tests/contract-fixtures/diagnostics/diagnostic-evidence-index.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.11.0",
+  "schemaVersion": "0.12.0",
   "generatedAt": "2026-05-22T12:00:00.000Z",
   "source": {
     "collectedAt": "2026-05-22T11:59:59.000Z",

--- a/tests/contract-fixtures/diagnostics/doctor-report.json
+++ b/tests/contract-fixtures/diagnostics/doctor-report.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.11.0",
+  "schemaVersion": "0.12.0",
   "generatedAt": "2026-05-20T12:00:00.000Z",
   "status": "degraded",
   "checks": [
@@ -15,7 +15,7 @@
     }
   ],
   "observer": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "status": "healthy",
     "pid": 1234,
     "startedAt": "2026-05-20T12:00:00.000Z",
@@ -68,7 +68,7 @@
     }
   },
   "snapshot": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 1234,

--- a/tests/contract-fixtures/hooks/invalid-provider-hook-event.json
+++ b/tests/contract-fixtures/hooks/invalid-provider-hook-event.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.11.0",
+  "schemaVersion": "0.12.0",
   "provider": "",
   "kind": "harness",
   "event": "",

--- a/tests/contract-fixtures/hooks/provider-hook-events.json
+++ b/tests/contract-fixtures/hooks/provider-hook-events.json
@@ -1,6 +1,6 @@
 {
   "worktrunkWorktreeCreated": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "hookId": "hook_worktrunk_1",
     "provider": "worktrunk",
     "kind": "worktree",
@@ -13,7 +13,7 @@
     }
   },
   "codexRunUpdated": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "hookId": "hook_codex_1",
     "provider": "codex",
     "kind": "harness",

--- a/tests/contract-fixtures/provider-observations/observations.json
+++ b/tests/contract-fixtures/provider-observations/observations.json
@@ -102,6 +102,7 @@
       "sessionId": "ses_web_feature_auth",
       "harnessRunId": "run_web_feature_auth",
       "state": "open",
+      "focusable": true,
       "cwd": "/tmp/station-fixtures/web/worktrees/feature-auth",
       "pid": 5012,
       "title": "web feature/auth agent",

--- a/tests/contract-fixtures/snapshots/invalid-snapshot.json
+++ b/tests/contract-fixtures/snapshots/invalid-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.11.0",
+  "schemaVersion": "0.12.0",
   "generatedAt": "not-a-date",
   "observer": {
     "pid": 0,

--- a/tests/contract-fixtures/snapshots/snapshot-scenarios.json
+++ b/tests/contract-fixtures/snapshots/snapshot-scenarios.json
@@ -1,6 +1,6 @@
 {
   "noProjects": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -26,7 +26,7 @@
     "sessionGroups": []
   },
   "multipleProjects": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -115,7 +115,7 @@
     "sessionGroups": []
   },
   "zeroWorktreeProject": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -167,7 +167,7 @@
     "sessionGroups": []
   },
   "noAgentWorktree": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -241,7 +241,7 @@
     "sessionGroups": []
   },
   "idleAgent": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -372,7 +372,7 @@
     "sessionGroups": []
   },
   "workingAgent": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -461,7 +461,7 @@
     "sessionGroups": []
   },
   "needsAttentionAgent": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -549,7 +549,7 @@
     "sessionGroups": []
   },
   "stuckAgent": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -638,7 +638,7 @@
     "sessionGroups": []
   },
   "exitedAgent": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -724,7 +724,7 @@
     "sessionGroups": []
   },
   "unknownLowConfidence": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -812,7 +812,7 @@
     "sessionGroups": []
   },
   "orphanedTerminalTarget": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -848,7 +848,7 @@
     "sessionGroups": []
   },
   "providerFailure": {
-    "schemaVersion": "0.11.0",
+    "schemaVersion": "0.12.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,

--- a/tests/diagnostics/injected-failures/provider-timeout.test.ts
+++ b/tests/diagnostics/injected-failures/provider-timeout.test.ts
@@ -7,7 +7,7 @@ describe("provider timeout diagnostic", () => {
     const index = buildDiagnosticEvidenceIndex(
       baseDiagnosticSnapshot({
         observerHealth: {
-          schemaVersion: "0.11.0",
+          schemaVersion: "0.12.0",
           status: "degraded",
           pid: 1234,
           startedAt: diagnosticNow,

--- a/tests/diagnostics/injected-failures/sqlite-write-failure.test.ts
+++ b/tests/diagnostics/injected-failures/sqlite-write-failure.test.ts
@@ -7,7 +7,7 @@ describe("SQLite write failure diagnostic", () => {
     const index = buildDiagnosticEvidenceIndex(
       baseDiagnosticSnapshot({
         observerHealth: {
-          schemaVersion: "0.11.0",
+          schemaVersion: "0.12.0",
           status: "degraded",
           pid: 1234,
           startedAt: diagnosticNow,

--- a/tests/e2e/observer-lifecycle.test.ts
+++ b/tests/e2e/observer-lifecycle.test.ts
@@ -94,7 +94,7 @@ describe("observer lifecycle e2e", () => {
         code: "ENOENT",
       });
       await expect(client.getSnapshot()).resolves.toMatchObject({
-        schemaVersion: "0.11.0",
+        schemaVersion: "0.12.0",
         observer: { version: build.version },
         counts: { projects: 0 },
       });
@@ -1039,7 +1039,7 @@ describe("observer lifecycle e2e", () => {
         stateDir: fixture.stateDir,
       });
       await expect(client.getSnapshot()).resolves.toMatchObject({
-        schemaVersion: "0.11.0",
+        schemaVersion: "0.12.0",
         counts: { projects: 0 },
       });
     } finally {

--- a/tests/support/diagnostics/index.ts
+++ b/tests/support/diagnostics/index.ts
@@ -44,10 +44,10 @@ export function baseDiagnosticSnapshot(
   overrides: Partial<DiagnosticSnapshot> = {},
 ): DiagnosticSnapshot {
   const snapshot: DiagnosticSnapshot = {
-    schemaVersion: "0.11.0",
+    schemaVersion: "0.12.0",
     collectedAt: diagnosticNow,
     observerHealth: {
-      schemaVersion: "0.11.0",
+      schemaVersion: "0.12.0",
       status: "healthy",
       pid: 1234,
       startedAt: diagnosticNow,
@@ -65,7 +65,7 @@ export function baseDiagnosticSnapshot(
 
 export function baseStationSnapshot(overrides: Partial<StationSnapshot> = {}): StationSnapshot {
   const snapshot: StationSnapshot = {
-    schemaVersion: "0.11.0",
+    schemaVersion: "0.12.0",
     generatedAt: diagnosticNow,
     observer: {
       pid: 1234,


### PR DESCRIPTION
## What this fixes

Observer normalizes terminal topology for Station clients, but it could not distinguish provider focus support from a current Station-managed attachment or explain which targets drove a decision. That made any future “openable here” UX depend on guesses, made detached sessions look incorrectly unavailable in Doctor, and left focus/launch decisions as unstructured log attributes with ambiguous severity.

## What changed

- define provider-neutral `hasManagedAttachment` evidence with exact absent-versus-false semantics and advance the shared schema to `0.12.0`
- expose sanitized terminal targets only through `snapshot.get({ includeDebug: true })` / `stn snapshot --json --include-debug`
- add a strict `operationalEvent` contract for terminal-focus and managed external-launch decisions, with stable event kinds and first-class correlation fields on the log envelope
- keep decision outcomes at `info` severity—including domain-level failure outcomes—while reserving warnings and errors for operational health evidence
- make `stn debug logs` return the typed event payload so operators can query stable event kinds and inspect the actual decision evidence instead of parsing presentation messages
- report external-focus and managed-attachment tallies in Doctor while warning on stale/orphaned evidence, not detached topology
- document the boundary across contracts, Observer, Station terminal integration, debugging, and the generated architecture manifest; track product-wide operational-evidence governance separately in #669

## Testing

- `env -u STATION_OPENCODE_PLUGIN_BODY_PATH pnpm test:all` before refreshing the branch from current `main`
- after rebasing onto current `main`: `pnpm build`, `pnpm typecheck`, `pnpm lint`, plus focused lanes covering 88 unit, 34 contract, and 41 integration tests
- pre-commit and pre-push lint/Observer architecture hooks

## User-visible behavior

Canonical sessions, Groups, counts, and dashboard visibility are unchanged. Operators gain opt-in terminal-target evidence and truthful Doctor/log diagnostics; Observer still does not claim that a native renderer opened or revealed a pane.

Manual verification: run `stn snapshot --json --include-debug`, `stn debug logs terminal.focus.decision`, or `stn debug logs agent.prepareExternalLaunch.decision` after exercising the corresponding operation.

Closes #631
