### PR TITLE
fix(codex): distinguish automatic permission review

### DIFF
--- a/apps/cli/src/ingress/sender.ts
+++ b/apps/cli/src/ingress/sender.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { isClaudeForwardedEventType } from "@station/claude";
-import { isCodexForwardedEventType } from "@station/codex";
+import { enrichCodexPermissionReviewerEvidence, isCodexForwardedEventType } from "@station/codex";
 import type { ObserverPaths } from "@station/config";
 import type {
   ProviderHookEvent,
@@ -215,8 +215,8 @@ export async function sendClaudeHookPayload(
 /**
  * ADAPTER
  *
- * Admits Codex's forwarded events before applying Station ownership/cwd
- * correlation and translating hook stdin into shared harness ingress.
+ * Admits Codex's forwarded events, adds bounded provider-private permission-reviewer
+ * evidence when available, then applies Station correlation and shared harness ingress.
  */
 export async function sendCodexHookPayload(
   input: SendCodexHookInput,
@@ -232,10 +232,11 @@ export async function sendCodexHookPayload(
       hookId: deps.hookId,
     });
   }
-  const enrichedPayload = enrichStationHookIdentityPayload({
+  const identityPayload = enrichStationHookIdentityPayload({
     payload: input.payload,
     env: input.env ?? process.env,
   });
+  const enrichedPayload = await enrichCodexPermissionReviewerEvidence(identityPayload);
   const correlationFailure = providerHookCorrelationFailureReason(
     enrichedPayload,
     input.projectRoots,

--- a/apps/cli/test/unit/ingress-command.test.ts
+++ b/apps/cli/test/unit/ingress-command.test.ts
@@ -827,6 +827,80 @@ describe("provider hook ingress command", () => {
     });
   });
 
+  it("delivers Codex auto-review evidence from the matching transcript turn", async () => {
+    const fixture = await createTempState();
+    const configPath = await writeConfigToml(fixture.root, fixture.config);
+    const transcriptPath = join(fixture.root, "codex-rollout.jsonl");
+    await writeFile(
+      transcriptPath,
+      `${JSON.stringify({
+        type: "turn_context",
+        payload: {
+          turn_id: "turn_1",
+          approval_policy: "on-request",
+          approvals_reviewer: "auto_review",
+        },
+      })}\n`,
+      "utf8",
+    );
+    let observedEvent: ProviderHookEvent | undefined;
+    const payload = {
+      ...codexPayload(),
+      hook_event_name: "PermissionRequest",
+      transcript_path: transcriptPath,
+    };
+    Reflect.deleteProperty(payload, "tool_use_id");
+
+    const receipt = await runProviderIngressCommand(
+      [
+        "--socket",
+        fixture.socketPath,
+        "--state-dir",
+        fixture.stateDir,
+        "--config",
+        configPath,
+        "codex",
+      ],
+      { stdin: JSON.stringify(payload), env: stationEnv() },
+      {
+        clock: { now: () => new Date(now) },
+        hookId: () => "hook_codex_auto_review",
+        clientFactory: () => {
+          const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
+            observedEvent = event;
+            return {
+              schemaVersion: "0.11.0",
+              hookId: event.hookId ?? "hook_codex_auto_review",
+              provider: event.provider,
+              event: event.event,
+              accepted: true,
+              status: "ingested",
+              receivedAt: event.receivedAt,
+              reconciled: false,
+            };
+          };
+          return {
+            health: async () => healthyObserver(fixture),
+            ingestProviderHookEvent: ingest,
+            ingestHookEvent: ingest,
+          } as never;
+        },
+      },
+    );
+
+    expect(receipt.status).toBe("ingested");
+    expect(observedEvent).toMatchObject({
+      event: "PermissionRequest",
+      payload: {
+        station_codex_permission_reviewer_evidence: {
+          status: "resolved",
+          source: "transcript_turn_context",
+          reviewer: "auto_review",
+        },
+      },
+    });
+  });
+
   it("keeps malformed JSON rejected and visible at the CLI boundary", async () => {
     const fixture = await createTempState();
 

--- a/apps/observer/test/integration/reconcile-codex-harness.test.ts
+++ b/apps/observer/test/integration/reconcile-codex-harness.test.ts
@@ -221,6 +221,98 @@ describe("observer reconcile with Codex harness", () => {
     sqlite.close();
   });
 
+  it("projects Codex PermissionRequest attention only when automatic review is unproven", async () => {
+    const { sqlite, core, api, eventBus } = createTestObserver({
+      config,
+      providers: codexProviders(),
+      clock: { now: () => new Date(now) },
+    });
+    await core.reconcile("initial-codex-reviewer-context");
+    const payload = {
+      session_id: "codex_session_123",
+      transcript_path: "/tmp/codex-rollout.jsonl",
+      cwd: "/tmp/station/web/task",
+      hook_event_name: "PermissionRequest",
+      model: "gpt-5.6-sol",
+      permission_mode: "default",
+      turn_id: "turn_1",
+      tool_name: "Bash",
+      tool_input: { command: "pnpm test:all" },
+      station_worktree_id: "wt_web_task",
+      station_session_id: "ses_web_task",
+      station_terminal_target_id: "tmux:station:@1:%2",
+    };
+
+    const autoReconciled = nextObserverReconciled(eventBus);
+    const autoReceipt = await api.ingestProviderHookEvent({
+      schemaVersion: STATION_SCHEMA_VERSION,
+      hookId: "hook_codex_auto_review",
+      provider: "codex",
+      kind: "harness",
+      event: "PermissionRequest",
+      receivedAt: "2026-05-21T12:00:01.000Z",
+      payload: {
+        ...payload,
+        station_codex_permission_reviewer_evidence: {
+          status: "resolved",
+          source: "transcript_turn_context",
+          reviewer: "auto_review",
+        },
+      },
+    });
+
+    expect(autoReceipt).toMatchObject({ status: "ingested", accepted: true });
+    await autoReconciled.next;
+    await autoReconciled.close();
+    expect(core.getSnapshot()).toMatchObject({
+      counts: { working: 1, attention: 0 },
+      sessions: [
+        expect.objectContaining({
+          id: "ses_web_task",
+          status: expect.objectContaining({
+            value: "working",
+            reason: "Codex routed permission for Bash to automatic review.",
+          }),
+        }),
+      ],
+    });
+
+    const userReconciled = nextObserverReconciled(eventBus);
+    const userReceipt = await api.ingestProviderHookEvent({
+      schemaVersion: STATION_SCHEMA_VERSION,
+      hookId: "hook_codex_user_review",
+      provider: "codex",
+      kind: "harness",
+      event: "PermissionRequest",
+      receivedAt: "2026-05-21T12:00:02.000Z",
+      payload: {
+        ...payload,
+        station_codex_permission_reviewer_evidence: {
+          status: "unavailable",
+          source: "transcript_turn_context",
+          reason: "turn_context_not_found",
+        },
+      },
+    });
+
+    expect(userReceipt).toMatchObject({ status: "ingested", accepted: true });
+    await userReconciled.next;
+    await userReconciled.close();
+    expect(core.getSnapshot()).toMatchObject({
+      counts: { working: 0, attention: 1 },
+      sessions: [
+        expect.objectContaining({
+          id: "ses_web_task",
+          status: expect.objectContaining({
+            value: "needs_attention",
+            attention: "tool_approval",
+          }),
+        }),
+      ],
+    });
+    sqlite.close();
+  });
+
   it("keeps a parent owner when inherited identity crosses into a nested managed worktree", async () => {
     const { sqlite, persistence, eventBus, core, api } = createTestObserver({
       config: nestedManagedConfig,

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -13051,7 +13051,7 @@
       "declaration": "sendCodexHookPayload",
       "kind": "function",
       "role": "ADAPTER",
-      "purpose": "Admits Codex's forwarded events before applying Station ownership/cwd correlation and translating hook stdin into shared harness ingress.",
+      "purpose": "Admits Codex's forwarded events, adds bounded provider-private permission-reviewer evidence when available, then applies Station correlation and shared harness ingress.",
       "dependencies": [
         {
           "path": "apps/cli/src/ingress/sender.ts",
@@ -15172,7 +15172,7 @@
       "declaration": "codexHookAdapter",
       "kind": "const",
       "role": "ADAPTER",
-      "purpose": "Normalizes Codex hook delivery into shared provider-event and harness-report contracts. Inherited Station identity is authoritative only when Codex cwd remains in the stamped worktree.",
+      "purpose": "Normalizes Codex hook delivery, including provider-private reviewer evidence, into shared harness reports. Inherited Station identity is authoritative only when Codex cwd remains in the stamped worktree.",
       "dependencies": [
         {
           "path": "packages/harness-shared/src/hookAdapter.ts",

--- a/docs/harness-signals.md
+++ b/docs/harness-signals.md
@@ -80,7 +80,11 @@ Normalized events are `HarnessEventReport` / `HarnessEventObservation`
    auto-accept resolves it with a matching `permission.replied` before the
    ask's 300 ms confirmation window expires, because such an ask never blocked
    a user. A genuine ask (no reply within the window) is forwarded unchanged
-   and opens attention as usual.
+   and opens attention as usual. Codex `PermissionRequest` has no reviewer field
+   or resolution identity. Its adapter therefore uses only a strictly parsed,
+   matching `turn_context` from the bounded provider transcript tail to recognize
+   `auto_review`; unavailable or changed transcript evidence remains a real
+   `needs_attention` signal rather than risking a hidden user approval.
 4. **Blocking states beat activity.** A tool call that *is* the user request
    (Codex `request_user_input`) must normalize as `needs_attention`, not as
    tool activity. When a provider separates prompt-open from tool preflight,

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -56,7 +56,7 @@ Events (`integrations/harness/codex/src/ingressRules.ts`): `SessionStart`, `User
 
 Hooks: a dedicated `station` profile (`station.config.toml`) under `~/.codex` calls `station-codex-hook.sh`. Setup can prove that Station's current profile and script artifacts are prepared, but Codex may still require review of the current definition through `/hooks`. Setup does not bypass trust, inspect private trust state, or force `[features] hooks = true`, so preparation is not proof that Codex executed the hook.
 
-Coverage: full. `PermissionRequest` drives **needs attention**, a completed `Stop` drives **idle**, and `stop_hook_active` keeps **working**. Codex has no session-end hook, so **exited** is inferred from process state.
+Coverage: full. `PermissionRequest` drives **working** when a bounded, matching Codex transcript `turn_context` proves `auto_review`; explicit user review or unavailable compatibility evidence drives **needs attention**. A completed `Stop` drives **idle**, and `stop_hook_active` keeps **working**. Codex has no session-end hook, so **exited** is inferred from process state.
 
 ### Cursor (Full)
 

--- a/integrations/harness/codex/src/compaction.ts
+++ b/integrations/harness/codex/src/compaction.ts
@@ -45,7 +45,12 @@ function fieldNamesForEvent(eventName: string): string[] {
     return fields;
   }
   if (eventName === "PermissionRequest") {
-    fields.push(...turnFieldNames, "tool_name", "tool_input");
+    fields.push(
+      ...turnFieldNames,
+      "tool_name",
+      "tool_input",
+      "station_codex_permission_reviewer_evidence",
+    );
     return fields;
   }
   if (eventName === "PostToolUse") {

--- a/integrations/harness/codex/src/events.ts
+++ b/integrations/harness/codex/src/events.ts
@@ -14,6 +14,7 @@ import {
 import { harnessEventDiagnostics, reportCorrelation } from "@station/harness-shared";
 import { z } from "zod";
 import { codexHarnessError } from "./errors.js";
+import { CodexPermissionReviewerEvidenceSchema } from "./permissionReviewerEvidence.js";
 
 const nonEmptyStringSchema = z.string().min(1);
 const USER_INPUT_TOOL = "request_user_input";
@@ -36,6 +37,7 @@ const CodexHookProviderDataSchema = z
     agentId: nonEmptyStringSchema.optional(),
     agentType: nonEmptyStringSchema.optional(),
     trigger: z.enum(["manual", "auto"]).optional(),
+    permissionReviewerEvidence: CodexPermissionReviewerEvidenceSchema.optional(),
     stationProjectId: nonEmptyStringSchema.optional(),
     stationWorktreeId: nonEmptyStringSchema.optional(),
     stationWorktreePath: nonEmptyStringSchema.optional(),
@@ -106,6 +108,7 @@ const PermissionRequestEventSchema = z
     hook_event_name: z.literal("PermissionRequest"),
     tool_name: nonEmptyStringSchema,
     tool_input: z.unknown(),
+    station_codex_permission_reviewer_evidence: CodexPermissionReviewerEvidenceSchema.optional(),
   })
   .strict();
 
@@ -253,6 +256,18 @@ export function statusFromCodexHookEvent(
     };
   }
   if (event.hook_event_name === "PermissionRequest") {
+    if (
+      event.station_codex_permission_reviewer_evidence?.status === "resolved" &&
+      event.station_codex_permission_reviewer_evidence.reviewer === "auto_review"
+    ) {
+      return {
+        value: "working",
+        confidence: "medium",
+        reason: `Codex routed permission for ${event.tool_name} to automatic review.`,
+        source: "harness_event",
+        updatedAt: observedAt,
+      };
+    }
     return {
       value: "needs_attention",
       confidence: "high",
@@ -394,6 +409,10 @@ function providerDataFromCodexEvent(event: CodexHookEvent): CodexHookProviderDat
   }
   if ("trigger" in event) {
     providerData.trigger = event.trigger;
+  }
+  if (event.hook_event_name === "PermissionRequest") {
+    const evidence = event.station_codex_permission_reviewer_evidence;
+    if (evidence !== undefined) providerData.permissionReviewerEvidence = evidence;
   }
   if (event.station_project_id !== undefined) {
     providerData.stationProjectId = event.station_project_id;

--- a/integrations/harness/codex/src/hookAdapter.ts
+++ b/integrations/harness/codex/src/hookAdapter.ts
@@ -13,8 +13,9 @@ import { isCodexForwardedEventType } from "./ingressRules.js";
 /**
  * ADAPTER
  *
- * Normalizes Codex hook delivery into shared provider-event and harness-report contracts.
- * Inherited Station identity is authoritative only when Codex cwd remains in the stamped worktree.
+ * Normalizes Codex hook delivery, including provider-private reviewer evidence, into shared
+ * harness reports. Inherited Station identity is authoritative only when Codex cwd remains in
+ * the stamped worktree.
  */
 export const codexHookAdapter = createHarnessHookAdapter({
   provider: "codex",

--- a/integrations/harness/codex/src/index.ts
+++ b/integrations/harness/codex/src/index.ts
@@ -6,5 +6,6 @@ export * from "./hookAdapter.js";
 export * from "./hooks.js";
 export * from "./ingressRules.js";
 export * from "./launch.js";
+export * from "./permissionReviewerEvidence.js";
 export * from "./provider.js";
 export * from "./recoveryArtifacts.js";

--- a/integrations/harness/codex/src/ingressRules.ts
+++ b/integrations/harness/codex/src/ingressRules.ts
@@ -21,8 +21,8 @@ export const codexIngressRules = [
   {
     provider: "codex",
     eventType: "PermissionRequest",
-    statusIntents: ["needs_attention"],
-    confidences: ["high"],
+    statusIntents: ["working", "needs_attention"],
+    confidences: ["medium", "high"],
   },
   {
     provider: "codex",

--- a/integrations/harness/codex/src/permissionReviewerEvidence.ts
+++ b/integrations/harness/codex/src/permissionReviewerEvidence.ts
@@ -1,0 +1,210 @@
+import { open } from "node:fs/promises";
+import { z } from "zod";
+
+const DEFAULT_MAX_TRANSCRIPT_BYTES = 32 * 1024 * 1024;
+const jsonObjectSchema = z.record(z.string(), z.unknown());
+const nonEmptyStringSchema = z.string().min(1);
+
+export const CodexApprovalsReviewerSchema = z.enum(["user", "auto_review"]);
+
+const CodexPermissionReviewerUnavailableReasonSchema = z.enum([
+  "transcript_path_missing",
+  "transcript_unreadable",
+  "turn_context_not_found",
+  "transcript_scan_limit_reached",
+  "approvals_reviewer_unrecognized",
+]);
+
+export const CodexPermissionReviewerEvidenceSchema = z.discriminatedUnion("status", [
+  z
+    .object({
+      status: z.literal("resolved"),
+      source: z.literal("transcript_turn_context"),
+      reviewer: CodexApprovalsReviewerSchema,
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("unavailable"),
+      source: z.literal("transcript_turn_context"),
+      reason: CodexPermissionReviewerUnavailableReasonSchema,
+    })
+    .strict(),
+]);
+
+export type CodexPermissionReviewerEvidence = z.infer<typeof CodexPermissionReviewerEvidenceSchema>;
+
+export const CODEX_PERMISSION_REVIEWER_EVIDENCE_FIELD =
+  "station_codex_permission_reviewer_evidence";
+
+const PermissionRequestLookupSchema = z
+  .object({
+    hook_event_name: z.literal("PermissionRequest"),
+    transcript_path: nonEmptyStringSchema.nullable(),
+    turn_id: nonEmptyStringSchema,
+  })
+  .strict();
+
+const TranscriptEnvelopeSchema = z
+  .object({
+    type: z.literal("turn_context"),
+    payload: jsonObjectSchema,
+  })
+  .strict();
+
+const TranscriptTurnIdSchema = z
+  .object({
+    turn_id: nonEmptyStringSchema,
+  })
+  .strict();
+
+export type CodexPermissionReviewerEnrichmentOptions = {
+  maxTranscriptBytes?: number;
+};
+
+/**
+ * Adds provider-private reviewer evidence to a Codex PermissionRequest payload.
+ * Raw payloads cannot supply this field; only a matching transcript turn context can resolve it.
+ */
+export async function enrichCodexPermissionReviewerEvidence(
+  payload: unknown,
+  options: CodexPermissionReviewerEnrichmentOptions = {},
+): Promise<unknown> {
+  const payloadResult = jsonObjectSchema.safeParse(payload);
+  if (!payloadResult.success) return payload;
+
+  const nativePayload = Object.fromEntries(
+    Object.entries(payloadResult.data).filter(
+      ([fieldName]) => fieldName !== CODEX_PERMISSION_REVIEWER_EVIDENCE_FIELD,
+    ),
+  );
+  const lookupResult = PermissionRequestLookupSchema.safeParse({
+    hook_event_name: nativePayload.hook_event_name,
+    transcript_path: nativePayload.transcript_path,
+    turn_id: nativePayload.turn_id,
+  });
+  if (!lookupResult.success) return nativePayload;
+
+  const evidence =
+    lookupResult.data.transcript_path === null
+      ? unavailableEvidence("transcript_path_missing")
+      : await reviewerEvidenceFromTranscript(
+          lookupResult.data.transcript_path,
+          lookupResult.data.turn_id,
+          options.maxTranscriptBytes ?? DEFAULT_MAX_TRANSCRIPT_BYTES,
+        );
+  return {
+    ...nativePayload,
+    [CODEX_PERMISSION_REVIEWER_EVIDENCE_FIELD]: evidence,
+  };
+}
+
+async function reviewerEvidenceFromTranscript(
+  transcriptPath: string,
+  turnId: string,
+  maxTranscriptBytes: number,
+): Promise<CodexPermissionReviewerEvidence> {
+  let transcript: BoundedTranscriptTail;
+  try {
+    transcript = await readBoundedTranscriptTail(transcriptPath, maxTranscriptBytes);
+  } catch {
+    return unavailableEvidence("transcript_unreadable");
+  }
+
+  const lines = transcript.text.split(/\r?\n/u);
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const line = lines[index];
+    if (line === undefined || !line.includes("turn_context") || !line.includes(turnId)) continue;
+    const context = transcriptTurnContext(line);
+    if (context === undefined || context.turnId !== turnId) continue;
+    if (context.reviewer === undefined) {
+      return unavailableEvidence("approvals_reviewer_unrecognized");
+    }
+    return CodexPermissionReviewerEvidenceSchema.parse({
+      status: "resolved",
+      source: "transcript_turn_context",
+      reviewer: context.reviewer,
+    });
+  }
+
+  return unavailableEvidence(
+    transcript.truncatedAtStart ? "transcript_scan_limit_reached" : "turn_context_not_found",
+  );
+}
+
+type TranscriptTurnContext = {
+  turnId: string;
+  reviewer?: z.infer<typeof CodexApprovalsReviewerSchema>;
+};
+
+function transcriptTurnContext(line: string): TranscriptTurnContext | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line) as unknown;
+  } catch {
+    return undefined;
+  }
+  const recordResult = jsonObjectSchema.safeParse(parsed);
+  if (!recordResult.success) return undefined;
+  const payloadResult = jsonObjectSchema.safeParse(recordResult.data.payload);
+  if (!payloadResult.success) return undefined;
+  const envelopeResult = TranscriptEnvelopeSchema.safeParse({
+    type: recordResult.data.type,
+    payload: payloadResult.data,
+  });
+  if (!envelopeResult.success) return undefined;
+  const turnResult = TranscriptTurnIdSchema.safeParse({
+    turn_id: envelopeResult.data.payload.turn_id,
+  });
+  if (!turnResult.success) return undefined;
+  const reviewerResult = CodexApprovalsReviewerSchema.safeParse(
+    envelopeResult.data.payload.approvals_reviewer,
+  );
+  const context: TranscriptTurnContext = { turnId: turnResult.data.turn_id };
+  if (reviewerResult.success) context.reviewer = reviewerResult.data;
+  return context;
+}
+
+type BoundedTranscriptTail = {
+  text: string;
+  truncatedAtStart: boolean;
+};
+
+async function readBoundedTranscriptTail(
+  transcriptPath: string,
+  maxTranscriptBytes: number,
+): Promise<BoundedTranscriptTail> {
+  const handle = await open(transcriptPath, "r");
+  try {
+    const stats = await handle.stat();
+    if (!stats.isFile()) throw new Error("Codex transcript path is not a regular file.");
+    const byteLimit = Math.max(1, Math.floor(maxTranscriptBytes));
+    const byteCount = Math.min(stats.size, byteLimit);
+    const start = stats.size - byteCount;
+    const buffer = Buffer.allocUnsafe(byteCount);
+    let bytesRead = 0;
+    while (bytesRead < byteCount) {
+      const result = await handle.read(buffer, bytesRead, byteCount - bytesRead, start + bytesRead);
+      if (result.bytesRead === 0) break;
+      bytesRead += result.bytesRead;
+    }
+    let text = buffer.subarray(0, bytesRead).toString("utf8");
+    if (start > 0) {
+      const firstLineEnd = text.indexOf("\n");
+      text = firstLineEnd === -1 ? "" : text.slice(firstLineEnd + 1);
+    }
+    return { text, truncatedAtStart: start > 0 };
+  } finally {
+    await handle.close();
+  }
+}
+
+function unavailableEvidence(
+  reason: z.infer<typeof CodexPermissionReviewerUnavailableReasonSchema>,
+): CodexPermissionReviewerEvidence {
+  return CodexPermissionReviewerEvidenceSchema.parse({
+    status: "unavailable",
+    source: "transcript_turn_context",
+    reason,
+  });
+}

--- a/integrations/harness/codex/test/unit/events.test.ts
+++ b/integrations/harness/codex/test/unit/events.test.ts
@@ -59,8 +59,8 @@ describe("Codex hook event parsing", () => {
       {
         provider: "codex",
         eventType: "PermissionRequest",
-        statusIntents: ["needs_attention"],
-        confidences: ["high"],
+        statusIntents: ["working", "needs_attention"],
+        confidences: ["medium", "high"],
       },
       {
         provider: "codex",
@@ -182,6 +182,83 @@ describe("Codex hook event parsing", () => {
       },
     });
     expect(JSON.stringify(report.providerData)).not.toContain("rm -rf");
+  });
+
+  it("keeps auto-reviewed PermissionRequest events working after compaction", () => {
+    const compacted = compactCodexHookPayload({
+      session_id: "codex_session_123",
+      transcript_path: "/tmp/codex-rollout.jsonl",
+      cwd: "/tmp/station/web/task",
+      hook_event_name: "PermissionRequest",
+      model: "gpt-5.6-sol",
+      permission_mode: "default",
+      turn_id: "turn_1",
+      tool_name: "Bash",
+      tool_input: { command: "pnpm test:all" },
+      station_codex_permission_reviewer_evidence: {
+        status: "resolved",
+        source: "transcript_turn_context",
+        reviewer: "auto_review",
+      },
+    });
+
+    const report = reportForCodexPayload(compacted.payload);
+
+    expect(report).toMatchObject({
+      eventType: "PermissionRequest",
+      status: {
+        value: "working",
+        confidence: "medium",
+        reason: "Codex routed permission for Bash to automatic review.",
+      },
+      providerData: {
+        permissionReviewerEvidence: {
+          status: "resolved",
+          reviewer: "auto_review",
+        },
+      },
+    });
+    expect(report.status).not.toHaveProperty("attention");
+    expectStatusAllowedByCodexIngressRule("PermissionRequest", report.status);
+  });
+
+  it("keeps explicit user review and unavailable reviewer evidence as attention", () => {
+    const permissionPayload = (permissionReviewerEvidence: Record<string, string>) => ({
+      session_id: "codex_session_123",
+      transcript_path: "/tmp/codex-rollout.jsonl",
+      cwd: "/tmp/station/web/task",
+      hook_event_name: "PermissionRequest" as const,
+      model: "gpt-5.6-sol",
+      permission_mode: "default" as const,
+      turn_id: "turn_1",
+      tool_name: "Bash",
+      tool_input: { command: "pnpm test:all" },
+      station_codex_permission_reviewer_evidence: permissionReviewerEvidence,
+    });
+
+    const userReview = reportForCodexPayload(
+      permissionPayload({
+        status: "resolved",
+        source: "transcript_turn_context",
+        reviewer: "user",
+      }),
+    );
+    const unavailable = reportForCodexPayload(
+      permissionPayload({
+        status: "unavailable",
+        source: "transcript_turn_context",
+        reason: "turn_context_not_found",
+      }),
+    );
+
+    for (const report of [userReview, unavailable]) {
+      expect(report.status).toMatchObject({
+        value: "needs_attention",
+        confidence: "high",
+        attention: "tool_approval",
+      });
+      expectStatusAllowedByCodexIngressRule("PermissionRequest", report.status);
+    }
   });
 
   it("maps request_user_input tool hooks to an attention question and back", () => {

--- a/integrations/harness/codex/test/unit/permissionReviewerEvidence.test.ts
+++ b/integrations/harness/codex/test/unit/permissionReviewerEvidence.test.ts
@@ -1,0 +1,149 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  CODEX_PERMISSION_REVIEWER_EVIDENCE_FIELD,
+  enrichCodexPermissionReviewerEvidence,
+} from "../../src/permissionReviewerEvidence";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("Codex permission reviewer evidence", () => {
+  it("resolves the effective reviewer from the newest matching turn context", async () => {
+    const transcriptPath = await writeTranscript([
+      turnContext("turn_1", "user"),
+      turnContext("turn_other", "user"),
+      JSON.stringify({ type: "response_item", payload: { text: "turn_1 auto_review" } }),
+      turnContext("turn_1", "auto_review"),
+    ]);
+
+    const enriched = await enrichCodexPermissionReviewerEvidence(permissionRequest(transcriptPath));
+
+    expect(enriched).toMatchObject({
+      [CODEX_PERMISSION_REVIEWER_EVIDENCE_FIELD]: {
+        status: "resolved",
+        source: "transcript_turn_context",
+        reviewer: "auto_review",
+      },
+    });
+  });
+
+  it("does not reuse older evidence when the newest matching context has an unknown reviewer", async () => {
+    const transcriptPath = await writeTranscript([
+      turnContext("turn_1", "auto_review"),
+      turnContext("turn_1", "future_reviewer"),
+    ]);
+
+    const enriched = await enrichCodexPermissionReviewerEvidence(permissionRequest(transcriptPath));
+
+    expect(enriched).toMatchObject({
+      [CODEX_PERMISSION_REVIEWER_EVIDENCE_FIELD]: {
+        status: "unavailable",
+        reason: "approvals_reviewer_unrecognized",
+      },
+    });
+  });
+
+  it("reports missing, unreadable, and scan-limited transcripts conservatively", async () => {
+    const scanLimitedPath = await writeTranscript([
+      turnContext("turn_1", "auto_review"),
+      JSON.stringify({ type: "response_item", payload: { text: "x".repeat(512) } }),
+    ]);
+
+    await expect(
+      enrichCodexPermissionReviewerEvidence(permissionRequest(null)),
+    ).resolves.toMatchObject({
+      [CODEX_PERMISSION_REVIEWER_EVIDENCE_FIELD]: {
+        status: "unavailable",
+        reason: "transcript_path_missing",
+      },
+    });
+    await expect(
+      enrichCodexPermissionReviewerEvidence(permissionRequest("/missing/codex-rollout.jsonl")),
+    ).resolves.toMatchObject({
+      [CODEX_PERMISSION_REVIEWER_EVIDENCE_FIELD]: {
+        status: "unavailable",
+        reason: "transcript_unreadable",
+      },
+    });
+    await expect(
+      enrichCodexPermissionReviewerEvidence(permissionRequest(scanLimitedPath), {
+        maxTranscriptBytes: 64,
+      }),
+    ).resolves.toMatchObject({
+      [CODEX_PERMISSION_REVIEWER_EVIDENCE_FIELD]: {
+        status: "unavailable",
+        reason: "transcript_scan_limit_reached",
+      },
+    });
+  });
+
+  it("overwrites raw reviewer claims and removes them from unrelated events", async () => {
+    const spoofed = {
+      ...permissionRequest(null),
+      [CODEX_PERMISSION_REVIEWER_EVIDENCE_FIELD]: {
+        status: "resolved",
+        source: "transcript_turn_context",
+        reviewer: "auto_review",
+      },
+    };
+    const unrelated = {
+      ...spoofed,
+      hook_event_name: "PreToolUse",
+      tool_use_id: "call_1",
+    };
+
+    await expect(enrichCodexPermissionReviewerEvidence(spoofed)).resolves.toMatchObject({
+      [CODEX_PERMISSION_REVIEWER_EVIDENCE_FIELD]: {
+        status: "unavailable",
+        reason: "transcript_path_missing",
+      },
+    });
+    const cleaned = await enrichCodexPermissionReviewerEvidence(unrelated);
+    expect(cleaned).not.toHaveProperty(CODEX_PERMISSION_REVIEWER_EVIDENCE_FIELD);
+  });
+});
+
+function permissionRequest(transcriptPath: string | null) {
+  return {
+    session_id: "codex_session_1",
+    transcript_path: transcriptPath,
+    cwd: "/tmp/station/web/task",
+    hook_event_name: "PermissionRequest",
+    model: "gpt-5.6-sol",
+    permission_mode: "default",
+    turn_id: "turn_1",
+    tool_name: "Bash",
+    tool_input: { command: "pnpm test:all" },
+  };
+}
+
+function turnContext(turnId: string, reviewer: string): string {
+  return JSON.stringify({
+    timestamp: "2026-08-22T18:10:00.927Z",
+    ordinal: 3102,
+    type: "turn_context",
+    payload: {
+      turn_id: turnId,
+      cwd: "/tmp/station/web/task",
+      approval_policy: "on-request",
+      approvals_reviewer: reviewer,
+      model: "gpt-5.6-sol",
+    },
+  });
+}
+
+async function writeTranscript(lines: string[]): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "station-codex-reviewer-"));
+  temporaryRoots.push(root);
+  const transcriptPath = join(root, "rollout.jsonl");
+  await writeFile(transcriptPath, `${lines.join("\n")}\n`, "utf8");
+  return transcriptPath;
+}


### PR DESCRIPTION
## What this fixes

Station treated every Codex `PermissionRequest` hook as a user-blocking approval because the hook payload does not identify whether the user or Codex automatic review owns the decision. That produced false attention and left automatically reviewed Bash requests looking stuck.

## What changed

- Enrich Codex permission hooks at CLI ingress from a bounded transcript tail using the exact hook `turn_id` and a strict provider-private schema.
- Strip caller-supplied reviewer evidence so only Station-derived transcript context can classify the reviewer.
- Normalize proven `auto_review` requests as `working` without attention; preserve `needs_attention` for user review and all missing, malformed, unreadable, or changed evidence.
- Retain the typed evidence through Codex compaction and normalization without introducing provider vocabulary into Observer core.
- Document the fail-conservative signal policy and add unit, CLI-ingress, and Observer reconciliation coverage.

## Testing

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- Focused Codex/CLI unit suite: 51 tests passed
- Focused Observer integration suite: 12 tests passed
- Repository unit, contract, integration, diagnostics, and scripted-agent stages passed
- Setup E2E: one process-interruption case timed out once in the aggregate run, then its isolated file passed all 4 tests
- Observer E2E: 22 tests passed
- `pnpm smoke:install`

## User-visible behavior

Codex permissions routed to automatic review remain visibly working and do not trigger approval attention. Genuine user approvals and any request whose automatic reviewer cannot be proven continue to alert normally. No configuration or app server is required.