### PR TITLE
fix(codex): preserve permissions on session resume

### DIFF
--- a/integrations/harness/codex/src/launch.ts
+++ b/integrations/harness/codex/src/launch.ts
@@ -117,8 +117,19 @@ function buildCodexResumeLaunchPlan(
   const configuredProfile = request.profile ?? options.defaultProfile;
   const hookProfile = options.defaultHookProfile;
   const profile = hookProfile ?? configuredProfile;
+  const permissionMode = request.permissionMode ?? options.defaultPermissionMode;
+  const approvalPolicy = request.approvalPolicy ?? options.defaultApprovalPolicy;
+  const sandboxMode = request.sandboxMode ?? options.defaultSandboxMode;
+  const yolo = isYoloPermissionMode({ permissionMode, approvalPolicy, sandboxMode });
+  const providerPermissionMode = yolo ? "yolo" : permissionMode;
   const args = ["resume", "--cd", request.worktree.path];
-  appendCodexOptions(args, { profile });
+  appendCodexOptions(args, {
+    profile,
+    permissionMode: providerPermissionMode,
+    approvalPolicy: yolo ? undefined : approvalPolicy,
+    sandboxMode: yolo ? undefined : sandboxMode,
+    noAltScreen: options.noAltScreen,
+  });
   args.push(request.resume.target.id);
   if (request.initialPrompt !== undefined) {
     args.push(request.initialPrompt);
@@ -133,7 +144,20 @@ function buildCodexResumeLaunchPlan(
   if (profile !== undefined) {
     providerDataInput.profile = profile;
   }
-  const providerData = codexProviderData(providerDataInput, { configuredProfile, hookProfile });
+  if (providerPermissionMode !== undefined) {
+    providerDataInput.permissionMode = providerPermissionMode;
+  }
+  if (!yolo && approvalPolicy !== undefined) {
+    providerDataInput.approvalPolicy = approvalPolicy;
+  }
+  if (!yolo && sandboxMode !== undefined) {
+    providerDataInput.sandboxMode = sandboxMode;
+  }
+  const providerData = codexProviderData(providerDataInput, {
+    configuredProfile,
+    hookProfile,
+    noAltScreen: options.noAltScreen,
+  });
 
   return {
     provider: "codex",

--- a/integrations/harness/codex/test/unit/launch.test.ts
+++ b/integrations/harness/codex/test/unit/launch.test.ts
@@ -274,6 +274,78 @@ describe("buildCodexLaunchPlan", () => {
     });
   });
 
+  it("preserves full-access permission defaults on interactive resume plans", () => {
+    const plan = buildCodexLaunchPlan(
+      {
+        ...request(),
+        resume: {
+          target: { kind: "native-session", id: "codex_session_123" },
+          previousSessionId: "ses_web_task",
+          recoveryHandleId: "rec_codex",
+        },
+      },
+      {
+        defaultPermissionMode: "yolo",
+        defaultApprovalPolicy: "on-request",
+        defaultSandboxMode: "workspace-write",
+        noAltScreen: true,
+      },
+    );
+
+    expect(plan.args).toEqual([
+      "resume",
+      "--cd",
+      "/tmp/station/web/task",
+      "--dangerously-bypass-approvals-and-sandbox",
+      "--no-alt-screen",
+      "codex_session_123",
+      "Review the task.",
+    ]);
+    expect(plan.args).not.toContain("--sandbox");
+    expect(plan.args).not.toContain("--ask-for-approval");
+    expect(plan.providerData).toMatchObject({
+      permissionMode: "yolo",
+      noAltScreen: true,
+      resume: true,
+      resumeTargetKind: "native-session",
+    });
+  });
+
+  it("preserves explicit sandbox and approval defaults on interactive resume plans", () => {
+    const plan = buildCodexLaunchPlan(
+      {
+        ...request(),
+        resume: {
+          target: { kind: "native-session", id: "codex_session_123" },
+          previousSessionId: "ses_web_task",
+          recoveryHandleId: "rec_codex",
+        },
+      },
+      {
+        defaultApprovalPolicy: "on-request",
+        defaultSandboxMode: "workspace-write",
+      },
+    );
+
+    expect(plan.args).toEqual([
+      "resume",
+      "--cd",
+      "/tmp/station/web/task",
+      "--sandbox",
+      "workspace-write",
+      "--ask-for-approval",
+      "on-request",
+      "codex_session_123",
+      "Review the task.",
+    ]);
+    expect(plan.providerData).toMatchObject({
+      approvalPolicy: "on-request",
+      sandboxMode: "workspace-write",
+      resume: true,
+      resumeTargetKind: "native-session",
+    });
+  });
+
   it("preserves the station hook profile on interactive resume plans", () => {
     const plan = buildCodexLaunchPlan(
       {


### PR DESCRIPTION
## What this fixes

The Codex harness adapter translates Station launch policy into native Codex CLI arguments. Interactive resume launches preserved the selected profile but dropped the effective permission mode, approval policy, sandbox mode, and terminal-display option, so a resumed session could unexpectedly return to restricted command execution even when Station was configured for full access.

## What changed

- Apply the same effective permission, approval, and sandbox resolution to resumed Codex sessions as fresh sessions.
- Normalize full-access policy to Codex's native bypass flag without also emitting conflicting sandbox or approval arguments.
- Preserve the configured no-alt-screen behavior and expose the effective resume policy in provider diagnostics.
- Add regression coverage for both full-access and explicitly sandboxed resume plans.

## Testing

- `pnpm exec vitest run --config config/vitest/vitest.unit.config.ts integrations/harness/codex/test/unit/launch.test.ts`
- `env -u STATION_OPENCODE_PLUGIN_BODY_PATH pnpm test:all`
