### PR TITLE
refactor(observer): isolate build precedence policy

### DIFF
--- a/apps/observer/src/runtime/observerHandoff.ts
+++ b/apps/observer/src/runtime/observerHandoff.ts
@@ -54,7 +54,7 @@ const HandoffCandidateSchema = z
   })
   .strict();
 
-/** Returns whether an Observer argv selector is valid legacy SemVer or an exact Station build. */
+/** Returns whether an Observer argv selector is valid unadorned SemVer or an exact Station build. */
 export function observerBuildSelectorIsValid(selector: string): boolean {
   const build = parseStationObserverBuildVersion(selector);
   return (
@@ -64,6 +64,13 @@ export function observerBuildSelectorIsValid(selector: string): boolean {
 }
 
 export type ObserverHandoffCandidate = z.infer<typeof HandoffCandidateSchema>;
+
+/** Selector ordering only; it never authorizes process replacement or lifecycle mutation. */
+export type ObserverBuildPrecedenceResult =
+  | { outcome: "exact-build" }
+  | { outcome: "candidate-precedes" }
+  | { outcome: "incumbent-precedes" }
+  | { outcome: "refused"; reason: string };
 
 export type ObserverIncumbentDecision =
   | { action: "attach"; reason: "exact-build" | "incumbent-wins" }
@@ -134,55 +141,51 @@ type ObserverHandoffDeps = {
 /**
  * POLICY
  *
- * Selects one stable Observer build winner without process or transport I/O,
- * refusing ambiguous same-version handoffs instead of silently reusing them.
+ * Orders Observer build selectors without process or lifecycle authority,
+ * preserving singleton SemVer, immutable-build, and public-version-line rules.
  */
-export function classifyObserverIncumbent(input: {
-  candidate: ObserverHandoffCandidate;
-  incumbent: Pick<ObserverHealth, "version" | "startedAt" | "pid">;
-}): ObserverIncumbentDecision {
-  const candidate = HandoffCandidateSchema.safeParse(input.candidate);
-  if (!candidate.success) {
-    return { action: "refuse", reason: "The candidate Observer identity is invalid." };
-  }
-  const candidateBuild = parseStationObserverBuildVersion(candidate.data.version);
+export function classifyObserverBuildPrecedence(input: {
+  candidateSelector: string;
+  incumbentSelector: string | undefined;
+}): ObserverBuildPrecedenceResult {
+  const candidateBuild = parseStationObserverBuildVersion(input.candidateSelector);
   if (
     candidateBuild.buildIdentity === undefined &&
-    hasStationObserverBuildIdentityMarker(candidate.data.version)
+    hasStationObserverBuildIdentityMarker(input.candidateSelector)
   ) {
-    return { action: "refuse", reason: "The candidate Observer build identity is invalid." };
+    return { outcome: "refused", reason: "The candidate Observer build identity is invalid." };
   }
   const candidateVersion = SemVerSchema.safeParse(candidateBuild.version);
   if (!candidateVersion.success) {
-    return { action: "refuse", reason: "The candidate Observer version is not valid SemVer." };
+    return { outcome: "refused", reason: "The candidate Observer version is not valid SemVer." };
   }
-  if (input.incumbent.version === undefined) {
-    return { action: "refuse", reason: "The incumbent Observer did not report a version." };
+  if (input.incumbentSelector === undefined) {
+    return { outcome: "refused", reason: "The incumbent Observer did not report a version." };
   }
-  const incumbentBuild = parseStationObserverBuildVersion(input.incumbent.version);
+  const incumbentBuild = parseStationObserverBuildVersion(input.incumbentSelector);
   if (
     incumbentBuild.buildIdentity === undefined &&
-    hasStationObserverBuildIdentityMarker(input.incumbent.version)
+    hasStationObserverBuildIdentityMarker(input.incumbentSelector)
   ) {
-    return { action: "refuse", reason: "The incumbent Observer build identity is invalid." };
+    return { outcome: "refused", reason: "The incumbent Observer build identity is invalid." };
   }
   const incumbentVersion = SemVerSchema.safeParse(incumbentBuild.version);
   if (!incumbentVersion.success) {
-    return { action: "refuse", reason: "The incumbent Observer version is not valid SemVer." };
+    return { outcome: "refused", reason: "The incumbent Observer version is not valid SemVer." };
   }
-  if (candidate.data.version === input.incumbent.version) {
+  if (input.candidateSelector === input.incumbentSelector) {
     if (candidateBuild.buildIdentity === undefined) {
       return {
-        action: "refuse",
+        outcome: "refused",
         reason: "Same-version Observer reuse requires immutable build identity.",
       };
     }
-    return { action: "attach", reason: "exact-build" };
+    return { outcome: "exact-build" };
   }
   if (candidateBuild.version === incumbentBuild.version) {
     if (candidateBuild.buildIdentity === undefined || incumbentBuild.buildIdentity === undefined) {
       return {
-        action: "refuse",
+        outcome: "refused",
         reason: "Same-version Observer handoff requires build identity from both contenders.",
       };
     }
@@ -192,7 +195,7 @@ export function classifyObserverIncumbent(input: {
     );
     if (identityOrder <= 0) {
       return {
-        action: "refuse",
+        outcome: "refused",
         reason: "A different build of this Station version already owns the Observer socket.",
       };
     }
@@ -202,7 +205,7 @@ export function classifyObserverIncumbent(input: {
     incumbentBuild.version,
   );
   const precedence = resetPrecedence ?? compareSemVer(candidateVersion.data, incumbentVersion.data);
-  if (precedence < 0) return { action: "attach", reason: "incumbent-wins" };
+  if (precedence < 0) return { outcome: "incumbent-precedes" };
   if (precedence === 0) {
     // Display-version strings are stable across the CLI parent and Observer child;
     // their process timestamps and PIDs are not the same contender identity.
@@ -210,7 +213,37 @@ export function classifyObserverIncumbent(input: {
       candidateVersion.data.version,
       incumbentVersion.data.version,
     );
-    if (buildOrder < 0) return { action: "attach", reason: "incumbent-wins" };
+    if (buildOrder < 0) return { outcome: "incumbent-precedes" };
+  }
+  return { outcome: "candidate-precedes" };
+}
+
+/**
+ * POLICY
+ *
+ * Maps shared build precedence to singleton attach, replace, or refusal,
+ * requiring complete contender identity before admitting replacement.
+ */
+export function classifyObserverIncumbent(input: {
+  candidate: ObserverHandoffCandidate;
+  incumbent: Pick<ObserverHealth, "version" | "startedAt" | "pid">;
+}): ObserverIncumbentDecision {
+  const candidate = HandoffCandidateSchema.safeParse(input.candidate);
+  if (!candidate.success) {
+    return { action: "refuse", reason: "The candidate Observer identity is invalid." };
+  }
+  const precedence = classifyObserverBuildPrecedence({
+    candidateSelector: candidate.data.version,
+    incumbentSelector: input.incumbent.version,
+  });
+  if (precedence.outcome === "exact-build") {
+    return { action: "attach", reason: "exact-build" };
+  }
+  if (precedence.outcome === "incumbent-precedes") {
+    return { action: "attach", reason: "incumbent-wins" };
+  }
+  if (precedence.outcome === "refused") {
+    return { action: "refuse", reason: precedence.reason };
   }
   const incumbentStartedAt = TimestampSchema.safeParse(input.incumbent.startedAt);
   if (!incumbentStartedAt.success || input.incumbent.pid === undefined) {

--- a/apps/observer/test/unit/observerHandoff.test.ts
+++ b/apps/observer/test/unit/observerHandoff.test.ts
@@ -1,6 +1,7 @@
 import type { ObserverHealth, ObserverProcessIdentity } from "@station/contracts";
 import { describe, expect, it, vi } from "vitest";
 import {
+  classifyObserverBuildPrecedence,
   classifyObserverIncumbent,
   negotiateObserverIncumbent,
   type ObserverIncumbentLifecycle,
@@ -17,33 +18,68 @@ const candidate = {
 const lowerBuildIdentity = "1".repeat(64);
 const higherBuildIdentity = "e".repeat(64);
 
-describe("classifyObserverIncumbent", () => {
-  it("attaches to an exact build", () => {
-    const buildVersion = observerBuildVersion("2.0.0", lowerBuildIdentity);
-    expect(
-      classifyObserverIncumbent({
-        candidate: { ...candidate, version: buildVersion },
-        incumbent: { version: buildVersion },
-      }),
-    ).toEqual({ action: "attach", reason: "exact-build" });
+describe("classifyObserverBuildPrecedence", () => {
+  it("classifies only an exact identified selector as the exact build", () => {
+    const exact = observerBuildVersion("2.0.0", lowerBuildIdentity);
+
+    expect(precedenceFor(exact, exact)).toEqual({ outcome: "exact-build" });
+    expect(precedenceFor("2.0.0", "2.0.0")).toEqual({
+      outcome: "refused",
+      reason: "Same-version Observer reuse requires immutable build identity.",
+    });
   });
 
-  it("replaces only in the winning direction for different same-version builds", () => {
+  it("orders different immutable builds at one display version in only the admitted direction", () => {
     const lower = observerBuildVersion("2.0.0", lowerBuildIdentity);
     const higher = observerBuildVersion("2.0.0", higherBuildIdentity);
 
-    expect(decisionFor(higher, lower)).toEqual({
-      action: "replace",
-      reason: "candidate-wins",
+    expect(precedenceFor(higher, lower)).toEqual({ outcome: "candidate-precedes" });
+    expect(precedenceFor(lower, higher)).toEqual({
+      outcome: "refused",
+      reason: "A different build of this Station version already owns the Observer socket.",
     });
-    expect(decisionFor(lower, higher)).toMatchObject({ action: "refuse" });
   });
 
-  it("refuses same-version handoff when only one contender has build identity", () => {
+  it("refuses incomplete immutable identity at one display version", () => {
     const identified = observerBuildVersion("2.0.0", higherBuildIdentity);
+    const refusal = {
+      outcome: "refused",
+      reason: "Same-version Observer handoff requires build identity from both contenders.",
+    } as const;
 
-    expect(decisionFor(identified, "2.0.0")).toMatchObject({ action: "refuse" });
-    expect(decisionFor("2.0.0", identified)).toMatchObject({ action: "refuse" });
+    expect(precedenceFor(identified, "2.0.0")).toEqual(refusal);
+    expect(precedenceFor("2.0.0", identified)).toEqual(refusal);
+  });
+
+  it("orders newer and older SemVer without numeric truncation", () => {
+    expect(precedenceFor("100000000000000000000.0.0", "99999999999999999999.0.0")).toEqual({
+      outcome: "candidate-precedes",
+    });
+    expect(precedenceFor("2.0.0-rc.10", "2.0.0-rc.2")).toEqual({
+      outcome: "candidate-precedes",
+    });
+    expect(precedenceFor("1.9.9", "2.0.0")).toEqual({ outcome: "incumbent-precedes" });
+  });
+
+  it("uses both directions of the exact selector as the equal-SemVer tiebreak", () => {
+    expect(precedenceFor("2.0.0+candidate", "2.0.0+incumbent")).toEqual({
+      outcome: "incumbent-precedes",
+    });
+    expect(precedenceFor("2.0.0+incumbent", "2.0.0+candidate")).toEqual({
+      outcome: "candidate-precedes",
+    });
+  });
+
+  it("orders the public pre-alpha after the internal preview version line", () => {
+    const publicPreAlpha = observerBuildVersion("0.0.0-pre-alpha.5.16", higherBuildIdentity);
+    const internalPreview = observerBuildVersion("0.7.1-rc.8", lowerBuildIdentity);
+
+    expect(precedenceFor(publicPreAlpha, internalPreview)).toEqual({
+      outcome: "candidate-precedes",
+    });
+    expect(precedenceFor(internalPreview, publicPreAlpha)).toEqual({
+      outcome: "incumbent-precedes",
+    });
   });
 
   it.each([
@@ -54,85 +90,116 @@ describe("classifyObserverIncumbent", () => {
     `2.0.0+station.${lowerBuildIdentity}.station.${higherBuildIdentity}`,
   ])("refuses malformed reserved build identity %s", (malformed) => {
     const identified = observerBuildVersion("2.0.0", higherBuildIdentity);
-    expect(decisionFor(identified, malformed)).toMatchObject({ action: "refuse" });
-    expect(decisionFor(malformed, identified)).toMatchObject({ action: "refuse" });
+
+    expect(precedenceFor(malformed, identified)).toEqual({
+      outcome: "refused",
+      reason: "The candidate Observer build identity is invalid.",
+    });
+    expect(precedenceFor(identified, malformed)).toEqual({
+      outcome: "refused",
+      reason: "The incumbent Observer build identity is invalid.",
+    });
   });
 
-  it("refuses exact legacy reuse while retaining cross-version SemVer handoff", () => {
-    expect(decisionFor("2.0.0", "2.0.0")).toMatchObject({ action: "refuse" });
+  it("refuses invalid or absent selectors in candidate-first order", () => {
+    expect(precedenceFor("v2.0.0", undefined)).toEqual({
+      outcome: "refused",
+      reason: "The candidate Observer version is not valid SemVer.",
+    });
+    expect(precedenceFor("2.0.0", undefined)).toEqual({
+      outcome: "refused",
+      reason: "The incumbent Observer did not report a version.",
+    });
+    expect(precedenceFor("2.0.0", "v1.0.0")).toEqual({
+      outcome: "refused",
+      reason: "The incumbent Observer version is not valid SemVer.",
+    });
+  });
+});
+
+describe("classifyObserverIncumbent", () => {
+  const exactSelector = observerBuildVersion("2.0.0", lowerBuildIdentity);
+  const lowerSelector = observerBuildVersion("2.0.0", lowerBuildIdentity);
+  const higherSelector = observerBuildVersion("2.0.0", higherBuildIdentity);
+  const mappingCases: ReadonlyArray<{
+    name: string;
+    candidateSelector: string;
+    incumbent: Pick<ObserverHealth, "version" | "startedAt" | "pid">;
+    precedence: ReturnType<typeof classifyObserverBuildPrecedence>;
+    decision: ReturnType<typeof classifyObserverIncumbent>;
+  }> = [
+    {
+      name: "exact build",
+      candidateSelector: exactSelector,
+      incumbent: { version: exactSelector },
+      precedence: { outcome: "exact-build" },
+      decision: { action: "attach", reason: "exact-build" },
+    },
+    {
+      name: "candidate precedence",
+      candidateSelector: higherSelector,
+      incumbent: {
+        version: lowerSelector,
+        startedAt: "2026-07-12T11:59:59.000Z",
+        pid: 100,
+      },
+      precedence: { outcome: "candidate-precedes" },
+      decision: { action: "replace", reason: "candidate-wins" },
+    },
+    {
+      name: "incumbent precedence without mutation identity",
+      candidateSelector: "1.0.0",
+      incumbent: { version: "2.0.0" },
+      precedence: { outcome: "incumbent-precedes" },
+      decision: { action: "attach", reason: "incumbent-wins" },
+    },
+    {
+      name: "refusal passthrough",
+      candidateSelector: "2.0.0",
+      incumbent: {},
+      precedence: {
+        outcome: "refused",
+        reason: "The incumbent Observer did not report a version.",
+      },
+      decision: {
+        action: "refuse",
+        reason: "The incumbent Observer did not report a version.",
+      },
+    },
+  ];
+
+  it.each(mappingCases)("maps $name", ({ candidateSelector, incumbent, precedence, decision }) => {
     expect(
-      decisionFor(
-        observerBuildVersion("2.0.0", lowerBuildIdentity),
-        observerBuildVersion("1.9.9", higherBuildIdentity),
-      ),
-    ).toEqual({ action: "replace", reason: "candidate-wins" });
-    expect(
-      decisionFor(
-        observerBuildVersion("1.9.9", higherBuildIdentity),
-        observerBuildVersion("2.0.0", lowerBuildIdentity),
-      ),
-    ).toEqual({ action: "attach", reason: "incumbent-wins" });
-  });
-
-  it("uses strict SemVer precedence without numeric truncation", () => {
-    expect(decisionFor("100000000000000000000.0.0", "99999999999999999999.0.0")).toEqual({
-      action: "replace",
-      reason: "candidate-wins",
-    });
-    expect(decisionFor("2.0.0-rc.10", "2.0.0-rc.2")).toEqual({
-      action: "replace",
-      reason: "candidate-wins",
-    });
-    expect(decisionFor("1.9.9", "2.0.0")).toEqual({
-      action: "attach",
-      reason: "incumbent-wins",
-    });
-  });
-
-  it("orders the public pre-alpha after the internal preview version line", () => {
-    const publicPreAlpha = observerBuildVersion("0.0.0-pre-alpha.5.16", higherBuildIdentity);
-    const internalPreview = observerBuildVersion("0.7.1-rc.8", lowerBuildIdentity);
-
-    expect(decisionFor(publicPreAlpha, internalPreview)).toEqual({
-      action: "replace",
-      reason: "candidate-wins",
-    });
-    expect(decisionFor(internalPreview, publicPreAlpha)).toEqual({
-      action: "attach",
-      reason: "incumbent-wins",
-    });
-  });
-
-  it("attaches to a valid higher incumbent without mutation-only identity fields", () => {
+      classifyObserverBuildPrecedence({
+        candidateSelector,
+        incumbentSelector: incumbent.version,
+      }),
+    ).toEqual(precedence);
     expect(
       classifyObserverIncumbent({
-        candidate: { ...candidate, version: "1.0.0" },
-        incumbent: { version: "2.0.0" },
+        candidate: { ...candidate, version: candidateSelector },
+        incumbent,
       }),
-    ).toEqual({ action: "attach", reason: "incumbent-wins" });
+    ).toEqual(decision);
   });
 
-  it("uses the exact build string as a stable equal-precedence tiebreak", () => {
+  it.each([
+    { startedAt: undefined, pid: 100 },
+    { startedAt: candidate.startedAt, pid: undefined },
+  ])("refuses candidate precedence without complete incumbent process identity %#", (incumbent) => {
+    const lower = observerBuildVersion("2.0.0", lowerBuildIdentity);
+    const higher = observerBuildVersion("2.0.0", higherBuildIdentity);
+
+    expect(precedenceFor(higher, lower)).toEqual({ outcome: "candidate-precedes" });
     expect(
       classifyObserverIncumbent({
-        candidate: { ...candidate, version: "2.0.0+candidate", pid: 20 },
-        incumbent: {
-          version: "2.0.0+incumbent",
-          startedAt: candidate.startedAt,
-          pid: 30,
-        },
+        candidate: { ...candidate, version: higher },
+        incumbent: { ...incumbent, version: lower },
       }),
-    ).toEqual({ action: "attach", reason: "incumbent-wins" });
-    expect(
-      classifyObserverIncumbent({
-        candidate: { ...candidate, version: "2.0.0+incumbent", pid: 30 },
-        incumbent: {
-          version: "2.0.0+candidate",
-          startedAt: "2026-07-12T11:59:59.000Z",
-          pid: 20,
-        },
-      }),
-    ).toEqual({ action: "replace", reason: "candidate-wins" });
+    ).toEqual({
+      action: "refuse",
+      reason: "Replacing a different-build Observer requires complete incumbent identity.",
+    });
   });
 
   it("keeps parent and child equal-precedence decisions consistent", () => {
@@ -183,15 +250,6 @@ describe("classifyObserverIncumbent", () => {
     expect(classifyObserverIncumbent({ candidate: second, incumbent: first }).action).toBe(
       "replace",
     );
-  });
-
-  it.each([
-    { version: undefined, startedAt: candidate.startedAt, pid: 100 },
-    { version: "v1.0.0", startedAt: candidate.startedAt, pid: 100 },
-    { version: "1.0.0", startedAt: undefined, pid: 100 },
-    { version: "1.0.0", startedAt: candidate.startedAt, pid: undefined },
-  ])("refuses invalid or incomplete replacement identity %#", (incumbent) => {
-    expect(classifyObserverIncumbent({ candidate, incumbent }).action).toBe("refuse");
   });
 });
 
@@ -607,15 +665,8 @@ describe("negotiateObserverIncumbent", () => {
   });
 });
 
-function decisionFor(candidateVersion: string, incumbentVersion: string) {
-  return classifyObserverIncumbent({
-    candidate: { ...candidate, version: candidateVersion },
-    incumbent: {
-      version: incumbentVersion,
-      startedAt: "2026-07-12T11:00:00.000Z",
-      pid: 100,
-    },
-  });
+function precedenceFor(candidateSelector: string, incumbentSelector: string | undefined) {
+  return classifyObserverBuildPrecedence({ candidateSelector, incumbentSelector });
 }
 
 function observerBuildVersion(version: string, buildIdentity: string): string {

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -4213,10 +4213,16 @@
           "purpose": null
         },
         {
+          "name": "classifyObserverBuildPrecedence",
+          "kind": "function",
+          "role": "POLICY",
+          "purpose": "Orders Observer build selectors without process or lifecycle authority, preserving singleton SemVer, immutable-build, and public-version-line rules."
+        },
+        {
           "name": "classifyObserverIncumbent",
           "kind": "function",
           "role": "POLICY",
-          "purpose": "Selects one stable Observer build winner without process or transport I/O, refusing ambiguous same-version handoffs instead of silently reusing them."
+          "purpose": "Maps shared build precedence to singleton attach, replace, or refusal, requiring complete contender identity before admitting replacement."
         },
         {
           "name": "CleanupRuntime",
@@ -4742,6 +4748,12 @@
         },
         {
           "name": "ObserverBootClaimResult",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "ObserverBuildPrecedenceResult",
           "kind": "type",
           "role": null,
           "purpose": null
@@ -11590,16 +11602,28 @@
       "path": "apps/observer/src/runtime/observerHandoff.ts",
       "exports": [
         {
+          "name": "classifyObserverBuildPrecedence",
+          "kind": "function",
+          "role": "POLICY",
+          "purpose": "Orders Observer build selectors without process or lifecycle authority, preserving singleton SemVer, immutable-build, and public-version-line rules."
+        },
+        {
           "name": "classifyObserverIncumbent",
           "kind": "function",
           "role": "POLICY",
-          "purpose": "Selects one stable Observer build winner without process or transport I/O, refusing ambiguous same-version handoffs instead of silently reusing them."
+          "purpose": "Maps shared build precedence to singleton attach, replace, or refusal, requiring complete contender identity before admitting replacement."
         },
         {
           "name": "negotiateObserverIncumbent",
           "kind": "function",
           "role": "USE CASE",
           "purpose": "Replaces an older incumbent only after corroborating its socket and process identity, completing candidate prerequisites, revalidating the incumbent, and synchronously refusing pending cancellation before committing to stop; any pre-commit failure preserves the incumbent and remains available as the typed handoff refusal's cause."
+        },
+        {
+          "name": "ObserverBuildPrecedenceResult",
+          "kind": "type",
+          "role": null,
+          "purpose": null
         },
         {
           "name": "observerBuildSelectorIsValid",
@@ -15927,11 +15951,27 @@
     },
     {
       "path": "apps/observer/src/runtime/observerHandoff.ts",
+      "declaration": "classifyObserverBuildPrecedence",
+      "kind": "function",
+      "role": "POLICY",
+      "purpose": "Orders Observer build selectors without process or lifecycle authority, preserving singleton SemVer, immutable-build, and public-version-line rules.",
+      "dependencies": []
+    },
+    {
+      "path": "apps/observer/src/runtime/observerHandoff.ts",
       "declaration": "classifyObserverIncumbent",
       "kind": "function",
       "role": "POLICY",
-      "purpose": "Selects one stable Observer build winner without process or transport I/O, refusing ambiguous same-version handoffs instead of silently reusing them.",
-      "dependencies": []
+      "purpose": "Maps shared build precedence to singleton attach, replace, or refusal, requiring complete contender identity before admitting replacement.",
+      "dependencies": [
+        {
+          "path": "apps/observer/src/runtime/observerHandoff.ts",
+          "declaration": "classifyObserverBuildPrecedence",
+          "kind": "function",
+          "role": "POLICY",
+          "edgeKind": "runtime"
+        }
+      ]
     },
     {
       "path": "apps/observer/src/runtime/observerHandoff.ts",


### PR DESCRIPTION
## What this fixes

Observer build ordering was embedded in the process-aware singleton classifier, so later planning code could not ask which exact build takes precedence without also depending on process-replacement decisions. This extracts the existing build-only policy while preserving the singleton classifier's validation order, refusal messages, and lifecycle behavior.

## What changed

- Added one pure `classifyObserverBuildPrecedence` policy with `exact-build`, `candidate-precedes`, `incumbent-precedes`, and `refused` outcomes.
- Moved the existing SemVer, immutable-build, lexical tie-break, and public-version-line reset ordering into that policy without copying or changing it.
- Kept process authority in `classifyObserverIncumbent`, which validates the complete candidate first, maps precedence to the existing process-aware decisions, and still requires PID and start-time evidence before replacement.
- Consolidated test ownership so the pure-policy suite owns the detailed ordering matrix, while focused wrapper tests cover outcome mapping and process-identity authority.
- Regenerated the Observer architecture manifest to record the policy and delegation edge.

## Testing

Deterministic and full validation is green:

- `pnpm test:all` passed under the normalized terminal environment, including build, package typechecks, lint, unit, contract, integration, diagnostics, scripted-agent, setup E2E, Observer E2E, and install smoke gates.
- Focused Observer handoff suite passed: 41 tests.
- Observer typecheck, architecture check, repository lint, and diff checks passed after the final test-ownership consolidation.

Real-lane evidence is mixed and is reported without treating unrelated failures as #680 defects:

- Native Station singleton E2E passed all three applicable source-mode cases in 10.61 seconds: cooperative takeover, refusal of unsafe owners, and simultaneous-contender exclusion. The optional compiled `__tui` repeat was skipped because `STATION_COMPILED_BIN` was not supplied.
- Real Station + authenticated Codex tmux popup navigation passed in 129.93 seconds.
- The combined native Station + Codex mouse lane timed out after command dispatch. Its retained evidence reports a scheduled reconcile failure; the independent singleton lane above confirms the changed build-precedence path itself works.
- The real Codex app-server proof encounters a current Codex envelope containing `emittedAtMs`, which the existing strict integration rejects.
- The real Codex tmux session-create proof times out because its existing launch shim does not record argv.
- Those Codex compatibility and harness failures are outside this policy-only slice and were not worked around here.

## Safety and scope

This result describes build precedence only. It grants no process replacement, lifecycle mutation, signaling, reaping, update, or convergence authority. PID and start-time evidence remain exclusively in the process-aware singleton classifier.

The change adds no CLI/update wiring, schema versioning, compatibility parsing, new parser, configuration, or user-facing command behavior.

User-visible behavior is intentionally unchanged. Manual verification is the native singleton lane:

`pnpm test:e2e:real:local tests/e2e/real/real-native-tui-singleton.test.ts`

It confirms that real Station still performs cooperative takeover, refuses unsafe ownership, and admits at most one renderer to raw mode.

Closes #680
