### PR TITLE
fix(tui): identify sessions in native activation failures

### DIFF
--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -655,11 +655,10 @@ recovery. A retained canonical Station session with no such target fails with
 uses the IO-free `sessionRecoveryEligibility` policy to admit only handles whose
 Station session is explicitly open, harness provider and worktree identities match,
 registered provider can resume, and present cwd remains inside the current worktree.
-Eligibility is applied before cardinality: zero eligible handles is unavailable, one
-is exact recovery authority, and more than one remains an ambiguity with no ordering
-or selection until a separate resolution feature is implemented. An explicitly
-selected imported handle may proceed without a local lifecycle row, while legacy,
-ended, or contradictory local identity always refuses. All failures occur before
+Eligibility precedes deterministic automatic selection: zero eligible handles is unavailable,
+while one or more candidates select the newest by `lastSeenAt`, `observedAt`, and opaque Station
+handle ID. An explicitly selected imported handle may proceed without a local lifecycle row,
+while legacy, ended, or contradictory local identity always refuses. All failures occur before
 terminal mutation, and only typed provider-neutral resume options reach the launch adapter.
 
 Automatic recovery opens and launches the replacement target under the retained

--- a/station/src/app/dashboardCapabilities.test.ts
+++ b/station/src/app/dashboardCapabilities.test.ts
@@ -120,6 +120,36 @@ describe("native dashboard capabilities", () => {
     expect(await handle.completion).toEqual({ kind: "success" });
   });
 
+  it("names the selected session when native activation fails", async () => {
+    const fixture = harness();
+    fixture.setActivationResult({
+      kind: "failure",
+      stage: "launch",
+      error: {
+        tag: "CommandValidationError",
+        code: "SESSION_RECOVERY_HANDLE_AMBIGUOUS",
+        message: "More than one recovery handle is available for this worktree.",
+        hint: "Select a specific recovery handle and retry.",
+        projectId: "station",
+        worktreeId: "wt_station_idle",
+      },
+    });
+
+    expect(await fixture.capabilities.activation.activate(ACTIVATION).completion).toEqual({
+      kind: "failure",
+      disposition: "remove-immediately",
+      error: {
+        tag: "CommandValidationError",
+        code: "SESSION_RECOVERY_HANDLE_AMBIGUOUS",
+        message:
+          'Could not open session "pty-buffer". More than one recovery handle is available for this worktree.',
+        hint: "Select a specific recovery handle and retry.",
+        projectId: "station",
+        worktreeId: "wt_station_idle",
+      },
+    });
+  });
+
   it("binds confirmed fresh start to the selected retained session", async () => {
     const fixture = harness();
     const handle = fixture.capabilities.activation.activate(FRESH_ACTIVATION);

--- a/station/src/app/dashboardCapabilities.ts
+++ b/station/src/app/dashboardCapabilities.ts
@@ -161,7 +161,7 @@ export function createDashboardCapabilities(
                 ? { freshStart: { expectedSessionId: session.id } }
                 : {}),
             })
-            .then((result) => settleNativeActivation(options.store, result)),
+            .then((result) => settleNativeActivation(options.store, result, session.title)),
           {
             optimistic:
               request.preferredObserverAction === "focus" ? "none" : "pending-start",
@@ -242,6 +242,7 @@ export function createDashboardCapabilities(
 function settleNativeActivation(
   store: StationStore,
   result: ManagedLaunchResult,
+  sessionTitle: string,
 ): DashboardExecutionResult {
   if (result.kind === "success") {
     if (result.landed) {
@@ -252,7 +253,14 @@ function settleNativeActivation(
   if (result.kind === "notice") {
     return result;
   }
-  return { kind: "failure", error: result.error, disposition: "remove-immediately" };
+  return {
+    kind: "failure",
+    error: {
+      ...result.error,
+      message: `Could not open session "${sessionTitle}". ${result.error.message}`,
+    },
+    disposition: "remove-immediately",
+  };
 }
 
 function managedSessionExecution(


### PR DESCRIPTION
## What this fixes

Station’s TUI dashboard translates native terminal activation outcomes into user-facing notices. Activation failures currently forward generic recovery text without identifying the selected session, leaving users to infer which dashboard row failed.

## What changed

- Prefix native activation failures with the selected session title while preserving the structured error, hint, and diagnostic context.
- Cover the ambiguous recovery-handle failure with a dashboard capability regression test.
- Align the external-launch architecture documentation with the existing deterministic newest-eligible-handle selection policy.

## Testing

- `bun test src/app/dashboardCapabilities.test.ts`
- `pnpm --dir station typecheck`
- `pnpm --dir station test` — 1,645 passed
- `pnpm architecture:observer:check`
- Pre-commit Biome and pre-push lint hooks

## User-visible behavior

A failed native activation now reports `Could not open session "<title>"` before the underlying failure. Manually verify by forcing a native activation failure and confirming the notice names the selected session.