### PR TITLE
refactor(protocol): share C0, SGR, SemVer, and xterm pins

### DIFF
--- a/apps/observer/test/integration/reconcile-codex-harness.test.ts
+++ b/apps/observer/test/integration/reconcile-codex-harness.test.ts
@@ -1441,7 +1441,7 @@ async function persistLegacySubagentStopSequence(
   );
   if (options.acknowledge === true) {
     await legacy.persistence.recordCommandAccepted({
-      commandId: "legacy_cmd_acknowledge",
+      commandId: "cmd_legacy_acknowledge",
       command: {
         type: "session.acknowledgeTurn",
         payload: {
@@ -1452,7 +1452,7 @@ async function persistLegacySubagentStopSequence(
       createdAt: "2026-05-21T12:00:02.500Z",
     });
     await legacy.persistence.markCommandStarted(
-      "legacy_cmd_acknowledge",
+      "cmd_legacy_acknowledge",
       "2026-05-21T12:00:02.500Z",
     );
     await legacy.persistence.deleteSessionTurnReadiness({
@@ -1460,7 +1460,7 @@ async function persistLegacySubagentStopSequence(
       token: "report_legacy_stop",
     });
     await legacy.persistence.markCommandSucceeded(
-      "legacy_cmd_acknowledge",
+      "cmd_legacy_acknowledge",
       "2026-05-21T12:00:02.500Z",
     );
   }
@@ -1843,7 +1843,7 @@ function prefixedIds(prefix: string) {
   let event = 0;
   let observation = 0;
   return {
-    commandId: () => `${prefix}_cmd_${++command}`,
+    commandId: () => `cmd_${prefix}_${++command}`,
     eventId: () => `${prefix}_evt_${++event}`,
     observationId: () => `${prefix}_obs_${++observation}`,
   };


### PR DESCRIPTION
## What this fixes

Follow-up to #684. Production paths still encoded the same protocol facts inline: C0/Ctrl math, packed RGB and SGR, xterm private pins, TOML basic-string unescaping, SemVer parse/compare, and Unix `128 + signal` wait status. That made each site look like a private dialect even after the unnesting work.

This PR collapses those facts onto the owners that already existed. It does not re-flatten control flow from #684. Call sites that still packed those owners into `safeParse`/ternary punctuation are flattened into named lookups and early returns.

## What changed

- Kitty/TUI Ctrl translation uses named C0 helpers (`controlByteForAsciiLetter`, `asciiLetterForControlCode`) instead of hex/codepoint arithmetic at the call site.
- Packed RGB channel unpacking and `GraphicRendition` SGR builders are shared; snapshot attributes, palette, theme contrast, and OSC color replies consume them. The VT escape-fragment heuristic is built from those constants.
- xterm parser-fallback pins stay on the VT screen; the ground-state check stays on semantic capture. Unicode 11 setup is inlined at both call sites. Buffer, mouse, and attribute pins stay on `xtermSnapshotAttributes`; snapshot and supplemental-state code no longer `as unknown as` into `_core`.
- Config block surgery still stays line-based. TOML basic-string unescape is `parseTomlBasicString` / `tomlBasicStringAssignment` next to `quoteTomlString`.
- `CommandIdSchema` requires the `cmd_` prefix. `parseCommandId` is the parse-or-undefined owner. `TraceIdSchema` stays a non-empty string; only `TRACE_ID_PREFIX` is shared. `stn debug trace` resolves suggested bundle ids with named lookups instead of `safeParse`/ternary punctuation.
- Observer handoff and GitHub release tag parse use `@station/runtime` SemVer. Product policy (`PUBLIC_PRE_ALPHA` vs `INTERNAL_PREVIEW`) stays in Observer. Unix wait-status (`128 + signal` when the code is null) is `unixWaitStatus`; numeric and named signals both go through `unixSignalNumber`. `toTerminalExit` still keeps `signal` absent, not `undefined`, matching #684's Host attach path.

Fast popup / `fastBinding.ts` is out of scope.

## Testing

- Station `bun test`: protocol syntax/CSI/kitty, `kittyToLegacy`, `sequenceToTuiKey`, palette, screen corruption (including ghost-text fragments), `ptyBridgeChannel` (null code + SIGTERM / numeric 15 → `128+15`, signal absent on code-only exit), semantic snapshot, supplemental state
- Vitest: runtime SemVer/process-status, config event-hook TOML blocks (escaped quoted ids), Observer handoff, CLI public-convergence fixtures (`cmd_` ids), contracts `parseCommandId` / schemas
- `pnpm lint`, package typecheck for contracts/runtime/config/observer/cli, `pnpm --dir station typecheck`

## User-visible behavior

No intended product change for valid inputs. Observer command IDs that do not start with `cmd_` now fail `CommandIdSchema`.

Manual check: attach a pane and restore a snapshot; `stn debug trace` with a `cmd_…` / `trc_…` id; `stn update` tag parse; Ctrl-C in a kitty pane still sends `\x03`.