### PR TITLE
refactor(runtime): unnest deep production control flow

### DIFF
--- a/apps/cli/src/commands/setup/harnessInstallation.ts
+++ b/apps/cli/src/commands/setup/harnessInstallation.ts
@@ -10,15 +10,16 @@ export function resolveSetupHarnessInstallation(input: {
   const macBrewAvailable = input.macos && input.brewAvailable;
   switch (input.harnessId) {
     case "codex":
-      return macBrewAvailable
-        ? {
-            command: ["brew", "install", "--cask", "homebrew/cask/codex"],
-            message: setupMessageRef("installer.codex-brew"),
-          }
-        : {
-            command: ["/bin/bash", "-c", codexInstallerCommand],
-            message: setupMessageRef("installer.codex-script"),
-          };
+      if (macBrewAvailable) {
+        return {
+          command: ["brew", "install", "--cask", "homebrew/cask/codex"],
+          message: setupMessageRef("installer.codex-brew"),
+        };
+      }
+      return {
+        command: ["/bin/bash", "-c", codexInstallerCommand],
+        message: setupMessageRef("installer.codex-script"),
+      };
     case "cursor":
       return {
         command: [
@@ -29,64 +30,70 @@ export function resolveSetupHarnessInstallation(input: {
         message: setupMessageRef("installer.cursor-script"),
       };
     case "opencode":
-      return input.brewAvailable
-        ? {
-            command: ["brew", "install", "homebrew/core/opencode"],
-            message: setupMessageRef("installer.opencode-brew"),
-          }
-        : {
-            command: [
-              "/bin/bash",
-              "-c",
-              downloadedInstallerCommand({
-                url: "https://opencode.ai/install",
-                execute:
-                  '/bin/bash "$installer" --no-modify-path && mkdir -p "$HOME/.local/bin" && ln -s "$HOME/.opencode/bin/opencode" "$HOME/.local/bin/opencode"',
-              }),
-            ],
-            message: setupMessageRef("installer.opencode-script"),
-          };
+      if (input.brewAvailable) {
+        return {
+          command: ["brew", "install", "homebrew/core/opencode"],
+          message: setupMessageRef("installer.opencode-brew"),
+        };
+      }
+      return {
+        command: [
+          "/bin/bash",
+          "-c",
+          downloadedInstallerCommand({
+            url: openCodeInstallerUrl,
+            execute: openCodeInstallerExecute,
+          }),
+        ],
+        message: setupMessageRef("installer.opencode-script"),
+      };
     case "pi":
-      return input.brewAvailable
-        ? {
-            command: ["brew", "install", "homebrew/core/pi-coding-agent"],
-            message: setupMessageRef("installer.pi-brew"),
-          }
-        : {
-            command: [
-              "npm",
-              "install",
-              "--global",
-              "--prefix",
-              `${input.homeDir}/.local`,
-              "--ignore-scripts",
-              "--no-fund",
-              "--no-audit",
-              "@earendil-works/pi-coding-agent",
-            ],
-            message: setupMessageRef("installer.pi-npm"),
-          };
+      if (input.brewAvailable) {
+        return {
+          command: ["brew", "install", "homebrew/core/pi-coding-agent"],
+          message: setupMessageRef("installer.pi-brew"),
+        };
+      }
+      return {
+        command: [
+          "npm",
+          "install",
+          "--global",
+          "--prefix",
+          `${input.homeDir}/.local`,
+          "--ignore-scripts",
+          "--no-fund",
+          "--no-audit",
+          "@earendil-works/pi-coding-agent",
+        ],
+        message: setupMessageRef("installer.pi-npm"),
+      };
     case "claude":
-      return macBrewAvailable
-        ? {
-            command: ["brew", "install", "--cask", "homebrew/cask/claude-code"],
-            message: setupMessageRef("installer.claude-brew"),
-          }
-        : {
-            command: [
-              "npm",
-              "install",
-              "--global",
-              "--prefix",
-              `${input.homeDir}/.local`,
-              "--no-fund",
-              "--no-audit",
-              "@anthropic-ai/claude-code",
-            ],
-            message: setupMessageRef("installer.claude-npm"),
-          };
+      if (macBrewAvailable) {
+        return {
+          command: ["brew", "install", "--cask", "homebrew/cask/claude-code"],
+          message: setupMessageRef("installer.claude-brew"),
+        };
+      }
+      return {
+        command: [
+          "npm",
+          "install",
+          "--global",
+          "--prefix",
+          `${input.homeDir}/.local`,
+          "--no-fund",
+          "--no-audit",
+          "@anthropic-ai/claude-code",
+        ],
+        message: setupMessageRef("installer.claude-npm"),
+      };
   }
 }
+
+const openCodeInstallerUrl = "https://opencode.ai/install";
+const openCodeInstallerExecute =
+  '/bin/bash "$installer" --no-modify-path && mkdir -p "$HOME/.local/bin" && ln -s "$HOME/.opencode/bin/opencode" "$HOME/.local/bin/opencode"';
 
 const codexInstallerCommand = [
   "set -eu",

--- a/apps/cli/src/commands/setup/presenters/text.ts
+++ b/apps/cli/src/commands/setup/presenters/text.ts
@@ -619,23 +619,19 @@ function operationText(
         ),
       };
     }
-    case "write-config":
+    case "write-config": {
+      const creating = operation.change === "create";
       return {
         label: resolveSetupMessage(
-          setupMessageRef(
-            operation.change === "create"
-              ? "action.config-create-label"
-              : "action.config-update-label",
-          ),
+          setupMessageRef(creating ? "action.config-create-label" : "action.config-update-label"),
         ),
         explanation: resolveSetupMessage(
           setupMessageRef(
-            operation.change === "create"
-              ? "action.config-create-message"
-              : "action.config-update-message",
+            creating ? "action.config-create-message" : "action.config-update-message",
           ),
         ),
       };
+    }
     case "activate-observer-config":
       return {
         label: resolveSetupMessage(setupMessageRef("label.observer-activation")),

--- a/apps/cli/src/commands/setup/presenters/text.ts
+++ b/apps/cli/src/commands/setup/presenters/text.ts
@@ -585,29 +585,21 @@ function operationText(
         label: resolveSetupMessage(setupMessageRef("action.worktrunk-shell-label")),
         explanation: resolveSetupMessage(setupMessageRef("action.worktrunk-shell-message")),
       };
-    case "configure-tmux-popup":
+    case "configure-tmux-popup": {
+      const persisted = operation.scope === "persisted";
+      const binding = projection.facts.tmuxBinding;
+      const key = binding.status === "conflict" ? "Space" : binding.bindingKey;
       return {
         label: resolveSetupMessage(
-          setupMessageRef(
-            operation.scope === "persisted"
-              ? "action.tmux-persist-label"
-              : "action.tmux-live-label",
-          ),
+          setupMessageRef(persisted ? "action.tmux-persist-label" : "action.tmux-live-label"),
         ),
         explanation: resolveSetupMessage(
-          setupMessageRef(
-            operation.scope === "persisted"
-              ? "action.tmux-persist-message"
-              : "action.tmux-live-message",
-            {
-              key:
-                projection.facts.tmuxBinding.status === "conflict"
-                  ? "Space"
-                  : projection.facts.tmuxBinding.bindingKey,
-            },
-          ),
+          setupMessageRef(persisted ? "action.tmux-persist-message" : "action.tmux-live-message", {
+            key,
+          }),
         ),
       };
+    }
     case "prepare-worktrunk-tracking":
       return {
         label: resolveSetupMessage(setupMessageRef("action.worktrunk-hooks-label")),

--- a/apps/cli/src/observerProcess/startup.ts
+++ b/apps/cli/src/observerProcess/startup.ts
@@ -119,13 +119,14 @@ export async function startObserverProcess(
         if (spawnInput.startupTimeoutMs <= 0) {
           throw startupTimeoutError;
         }
-        child =
-          deps.spawnObserver === undefined
-            ? await defaultSpawnObserver({
-                ...spawnInput,
-                buildVersion: input.buildVersion,
-              })
-            : await deps.spawnObserver(spawnInput);
+        if (deps.spawnObserver === undefined) {
+          child = await defaultSpawnObserver({
+            ...spawnInput,
+            buildVersion: input.buildVersion,
+          });
+        } else {
+          child = await deps.spawnObserver(spawnInput);
+        }
         if (signal.aborted) {
           child.kill?.();
           throw observerHealthWaitCancelledError();

--- a/apps/observer/src/commands/session/create.ts
+++ b/apps/observer/src/commands/session/create.ts
@@ -181,20 +181,20 @@ export function createSessionCreateHandler(
         }
         throw error;
       }
-      const worktreeRemoved =
-        createdWorktree === undefined
-          ? false
-          : await removeWorktreeBestEffort({
-              providers: options.providers,
-              project,
-              worktreeId: createdWorktree.id,
-              expectedPath: createdWorktree.path,
-              expectedBranch: createdWorktree.branch,
-              expectedRegistrationIdentity: createdWorktree.registrationIdentity,
-              context,
-              logger: options.logger,
-              clock: options.clock,
-            });
+      let worktreeRemoved = false;
+      if (createdWorktree !== undefined) {
+        worktreeRemoved = await removeWorktreeBestEffort({
+          providers: options.providers,
+          project,
+          worktreeId: createdWorktree.id,
+          expectedPath: createdWorktree.path,
+          expectedBranch: createdWorktree.branch,
+          expectedRegistrationIdentity: createdWorktree.registrationIdentity,
+          context,
+          logger: options.logger,
+          clock: options.clock,
+        });
+      }
       if (sessionSeeded && worktreeRemoved) {
         await discardSessionSeedBestEffort({
           persistence: options.persistence,

--- a/apps/observer/src/commands/session/fork.ts
+++ b/apps/observer/src/commands/session/fork.ts
@@ -221,20 +221,20 @@ export function createSessionForkHandler(
         }
         throw error;
       }
-      const worktreeRemoved =
-        createdWorktree === undefined
-          ? false
-          : await removeWorktreeBestEffort({
-              providers: options.providers,
-              project,
-              worktreeId: createdWorktree.id,
-              expectedPath: createdWorktree.path,
-              expectedBranch: createdWorktree.branch,
-              expectedRegistrationIdentity: createdWorktree.registrationIdentity,
-              context,
-              logger: options.logger,
-              clock: options.clock,
-            });
+      let worktreeRemoved = false;
+      if (createdWorktree !== undefined) {
+        worktreeRemoved = await removeWorktreeBestEffort({
+          providers: options.providers,
+          project,
+          worktreeId: createdWorktree.id,
+          expectedPath: createdWorktree.path,
+          expectedBranch: createdWorktree.branch,
+          expectedRegistrationIdentity: createdWorktree.registrationIdentity,
+          context,
+          logger: options.logger,
+          clock: options.clock,
+        });
+      }
       if (sessionSeeded && worktreeRemoved) {
         await discardSessionSeedBestEffort({
           persistence: options.persistence,

--- a/apps/observer/src/hooks/ingestion.ts
+++ b/apps/observer/src/hooks/ingestion.ts
@@ -31,6 +31,7 @@ import {
   providerObservationExpiresAt,
   providerObservationRetentionDays,
 } from "../persistence/retention.js";
+import type { RecordProviderObservationInput } from "../persistence/types.js";
 import type { ProviderRegistry } from "../providers/registry.js";
 import type { ObserverEventBus } from "../runtime/eventBus.js";
 import { sessionTurnReadinessMutationFromHarnessObservation } from "./turnReadiness.js";
@@ -340,23 +341,21 @@ export function createHarnessEventReportIngestion(
             ...(recoveryHandle === undefined ? {} : { recoveryHandle }),
             ...(turnReadiness === undefined ? {} : { turnReadiness }),
           };
+          const storedObservation: RecordProviderObservationInput = {
+            provider: report.provider,
+            providerType: "harness",
+            entityKind: "harness_event",
+            entityKey: harnessEventReportEntityKey(report),
+            payload: observation,
+            observedAt: report.observedAt,
+            expiresAt: providerObservationExpiresAt(report.observedAt, retentionDays),
+          };
           const result =
             await options.persistence.recordEventAndProviderObservationWithIngressDedupe({
               event: reportedEvent,
-              eventOptions: {
-                source: "hook",
-                createdAt: report.observedAt,
-              },
+              eventOptions: { source: "hook", createdAt: report.observedAt },
               dedupe: { kind: "harness_report", id: report.reportId },
-              observation: {
-                provider: report.provider,
-                providerType: "harness",
-                entityKind: "harness_event",
-                entityKey: harnessEventReportEntityKey(report),
-                payload: observation,
-                observedAt: report.observedAt,
-                expiresAt: providerObservationExpiresAt(report.observedAt, retentionDays),
-              },
+              observation: storedObservation,
               harnessExecution,
             });
           if (!result.deduped) {

--- a/apps/observer/src/hooks/ingestion.ts
+++ b/apps/observer/src/hooks/ingestion.ts
@@ -7,6 +7,7 @@ import type {
   ProviderHookAdapter,
   ProviderHookEvent,
   ProviderHookReceipt,
+  SafeError,
   SessionRecoveryHandle,
   StationEvent,
 } from "@station/contracts";
@@ -148,6 +149,12 @@ export function createProviderHookIngress(
       if (adapter?.toHarnessEventReport !== undefined) {
         // Adapter-normalized harness hooks must pass the native-execution gate on the report path.
         if (reportHarnessEvent === undefined) {
+          const error: SafeError = {
+            tag: "HookIngestionError",
+            code: "HARNESS_REPORT_INGRESS_UNAVAILABLE",
+            message: "Harness hook normalization requires the report ingress handoff.",
+            provider: event.provider,
+          };
           return ProviderHookReceiptSchema.parse({
             schemaVersion: STATION_SCHEMA_VERSION,
             hookId: id,
@@ -156,12 +163,7 @@ export function createProviderHookIngress(
             accepted: false,
             status: "rejected",
             receivedAt: event.receivedAt,
-            error: {
-              tag: "HookIngestionError",
-              code: "HARNESS_REPORT_INGRESS_UNAVAILABLE",
-              message: "Harness hook normalization requires the report ingress handoff.",
-              provider: event.provider,
-            },
+            error,
           });
         }
         return ingestViaHookAdapter({
@@ -350,14 +352,17 @@ export function createHarnessEventReportIngestion(
             observedAt: report.observedAt,
             expiresAt: providerObservationExpiresAt(report.observedAt, retentionDays),
           };
+          const persistInput = {
+            event: reportedEvent,
+            eventOptions: { source: "hook", createdAt: report.observedAt },
+            dedupe: { kind: "harness_report", id: report.reportId },
+            observation: storedObservation,
+            harnessExecution,
+          };
           const result =
-            await options.persistence.recordEventAndProviderObservationWithIngressDedupe({
-              event: reportedEvent,
-              eventOptions: { source: "hook", createdAt: report.observedAt },
-              dedupe: { kind: "harness_report", id: report.reportId },
-              observation: storedObservation,
-              harnessExecution,
-            });
+            await options.persistence.recordEventAndProviderObservationWithIngressDedupe(
+              persistInput,
+            );
           if (!result.deduped) {
             options.eventBus?.publish(reportedEvent);
           }

--- a/apps/observer/src/hooks/ingestion.ts
+++ b/apps/observer/src/hooks/ingestion.ts
@@ -32,7 +32,7 @@ import {
   providerObservationExpiresAt,
   providerObservationRetentionDays,
 } from "../persistence/retention.js";
-import type { RecordProviderObservationInput } from "../persistence/types.js";
+import type { IngressDedupeKey, RecordProviderObservationInput } from "../persistence/types.js";
 import type { ProviderRegistry } from "../providers/registry.js";
 import type { ObserverEventBus } from "../runtime/eventBus.js";
 import { sessionTurnReadinessMutationFromHarnessObservation } from "./turnReadiness.js";
@@ -352,10 +352,11 @@ export function createHarnessEventReportIngestion(
             observedAt: report.observedAt,
             expiresAt: providerObservationExpiresAt(report.observedAt, retentionDays),
           };
+          const dedupe: IngressDedupeKey = { kind: "harness_report", id: report.reportId };
           const persistInput = {
             event: reportedEvent,
             eventOptions: { source: "hook", createdAt: report.observedAt },
-            dedupe: { kind: "harness_report", id: report.reportId },
+            dedupe,
             observation: storedObservation,
             harnessExecution,
           };

--- a/apps/observer/src/persistence/correlations.ts
+++ b/apps/observer/src/persistence/correlations.ts
@@ -25,6 +25,19 @@ import {
   upsertWorktreeDisplayTitle,
 } from "./worktreeDisplayTitles.js";
 
+const END_OPEN_SESSION_SQL = `
+  UPDATE sessions
+  SET lifecycle = 'ended', ended_at = ?
+  WHERE id = ? AND (lifecycle IS NULL OR lifecycle = 'open')
+`;
+
+const END_OPEN_WORKTREE_SESSIONS_SQL = `
+  UPDATE sessions
+  SET lifecycle = 'ended', ended_at = ?
+  WHERE project_id = ? AND worktree_id = ?
+    AND (lifecycle IS NULL OR lifecycle = 'open')
+`;
+
 export function persistReconcileResult(
   database: SqlDatabase,
   input: PersistReconcileResultInput,
@@ -146,24 +159,9 @@ export function markSessionsEnded(
 ): number {
   const result =
     input.subject.kind === "session"
-      ? database
-          .prepare(
-            `
-              UPDATE sessions
-              SET lifecycle = 'ended', ended_at = ?
-              WHERE id = ? AND (lifecycle IS NULL OR lifecycle = 'open')
-            `,
-          )
-          .run(input.endedAt, input.subject.sessionId)
+      ? database.prepare(END_OPEN_SESSION_SQL).run(input.endedAt, input.subject.sessionId)
       : database
-          .prepare(
-            `
-              UPDATE sessions
-              SET lifecycle = 'ended', ended_at = ?
-              WHERE project_id = ? AND worktree_id = ?
-                AND (lifecycle IS NULL OR lifecycle = 'open')
-            `,
-          )
+          .prepare(END_OPEN_WORKTREE_SESSIONS_SQL)
           .run(input.endedAt, input.subject.projectId, input.subject.worktreeId);
   return Number(result.changes);
 }

--- a/apps/observer/src/persistence/sqliteAdapter.ts
+++ b/apps/observer/src/persistence/sqliteAdapter.ts
@@ -23,6 +23,7 @@ import * as sessionTurnReadinessStore from "./sessionTurnReadiness.js";
 import type {
   HarnessExecutionIngress,
   ObserverIdFactory,
+  PersistReconcileResultInput,
   SessionTurnReadinessMutation,
 } from "./types.js";
 import * as worktreeDisplayTitleStore from "./worktreeDisplayTitles.js";
@@ -280,13 +281,7 @@ export function createSqliteObserverPersistence(
 
     persistReconcileResult: (input) =>
       transaction((database) => {
-        const reconcileInput =
-          input.expiresAt === undefined && input.providerObservationRetentionDays === undefined
-            ? {
-                ...input,
-                providerObservationRetentionDays: providerObservationRetentionDays(),
-              }
-            : input;
+        const reconcileInput = withDefaultObservationRetention(input);
         correlationStore.persistReconcileResult(database, reconcileInput, {
           observedAt: input.observedAt ?? now(),
           idFactory,
@@ -575,4 +570,16 @@ function applySessionTurnReadinessMutation(
   sessionTurnReadinessStore.deleteSessionTurnReadiness(database, {
     sessionId: mutation.sessionId,
   });
+}
+
+function withDefaultObservationRetention(
+  input: PersistReconcileResultInput,
+): PersistReconcileResultInput {
+  if (input.expiresAt !== undefined || input.providerObservationRetentionDays !== undefined) {
+    return input;
+  }
+  return {
+    ...input,
+    providerObservationRetentionDays: providerObservationRetentionDays(),
+  };
 }

--- a/apps/observer/src/providers/registry.ts
+++ b/apps/observer/src/providers/registry.ts
@@ -151,20 +151,22 @@ export class ProviderRegistry {
           return;
         }
         try {
+          const probeError = {
+            tag: "RuntimeError",
+            code: "HARNESS_VERSION_PROBE_FAILED",
+            message: "Harness version probe failed.",
+            provider: provider.id,
+          };
+          const probeTimeout = {
+            tag: "TimeoutError",
+            code: "HARNESS_VERSION_PROBE_TIMEOUT",
+            message: "Harness version probe timed out.",
+            provider: provider.id,
+          };
           const info = await withTimeout(() => versionInfo(), {
             timeoutMs,
-            error: {
-              tag: "RuntimeError",
-              code: "HARNESS_VERSION_PROBE_FAILED",
-              message: "Harness version probe failed.",
-              provider: provider.id,
-            },
-            timeoutError: {
-              tag: "TimeoutError",
-              code: "HARNESS_VERSION_PROBE_TIMEOUT",
-              message: "Harness version probe timed out.",
-              provider: provider.id,
-            },
+            error: probeError,
+            timeoutError: probeTimeout,
           });
           if (info.installedVersion !== undefined || info.latestVersion !== undefined) {
             this.harnessVersions.set(provider.id, info);

--- a/apps/observer/src/reconcile/core.ts
+++ b/apps/observer/src/reconcile/core.ts
@@ -295,12 +295,7 @@ export function createObserverCore(input: CreateObserverCoreInput): ObserverCore
       snapshot = {
         ...snapshot,
         rows: snapshot.rows.map((row) =>
-          row.id === match.id
-            ? {
-                ...row,
-                agent: nextAgent,
-              }
-            : row,
+          row.id === match.id ? { ...row, agent: nextAgent } : row,
         ),
       };
       return {

--- a/apps/observer/src/runtime/externalLaunch.ts
+++ b/apps/observer/src/runtime/externalLaunch.ts
@@ -105,14 +105,13 @@ async function prepareExternalLaunchForWorktree(
       }
       const attachment = await managedTerminal.attachmentForTarget(target.id);
       if (attachment !== undefined) {
+        const harnessProvider =
+          target.harnessBinding?.harnessProvider ?? row.agent?.harness ?? project.defaults.harness;
         return {
           outcome: {
             kind: "existing-session",
             sessionId: target.sessionId,
-            harnessProvider:
-              target.harnessBinding?.harnessProvider ??
-              row.agent?.harness ??
-              project.defaults.harness,
+            harnessProvider,
             attachment,
           },
           reconcile: false,

--- a/apps/observer/src/runtime/main.ts
+++ b/apps/observer/src/runtime/main.ts
@@ -621,18 +621,7 @@ async function runClaimedObserverRuntime(input: {
           try {
             await removeObserverProcessIdentity(processIdentity);
           } catch (error) {
-            const cleanupError = safeErrorFromUnknown(error, {
-              tag: "ObserverLifecycleError",
-              code: "OBSERVER_IDENTITY_REMOVE_FAILED",
-              message: "Observer process identity could not be removed.",
-            });
-            await logger
-              .warn("Observer process identity could not be removed during shutdown.", {
-                socketPath,
-                pid: processIdentity.pid,
-                error: cleanupError,
-              })
-              .catch(() => undefined);
+            await warnIdentityCleanupFailed(logger, socketPath, processIdentity.pid, error);
           }
         }
         ownership?.stop();
@@ -1056,4 +1045,23 @@ function releaseObserverBootClaim(claim: AcquiredObserverBootClaim): void {
   if (released.status === "failed") {
     throw released.error;
   }
+}
+
+async function warnIdentityCleanupFailed(
+  logger: StationLogger,
+  socketPath: string,
+  pid: number,
+  error: unknown,
+): Promise<void> {
+  await logger
+    .warn("Observer process identity could not be removed during shutdown.", {
+      socketPath,
+      pid,
+      error: safeErrorFromUnknown(error, {
+        tag: "ObserverLifecycleError",
+        code: "OBSERVER_IDENTITY_REMOVE_FAILED",
+        message: "Observer process identity could not be removed.",
+      }),
+    })
+    .catch(() => undefined);
 }

--- a/apps/observer/src/runtime/observerBootClaim.ts
+++ b/apps/observer/src/runtime/observerBootClaim.ts
@@ -297,19 +297,20 @@ function createRelease(database: SqlDatabase): () => ObserverBootClaimReleaseRes
       errors.push(error);
     }
 
-    result =
-      errors.length === 0
-        ? { status: "released" }
-        : {
-            status: "failed",
-            error: observerBootClaimError(
-              new AggregateError(errors, "Observer boot claim release failed."),
-              {
-                code: "OBSERVER_BOOT_CLAIM_RELEASE_FAILED",
-                message: "Observer boot ownership could not be released cleanly.",
-              },
-            ),
-          };
+    if (errors.length === 0) {
+      result = { status: "released" };
+    } else {
+      result = {
+        status: "failed",
+        error: observerBootClaimError(
+          new AggregateError(errors, "Observer boot claim release failed."),
+          {
+            code: "OBSERVER_BOOT_CLAIM_RELEASE_FAILED",
+            message: "Observer boot ownership could not be released cleanly.",
+          },
+        ),
+      };
+    }
     return result;
   };
 }

--- a/apps/observer/src/runtime/observerBootClaim.ts
+++ b/apps/observer/src/runtime/observerBootClaim.ts
@@ -147,12 +147,15 @@ export function createObserverReapExclusion(
         value = await operation();
       } catch {
         const release = claim.release();
+        if (release.status === "released") {
+          return {
+            status: "failed",
+            reason: "Duplicate cleanup failed while holding the boot claim.",
+          };
+        }
         return {
           status: "failed",
-          reason:
-            release.status === "released"
-              ? "Duplicate cleanup failed while holding the boot claim."
-              : "Duplicate cleanup and boot claim release both failed.",
+          reason: "Duplicate cleanup and boot claim release both failed.",
         };
       }
       const release = claim.release();

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -3855,6 +3855,7 @@
             "ProviderHookAdapter",
             "ProviderHookEvent",
             "ProviderHookReceipt",
+            "SafeError",
             "SessionRecoveryHandle",
             "StationEvent"
           ]

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -3805,7 +3805,7 @@
           "specifier": "../persistence/types.js",
           "resolvedPath": "apps/observer/src/persistence/types.ts",
           "edgeKind": "type-only",
-          "bindings": ["RecordProviderObservationInput"]
+          "bindings": ["IngressDedupeKey", "RecordProviderObservationInput"]
         },
         {
           "specifier": "../providers/registry.js",

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -3802,6 +3802,12 @@
           "bindings": ["providerObservationExpiresAt", "providerObservationRetentionDays"]
         },
         {
+          "specifier": "../persistence/types.js",
+          "resolvedPath": "apps/observer/src/persistence/types.ts",
+          "edgeKind": "type-only",
+          "bindings": ["RecordProviderObservationInput"]
+        },
+        {
           "specifier": "../providers/registry.js",
           "resolvedPath": "apps/observer/src/providers/registry.ts",
           "edgeKind": "type-only",
@@ -8971,6 +8977,7 @@
           "bindings": [
             "HarnessExecutionIngress",
             "ObserverIdFactory",
+            "PersistReconcileResultInput",
             "SessionTurnReadinessMutation"
           ]
         },

--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -218,13 +218,12 @@ export class WorktrunkProvider implements WorktreeProvider {
         message: `${result.message} Config: ${result.configPath}.`,
       };
       if (result.status !== "ok") {
+        const ownershipConflict =
+          result.ownership?.status === "different-owner" ||
+          result.ownership?.status === "unknown-owner";
         check.error = {
           tag: "WorktrunkHookSetupError",
-          code:
-            result.ownership?.status === "different-owner" ||
-            result.ownership?.status === "unknown-owner"
-              ? "WORKTRUNK_HOOK_OWNERSHIP_CONFLICT"
-              : "WORKTRUNK_HOOKS_MISSING",
+          code: ownershipConflict ? "WORKTRUNK_HOOK_OWNERSHIP_CONFLICT" : "WORKTRUNK_HOOKS_MISSING",
           message: result.message,
           provider: this.id,
         };
@@ -649,17 +648,14 @@ export class WorktrunkProvider implements WorktreeProvider {
       await Promise.all(
         batch.map(async (project, batchIndex) => {
           const inspection = await this.#inspectStaleRegistration(project, options);
-          switch (inspection.status) {
-            case "skipped":
-              return;
-            case "completed":
-              completed += 1;
-              if (inspection.check !== undefined) {
-                checks[offset + batchIndex] = inspection.check;
-              }
-              return;
-            case "failed":
-              checks[offset + batchIndex] = inspection.check;
+          if (inspection.status === "skipped") {
+            return;
+          }
+          if (inspection.status === "completed") {
+            completed += 1;
+          }
+          if (inspection.check !== undefined) {
+            checks[offset + batchIndex] = inspection.check;
           }
         }),
       );
@@ -759,16 +755,14 @@ export class WorktrunkProvider implements WorktreeProvider {
     env?: Record<string, string>,
   ) {
     const operation = `provider.worktrunk.${worktrunkSubcommand(args)}`;
+    const unavailable = fallback.code === "WORKTRUNK_UNAVAILABLE";
     const result = await runRuntimeBoundaryWithRetryAndTimeout(
       {
         operation,
         clock: this.#clock,
         timeoutMs: policy.timeoutMs ?? this.#timeoutMs,
         error: {
-          tag:
-            fallback.code === "WORKTRUNK_UNAVAILABLE"
-              ? "ProviderUnavailableError"
-              : "WorktreeProviderError",
+          tag: unavailable ? "ProviderUnavailableError" : "WorktreeProviderError",
           code: fallback.code,
           message: fallback.message,
           provider: this.id,

--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -65,6 +65,11 @@ const defaultCapabilities: WorktreeCapabilities = {
   canSeedWorkingTree: true,
 };
 
+type StaleRegistrationInspection =
+  | { status: "skipped" }
+  | { status: "completed"; check?: ProviderDoctorCheck }
+  | { status: "failed"; check: ProviderDoctorCheck };
+
 /**
  * ADAPTER
  *
@@ -643,78 +648,19 @@ export class WorktrunkProvider implements WorktreeProvider {
       const batch = enabledProjects.slice(offset, offset + 4);
       await Promise.all(
         batch.map(async (project, batchIndex) => {
-          if (options.signal.aborted) return;
-          const index = offset + batchIndex;
-          if (
-            await isGitCheckoutConfiguredBare(project.root, {
-              ...(this.#runner === undefined ? {} : { runner: this.#runner }),
-              signal: options.signal,
-              timeoutMs: options.timeoutMs,
-            })
-          ) {
-            const providerError = projectRootBareError(project);
-            const error: SafeError = {
-              tag: providerError.tag,
-              code: providerError.code,
-              message: providerError.message,
-              provider: providerError.provider,
-              projectId: project.id,
-            };
-            if (providerError.hint !== undefined) error.hint = providerError.hint;
-            checks[index] = {
-              name: `worktrunk-project-root-${project.id}`,
-              status: "warn",
-              message: `${providerError.message} ${providerError.hint}`,
-              error,
-            };
-            completed += 1;
-            return;
+          const inspection = await this.#inspectStaleRegistration(project, options);
+          switch (inspection.status) {
+            case "skipped":
+              return;
+            case "completed":
+              completed += 1;
+              if (inspection.check !== undefined) {
+                checks[offset + batchIndex] = inspection.check;
+              }
+              return;
+            case "failed":
+              checks[offset + batchIndex] = inspection.check;
           }
-          let missing: WorktreeObservation[];
-          try {
-            missing = (
-              await this.#listWorktrees(project, {
-                retries: 0,
-                signal: options.signal,
-                timeoutMs: options.timeoutMs,
-              })
-            ).filter((observation) => observation.state !== "exists");
-            completed += 1;
-          } catch (cause) {
-            if (options.signal.aborted) return;
-            const failure = safeErrorFromUnknown(cause, {
-              tag: "WorktrunkStaleRegistrationDiagnosticError",
-              code: "WORKTRUNK_STALE_REGISTRATION_CHECK_FAILED",
-              message: `Worktrunk could not inspect stale registrations for ${project.label}.`,
-              provider: this.id,
-            });
-            const error: SafeError = {
-              tag: failure.tag,
-              code: failure.code,
-              message: failure.message,
-              projectId: project.id,
-            };
-            if (failure.hint !== undefined) error.hint = failure.hint;
-            if (failure.provider !== undefined) error.provider = failure.provider;
-            checks[index] = {
-              name: `worktrunk-stale-registrations-${project.id}`,
-              status: "warn",
-              message: error.message,
-              error,
-            };
-            return;
-          }
-          if (missing.length === 0) return;
-          const root = shellQuote(project.root);
-          checks[index] = {
-            name: `worktrunk-stale-registrations-${project.id}`,
-            status: "warn",
-            message: `Worktrunk found missing/prunable registrations for ${project.label}: ${missing
-              .map((item) => `${item.branch} (${item.path})`)
-              .join(
-                ", ",
-              )}. Inspect with git -C ${root} worktree prune --dry-run --verbose, then clean with git -C ${root} worktree prune --verbose.`,
-          };
         }),
       );
       if (options.signal.aborted) break;
@@ -730,6 +676,72 @@ export class WorktrunkProvider implements WorktreeProvider {
       });
     }
     return completedChecks;
+  }
+
+  async #inspectStaleRegistration(
+    project: ProviderProjectConfig,
+    options: { signal: AbortSignal; timeoutMs: number },
+  ): Promise<StaleRegistrationInspection> {
+    if (options.signal.aborted) {
+      return { status: "skipped" };
+    }
+    const gitOptions = {
+      ...(this.#runner === undefined ? {} : { runner: this.#runner }),
+      signal: options.signal,
+      timeoutMs: options.timeoutMs,
+    };
+    if (await isGitCheckoutConfiguredBare(project.root, gitOptions)) {
+      const providerError = projectRootBareError(project);
+      return {
+        status: "completed",
+        check: {
+          name: `worktrunk-project-root-${project.id}`,
+          status: "warn",
+          message: `${providerError.message} ${providerError.hint}`,
+          error: projectDoctorError(providerError, project.id),
+        },
+      };
+    }
+    let missing: WorktreeObservation[];
+    try {
+      missing = (
+        await this.#listWorktrees(project, {
+          retries: 0,
+          signal: options.signal,
+          timeoutMs: options.timeoutMs,
+        })
+      ).filter((observation) => observation.state !== "exists");
+    } catch (cause) {
+      if (options.signal.aborted) {
+        return { status: "skipped" };
+      }
+      const failure = safeErrorFromUnknown(cause, {
+        tag: "WorktrunkStaleRegistrationDiagnosticError",
+        code: "WORKTRUNK_STALE_REGISTRATION_CHECK_FAILED",
+        message: `Worktrunk could not inspect stale registrations for ${project.label}.`,
+        provider: this.id,
+      });
+      return {
+        status: "failed",
+        check: {
+          name: `worktrunk-stale-registrations-${project.id}`,
+          status: "warn",
+          message: failure.message,
+          error: projectDoctorError(failure, project.id),
+        },
+      };
+    }
+    if (missing.length === 0) {
+      return { status: "completed" };
+    }
+    return {
+      status: "completed",
+      check: {
+        name: `worktrunk-stale-registrations-${project.id}`,
+        status: "warn",
+        message: staleRegistrationMessage(project, missing),
+      },
+    };
   }
 
   async #run(
@@ -807,6 +819,27 @@ export class WorktrunkProvider implements WorktreeProvider {
       installHint: worktrunkInstallHint(this.#command),
     });
   }
+}
+
+function staleRegistrationMessage(
+  project: ProviderProjectConfig,
+  missing: readonly WorktreeObservation[],
+): string {
+  const registrations = missing.map((item) => `${item.branch} (${item.path})`).join(", ");
+  const root = shellQuote(project.root);
+  return `Worktrunk found missing/prunable registrations for ${project.label}: ${registrations}. Inspect with git -C ${root} worktree prune --dry-run --verbose, then clean with git -C ${root} worktree prune --verbose.`;
+}
+
+function projectDoctorError(error: SafeError, projectId: string): SafeError {
+  const next: SafeError = {
+    tag: error.tag,
+    code: error.code,
+    message: error.message,
+    projectId,
+  };
+  if (error.hint !== undefined) next.hint = error.hint;
+  if (error.provider !== undefined) next.provider = error.provider;
+  return next;
 }
 
 function projectRootBareError(project: ProviderProjectConfig): WorktrunkProviderError {

--- a/packages/dashboard-core/src/flows/addProject/flow.ts
+++ b/packages/dashboard-core/src/flows/addProject/flow.ts
@@ -32,26 +32,30 @@ export function transitionAddProjectFlow(
 ): AddProjectTransition {
   switch (action.type) {
     case "startOpen":
-      return state.mode === "start"
-        ? { state, effects: [{ type: "loadDirectory", path: action.path }] }
-        : { state };
+      if (state.mode !== "start") {
+        return { state };
+      }
+      return { state, effects: [{ type: "loadDirectory", path: action.path }] };
     case "chooseOpen":
-      return state.mode === "choose"
-        ? { state, effects: [{ type: "loadDirectory", path: action.path }] }
-        : { state };
+      if (state.mode !== "choose") {
+        return { state };
+      }
+      return { state, effects: [{ type: "loadDirectory", path: action.path }] };
     case "chooseParent":
-      return state.mode === "choose"
-        ? {
-            state,
-            effects: [
-              { type: "loadDirectory", path: parentPath?.(state.currentPath) ?? state.currentPath },
-            ],
-          }
-        : { state };
+      if (state.mode !== "choose") {
+        return { state };
+      }
+      return {
+        state,
+        effects: [
+          { type: "loadDirectory", path: parentPath?.(state.currentPath) ?? state.currentPath },
+        ],
+      };
     case "chooseSelected":
-      return state.mode === "choose"
-        ? { state, effects: [{ type: "reviewFolder", path: action.path }] }
-        : { state };
+      if (state.mode !== "choose") {
+        return { state };
+      }
+      return { state, effects: [{ type: "reviewFolder", path: action.path }] };
     case "folderLoaded":
       return {
         state: chooseStateForLoadedFolder(state, action.result.path, action.result.entries),
@@ -61,93 +65,105 @@ export function transitionAddProjectFlow(
         state: chooseStateForLoadedFolder(state, action.path, [], { error: action.error }),
       };
     case "folderSearchLoaded":
-      return state.mode === "choose" && action.result.query === normalizedFilter(state.filter)
-        ? {
-            state: withoutSearchError({
-              ...state,
-              searchEntries: action.result.entries,
-              searching: false,
-              searchTruncated: action.result.truncated,
-            }),
-          }
-        : { state };
+      if (state.mode !== "choose" || action.result.query !== normalizedFilter(state.filter)) {
+        return { state };
+      }
+      return {
+        state: withoutSearchError({
+          ...state,
+          searchEntries: action.result.entries,
+          searching: false,
+          searchTruncated: action.result.truncated,
+        }),
+      };
     case "folderSearchFailed":
-      return state.mode === "choose" && action.query === normalizedFilter(state.filter)
-        ? {
-            state: {
-              ...state,
-              searchEntries: [],
-              searching: false,
-              searchTruncated: false,
-              searchError: action.error,
-            },
-          }
-        : { state };
+      if (state.mode !== "choose" || action.query !== normalizedFilter(state.filter)) {
+        return { state };
+      }
+      return {
+        state: {
+          ...state,
+          searchEntries: [],
+          searching: false,
+          searchTruncated: false,
+          searchError: action.error,
+        },
+      };
     case "folderReviewed":
       return { state: reviewStateForFolder(state, action.review) };
     case "folderReviewFailed":
       return { state: failedStateForError(state, action.path, action.error) };
     case "filterStart":
-      return state.mode === "choose" ? { state: { ...state, filterMode: true } } : { state };
+      if (state.mode !== "choose") {
+        return { state };
+      }
+      return { state: { ...state, filterMode: true } };
     case "filterInput":
       return updateFilter(state, `${state.mode === "choose" ? state.filter : ""}${action.value}`);
     case "filterBackspace":
       return updateFilter(state, state.mode === "choose" ? state.filter.slice(0, -1) : "");
     case "filterClear":
-      return state.mode === "choose"
-        ? {
-            state: withoutSearchError({
-              ...state,
-              filter: "",
-              filterMode: false,
-              searchEntries: [],
-              searching: false,
-              searchTruncated: false,
-            }),
-          }
-        : { state };
+      if (state.mode !== "choose") {
+        return { state };
+      }
+      return {
+        state: withoutSearchError({
+          ...state,
+          filter: "",
+          filterMode: false,
+          searchEntries: [],
+          searching: false,
+          searchTruncated: false,
+        }),
+      };
     case "submit":
       return submitReview(state);
     case "submitted":
       return { state: successStateForProject(state, action.label, action.root) };
     case "submitFailed":
-      return state.mode === "review"
-        ? { state: failedStateForError(state, state.selectedPath, action.error) }
-        : { state };
+      if (state.mode !== "review") {
+        return { state };
+      }
+      return { state: failedStateForError(state, state.selectedPath, action.error) };
     case "editIdStart":
-      return state.mode === "review" && !state.submitting
-        ? {
-            state: {
-              ...state,
-              actionFocus: "editId",
-              editingId: createEditableTextInputState(state.id),
-              editIdActionFocus: "save",
-            },
-          }
-        : { state };
+      if (state.mode !== "review" || state.submitting) {
+        return { state };
+      }
+      return {
+        state: {
+          ...state,
+          actionFocus: "editId",
+          editingId: createEditableTextInputState(state.id),
+          editIdActionFocus: "save",
+        },
+      };
     case "editIdInput":
-      return state.mode === "review" && state.editingId !== undefined
-        ? {
-            state: {
-              ...state,
-              editingId: transitionEditableTextInput(state.editingId, action.action),
-            },
-          }
-        : { state };
+      if (state.mode !== "review" || state.editingId === undefined) {
+        return { state };
+      }
+      return {
+        state: {
+          ...state,
+          editingId: transitionEditableTextInput(state.editingId, action.action),
+        },
+      };
     case "editIdCommit":
-      return state.mode === "review" && state.editingId !== undefined
-        ? { state: commitEditedProjectId(state) }
-        : { state };
+      if (state.mode !== "review" || state.editingId === undefined) {
+        return { state };
+      }
+      return { state: commitEditedProjectId(state) };
     case "editIdCancel":
-      return state.mode === "review" && state.editingId !== undefined
-        ? { state: reviewWithoutEditingId(state) }
-        : { state };
+      if (state.mode !== "review" || state.editingId === undefined) {
+        return { state };
+      }
+      return { state: reviewWithoutEditingId(state) };
     case "actionFocus":
       return { state: moveActionFocus(state, action.dir) };
     case "backToChoose":
-      return state.mode === "review" || state.mode === "failed"
-        ? { state, effects: [{ type: "loadDirectory", path: state.selectedPath }] }
-        : { state };
+      if (state.mode !== "review" && state.mode !== "failed") {
+        return { state };
+      }
+      return { state, effects: [{ type: "loadDirectory", path: state.selectedPath }] };
   }
 }
 

--- a/packages/dashboard-core/src/widgets/useTopRowWidgets.ts
+++ b/packages/dashboard-core/src/widgets/useTopRowWidgets.ts
@@ -155,16 +155,10 @@ export function createUseTopRowWidgets(hooks: TopRowWidgetHookRuntime) {
         activeWidgets.map(({ widget, index }): TopRowWidgetView => {
           switch (widget.type) {
             case "time":
-              return {
-                id: `time:${index}`,
-                text: formatTimeWidget(currentMinute, widget),
-              };
+              return { id: `time:${index}`, text: formatTimeWidget(currentMinute, widget) };
             case "weather": {
               const id = `weather:${index}`;
-              return {
-                id,
-                text: weatherTexts[id] ?? renderWeatherLoading(widget),
-              };
+              return { id, text: weatherTexts[id] ?? renderWeatherLoading(widget) };
             }
             case "tz":
               return { id: `tz:${index}`, ...formatTimezoneWidget(currentMinute, widget) };

--- a/packages/station-host/src/client.ts
+++ b/packages/station-host/src/client.ts
@@ -141,6 +141,13 @@ type FrameSink = {
 
 const defaultTimeoutMs = 5000;
 
+function frameIteratorResult(frame: HostFrame | undefined): IteratorResult<HostFrame> {
+  if (frame === undefined) {
+    return { done: true, value: undefined };
+  }
+  return { done: false, value: frame };
+}
+
 export function createStationHostClient(options: StationHostClientOptions): StationHostClient {
   const timeoutMs = options.timeoutMs ?? defaultTimeoutMs;
   const expectedBuildVersion = options.expectedBuildVersion ?? stationBuildInfo().version;
@@ -326,40 +333,29 @@ export function createStationHostClient(options: StationHostClientOptions): Stat
     let ptyId: string | undefined;
     let attachmentId: string | undefined;
     let state: HostControlState | undefined;
-    const drain = () => {
+    // next() only parks; drain is the single path that completes a pull.
+    const drain = (): void => {
       while (waiters.length > 0 && (queue.length > 0 || ended)) {
         const waiter = waiters.shift();
-        if (waiter === undefined) break;
-        const next = queue.shift();
-        waiter(
-          next === undefined ? { done: true, value: undefined } : { done: false, value: next },
-        );
+        if (waiter === undefined) {
+          break;
+        }
+        waiter(frameIteratorResult(queue.shift()));
       }
     };
+    const pullFrame = (): Promise<IteratorResult<HostFrame>> =>
+      new Promise((resolve) => {
+        waiters.push(resolve);
+        drain();
+      });
     const sink: FrameSink = {
       get frames() {
         return {
           [Symbol.asyncIterator]: () => ({
-            next: () =>
-              new Promise<IteratorResult<HostFrame>>((resolve) => {
-                if (queue.length > 0) {
-                  const next = queue.shift();
-                  resolve(
-                    next === undefined
-                      ? { done: true, value: undefined }
-                      : { done: false, value: next },
-                  );
-                  return;
-                }
-                if (ended) {
-                  resolve({ done: true, value: undefined });
-                  return;
-                }
-                waiters.push(resolve);
-              }),
+            next: pullFrame,
             return: () => {
               sink.release();
-              return Promise.resolve({ done: true as const, value: undefined });
+              return Promise.resolve(frameIteratorResult(undefined));
             },
           }),
         };

--- a/station/src/app/dashboardCapabilities.ts
+++ b/station/src/app/dashboardCapabilities.ts
@@ -83,14 +83,13 @@ export function createDashboardCapabilities(
 
         try {
           const refreshed = await options.observerService.loadSnapshot();
-          if (
-            findSessionPlacementByBranch(
-              refreshed,
-              request.project.id,
-              request.hiddenBranch,
-              request.group,
-            ) !== undefined
-          ) {
+          const placed = findSessionPlacementByBranch(
+            refreshed,
+            request.project.id,
+            request.hiddenBranch,
+            request.group,
+          );
+          if (placed !== undefined) {
             return { kind: "success" };
           }
         } catch {
@@ -151,20 +150,18 @@ export function createDashboardCapabilities(
         if (session.origin === "external") {
           return observerActivation.activate(request);
         }
+        const launched = options.managedLaunch.activate(agentWorktreePaneId(row.id), {
+          projectId: row.projectId,
+          worktreeId: row.id,
+          cwd: row.path,
+          ...(request.preferredObserverAction === "fresh"
+            ? { freshStart: { expectedSessionId: session.id } }
+            : {}),
+        });
         return dashboardExecution(
-          options.managedLaunch
-            .activate(agentWorktreePaneId(row.id), {
-              projectId: row.projectId,
-              worktreeId: row.id,
-              cwd: row.path,
-              ...(request.preferredObserverAction === "fresh"
-                ? { freshStart: { expectedSessionId: session.id } }
-                : {}),
-            })
-            .then((result) => settleNativeActivation(options.store, result, session.title)),
+          launched.then((result) => settleNativeActivation(options.store, result, session.title)),
           {
-            optimistic:
-              request.preferredObserverAction === "focus" ? "none" : "pending-start",
+            optimistic: request.preferredObserverAction === "focus" ? "none" : "pending-start",
             successDisposition: "wait-for-canonical",
           },
         );

--- a/station/src/host/frameStream.ts
+++ b/station/src/host/frameStream.ts
@@ -6,22 +6,34 @@ export type FrameStream = {
   end(): void;
 };
 
+function frameIteratorResult(frame: HostFrame | undefined): IteratorResult<HostFrame> {
+  if (frame === undefined) {
+    return { done: true, value: undefined };
+  }
+  return { done: false, value: frame };
+}
+
 /** A pull-based frame stream fed by `push`/`end`; `frames.return()` runs onReturn. */
 export function createFrameStream(onReturn: () => void): FrameStream {
   const queue: HostFrame[] = [];
   const waiters: Array<(result: IteratorResult<HostFrame>) => void> = [];
   let ended = false;
 
-  const drain = () => {
+  // next() only parks; drain is the single path that completes a pull.
+  const drain = (): void => {
     while (waiters.length > 0 && (queue.length > 0 || ended)) {
       const waiter = waiters.shift();
       if (waiter === undefined) {
         break;
       }
-      const next = queue.shift();
-      waiter(next === undefined ? { done: true, value: undefined } : { done: false, value: next });
+      waiter(frameIteratorResult(queue.shift()));
     }
   };
+  const pullFrame = (): Promise<IteratorResult<HostFrame>> =>
+    new Promise((resolve) => {
+      waiters.push(resolve);
+      drain();
+    });
 
   return {
     push: (frame) => {
@@ -34,24 +46,12 @@ export function createFrameStream(onReturn: () => void): FrameStream {
     },
     frames: {
       [Symbol.asyncIterator]: () => ({
-        next: () =>
-          new Promise<IteratorResult<HostFrame>>((resolve) => {
-            const next = queue.shift();
-            if (next !== undefined) {
-              resolve({ done: false, value: next });
-              return;
-            }
-            if (ended) {
-              resolve({ done: true, value: undefined });
-              return;
-            }
-            waiters.push(resolve);
-          }),
+        next: pullFrame,
         return: () => {
           ended = true;
           onReturn();
           drain();
-          return Promise.resolve({ done: true, value: undefined });
+          return Promise.resolve(frameIteratorResult(undefined));
         },
       }),
     },

--- a/station/src/host/ptyTable.ts
+++ b/station/src/host/ptyTable.ts
@@ -769,22 +769,12 @@ export function createPtyTable(options: PtyTableOptions = {}): PtyTable {
           captureDurationMs = performance.now() - captureStartedAt;
           if (entry.exited || !entriesByPtyId.has(ptyRef.ptyId)) {
             detachAttachment(entry, attachment);
-            throw new StationHostProviderError(
-              "HOST_ATTACH_GONE",
-              `Host PTY "${ptyRef.ptyId}" exited while its snapshot was captured.`,
-              { cause: error },
-            );
+            throw attachGoneDuringSnapshot(ptyRef.ptyId, error);
           }
           if (error instanceof TerminalSnapshotUnavailableError) {
             const failure = terminalSnapshotFailure(error);
             emit("pty.snapshot.degraded", { ptyId: ptyRef.ptyId, ...failure });
-            replay = {
-              kind: "live-reset-recovery",
-              initialCols: recorded.cols,
-              initialRows: recorded.rows,
-              events: [],
-              resetData: error.resetData,
-            };
+            replay = liveResetReplay(recorded, error);
           } else {
             detachAttachment(entry, attachment);
             throw snapshotCaptureFailure(ptyRef.ptyId, error);
@@ -901,6 +891,27 @@ export function createPtyTable(options: PtyTableOptions = {}): PtyTable {
         reap(entry, { type: "exit", ptyId: entry.ptyId, exitCode: 0 }, "host-stop");
       }
     },
+  };
+}
+
+function attachGoneDuringSnapshot(ptyId: string, error: unknown): StationHostProviderError {
+  return new StationHostProviderError(
+    "HOST_ATTACH_GONE",
+    `Host PTY "${ptyId}" exited while its snapshot was captured.`,
+    { cause: error },
+  );
+}
+
+function liveResetReplay(
+  recorded: { cols: number; rows: number },
+  error: TerminalSnapshotUnavailableError,
+): Extract<HostAttachAck["replay"], { kind: "live-reset-recovery" }> {
+  return {
+    kind: "live-reset-recovery",
+    initialCols: recorded.cols,
+    initialRows: recorded.rows,
+    events: [],
+    resetData: error.resetData,
   };
 }
 

--- a/station/src/host/ptyTable.ts
+++ b/station/src/host/ptyTable.ts
@@ -787,14 +787,7 @@ export function createPtyTable(options: PtyTableOptions = {}): PtyTable {
             };
           } else {
             detachAttachment(entry, attachment);
-            const pending = error instanceof TerminalSnapshotPendingError;
-            throw new StationHostProviderError(
-              pending ? "HOST_SNAPSHOT_PENDING" : "HOST_SNAPSHOT_FAILED",
-              pending
-                ? `Host PTY "${ptyRef.ptyId}" ended between terminal parser boundaries; retrying may succeed after more output.`
-                : `Could not capture terminal state for host PTY "${ptyRef.ptyId}".`,
-              { cause: error },
-            );
+            throw snapshotCaptureFailure(ptyRef.ptyId, error);
           }
         }
       }
@@ -909,4 +902,15 @@ export function createPtyTable(options: PtyTableOptions = {}): PtyTable {
       }
     },
   };
+}
+
+function snapshotCaptureFailure(ptyId: string, error: unknown): StationHostProviderError {
+  const pending = error instanceof TerminalSnapshotPendingError;
+  return new StationHostProviderError(
+    pending ? "HOST_SNAPSHOT_PENDING" : "HOST_SNAPSHOT_FAILED",
+    pending
+      ? `Host PTY "${ptyId}" ended between terminal parser boundaries; retrying may succeed after more output.`
+      : `Could not capture terminal state for host PTY "${ptyId}".`,
+    { cause: error },
+  );
 }

--- a/station/src/input/runtime/managedLaunch.ts
+++ b/station/src/input/runtime/managedLaunch.ts
@@ -95,16 +95,15 @@ export function createManagedLaunch(deps: ManagedLaunchDeps): ManagedLaunch {
         clientLabel: "Station",
       });
       if (execution.status !== "succeeded" && execution.status !== "accepted") {
-        const error =
-          execution.status === "rejected" && execution.receipt.error === undefined
-            ? {
-                ...execution.error,
-                tag: "ClientObserverError" as const,
-                code: `STATION_WORKTREE_${spec.verb.toUpperCase()}_REJECTED`,
-                message: `Station could not ${spec.verb} the worktree.`,
-              }
-            : execution.error;
-        return worktreeFailure(error);
+        if (execution.status === "rejected" && execution.receipt.error === undefined) {
+          return worktreeFailure({
+            ...execution.error,
+            tag: "ClientObserverError",
+            code: `STATION_WORKTREE_${spec.verb.toUpperCase()}_REJECTED`,
+            message: `Station could not ${spec.verb} the worktree.`,
+          });
+        }
+        return worktreeFailure(execution.error);
       }
       // A bare worktree does not prune the optimistic row; only canonical session projection does.
       const row = await waitForWorktreeByBranch(deps.clientState, spec.projectId, spec.branch);

--- a/station/src/main.tsx
+++ b/station/src/main.tsx
@@ -18,6 +18,8 @@ import {
   getOrCreateStationHotRuntime,
   STATION_HOT_RUNTIME_VERSION,
   stationHotSlots,
+  type StationHotRenderer,
+  type StationHotSlots,
 } from "./hmr/stationHotRuntime.js";
 import { invokeCleanup, settleCleanupSteps } from "./lifecycle/cleanup.js";
 import { createRenderProfiler, readRenderProfileEnabled } from "./profiling/renderProfiler.js";
@@ -467,11 +469,7 @@ async function startStationMain(
               () => stopSurfaceObservation?.(),
               () => root.unmount(),
               () => renderer.destroy(),
-              () => {
-                if (stationGlobalSlots.__stationHotRenderer === renderer) {
-                  delete stationGlobalSlots.__stationHotRenderer;
-                }
-              },
+              () => releaseHotRendererIfCurrent(stationGlobalSlots, renderer),
               () => station.disposeForHotReload(),
             ],
             "Native Station HMR cleanup failed.",
@@ -485,6 +483,15 @@ async function startStationMain(
     });
   }
   return true;
+}
+
+function releaseHotRendererIfCurrent(
+  slots: StationHotSlots,
+  renderer: StationHotRenderer,
+): void {
+  if (slots.__stationHotRenderer === renderer) {
+    delete slots.__stationHotRenderer;
+  }
 }
 
 function reportNativeHotDisposalFailure(error: unknown): void {

--- a/station/src/state/store.ts
+++ b/station/src/state/store.ts
@@ -206,21 +206,21 @@ export function createStationStore(options?: StationStoreOptions): StationStore 
         ) {
           return;
         }
+        const panes = state.workspace.panes.map((pane) => {
+          if (pane.id !== paneId) {
+            return pane;
+          }
+          const worktreeId = pane.worktreeId ?? worktreeIdFromAgentPaneId(pane.id);
+          return {
+            ...pane,
+            role: "primary-agent",
+            agentIdentity: nextIdentity,
+            ...(worktreeId === undefined ? {} : { worktreeId }),
+          };
+        });
         setState({
           ...state,
-          workspace: {
-            ...state.workspace,
-            panes: state.workspace.panes.map((pane) => {
-              if (pane.id !== paneId) return pane;
-              const worktreeId = pane.worktreeId ?? worktreeIdFromAgentPaneId(pane.id);
-              return {
-                ...pane,
-                role: "primary-agent",
-                agentIdentity: nextIdentity,
-                ...(worktreeId === undefined ? {} : { worktreeId }),
-              };
-            }),
-          },
+          workspace: { ...state.workspace, panes },
         });
       },
       // Overlay-aware via the same withActivePane helper createPane uses: revealing

--- a/station/src/state/store.ts
+++ b/station/src/state/store.ts
@@ -210,13 +210,15 @@ export function createStationStore(options?: StationStoreOptions): StationStore 
           if (pane.id !== paneId) {
             return pane;
           }
-          const worktreeId = pane.worktreeId ?? worktreeIdFromAgentPaneId(pane.id);
-          return {
-            ...pane,
+          const next: PaneRecord = {
+            id: pane.id,
+            split: pane.split,
             role: "primary-agent",
             agentIdentity: nextIdentity,
-            ...(worktreeId === undefined ? {} : { worktreeId }),
           };
+          const worktreeId = pane.worktreeId ?? worktreeIdFromAgentPaneId(pane.id);
+          if (worktreeId !== undefined) next.worktreeId = worktreeId;
+          return next;
         });
         setState({
           ...state,

--- a/station/src/station/view/sheets/AgentChoiceListView.tsx
+++ b/station/src/station/view/sheets/AgentChoiceListView.tsx
@@ -27,28 +27,25 @@ export function AgentChoiceListView({
   return (
     <>
       {choices.map((choice) => {
-        const current = choice.value.id === currentId;
-        // The update nudge never displaces a problem status — unavailable or
-        // degraded providers keep their state as the row's detail.
+        const option = choice.value;
+        const current = option.id === currentId;
+        // Problem statuses stay as the row detail; only healthy/unknown rows may
+        // show an update nudge.
         const update =
-          choice.value.status === "healthy" || choice.value.status === "unknown"
-            ? choice.value.update
-            : undefined;
+          option.status === "healthy" || option.status === "unknown" ? option.update : undefined;
+        let detail = option.status;
+        let color = providerHealthColor(theme, option.status);
+        if (update !== undefined) {
+          detail = `● update v${update.installed} → v${update.latest}`;
+          color = theme.status.success;
+        }
         return (
           <SheetChoiceLine
-            key={choice.value.id}
+            key={option.id}
             choiceKey={choice.key}
-            label={choice.value.label}
-            detail={
-              update === undefined
-                ? choice.value.status
-                : `● update v${update.installed} → v${update.latest}`
-            }
-            color={
-              update === undefined
-                ? providerHealthColor(theme, choice.value.status)
-                : theme.status.success
-            }
+            label={option.label}
+            detail={detail}
+            color={color}
             width={width}
             current={current}
             selected={choice.value.id === selectedId}

--- a/station/src/station/view/sheets/AgentChoiceListView.tsx
+++ b/station/src/station/view/sheets/AgentChoiceListView.tsx
@@ -33,7 +33,7 @@ export function AgentChoiceListView({
         // show an update nudge.
         const update =
           option.status === "healthy" || option.status === "unknown" ? option.update : undefined;
-        let detail = option.status;
+        let detail: string = option.status;
         let color = providerHealthColor(theme, option.status);
         if (update !== undefined) {
           detail = `● update v${update.installed} → v${update.latest}`;

--- a/station/src/station/view/sheets/NewSessionSheetView.tsx
+++ b/station/src/station/view/sheets/NewSessionSheetView.tsx
@@ -20,7 +20,7 @@ import type {
   DashboardStateView,
   NewSessionFlowStateView,
 } from "@station/dashboard-core/state";
-import { providerHealthColor, useStationTheme } from "../../../theme/index.js";
+import { providerHealthColor, useStationTheme, type StationColor } from "../../../theme/index.js";
 import { EditableTextInputView } from "../EditableTextInputView.js";
 import { bottomSheetContentWidth } from "../layout/bottomSheetFrame.js";
 import { AgentChoiceListView } from "./AgentChoiceListView.js";
@@ -197,7 +197,15 @@ function Review({
   return (
     <>
       {content.fields.map((field) => {
-        const status = field.status;
+        const health = field.status;
+        let rowStatus: { glyph: string; text: string; color: StationColor } | undefined;
+        if (health !== undefined) {
+          rowStatus = {
+            glyph: health.glyph,
+            text: health.text,
+            color: providerHealthColor(theme, health.tone),
+          };
+        }
         return (
           <SheetControlRow
             key={field.id}
@@ -208,15 +216,7 @@ function Review({
             focused={state.reviewFocus === field.focusId}
             disabled={!field.enabled}
             mouseTarget={{ kind: "newSessionAction", actionId: field.actionId }}
-            {...(status === undefined
-              ? {}
-              : {
-                  status: {
-                    glyph: status.glyph,
-                    text: status.text,
-                    color: providerHealthColor(theme, status.tone),
-                  },
-                })}
+            status={rowStatus}
           />
         );
       })}

--- a/station/src/station/view/sheets/parts.tsx
+++ b/station/src/station/view/sheets/parts.tsx
@@ -362,7 +362,7 @@ export function SheetControlRow({
   shortcut?: string;
   value: string | ReactNode;
   valueCells?: number;
-  status?: { glyph: string; text: string; color?: StationColor };
+  status?: { glyph: string; text: string; color?: StationColor } | undefined;
   focused?: boolean;
   disabled?: boolean;
   mouseTarget: StationMouseTarget;

--- a/station/src/terminal/pty/hostAttachedTerminal.ts
+++ b/station/src/terminal/pty/hostAttachedTerminal.ts
@@ -13,6 +13,7 @@ import { type SafeErrorFallback, toSafeError } from "@station/observability";
 import { stationBuildInfo } from "@station/runtime";
 import { reportTerminalCorruption } from "../diagnostics.js";
 import { CsiSequence } from "../protocol/csi.js";
+import { toTerminalExit } from "./ptyBridgeChannel.js";
 import type {
   StationTerminalDisposable,
   StationTerminalExit,
@@ -487,12 +488,7 @@ export function createHostAttachedTerminal(
         case "exit":
           return {
             kind: "exited",
-            exit: {
-              exitCode: frame.exitCode ?? 0,
-              ...(frame.signal === undefined || frame.signal === null
-                ? {}
-                : { signal: frame.signal }),
-            },
+            exit: toTerminalExit(frame.exitCode ?? 0, frame.signal ?? undefined),
           };
         case "focus":
           // Focus is best-effort host metadata with no terminal-output meaning.

--- a/station/src/terminal/registry/ptyRegistry.ts
+++ b/station/src/terminal/registry/ptyRegistry.ts
@@ -11,6 +11,7 @@ import {
 import type {
   StationTerminalExit,
   StationTerminalProcess,
+  StationTerminalReplayEvent,
   StationTerminalSize,
   StationTerminalSpawnOptions,
 } from "../types.js";
@@ -295,18 +296,10 @@ export function createPtyRegistry(options: PtyRegistryOptions = {}): PtyRegistry
           entry.replayingSnapshot = true;
           try {
             current.resize(initialSize);
-            for (const event of events) {
-              if (event.type === "data") {
-                current.feed(event.data);
-                continue;
-              }
-              await current.whenIdle();
-              if (entries.get(entry.paneId) !== entry) {
-                return;
-              }
-              current.resize({ cols: event.cols, rows: event.rows });
+            const entryStillCurrent = () => entries.get(entry.paneId) === entry;
+            if (!(await applyReplayEvents(current, events, entryStillCurrent))) {
+              return;
             }
-            await current.whenIdle();
           } finally {
             entry.replayingSnapshot = false;
           }
@@ -703,6 +696,26 @@ export function createPtyRegistry(options: PtyRegistryOptions = {}): PtyRegistry
       notify();
     },
   };
+}
+
+async function applyReplayEvents(
+  screen: StationVtScreen,
+  events: readonly StationTerminalReplayEvent[],
+  entryStillCurrent: () => boolean,
+): Promise<boolean> {
+  for (const event of events) {
+    if (event.type === "data") {
+      screen.feed(event.data);
+      continue;
+    }
+    await screen.whenIdle();
+    if (!entryStillCurrent()) {
+      return false;
+    }
+    screen.resize({ cols: event.cols, rows: event.rows });
+  }
+  await screen.whenIdle();
+  return true;
 }
 
 function formatExit(event: StationTerminalExit): string {

--- a/station/src/terminal/vt/screen.ts
+++ b/station/src/terminal/vt/screen.ts
@@ -55,6 +55,21 @@ const DEFAULT_SCROLL_ON_OUTPUT: ScrollOnOutputMode = "freeze";
 const MIN_COLS = 2;
 const MIN_ROWS = 1;
 
+type XtermParserFallbacks = {
+  setCsiHandlerFallback(callback: (ident: number, params: { toArray(): unknown[] }) => void): void;
+  setEscHandlerFallback(callback: (ident: number) => void): void;
+  setOscHandlerFallback(callback: (identifier: number, action: string, data: string) => void): void;
+  setDcsHandlerFallback(callback: (ident: number, action: string) => void): void;
+};
+
+type XtermParserInternals = {
+  _core?: {
+    _inputHandler?: {
+      _parser?: XtermParserFallbacks;
+    };
+  };
+};
+
 export type StationVtScreenOptions = {
   size: StationTerminalSize;
   /** Normal-buffer history depth in lines, clamped to the native workspace safety ceiling. */
@@ -575,24 +590,7 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
   // fallback hook, so this reaches into engine internals — an engine bump that
   // moves them turns detection off instead of breaking the screen.
   try {
-    const parser = (
-      terminal as unknown as {
-        _core?: {
-          _inputHandler?: {
-            _parser?: {
-              setCsiHandlerFallback(
-                callback: (ident: number, params: { toArray(): unknown[] }) => void,
-              ): void;
-              setEscHandlerFallback(callback: (ident: number) => void): void;
-              setOscHandlerFallback(
-                callback: (identifier: number, action: string, data: string) => void,
-              ): void;
-              setDcsHandlerFallback(callback: (ident: number, action: string) => void): void;
-            };
-          };
-        };
-      }
-    )._core?._inputHandler?._parser;
+    const parser = (terminal as unknown as XtermParserInternals)._core?._inputHandler?._parser;
     if (parser === undefined) {
       // An engine bump moved the private path; make the silent loss of
       // unhandled-sequence detection observable instead of trusting empty counters.


### PR DESCRIPTION
## What this fixes

Production paths in Station, Observer, Host, setup, and Worktrunk buried their jobs in nested ternaries, spreads, and leftover-shaped extracts (`*Presentation`, `*Props`, `*Log`, `{ counted, check? }`). That made indent deep without making the jobs clearer.

This PR rewrites those paths into the control flow they already were: locals, early returns, exhaustive statuses, and helpers only when the helper is a real job (policy, identity check, error distinction, drain completion).

## What changed

- Flattened every production site at 16 spaces or deeper, then the leftover 14-space *control-flow* nests. JSX props, command argv lists, widget `{ id, text }` returns, and biome-wrapped one-liners at 14 spaces stay as wrapping.
- Helpers stay only when they name a job: Host attach `next()` parks and `drain()` is the only completion path (`packages/station-host` and Station `frameStream`); session-end SQL keeps the open-lifecycle predicate; snapshot capture distinguishes pending vs failed; Worktrunk doctor inspects stale registrations as `skipped | completed | failed`; identity cleanup *warns*; boot-claim release uses `if/else` in the release function.
- Leftover extracts became locals and early returns: brew-vs-fallback installers, tmux/config setup copy, agent-picker health then update nudge, Create Session `rowStatus` only when health is present, Add Project mode guards as `if` / `{ state }`, session create/fork rollback as `if (createdWorktree !== undefined)`, hook ingest `SafeError` + `persistInput`, dashboard `placed` / `launched`.
- Tests, tools, and scripts are out of scope. Remaining production 14-space lines are wrapping, not nested guards.

## Testing

- `pnpm test:unit`: host client, Worktrunk provider, setup text presenter (`env -u STATION_OPENCODE_PLUGIN_BODY_PATH`), setup package installation, dashboard-core top-row widgets, Add Project flow
- Station `bun test`: `NewSessionSheetView.test.tsx`, `managedLaunch.test.ts`, `ptyTable.test.ts`, `semanticTerminalSnapshot.test.ts`
- Pre-commit: biome, source-order, raw hex/VT, Observer architecture (manifest regenerated for the new type-only imports)

## User-visible behavior

No intended product change. Same Create Session health, agent-list update nudge (unhealthy/degraded keep status as detail; only healthy/unknown may show `● update vX → vY`; `note="updating…"` when current+pending), `stn setup` installer commands and tmux/config copy, Worktrunk doctor (bare-root **counts**; list failure **does not**; abort **skips**), Host attach/replay/snapshot pending vs failed, Observer identity-cleanup warn and boot-claim release.

Manual check: Create Session review + agent picker; Add Project search/filter/submit; `stn setup` tmux/OpenCode/config copy; Worktrunk doctor on a bare root and on missing registrations; attach a native pane and confirm frames still arrive.

## Cleanup catalog

First commit flattens 16-space+ leftovers. Second commit flattens 14-space control-flow nests. Diffs are in the commits, not pasted here (GitHub’s PR-body limit).

### 16-space+ leftovers

1. Setup harness installers — brew early-returns; OpenCode URL/execute constants (`harnessInstallation.ts`)
2. Setup tmux popup copy — case-block `persisted` / `key` locals (`presenters/text.ts`)
3. Observer spawn — default vs injected spawner as `if` / `else` (`observerProcess/startup.ts`)
4. Harness report persist — named `storedObservation`, typed persist input (`ingestion.ts`)
5. Session-end SQL — named statements that keep `lifecycle IS NULL OR lifecycle = 'open'` (`correlations.ts`)
6. Reconcile persist — `withDefaultObservationRetention` (`sqliteAdapter.ts`)
7. Turn-readiness clear — one-line row map (`reconcile/core.ts`)
8. Identity cleanup — `warnIdentityCleanupFailed()` does the warn (`runtime/main.ts`)
9. Boot-claim release — `if/else` in the release function (`observerBootClaim.ts`)
10. Stale-registration doctor — `#inspectStaleRegistration` returns `skipped | completed | failed` (`worktrunk/src/provider.ts`)
11. Top-row time/weather — same one-line `{ id, text }` as tz/moon (`useTopRowWidgets.ts`)
12. Host attach frames — `next()` parks; `drain()` completes; `frameIteratorResult()` (`station-host/src/client.ts`)
13. Snapshot capture failure — pending vs failed as one factory (`ptyTable.ts`)
14. Worktree reject-without-receipt — two `if`s, overlay SafeError inline (`managedLaunch.ts`)
15. HMR renderer slot — `releaseHotRendererIfCurrent()` (`main.tsx`)
16. Primary-agent stamp — map panes like `closePane` (`store.ts`)
17. Loading lines — muted vs primary color inline (`DashboardRoot.tsx`)
18. Agent picker — paint health, override only for an allowed update nudge (`AgentChoiceListView.tsx`)
19. Create Session review — assign `rowStatus` only when the field has health (`NewSessionSheetView.tsx`)
20. `SheetControlRow.status` — `T | undefined` so explicit undefined is legal (`parts.tsx`)
21. Host exit frames — `toTerminalExit` preserves absent-vs-undefined `signal` (`hostAttachedTerminal.ts`)
22. Replay — `applyReplayEvents(..., entryStillCurrent)` (`ptyRegistry.ts`)
23. xterm private parser path — `XtermParserFallbacks` / `XtermParserInternals` (`vt/screen.ts`)

### 14-space control-flow follow-up

1. Add Project flow — mode guards as `if` / early `{ state }`, not nested ternaries of state blobs (`addProject/flow.ts`)
2. Host `frameStream` — same park + drain + `frameIteratorResult` as the host client
3. Session create/fork — rollback is `if (createdWorktree !== undefined)`, not a ternary-to-`false`
4. Worktrunk doctor batch — skipped/completed/failed without a switch-in-map; `ownershipConflict` / `unavailable` locals
5. Setup `write-config` copy — `creating` local, same pattern as tmux
6. Hook ingest — missing-ingress `SafeError` local; persist payload is `persistInput`
7. Harness version probe — `probeError` / `probeTimeout` locals (`providers/registry.ts`)
8. Boot-claim duplicate cleanup — two returns instead of a nested reason ternary
9. External launch — `harnessProvider` local
10. PTY attach — `attachGoneDuringSnapshot` / `liveResetReplay`
11. Dashboard create — `placed` after snapshot refresh; `launched` then `dashboardExecution`
