### PR TITLE
fix(terminal): close Bun-backed native panes with terminal hangup

### DIFF
--- a/station/src/host/test/ptyTable.smoke.test.ts
+++ b/station/src/host/test/ptyTable.smoke.test.ts
@@ -110,5 +110,37 @@ if (SMOKE) {
         table.disposeAll();
       }
     });
+
+    it("closes a Host-owned PTY whose payload ignores SIGTERM", async () => {
+      const table = createPtyTable();
+      try {
+        const { ptyId } = table.spawn({
+          kind: "aux",
+          terminalTargetId: "aux:close-smoke",
+          worktreeId: "aux",
+          projectId: "aux",
+          sessionId: "aux:close-smoke",
+          worktreePath: process.cwd(),
+          harnessProvider: "aux",
+          command: process.execPath,
+          args: [
+            "-e",
+            'process.on("SIGTERM", () => {}); process.stdout.write("READY"); setInterval(() => {}, 1000)',
+          ],
+          cwd: process.cwd(),
+          cols: 80,
+          rows: 24,
+        });
+        await waitUntil(
+          () => table.snapshot(ptyId).rawChunks.join("").includes("READY"),
+          2_000,
+        );
+
+        expect(await table.close(ptyId)).toBe(true);
+        expect(table.has(ptyId)).toBe(false);
+      } finally {
+        table.disposeAll();
+      }
+    });
   });
 }

--- a/station/src/terminal/pty/bunTerminalProcess.ts
+++ b/station/src/terminal/pty/bunTerminalProcess.ts
@@ -12,6 +12,7 @@ import { TerminalProcessEmitter } from "./terminalProcessEmitter.js";
 
 const MIN_COLS = 2;
 const MIN_ROWS = 1;
+const DEFAULT_TERMINAL_KILL_SIGNAL = "SIGHUP";
 
 type BunTerminal = {
   readonly closed: boolean;
@@ -215,7 +216,8 @@ export class BunTerminalProcess implements StationTerminalProcess {
     if (this.#disposed || this.#events.exited) {
       return;
     }
-    this.#child.kill(signal);
+    // Match node-pty's terminal hangup default; interactive shells commonly ignore SIGTERM.
+    this.#child.kill(signal ?? DEFAULT_TERMINAL_KILL_SIGNAL);
   }
 
   dispose(): void {
@@ -227,7 +229,7 @@ export class BunTerminalProcess implements StationTerminalProcess {
     this.#events.dispose();
     if (!exited) {
       try {
-        this.#child.kill();
+        this.#child.kill(DEFAULT_TERMINAL_KILL_SIGNAL);
       } catch {
         // The payload may have exited between the state check and the signal.
       }

--- a/station/src/terminal/pty/test/bunTerminalProcess.test.ts
+++ b/station/src/terminal/pty/test/bunTerminalProcess.test.ts
@@ -324,6 +324,29 @@ if (RUN_REAL_BUN_PTY) {
       expect(isProcessAlive(payloadPid)).toBe(false);
     });
 
+    it("kill defaults to terminal hangup when the payload ignores SIGTERM", async () => {
+      const terminal = trackTerminal(
+        createLocalPtyTerminal({
+          command: process.execPath,
+          args: [
+            "-e",
+            'process.on("SIGTERM", () => {}); process.stdout.write("READY"); setInterval(() => {}, 1000)',
+          ],
+        }),
+      );
+      const observed = observe(terminal);
+      const payloadPid = terminal.pid;
+      cleanups.push(() => {
+        if (isProcessAlive(payloadPid)) process.kill(payloadPid, "SIGKILL");
+      });
+
+      await waitFor(() => observed.output().includes("READY"), 5_000);
+      terminal.kill();
+      await waitFor(() => observed.exit() !== undefined, 5_000);
+
+      expect(isProcessAlive(payloadPid)).toBe(false);
+    });
+
     it("supports Ctrl-Z, fg, and Ctrl-C through the controlling terminal", async () => {
       const prompt = `__STATION_PTY_PROMPT_${process.pid}__ `;
       const terminal = trackTerminal(

--- a/station/src/terminal/types.ts
+++ b/station/src/terminal/types.ts
@@ -111,6 +111,7 @@ export type StationTerminalProcess = {
   ): StationTerminalDisposable;
   write(data: string): void;
   resize(size: StationTerminalSize): void;
+  /** Signal the PTY payload; an omitted signal uses terminal hangup semantics (SIGHUP). */
   kill(signal?: string): void;
   /**
    * Bridge-only ownership release: close owner pipes or an adopted control


### PR DESCRIPTION
## What this fixes

Station Host owns native pane PTYs beyond the renderer lifetime. On the packaged Bun PTY lane, closing a split pane used the subprocess default `SIGTERM`; interactive shells can ignore that signal, so Host returned `HOST_PTY_CLOSE_TIMEOUT` and both Ctrl-/ and the Close Pane menu appeared to do nothing.

## What changed

- Define omitted terminal-process kill signals as terminal hangup (`SIGHUP`).
- Apply the same hangup behavior to Bun PTY disposal, matching the node-pty backend.
- Cover the Bun process boundary with a payload that deliberately ignores `SIGTERM`.
- Exercise the complete Host-owned aux PTY close path against the same condition.

## Testing

- `bun run test:pty:bun` — 69 passed
- `pnpm test:all`
- `pnpm lint`

## User-visible behavior

Native split panes now close promptly from Ctrl-/ and the Close Pane menu. To verify manually, open a native split shell, use each close path, and confirm the pane disappears without a `HOST_PTY_CLOSE_TIMEOUT` record.