### PR TITLE
fix(groups): preserve memberships through degraded reconcile

### DIFF
--- a/apps/observer/src/persistence/ports.ts
+++ b/apps/observer/src/persistence/ports.ts
@@ -32,6 +32,7 @@ import type {
   ProviderObservationsIngressDedupeResult,
   RecordProviderObservationInput,
   SessionGroupMemberExpectation,
+  SessionGroupRepairInput,
   SessionGroupRepairResult,
   SessionGroupStoreResult,
   SessionHarnessDerivedStateRepair,
@@ -235,7 +236,9 @@ export interface SessionStore {
  * DRIVEN PORT
  *
  * Maintains recorded project-local Group mutation and atomic reconcile repair of definitions,
- * exclusive membership, and parentage. Fresh-session placement is owned by SessionStore.
+ * exclusive membership, and parentage. Reconcile must name the projects whose complete provider
+ * evidence authorizes absent-member pruning; identity and parent corruption repair remains
+ * unconditional. Fresh-session placement is owned by SessionStore.
  */
 export interface SessionGroupStore {
   listSessionGroups(): Promise<SessionGroupView[]>;
@@ -271,10 +274,7 @@ export interface SessionGroupStore {
     expectedVersion: number;
     updatedAt?: string;
   }): Promise<SessionGroupStoreResult>;
-  repairSessionGroups(input: {
-    sessions: Array<{ id: string; projectId: string }>;
-    updatedAt?: string;
-  }): Promise<SessionGroupRepairResult>;
+  repairSessionGroups(input: SessionGroupRepairInput): Promise<SessionGroupRepairResult>;
 }
 
 /**

--- a/apps/observer/src/persistence/sessionGroups.ts
+++ b/apps/observer/src/persistence/sessionGroups.ts
@@ -6,6 +6,7 @@ import {
 import type {
   SessionGroupMemberExpectation,
   SessionGroupRepairEvidence,
+  SessionGroupRepairInput,
   SessionGroupRepairResult,
   SessionGroupStoreResult,
   SessionSeedGroupPlacement,
@@ -425,9 +426,10 @@ export function deleteSessionGroup(
 
 export function repairSessionGroups(
   state: SessionGroupPersistenceState,
-  input: { sessions: Array<{ id: string; projectId: string }>; updatedAt: string },
+  input: SessionGroupRepairInput & { updatedAt: string },
 ): SessionGroupMutation<SessionGroupRepairResult> {
   const validSessions = new Map(input.sessions.map((session) => [session.id, session.projectId]));
+  const absenceAuthorityProjectIds = new Set(input.absenceAuthorityProjectIds);
   const draft = cloneSessionGroupState(state);
   const touched = new Set<SessionGroupId>();
   const repairs: SessionGroupRepairEvidence[] = [];
@@ -443,10 +445,12 @@ export function repairSessionGroups(
     if (group === undefined) {
       throw new Error("Session Group assignment references a missing Group.");
     }
-    if (
-      validSessions.get(sessionId) !== group.projectId ||
-      assignment.projectId !== group.projectId
-    ) {
+    const currentProjectId = validSessions.get(sessionId);
+    const identityMismatch = currentProjectId !== undefined && currentProjectId !== group.projectId;
+    const assignmentCorrupt = assignment.projectId !== group.projectId;
+    const authoritativeAbsence =
+      currentProjectId === undefined && absenceAuthorityProjectIds.has(group.projectId);
+    if (identityMismatch || assignmentCorrupt || authoritativeAbsence) {
       draft.assignments.delete(sessionId);
       touched.add(group.id);
       recordRepair({

--- a/apps/observer/src/persistence/types.ts
+++ b/apps/observer/src/persistence/types.ts
@@ -6,6 +6,7 @@ import type {
   HarnessEventObservation,
   HarnessRunObservation,
   ObservedStatus,
+  ProjectId,
   ProviderHealth,
   ProviderId,
   SafeError,
@@ -54,6 +55,12 @@ export type SessionGroupRepairEvidence =
 export type SessionGroupRepairResult = {
   groups: SessionGroupView[];
   repairs: SessionGroupRepairEvidence[];
+};
+
+export type SessionGroupRepairInput = {
+  sessions: Array<{ id: string; projectId: ProjectId }>;
+  absenceAuthorityProjectIds: ProjectId[];
+  updatedAt?: string;
 };
 
 export type PersistedCommandStatus = "accepted" | "started" | "succeeded" | "failed";

--- a/apps/observer/src/reconcile/providerObservations.ts
+++ b/apps/observer/src/reconcile/providerObservations.ts
@@ -1,6 +1,7 @@
 import type {
   HarnessCapabilities,
   HarnessRunObservation,
+  ProjectId,
   ProviderHealth,
   ProviderId,
   ProviderProjectConfig,
@@ -26,11 +27,50 @@ export type ProviderReadOptions = {
   logger?: StationLogger;
 };
 
+type CompleteProviderReadOutcome = {
+  status: "complete";
+  providerId: ProviderId;
+};
+
+type IndeterminateProviderReadOutcome = {
+  status: "indeterminate";
+  providerId: ProviderId;
+  failureCode: string;
+};
+
+export type WorktreeProjectReadOutcome = (
+  | CompleteProviderReadOutcome
+  | IndeterminateProviderReadOutcome
+) & {
+  providerType: "worktree";
+  projectId: ProjectId;
+};
+
+export type TerminalProviderReadOutcome = (
+  | CompleteProviderReadOutcome
+  | IndeterminateProviderReadOutcome
+) & {
+  providerType: "terminal";
+};
+
+export type HarnessProviderReadOutcome = (
+  | CompleteProviderReadOutcome
+  | IndeterminateProviderReadOutcome
+) & {
+  providerType: "harness";
+};
+
+export type ProviderReadOutcome =
+  | WorktreeProjectReadOutcome
+  | TerminalProviderReadOutcome
+  | HarnessProviderReadOutcome;
+
 // Caps concurrent provider subprocesses (wt list / listTargets) per reconcile.
 const providerReadConcurrency = 4;
 
 /**
- * Reads worktrees with bounded provider concurrency while preserving project order and health errors.
+ * Reads worktrees with bounded provider concurrency while preserving project order, health errors,
+ * and an explicit completeness outcome for every configured project.
  */
 export async function readWorktreeObservations(input: {
   providers: ProviderRegistry;
@@ -41,6 +81,7 @@ export async function readWorktreeObservations(input: {
 }): Promise<{
   worktrees: WorktreeObservation[];
   projectsScanned: number;
+  outcomes: WorktreeProjectReadOutcome[];
 }> {
   const provider = input.providers.worktree;
   const capabilities = provider.capabilities();
@@ -56,15 +97,24 @@ export async function readWorktreeObservations(input: {
   // Indexed collection keeps worktree order deterministic (config project order)
   // while listWorktrees calls run concurrently.
   const worktreesByProject: WorktreeObservation[][] = input.projects.map(() => []);
-  let projectsScanned = 0;
+  const outcomesByProject: Array<WorktreeProjectReadOutcome | undefined> = input.projects.map(
+    () => undefined,
+  );
   // One provider-level failure stops the remaining project scans: a hung
   // provider would otherwise burn its full timeout budget once per project.
-  let providerFailed = false;
+  let providerFailureCode: string | undefined;
   await forEachConcurrent(
     input.projects,
     { concurrency: providerReadConcurrency },
     async (project, index) => {
-      if (providerFailed) {
+      if (providerFailureCode !== undefined) {
+        outcomesByProject[index] = {
+          status: "indeterminate",
+          providerType: "worktree",
+          providerId: provider.id,
+          projectId: project.id,
+          failureCode: providerFailureCode,
+        };
         return;
       }
       const result = await runProviderReadBoundary(
@@ -83,7 +133,14 @@ export async function readWorktreeObservations(input: {
         () => provider.listWorktrees(project),
       );
       if (!result.ok) {
-        providerFailed = true;
+        providerFailureCode ??= result.error.code;
+        outcomesByProject[index] = {
+          status: "indeterminate",
+          providerType: "worktree",
+          providerId: provider.id,
+          projectId: project.id,
+          failureCode: result.error.code,
+        };
         await recordProviderReadFailure({
           providers: input.providers,
           providerId: provider.id,
@@ -99,16 +156,36 @@ export async function readWorktreeObservations(input: {
         return;
       }
 
-      projectsScanned += 1;
       worktreesByProject[index] = result.value;
+      outcomesByProject[index] = {
+        status: "complete",
+        providerType: "worktree",
+        providerId: provider.id,
+        projectId: project.id,
+      };
     },
   );
 
-  return { worktrees: worktreesByProject.flat(), projectsScanned };
+  const outcomes = input.projects.map(
+    (project, index): WorktreeProjectReadOutcome =>
+      outcomesByProject[index] ?? {
+        status: "indeterminate",
+        providerType: "worktree",
+        providerId: provider.id,
+        projectId: project.id,
+        failureCode: providerFailureCode ?? "WORKTREE_LIST_FAILED",
+      },
+  );
+  return {
+    worktrees: worktreesByProject.flat(),
+    projectsScanned: outcomes.filter((outcome) => outcome.status === "complete").length,
+    outcomes,
+  };
 }
 
 /**
- * Reads all terminal providers concurrently, retaining registration order and failure health.
+ * Reads all terminal providers concurrently, retaining registration order, failure health, and
+ * one explicit completeness outcome per provider.
  */
 export async function readTerminalTargetObservations(input: {
   providers: ProviderRegistry;
@@ -117,11 +194,15 @@ export async function readTerminalTargetObservations(input: {
   errors: SafeError[];
 }): Promise<{
   terminalTargets: TerminalTargetObservation[];
+  outcomes: TerminalProviderReadOutcome[];
 }> {
   const providers = Array.from(input.providers.terminals.values());
   // Indexed collection keeps target order deterministic (provider registration
   // order) while listTargets calls run concurrently.
   const targetsByProvider: TerminalTargetObservation[][] = providers.map(() => []);
+  const outcomesByProvider: Array<TerminalProviderReadOutcome | undefined> = providers.map(
+    () => undefined,
+  );
 
   await forEachConcurrent(
     providers,
@@ -154,7 +235,18 @@ export async function readTerminalTargetObservations(input: {
       );
       if (result.ok) {
         targetsByProvider[index] = result.value;
+        outcomesByProvider[index] = {
+          status: "complete",
+          providerType: "terminal",
+          providerId: provider.id,
+        };
       } else {
+        outcomesByProvider[index] = {
+          status: "indeterminate",
+          providerType: "terminal",
+          providerId: provider.id,
+          failureCode: result.error.code,
+        };
         await recordProviderReadFailure({
           providers: input.providers,
           providerId: provider.id,
@@ -171,11 +263,23 @@ export async function readTerminalTargetObservations(input: {
     },
   );
 
-  return { terminalTargets: targetsByProvider.flat() };
+  return {
+    terminalTargets: targetsByProvider.flat(),
+    outcomes: providers.map(
+      (provider, index): TerminalProviderReadOutcome =>
+        outcomesByProvider[index] ?? {
+          status: "indeterminate",
+          providerType: "terminal",
+          providerId: provider.id,
+          failureCode: "TERMINAL_LIST_FAILED",
+        },
+    ),
+  };
 }
 
 /**
- * Discovers harness runs sequentially per provider with the shared read boundary.
+ * Discovers harness runs sequentially per provider with the shared read boundary and records one
+ * explicit completeness outcome per provider.
  */
 export async function readHarnessObservations(input: {
   providers: ProviderRegistry;
@@ -188,9 +292,11 @@ export async function readHarnessObservations(input: {
 }): Promise<{
   harnessRuns: HarnessRunObservation[];
   harnessCapabilities: Record<string, HarnessCapabilities>;
+  outcomes: HarnessProviderReadOutcome[];
 }> {
   const harnessRuns: HarnessRunObservation[] = [];
   const harnessCapabilities: Record<string, HarnessCapabilities> = {};
+  const outcomes: HarnessProviderReadOutcome[] = [];
 
   for (const provider of input.providers.harnesses.values()) {
     const capabilities = provider.capabilities();
@@ -226,8 +332,20 @@ export async function readHarnessObservations(input: {
 
     if (result.ok) {
       harnessRuns.push(...result.value);
+      outcomes.push({
+        status: "complete",
+        providerType: "harness",
+        providerId: provider.id,
+      });
       continue;
     }
+
+    outcomes.push({
+      status: "indeterminate",
+      providerType: "harness",
+      providerId: provider.id,
+      failureCode: result.error.code,
+    });
 
     await recordProviderReadFailure({
       providers: input.providers,
@@ -243,7 +361,7 @@ export async function readHarnessObservations(input: {
     });
   }
 
-  return { harnessRuns, harnessCapabilities };
+  return { harnessRuns, harnessCapabilities, outcomes };
 }
 
 /**

--- a/apps/observer/src/reconcile/reconcileResult.ts
+++ b/apps/observer/src/reconcile/reconcileResult.ts
@@ -1,4 +1,4 @@
-import type { SafeError } from "@station/contracts";
+import type { SafeError, SessionGroupRepairSummary } from "@station/contracts";
 
 export type ReconcileTiming = {
   reason: string;
@@ -11,4 +11,5 @@ export type ReconcileTiming = {
   harnessRunsObserved: number;
   eventsEmitted: number;
   errors: SafeError[];
+  sessionGroupRepair?: SessionGroupRepairSummary;
 };

--- a/apps/observer/src/reconcile/run.ts
+++ b/apps/observer/src/reconcile/run.ts
@@ -5,6 +5,7 @@ import type {
   ProviderId,
   ProviderProjectConfig,
   SafeError,
+  SessionGroupRepairSummary,
   StationSnapshot,
   TerminalTargetObservation,
   WorktreeObservation,
@@ -30,6 +31,7 @@ import {
   readCurrentReconcileObservations,
 } from "./run/currentObservations.js";
 import { type ReconcileSnapshotInputs, readReconcileSnapshotInputs } from "./run/snapshotInputs.js";
+import { decideSessionGroupRepairAuthority } from "./sessionGroupRepairAuthority.js";
 import { reconcileSessionGroups } from "./sessionGroups.js";
 import { harnessesFromRegistry } from "./snapshotSeed.js";
 
@@ -62,9 +64,10 @@ type ReconcileOnceResult = {
 /**
  * USE CASE
  *
- * Orchestrates provider reads, relationship correlation, durable harness-event repair and overlays,
- * cached metadata hydration, Group projection, snapshot assembly, and atomic session persistence.
- * The same resolved title records feed snapshot composition and atomic reconcile persistence.
+ * Orchestrates provider reads and their completeness evidence, relationship correlation, durable
+ * harness-event repair and overlays, cached metadata hydration, authority-scoped Group repair and
+ * projection, snapshot assembly, and atomic session persistence. The same resolved title records
+ * feed snapshot composition and atomic reconcile persistence.
  */
 export async function runReconcileOnce(input: ReconcileOnceInput): Promise<ReconcileOnceResult> {
   const started = toIsoTimestamp(input.read.clock.now());
@@ -94,6 +97,10 @@ export async function runReconcileOnce(input: ReconcileOnceInput): Promise<Recon
     errors,
   });
   const finishedAt = observations.observedAt;
+  const sessionGroupRepair = decideSessionGroupRepairAuthority({
+    projectIds: input.projects.map((project) => project.id),
+    providerReadOutcomes: observations.providerReadOutcomes,
+  });
 
   // Snapshot records are loaded after current identities so title evidence is reattached correctly.
   const snapshotInputs = await readReconcileSnapshotInputs({
@@ -116,6 +123,9 @@ export async function runReconcileOnce(input: ReconcileOnceInput): Promise<Recon
     eventsEmitted: 0,
     errors,
   };
+  if (input.persistence !== undefined) {
+    lastReconcile.sessionGroupRepair = sessionGroupRepair;
+  }
 
   // Graph assembly and atomic persistence consume the same correlated records.
   const snapshot = await buildReconcileSnapshot({
@@ -129,6 +139,7 @@ export async function runReconcileOnce(input: ReconcileOnceInput): Promise<Recon
     terminalTargets: observations.terminalTargets,
     harnessRuns: observations.harnessRuns,
     snapshotInputs,
+    sessionGroupRepair,
     ...(input.featureFlags === undefined ? {} : { featureFlags: input.featureFlags }),
     ...(input.persistence === undefined ? {} : { persistence: input.persistence }),
     generatedAt: finishedAt,
@@ -146,7 +157,7 @@ export async function runReconcileOnce(input: ReconcileOnceInput): Promise<Recon
     providerObservationRetentionDays: retentionDays,
   });
 
-  await input.read.logger?.info("Reconcile finished.", {
+  const finishedLogAttributes: Record<string, unknown> = {
     reason: input.reason,
     durationMs: lastReconcile.durationMs,
     projectsScanned: observations.projectsScanned,
@@ -154,7 +165,11 @@ export async function runReconcileOnce(input: ReconcileOnceInput): Promise<Recon
     terminalTargetsObserved: observations.terminalTargetsRead,
     harnessRunsObserved: observations.harnessRuns.length,
     errorCount: errors.length,
-  });
+  };
+  if (input.persistence !== undefined) {
+    finishedLogAttributes.sessionGroupRepair = sessionGroupRepair;
+  }
+  await input.read.logger?.info("Reconcile finished.", finishedLogAttributes);
 
   return {
     snapshot,
@@ -164,7 +179,8 @@ export async function runReconcileOnce(input: ReconcileOnceInput): Promise<Recon
 }
 
 /**
- * Builds the graph and applies durable Group repair from the same correlated records used for persistence.
+ * Builds the provider-truthful graph and applies durable Group repair with the explicit absence
+ * authority derived from the same provider-read completeness evidence.
  */
 async function buildReconcileSnapshot(input: {
   generatedAt: string;
@@ -178,6 +194,7 @@ async function buildReconcileSnapshot(input: {
   terminalTargets: TerminalTargetObservation[];
   harnessRuns: HarnessRunObservation[];
   snapshotInputs: ReconcileSnapshotInputs;
+  sessionGroupRepair: SessionGroupRepairSummary;
   featureFlags?: ClientFeatureFlags;
   persistence?: SessionGroupStore;
   errors: SafeError[];
@@ -203,6 +220,7 @@ async function buildReconcileSnapshot(input: {
     ...(input.persistence === undefined ? {} : { store: input.persistence }),
     projects: input.projects,
     sessions: baseSnapshot.sessions,
+    absenceAuthorityProjectIds: input.sessionGroupRepair.absenceAuthorityProjectIds,
     updatedAt: input.generatedAt,
   });
   input.errors.push(...groupProjection.errors);

--- a/apps/observer/src/reconcile/run/currentObservations.ts
+++ b/apps/observer/src/reconcile/run/currentObservations.ts
@@ -22,6 +22,7 @@ import {
 } from "../observationCorrelation.js";
 import {
   type ProviderReadOptions,
+  type ProviderReadOutcome,
   readHarnessObservations,
   readRepositoryProviderHealth,
   readTerminalTargetObservations,
@@ -40,10 +41,12 @@ export type CurrentReconcileObservations = {
   harnessRuns: HarnessRunObservation[];
   harnessCapabilities: Record<string, HarnessCapabilities>;
   worktreesForSnapshot: WorktreeObservation[];
+  providerReadOutcomes: ProviderReadOutcome[];
 };
 
 /**
- * Reads and overlays current reconcile observations, preserving provider-read concurrency and phase order.
+ * Reads and overlays current reconcile observations, preserving provider-read concurrency, phase
+ * order, and the completeness evidence later used to authorize destructive Group repair.
  */
 export async function readCurrentReconcileObservations(input: {
   providers: ProviderRegistry;
@@ -133,5 +136,10 @@ export async function readCurrentReconcileObservations(input: {
     harnessRuns,
     harnessCapabilities: harnessResult.harnessCapabilities,
     worktreesForSnapshot,
+    providerReadOutcomes: [
+      ...worktreeResult.outcomes,
+      ...terminalResult.outcomes,
+      ...harnessResult.outcomes,
+    ],
   };
 }

--- a/apps/observer/src/reconcile/sessionGroupRepairAuthority.ts
+++ b/apps/observer/src/reconcile/sessionGroupRepairAuthority.ts
@@ -1,0 +1,77 @@
+import type {
+  ProjectId,
+  SessionGroupRepairBlocker,
+  SessionGroupRepairSummary,
+} from "@station/contracts";
+import type { ProviderReadOutcome } from "./providerObservations.js";
+
+/**
+ * POLICY
+ *
+ * Decides which configured projects have enough provider evidence to prune absent Group members.
+ * Terminal or harness uncertainty blocks absence pruning globally because assignments retain no
+ * provider provenance; positive identity corruption remains repairable by persistence.
+ */
+export function decideSessionGroupRepairAuthority(input: {
+  projectIds: readonly ProjectId[];
+  providerReadOutcomes: readonly ProviderReadOutcome[];
+}): SessionGroupRepairSummary {
+  const configuredProjectIds = new Set(input.projectIds);
+  const completeWorktreeProjectIds = new Set<ProjectId>();
+  const indeterminateWorktreeProjectIds = new Set<ProjectId>();
+  const blockers: SessionGroupRepairBlocker[] = [];
+  let globallyBlocked = false;
+
+  for (const outcome of input.providerReadOutcomes) {
+    if (outcome.providerType === "worktree") {
+      if (!configuredProjectIds.has(outcome.projectId)) continue;
+      if (outcome.status === "complete") {
+        completeWorktreeProjectIds.add(outcome.projectId);
+        continue;
+      }
+      indeterminateWorktreeProjectIds.add(outcome.projectId);
+      blockers.push({
+        scope: "project",
+        providerType: "worktree",
+        providerId: outcome.providerId,
+        projectId: outcome.projectId,
+        code: outcome.failureCode,
+      });
+      continue;
+    }
+
+    if (outcome.status === "complete") continue;
+    globallyBlocked = true;
+    blockers.push({
+      scope: "global",
+      providerType: outcome.providerType,
+      providerId: outcome.providerId,
+      code: outcome.failureCode,
+    });
+  }
+
+  const absenceAuthorityProjectIds = globallyBlocked
+    ? []
+    : input.projectIds.filter(
+        (projectId) =>
+          completeWorktreeProjectIds.has(projectId) &&
+          !indeterminateWorktreeProjectIds.has(projectId),
+      );
+  const authorityProjectIds = new Set(absenceAuthorityProjectIds);
+  const preservedProjectIds = input.projectIds.filter(
+    (projectId) => !authorityProjectIds.has(projectId),
+  );
+  const status =
+    absenceAuthorityProjectIds.length === 0
+      ? "skipped"
+      : preservedProjectIds.length === 0
+        ? "applied"
+        : "partially_scoped";
+
+  return {
+    status,
+    absenceAuthorityProjectIds,
+    preservedProjectIds,
+    blockers,
+  };
+}

--- a/apps/observer/src/reconcile/sessionGroups.ts
+++ b/apps/observer/src/reconcile/sessionGroups.ts
@@ -1,4 +1,5 @@
 import type {
+  ProjectId,
   ProviderProjectConfig,
   SafeError,
   SessionGroupView,
@@ -14,12 +15,15 @@ export type SessionGroupProjection = {
 /**
  * USE CASE
  *
- * Repairs durable Group membership and parentage against canonical state, then projects configured Groups with reason-specific diagnostics.
+ * Repairs durable Group identity and parentage against canonical state, prunes absent membership
+ * only for explicitly authoritative projects, then projects configured Groups with reason-specific
+ * diagnostics.
  */
 export async function reconcileSessionGroups(input: {
   store?: SessionGroupStore | undefined;
   projects: readonly ProviderProjectConfig[];
   sessions: readonly SessionView[];
+  absenceAuthorityProjectIds: readonly ProjectId[];
   updatedAt: string;
 }): Promise<SessionGroupProjection> {
   if (input.store === undefined) {
@@ -28,6 +32,7 @@ export async function reconcileSessionGroups(input: {
 
   const repaired = await input.store.repairSessionGroups({
     sessions: input.sessions.map((session) => ({ id: session.id, projectId: session.projectId })),
+    absenceAuthorityProjectIds: [...input.absenceAuthorityProjectIds],
     updatedAt: input.updatedAt,
   });
   const groups = repaired.groups;

--- a/apps/observer/test/integration/reconcile-persistence.test.ts
+++ b/apps/observer/test/integration/reconcile-persistence.test.ts
@@ -325,7 +325,11 @@ describe("observer reconcile persistence", () => {
     `);
 
     await expect(
-      persistence.repairSessionGroups({ sessions: [], updatedAt: "2026-05-20T12:01:00.000Z" }),
+      persistence.repairSessionGroups({
+        sessions: [],
+        absenceAuthorityProjectIds: ["web"],
+        updatedAt: "2026-05-20T12:01:00.000Z",
+      }),
     ).rejects.toBeDefined();
     expect(
       sqlite.database
@@ -335,6 +339,46 @@ describe("observer reconcile persistence", () => {
       { id: "grp_a", parent_group_id: "missing", version: 1 },
       { id: "grp_b", parent_group_id: "missing", version: 1 },
     ]);
+    sqlite.close();
+  });
+
+  it("repairs assignment project corruption without absence-pruning authority", async () => {
+    const { sqlite, persistence } = createTestObserverCore({
+      config,
+      providers: providersWithOneSession(),
+      clock: { now: () => new Date(now) },
+    });
+    await persistence.createSessionGroup({
+      id: "grp_corrupt_assignment",
+      projectId: "web",
+      name: "Corrupt assignment",
+      initialMembers: [
+        { sessionId: "ses_corrupt_assignment", projectId: "web", expectedGroupId: null },
+      ],
+      createdAt: now,
+    });
+    sqlite.database
+      .prepare("UPDATE session_group_memberships SET project_id = ? WHERE session_id = ?")
+      .run("api", "ses_corrupt_assignment");
+
+    await expect(
+      persistence.repairSessionGroups({
+        sessions: [],
+        absenceAuthorityProjectIds: [],
+        updatedAt: "2026-05-20T12:01:00.000Z",
+      }),
+    ).resolves.toEqual({
+      groups: [
+        expect.objectContaining({ id: "grp_corrupt_assignment", sessionIds: [], version: 2 }),
+      ],
+      repairs: [
+        {
+          reason: "invalid_membership",
+          groupId: "grp_corrupt_assignment",
+          projectId: "web",
+        },
+      ],
+    });
     sqlite.close();
   });
 
@@ -625,6 +669,7 @@ describe("observer reconcile persistence", () => {
     const clock = { now: () => new Date(now) };
     const sqlite = openObserverSqlite({ clock });
     const persistence = createSqliteObserverPersistence({ sqlite, clock, idFactory: ids() });
+    const logInfos: Array<{ message: string; attributes?: Record<string, unknown> }> = [];
     const logErrors: Array<{ message: string; attributes?: Record<string, unknown> }> = [];
     const core = createObserverCore({
       config,
@@ -636,7 +681,9 @@ describe("observer reconcile persistence", () => {
       persistence,
       clock,
       logger: {
-        info: async () => undefined,
+        info: async (message, attributes) => {
+          logInfos.push({ message, ...(attributes === undefined ? {} : { attributes }) });
+        },
         warn: async () => undefined,
         error: async (message, attributes) => {
           logErrors.push({ message, ...(attributes === undefined ? {} : { attributes }) });
@@ -659,6 +706,24 @@ describe("observer reconcile persistence", () => {
       "diagnosticDetails",
     );
     expect(core.getHealth().lastReconcile?.errors[0]).not.toHaveProperty("diagnosticDetails");
+    const sessionGroupRepair = {
+      status: "skipped",
+      absenceAuthorityProjectIds: [],
+      preservedProjectIds: ["web"],
+      blockers: [
+        {
+          scope: "global",
+          providerType: "terminal",
+          providerId: "fake-terminal",
+          code: "TERMINAL_LIST_FAILED",
+        },
+      ],
+    };
+    expect(core.getHealth().lastReconcile?.sessionGroupRepair).toEqual(sessionGroupRepair);
+    expect(logInfos).toContainEqual({
+      message: "Reconcile finished.",
+      attributes: expect.objectContaining({ sessionGroupRepair }),
+    });
     expect(logErrors).toEqual([
       {
         message: "Terminal provider list failed.",

--- a/apps/observer/test/integration/reconcile-session-group-authority.test.ts
+++ b/apps/observer/test/integration/reconcile-session-group-authority.test.ts
@@ -1,0 +1,255 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { StationConfig } from "@station/config";
+import type { ProviderProjectConfig, SafeError } from "@station/contracts";
+import {
+  createFakeHarnessRun,
+  createFakeTerminalTarget,
+  createFakeWorktree,
+  FakeHarnessProvider,
+  FakeTerminalProvider,
+  FakeWorktreeProvider,
+} from "@station/testing";
+import { describe, expect, it, vi } from "vitest";
+import { ProviderRegistry } from "../../src/internal.js";
+import { createTestIdFactory, createTestObserverCore } from "../support/testObserver.js";
+
+const now = "2026-08-24T08:53:09.000Z";
+
+function project(id: string): StationConfig["projects"][number] {
+  return {
+    id,
+    label: id,
+    root: `/tmp/station/${id}`,
+    defaults: {
+      harness: "fake-harness",
+      terminal: "fake-terminal",
+      layout: "agent-shell",
+    },
+    worktrunk: { enabled: true },
+  };
+}
+
+function configFor(...projectIds: string[]): StationConfig {
+  return {
+    schemaVersion: 1,
+    defaults: {
+      worktreeProvider: "fake-worktree",
+      terminal: "fake-terminal",
+      harness: "fake-harness",
+      layout: "agent-shell",
+    },
+    projects: projectIds.map(project),
+  };
+}
+
+function providersFor(
+  sessions: Array<{ projectId: string; worktreeId: string; sessionId: string }>,
+): ProviderRegistry {
+  return new ProviderRegistry({
+    worktree: new FakeWorktreeProvider({
+      now,
+      worktrees: sessions.map(({ projectId, worktreeId }) =>
+        createFakeWorktree({ id: worktreeId, projectId, now }),
+      ),
+    }),
+    terminal: new FakeTerminalProvider({
+      now,
+      targets: sessions.map(({ projectId, worktreeId, sessionId }) =>
+        createFakeTerminalTarget({
+          id: `term_${sessionId}`,
+          projectId,
+          worktreeId,
+          sessionId,
+          harnessRunId: `run_${sessionId}`,
+          now,
+        }),
+      ),
+    }),
+    harnesses: [
+      new FakeHarnessProvider({
+        now,
+        runs: sessions.map(({ projectId, worktreeId, sessionId }) =>
+          createFakeHarnessRun({
+            id: `run_${sessionId}`,
+            projectId,
+            worktreeId,
+            sessionId,
+            state: "idle",
+            now,
+          }),
+        ),
+      }),
+    ],
+  });
+}
+
+function providerTimeout(provider: string): SafeError {
+  return {
+    tag: "TimeoutError",
+    code: "PROVIDER_TIMEOUT",
+    message: "Provider operation timed out.",
+    provider,
+  };
+}
+
+describe("reconcile Session Group repair authority", () => {
+  it("preserves membership through provider timeouts, SQLite reopen, and healthy recovery", async () => {
+    const dbPath = join(
+      await mkdtemp(join(tmpdir(), "station-group-reconcile-authority-")),
+      "observer.sqlite",
+    );
+    const config = configFor("web");
+    const idFactory = createTestIdFactory();
+    const providers = providersFor([
+      { projectId: "web", worktreeId: "wt_web_main", sessionId: "ses_web_main" },
+    ]);
+    const first = createTestObserverCore({
+      config,
+      providers,
+      clock: { now: () => new Date(now) },
+      sqlitePath: dbPath,
+      idFactory,
+    });
+    await first.persistence.createSessionGroup({
+      id: "grp_web",
+      projectId: "web",
+      name: "Web",
+      initialMembers: [{ sessionId: "ses_web_main", projectId: "web", expectedGroupId: null }],
+      createdAt: now,
+    });
+
+    const healthy = await first.core.reconcile("healthy-before-timeout");
+    expect(healthy.sessionGroups).toEqual([
+      expect.objectContaining({ id: "grp_web", sessionIds: ["ses_web_main"], version: 1 }),
+    ]);
+    expect(first.core.getHealth().lastReconcile?.sessionGroupRepair).toEqual({
+      status: "applied",
+      absenceAuthorityProjectIds: ["web"],
+      preservedProjectIds: [],
+      blockers: [],
+    });
+
+    const worktreeRead = vi
+      .spyOn(providers.worktree, "listWorktrees")
+      .mockRejectedValue(providerTimeout("fake-worktree"));
+    const terminalRead = vi
+      .spyOn(providers.terminal, "listTargets")
+      .mockRejectedValue(providerTimeout("fake-terminal"));
+
+    const degraded = await first.core.reconcile("provider-timeouts");
+    expect(degraded.sessions).toEqual([]);
+    expect(degraded.sessionGroups).toEqual([
+      expect.objectContaining({ id: "grp_web", sessionIds: [], version: 1 }),
+    ]);
+    await expect(first.persistence.listSessionGroups()).resolves.toEqual([
+      expect.objectContaining({ id: "grp_web", sessionIds: ["ses_web_main"], version: 1 }),
+    ]);
+    expect(first.core.getHealth().lastReconcile?.sessionGroupRepair).toEqual({
+      status: "skipped",
+      absenceAuthorityProjectIds: [],
+      preservedProjectIds: ["web"],
+      blockers: [
+        {
+          scope: "project",
+          providerType: "worktree",
+          providerId: "fake-worktree",
+          projectId: "web",
+          code: "PROVIDER_TIMEOUT",
+        },
+        {
+          scope: "global",
+          providerType: "terminal",
+          providerId: "fake-terminal",
+          code: "PROVIDER_TIMEOUT",
+        },
+      ],
+    });
+
+    worktreeRead.mockRestore();
+    terminalRead.mockRestore();
+    first.sqlite.close();
+
+    const recovered = createTestObserverCore({
+      config,
+      providers,
+      clock: { now: () => new Date(now) },
+      sqlitePath: dbPath,
+      idFactory,
+    });
+    const recoveredSnapshot = await recovered.core.reconcile("healthy-after-restart");
+    expect(recoveredSnapshot.sessionGroups).toEqual([
+      expect.objectContaining({ id: "grp_web", sessionIds: ["ses_web_main"], version: 1 }),
+    ]);
+    await expect(recovered.persistence.listSessionGroups()).resolves.toEqual([
+      expect.objectContaining({ id: "grp_web", sessionIds: ["ses_web_main"], version: 1 }),
+    ]);
+    recovered.sqlite.close();
+  });
+
+  it("prunes a confirmed deletion while preserving membership in a failed project", async () => {
+    const config = configFor("web", "api");
+    const providers = providersFor([
+      { projectId: "web", worktreeId: "wt_web_main", sessionId: "ses_web_main" },
+      { projectId: "api", worktreeId: "wt_api_main", sessionId: "ses_api_main" },
+    ]);
+    const originalListWorktrees = providers.worktree.listWorktrees.bind(providers.worktree);
+    vi.spyOn(providers.worktree, "listWorktrees").mockImplementation(
+      async (configuredProject: ProviderProjectConfig) => {
+        if (configuredProject.id === "api") throw providerTimeout("fake-worktree");
+        return originalListWorktrees(configuredProject);
+      },
+    );
+    const { sqlite, persistence, core } = createTestObserverCore({
+      config,
+      providers,
+      clock: { now: () => new Date(now) },
+    });
+    await persistence.createSessionGroup({
+      id: "grp_web_deleted",
+      projectId: "web",
+      name: "Deleted",
+      initialMembers: [{ sessionId: "ses_web_deleted", projectId: "web", expectedGroupId: null }],
+      createdAt: now,
+    });
+    await persistence.createSessionGroup({
+      id: "grp_api_preserved",
+      projectId: "api",
+      name: "Preserved",
+      initialMembers: [{ sessionId: "ses_api_main", projectId: "api", expectedGroupId: null }],
+      createdAt: now,
+    });
+
+    const snapshot = await core.reconcile("partial-worktree-scan");
+
+    expect(snapshot.sessions.map((session) => session.id)).toEqual(["ses_web_main"]);
+    expect(snapshot.sessionGroups).toEqual([
+      expect.objectContaining({ id: "grp_api_preserved", sessionIds: [], version: 1 }),
+      expect.objectContaining({ id: "grp_web_deleted", sessionIds: [], version: 2 }),
+    ]);
+    await expect(persistence.listSessionGroups()).resolves.toEqual([
+      expect.objectContaining({
+        id: "grp_api_preserved",
+        sessionIds: ["ses_api_main"],
+        version: 1,
+      }),
+      expect.objectContaining({ id: "grp_web_deleted", sessionIds: [], version: 2 }),
+    ]);
+    expect(core.getHealth().lastReconcile?.sessionGroupRepair).toEqual({
+      status: "partially_scoped",
+      absenceAuthorityProjectIds: ["web"],
+      preservedProjectIds: ["api"],
+      blockers: [
+        {
+          scope: "project",
+          providerType: "worktree",
+          providerId: "fake-worktree",
+          projectId: "api",
+          code: "PROVIDER_TIMEOUT",
+        },
+      ],
+    });
+    sqlite.close();
+  });
+});

--- a/apps/observer/test/integration/reconcile-session-group-authority.test.ts
+++ b/apps/observer/test/integration/reconcile-session-group-authority.test.ts
@@ -46,6 +46,7 @@ function configFor(...projectIds: string[]): StationConfig {
 
 function providersFor(
   sessions: Array<{ projectId: string; worktreeId: string; sessionId: string }>,
+  options: { terminalTargets?: boolean } = {},
 ): ProviderRegistry {
   return new ProviderRegistry({
     worktree: new FakeWorktreeProvider({
@@ -56,16 +57,19 @@ function providersFor(
     }),
     terminal: new FakeTerminalProvider({
       now,
-      targets: sessions.map(({ projectId, worktreeId, sessionId }) =>
-        createFakeTerminalTarget({
-          id: `term_${sessionId}`,
-          projectId,
-          worktreeId,
-          sessionId,
-          harnessRunId: `run_${sessionId}`,
-          now,
-        }),
-      ),
+      targets:
+        options.terminalTargets === false
+          ? []
+          : sessions.map(({ projectId, worktreeId, sessionId }) =>
+              createFakeTerminalTarget({
+                id: `term_${sessionId}`,
+                projectId,
+                worktreeId,
+                sessionId,
+                harnessRunId: `run_${sessionId}`,
+                now,
+              }),
+            ),
     }),
     harnesses: [
       new FakeHarnessProvider({
@@ -186,6 +190,124 @@ describe("reconcile Session Group repair authority", () => {
       expect.objectContaining({ id: "grp_web", sessionIds: ["ses_web_main"], version: 1 }),
     ]);
     recovered.sqlite.close();
+  });
+
+  it("preserves an absent member when terminal failure is the sole authority blocker", async () => {
+    const config = configFor("web");
+    const providers = providersFor([
+      { projectId: "web", worktreeId: "wt_web_main", sessionId: "ses_web_main" },
+    ]);
+    const harness = providers.harnesses.get("fake-harness");
+    if (harness === undefined) throw new Error("Expected fake harness provider.");
+    const harnessRead = vi.spyOn(harness, "discoverRuns").mockResolvedValue([]);
+    const terminalRead = vi
+      .spyOn(providers.terminal, "listTargets")
+      .mockRejectedValue(providerTimeout("fake-terminal"));
+    const { sqlite, persistence, core } = createTestObserverCore({
+      config,
+      providers,
+      clock: { now: () => new Date(now) },
+    });
+    await persistence.createSessionGroup({
+      id: "grp_web",
+      projectId: "web",
+      name: "Web",
+      initialMembers: [{ sessionId: "ses_web_main", projectId: "web", expectedGroupId: null }],
+      createdAt: now,
+    });
+
+    const degraded = await core.reconcile("terminal-only-failure");
+    expect(degraded.sessions).toEqual([]);
+    expect(degraded.sessionGroups).toEqual([
+      expect.objectContaining({ id: "grp_web", sessionIds: [], version: 1 }),
+    ]);
+    await expect(persistence.listSessionGroups()).resolves.toEqual([
+      expect.objectContaining({ id: "grp_web", sessionIds: ["ses_web_main"], version: 1 }),
+    ]);
+    expect(core.getHealth().lastReconcile?.sessionGroupRepair).toEqual({
+      status: "skipped",
+      absenceAuthorityProjectIds: [],
+      preservedProjectIds: ["web"],
+      blockers: [
+        {
+          scope: "global",
+          providerType: "terminal",
+          providerId: "fake-terminal",
+          code: "PROVIDER_TIMEOUT",
+        },
+      ],
+    });
+
+    harnessRead.mockRestore();
+    terminalRead.mockRestore();
+    const recovered = await core.reconcile("healthy-after-terminal-recovery");
+    expect(recovered.sessionGroups).toEqual([
+      expect.objectContaining({ id: "grp_web", sessionIds: ["ses_web_main"], version: 1 }),
+    ]);
+    sqlite.close();
+  });
+
+  it("preserves harness-only membership through failed harness discovery and recovery", async () => {
+    const config = configFor("web");
+    const providers = providersFor(
+      [{ projectId: "web", worktreeId: "wt_web_main", sessionId: "ses_web_main" }],
+      { terminalTargets: false },
+    );
+    const { sqlite, persistence, core } = createTestObserverCore({
+      config,
+      providers,
+      clock: { now: () => new Date(now) },
+    });
+    await persistence.createSessionGroup({
+      id: "grp_web",
+      projectId: "web",
+      name: "Web",
+      initialMembers: [{ sessionId: "ses_web_main", projectId: "web", expectedGroupId: null }],
+      createdAt: now,
+    });
+
+    const healthy = await core.reconcile("healthy-before-harness-failure");
+    expect(healthy.sessionGroups).toEqual([
+      expect.objectContaining({ id: "grp_web", sessionIds: ["ses_web_main"], version: 1 }),
+    ]);
+
+    const harness = providers.harnesses.get("fake-harness");
+    if (harness === undefined) throw new Error("Expected fake harness provider.");
+    const harnessRead = vi.spyOn(harness, "discoverRuns").mockRejectedValue({
+      tag: "HarnessProviderError",
+      code: "HARNESS_DISCOVER_FAILED",
+      message: "The fake harness could not discover runs.",
+      provider: "fake-harness",
+    } satisfies SafeError);
+
+    const degraded = await core.reconcile("harness-discovery-failure");
+    expect(degraded.sessions).toEqual([]);
+    expect(degraded.sessionGroups).toEqual([
+      expect.objectContaining({ id: "grp_web", sessionIds: [], version: 1 }),
+    ]);
+    await expect(persistence.listSessionGroups()).resolves.toEqual([
+      expect.objectContaining({ id: "grp_web", sessionIds: ["ses_web_main"], version: 1 }),
+    ]);
+    expect(core.getHealth().lastReconcile?.sessionGroupRepair).toEqual({
+      status: "skipped",
+      absenceAuthorityProjectIds: [],
+      preservedProjectIds: ["web"],
+      blockers: [
+        {
+          scope: "global",
+          providerType: "harness",
+          providerId: "fake-harness",
+          code: "HARNESS_DISCOVER_FAILED",
+        },
+      ],
+    });
+
+    harnessRead.mockRestore();
+    const recovered = await core.reconcile("healthy-after-harness-recovery");
+    expect(recovered.sessionGroups).toEqual([
+      expect.objectContaining({ id: "grp_web", sessionIds: ["ses_web_main"], version: 1 }),
+    ]);
+    sqlite.close();
   });
 
   it("prunes a confirmed deletion while preserving membership in a failed project", async () => {

--- a/apps/observer/test/support/observerPersistenceContract.ts
+++ b/apps/observer/test/support/observerPersistenceContract.ts
@@ -3226,6 +3226,7 @@ export function observerPersistenceContract(
           await expect(
             persistence.repairSessionGroups({
               sessions: [{ id: "ses_keep", projectId: "other" }],
+              absenceAuthorityProjectIds: ["web"],
               updatedAt: now,
             }),
           ).resolves.toEqual({
@@ -3236,13 +3237,85 @@ export function observerPersistenceContract(
             repairs: [{ reason: "invalid_membership", groupId: "group_prune", projectId: "web" }],
           });
           await expect(
-            persistence.repairSessionGroups({ sessions: [], updatedAt: later }),
+            persistence.repairSessionGroups({
+              sessions: [],
+              absenceAuthorityProjectIds: ["web"],
+              updatedAt: later,
+            }),
           ).resolves.toEqual({
             groups: [
               expect.objectContaining({ id: "group_prune", sessionIds: [], version: 2 }),
               expect.objectContaining({ id: "group_untouched", sessionIds: [], version: 1 }),
             ],
             repairs: [],
+          });
+        });
+      });
+
+      it("scopes absent-member pruning while always repairing positive project mismatches", async () => {
+        await withPersistence(createFixture, async ({ persistence }) => {
+          await persistence.createSessionGroup({
+            id: "group_authoritative",
+            projectId: "web",
+            name: "Authoritative",
+            initialMembers: [
+              { sessionId: "ses_web_missing", projectId: "web", expectedGroupId: null },
+            ],
+            createdAt: earlier,
+          });
+          await persistence.createSessionGroup({
+            id: "group_preserved",
+            projectId: "api",
+            name: "Preserved",
+            initialMembers: [
+              { sessionId: "ses_api_missing", projectId: "api", expectedGroupId: null },
+            ],
+            createdAt: earlier,
+          });
+          await persistence.createSessionGroup({
+            id: "group_mismatch",
+            projectId: "api",
+            name: "Mismatch",
+            initialMembers: [{ sessionId: "ses_moved", projectId: "api", expectedGroupId: null }],
+            createdAt: earlier,
+          });
+
+          await expect(
+            persistence.repairSessionGroups({
+              sessions: [{ id: "ses_moved", projectId: "web" }],
+              absenceAuthorityProjectIds: ["web"],
+              updatedAt: now,
+            }),
+          ).resolves.toEqual({
+            groups: [
+              expect.objectContaining({
+                id: "group_mismatch",
+                sessionIds: [],
+                version: 2,
+              }),
+              expect.objectContaining({
+                id: "group_preserved",
+                sessionIds: ["ses_api_missing"],
+                version: 1,
+              }),
+              expect.objectContaining({
+                id: "group_authoritative",
+                sessionIds: [],
+                version: 2,
+              }),
+            ],
+            repairs: [
+              {
+                reason: "invalid_membership",
+                groupId: "group_mismatch",
+                projectId: "api",
+              },
+              {
+                reason: "invalid_membership",
+                groupId: "group_authoritative",
+                projectId: "web",
+              },
+            ],
           });
         });
       });

--- a/apps/observer/test/unit/sessionGroupRepairAuthority.test.ts
+++ b/apps/observer/test/unit/sessionGroupRepairAuthority.test.ts
@@ -1,0 +1,180 @@
+import type { ProjectId } from "@station/contracts";
+import { describe, expect, it } from "vitest";
+import type { ProviderReadOutcome } from "../../src/reconcile/providerObservations.js";
+import { decideSessionGroupRepairAuthority } from "../../src/reconcile/sessionGroupRepairAuthority.js";
+
+const projectIds: ProjectId[] = ["web", "api"];
+
+function completeWorktrees(...ids: ProjectId[]): ProviderReadOutcome[] {
+  return ids.map((projectId) => ({
+    status: "complete",
+    providerType: "worktree",
+    providerId: "worktrunk",
+    projectId,
+  }));
+}
+
+const completeTerminalRead: ProviderReadOutcome = {
+  status: "complete",
+  providerType: "terminal",
+  providerId: "tmux",
+};
+const completeHarnessRead: ProviderReadOutcome = {
+  status: "complete",
+  providerType: "harness",
+  providerId: "codex",
+};
+const completeGlobalReads: ProviderReadOutcome[] = [completeTerminalRead, completeHarnessRead];
+
+describe("decideSessionGroupRepairAuthority", () => {
+  it("applies absence repair to every completely observed project", () => {
+    expect(
+      decideSessionGroupRepairAuthority({
+        projectIds,
+        providerReadOutcomes: [...completeWorktrees(...projectIds), ...completeGlobalReads],
+      }),
+    ).toEqual({
+      status: "applied",
+      absenceAuthorityProjectIds: ["web", "api"],
+      preservedProjectIds: [],
+      blockers: [],
+    });
+  });
+
+  it("partially scopes repair across successful and failed worktree projects", () => {
+    expect(
+      decideSessionGroupRepairAuthority({
+        projectIds,
+        providerReadOutcomes: [
+          ...completeWorktrees("web"),
+          {
+            status: "indeterminate",
+            providerType: "worktree",
+            providerId: "worktrunk",
+            projectId: "api",
+            failureCode: "PROVIDER_TIMEOUT",
+          },
+          ...completeGlobalReads,
+        ],
+      }),
+    ).toEqual({
+      status: "partially_scoped",
+      absenceAuthorityProjectIds: ["web"],
+      preservedProjectIds: ["api"],
+      blockers: [
+        {
+          scope: "project",
+          providerType: "worktree",
+          providerId: "worktrunk",
+          projectId: "api",
+          code: "PROVIDER_TIMEOUT",
+        },
+      ],
+    });
+  });
+
+  it("skips absence repair globally after a terminal read failure", () => {
+    expect(
+      decideSessionGroupRepairAuthority({
+        projectIds,
+        providerReadOutcomes: [
+          ...completeWorktrees(...projectIds),
+          {
+            status: "indeterminate",
+            providerType: "terminal",
+            providerId: "tmux",
+            failureCode: "PROVIDER_TIMEOUT",
+          },
+          completeHarnessRead,
+        ],
+      }),
+    ).toEqual({
+      status: "skipped",
+      absenceAuthorityProjectIds: [],
+      preservedProjectIds: projectIds,
+      blockers: [
+        {
+          scope: "global",
+          providerType: "terminal",
+          providerId: "tmux",
+          code: "PROVIDER_TIMEOUT",
+        },
+      ],
+    });
+  });
+
+  it("skips absence repair globally after a harness discovery failure", () => {
+    expect(
+      decideSessionGroupRepairAuthority({
+        projectIds,
+        providerReadOutcomes: [
+          ...completeWorktrees(...projectIds),
+          completeTerminalRead,
+          {
+            status: "indeterminate",
+            providerType: "harness",
+            providerId: "codex",
+            failureCode: "HARNESS_DISCOVER_FAILED",
+          },
+        ],
+      }),
+    ).toEqual({
+      status: "skipped",
+      absenceAuthorityProjectIds: [],
+      preservedProjectIds: projectIds,
+      blockers: [
+        {
+          scope: "global",
+          providerType: "harness",
+          providerId: "codex",
+          code: "HARNESS_DISCOVER_FAILED",
+        },
+      ],
+    });
+  });
+
+  it("skips absence repair when every worktree project is indeterminate", () => {
+    expect(
+      decideSessionGroupRepairAuthority({
+        projectIds,
+        providerReadOutcomes: [
+          ...projectIds.map(
+            (projectId): ProviderReadOutcome => ({
+              status: "indeterminate",
+              providerType: "worktree",
+              providerId: "worktrunk",
+              projectId,
+              failureCode: "WORKTREE_LIST_FAILED",
+            }),
+          ),
+          ...completeGlobalReads,
+        ],
+      }),
+    ).toEqual({
+      status: "skipped",
+      absenceAuthorityProjectIds: [],
+      preservedProjectIds: projectIds,
+      blockers: projectIds.map((projectId) => ({
+        scope: "project",
+        providerType: "worktree",
+        providerId: "worktrunk",
+        projectId,
+        code: "WORKTREE_LIST_FAILED",
+      })),
+    });
+  });
+
+  it("never grants authority to an unconfigured project", () => {
+    expect(
+      decideSessionGroupRepairAuthority({
+        projectIds: ["web"],
+        providerReadOutcomes: [...completeWorktrees("web", "removed"), ...completeGlobalReads],
+      }),
+    ).toEqual({
+      status: "applied",
+      absenceAuthorityProjectIds: ["web"],
+      preservedProjectIds: [],
+      blockers: [],
+    });
+  });
+});

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,11 +61,12 @@ No single layer owns all truth.
   admission, compaction, and normalization into harness reports.
 - A sealed session-rescue archive becomes temporary cutover authority only after the exact source sessions have stopped and every recovery-critical asset has been captured and hashed; a live-source archive remains evidence, not launch authority.
 - Repository providers are authoritative only for code-host metadata they fetch or cache through their integration boundary.
-- Observer SQLite is durable observer memory for commands, events, correlations, explicit Station-session lifecycle, project-local Session Group definitions and exclusive membership, canonical worktree display titles keyed by project and worktree, provider observations, and current metadata cache rows.
+- Observer SQLite is durable observer memory for commands, events, correlations, explicit Station-session lifecycle, project-local Session Group definitions and exclusive membership, canonical worktree display titles keyed by project and worktree, provider observations, and current metadata cache rows. Reconcile prunes an absent Group assignment only when provider-read completeness grants authority for that project; provider uncertainty preserves the durable assignment and its Group version.
 - Observer snapshots are the normalized current graph exposed to clients. `rows` is configured
   worktree inventory; `sessions` is canonical session membership; and `sessionGroups` is the
   flat project-local organizational projection, retaining optional parent relationships in
-  deterministic parent-before-child order. `WorktreeRow.title` is the
+  deterministic parent-before-child order. Snapshots remain provider-truthful during degraded
+  reads and do not hydrate preserved but currently unavailable sessions from SQLite. `WorktreeRow.title` is the
   display authority, while `SessionView.title` is its lifecycle projection. Session and activity
   counts derive from `sessions`, while worktree counts derive from `rows`.
 - Session start and resume resolve only from current snapshot `rows`; absence is not repaired from

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -80,6 +80,15 @@ new redacted bundle. `reconcile`, `command dispatch`, `project add/remove`,
 hook install/uninstall, and setup apply commands intentionally mutate runtime,
 config, hooks, or local machine state.
 
+Observer health reports the latest durable Group-repair decision at
+`lastReconcile.sessionGroupRepair`. `applied` means every configured project authorized absent-member
+pruning, `partially_scoped` means only the named `absenceAuthorityProjectIds` did, and `skipped`
+means none did. `preservedProjectIds` names assignments protected from absence pruning, while strict
+`blockers` identify an indeterminate worktree project or the terminal/harness provider that blocked
+repair globally. The structured `Reconcile finished.` log carries the same summary. Provider errors
+remain the evidence for why a read was indeterminate; the repair summary is authority evidence, not a
+duplicate failure.
+
 ## Provider Command Failures
 
 When a provider command fails, use the correlation ids before inspecting the

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -5611,6 +5611,12 @@
           "purpose": null
         },
         {
+          "name": "SessionGroupRepairInput",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
           "name": "SessionGroupRepairResult",
           "kind": "type",
           "role": null,
@@ -5620,7 +5626,7 @@
           "name": "SessionGroupStore",
           "kind": "interface",
           "role": "DRIVEN PORT",
-          "purpose": "Maintains recorded project-local Group mutation and atomic reconcile repair of definitions, exclusive membership, and parentage. Fresh-session placement is owned by SessionStore."
+          "purpose": "Maintains recorded project-local Group mutation and atomic reconcile repair of definitions, exclusive membership, and parentage. Reconcile must name the projects whose complete provider evidence authorizes absent-member pruning; identity and parent corruption repair remains unconditional. Fresh-session placement is owned by SessionStore."
         },
         {
           "name": "SessionGroupStoreConflictReason",
@@ -7700,6 +7706,12 @@
           "purpose": null
         },
         {
+          "name": "SessionGroupRepairInput",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
           "name": "SessionGroupRepairResult",
           "kind": "type",
           "role": null,
@@ -7709,7 +7721,7 @@
           "name": "SessionGroupStore",
           "kind": "interface",
           "role": "DRIVEN PORT",
-          "purpose": "Maintains recorded project-local Group mutation and atomic reconcile repair of definitions, exclusive membership, and parentage. Fresh-session placement is owned by SessionStore."
+          "purpose": "Maintains recorded project-local Group mutation and atomic reconcile repair of definitions, exclusive membership, and parentage. Reconcile must name the projects whose complete provider evidence authorizes absent-member pruning; identity and parent corruption repair remains unconditional. Fresh-session placement is owned by SessionStore."
         },
         {
           "name": "SessionGroupStoreConflictReason",
@@ -8054,7 +8066,7 @@
           "name": "SessionGroupStore",
           "kind": "interface",
           "role": "DRIVEN PORT",
-          "purpose": "Maintains recorded project-local Group mutation and atomic reconcile repair of definitions, exclusive membership, and parentage. Fresh-session placement is owned by SessionStore."
+          "purpose": "Maintains recorded project-local Group mutation and atomic reconcile repair of definitions, exclusive membership, and parentage. Reconcile must name the projects whose complete provider evidence authorizes absent-member pruning; identity and parent corruption repair remains unconditional. Fresh-session placement is owned by SessionStore."
         },
         {
           "name": "SessionStore",
@@ -8096,6 +8108,7 @@
             "ProviderObservationsIngressDedupeResult",
             "RecordProviderObservationInput",
             "SessionGroupMemberExpectation",
+            "SessionGroupRepairInput",
             "SessionGroupRepairResult",
             "SessionGroupStoreResult",
             "SessionHarnessDerivedStateRepair",
@@ -8414,6 +8427,7 @@
           "bindings": [
             "SessionGroupMemberExpectation",
             "SessionGroupRepairEvidence",
+            "SessionGroupRepairInput",
             "SessionGroupRepairResult",
             "SessionGroupStoreResult",
             "SessionSeedGroupPlacement",
@@ -9040,6 +9054,12 @@
           "purpose": null
         },
         {
+          "name": "SessionGroupRepairInput",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
           "name": "SessionGroupRepairResult",
           "kind": "type",
           "role": null,
@@ -9119,6 +9139,7 @@
             "HarnessEventObservation",
             "HarnessRunObservation",
             "ObservedStatus",
+            "ProjectId",
             "ProviderHealth",
             "ProviderId",
             "SafeError",
@@ -9862,7 +9883,19 @@
       "path": "apps/observer/src/reconcile/providerObservations.ts",
       "exports": [
         {
+          "name": "HarnessProviderReadOutcome",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
           "name": "ProviderReadOptions",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "ProviderReadOutcome",
           "kind": "type",
           "role": null,
           "purpose": null
@@ -9888,6 +9921,18 @@
         {
           "name": "readWorktreeObservations",
           "kind": "function",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "TerminalProviderReadOutcome",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "WorktreeProjectReadOutcome",
+          "kind": "type",
           "role": null,
           "purpose": null
         }
@@ -9918,6 +9963,7 @@
           "bindings": [
             "HarnessCapabilities",
             "HarnessRunObservation",
+            "ProjectId",
             "ProviderHealth",
             "ProviderId",
             "ProviderProjectConfig",
@@ -9960,7 +10006,7 @@
           "specifier": "@station/contracts",
           "resolvedPath": "packages/contracts/src/index.ts",
           "edgeKind": "type-only",
-          "bindings": ["SafeError"]
+          "bindings": ["SafeError", "SessionGroupRepairSummary"]
         }
       ]
     },
@@ -9971,7 +10017,7 @@
           "name": "runReconcileOnce",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Orchestrates provider reads, relationship correlation, durable harness-event repair and overlays, cached metadata hydration, Group projection, snapshot assembly, and atomic session persistence. The same resolved title records feed snapshot composition and atomic reconcile persistence."
+          "purpose": "Orchestrates provider reads and their completeness evidence, relationship correlation, durable harness-event repair and overlays, cached metadata hydration, authority-scoped Group repair and projection, snapshot assembly, and atomic session persistence. The same resolved title records feed snapshot composition and atomic reconcile persistence."
         }
       ],
       "imports": [
@@ -10050,6 +10096,12 @@
           "bindings": ["ReconcileSnapshotInputs"]
         },
         {
+          "specifier": "./sessionGroupRepairAuthority.js",
+          "resolvedPath": "apps/observer/src/reconcile/sessionGroupRepairAuthority.ts",
+          "edgeKind": "runtime",
+          "bindings": ["decideSessionGroupRepairAuthority"]
+        },
+        {
           "specifier": "./sessionGroups.js",
           "resolvedPath": "apps/observer/src/reconcile/sessionGroups.ts",
           "edgeKind": "runtime",
@@ -10072,6 +10124,7 @@
             "ProviderId",
             "ProviderProjectConfig",
             "SafeError",
+            "SessionGroupRepairSummary",
             "StationSnapshot",
             "TerminalTargetObservation",
             "WorktreeObservation"
@@ -10150,7 +10203,7 @@
           "specifier": "../providerObservations.js",
           "resolvedPath": "apps/observer/src/reconcile/providerObservations.ts",
           "edgeKind": "type-only",
-          "bindings": ["ProviderReadOptions"]
+          "bindings": ["ProviderReadOptions", "ProviderReadOutcome"]
         },
         {
           "specifier": "../worktreeMetadataOverlay.js",
@@ -10235,6 +10288,31 @@
       ]
     },
     {
+      "path": "apps/observer/src/reconcile/sessionGroupRepairAuthority.ts",
+      "exports": [
+        {
+          "name": "decideSessionGroupRepairAuthority",
+          "kind": "function",
+          "role": "POLICY",
+          "purpose": "Decides which configured projects have enough provider evidence to prune absent Group members. Terminal or harness uncertainty blocks absence pruning globally because assignments retain no provider provenance; positive identity corruption remains repairable by persistence."
+        }
+      ],
+      "imports": [
+        {
+          "specifier": "./providerObservations.js",
+          "resolvedPath": "apps/observer/src/reconcile/providerObservations.ts",
+          "edgeKind": "type-only",
+          "bindings": ["ProviderReadOutcome"]
+        },
+        {
+          "specifier": "@station/contracts",
+          "resolvedPath": "packages/contracts/src/index.ts",
+          "edgeKind": "type-only",
+          "bindings": ["ProjectId", "SessionGroupRepairBlocker", "SessionGroupRepairSummary"]
+        }
+      ]
+    },
+    {
       "path": "apps/observer/src/reconcile/sessionGroups.ts",
       "exports": [
         {
@@ -10247,7 +10325,7 @@
           "name": "reconcileSessionGroups",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Repairs durable Group membership and parentage against canonical state, then projects configured Groups with reason-specific diagnostics."
+          "purpose": "Repairs durable Group identity and parentage against canonical state, prunes absent membership only for explicitly authoritative projects, then projects configured Groups with reason-specific diagnostics."
         },
         {
           "name": "SessionGroupProjection",
@@ -10267,7 +10345,13 @@
           "specifier": "@station/contracts",
           "resolvedPath": "packages/contracts/src/index.ts",
           "edgeKind": "type-only",
-          "bindings": ["ProviderProjectConfig", "SafeError", "SessionGroupView", "SessionView"]
+          "bindings": [
+            "ProjectId",
+            "ProviderProjectConfig",
+            "SafeError",
+            "SessionGroupView",
+            "SessionView"
+          ]
         }
       ]
     },
@@ -15443,7 +15527,7 @@
       "declaration": "SessionGroupStore",
       "kind": "interface",
       "role": "DRIVEN PORT",
-      "purpose": "Maintains recorded project-local Group mutation and atomic reconcile repair of definitions, exclusive membership, and parentage. Fresh-session placement is owned by SessionStore.",
+      "purpose": "Maintains recorded project-local Group mutation and atomic reconcile repair of definitions, exclusive membership, and parentage. Reconcile must name the projects whose complete provider evidence authorizes absent-member pruning; identity and parent corruption repair remains unconditional. Fresh-session placement is owned by SessionStore.",
       "dependencies": []
     },
     {
@@ -15528,7 +15612,7 @@
       "declaration": "runReconcileOnce",
       "kind": "function",
       "role": "USE CASE",
-      "purpose": "Orchestrates provider reads, relationship correlation, durable harness-event repair and overlays, cached metadata hydration, Group projection, snapshot assembly, and atomic session persistence. The same resolved title records feed snapshot composition and atomic reconcile persistence.",
+      "purpose": "Orchestrates provider reads and their completeness evidence, relationship correlation, durable harness-event repair and overlays, cached metadata hydration, authority-scoped Group repair and projection, snapshot assembly, and atomic session persistence. The same resolved title records feed snapshot composition and atomic reconcile persistence.",
       "dependencies": [
         {
           "path": "apps/observer/src/persistence/ports.ts",
@@ -15580,6 +15664,13 @@
           "edgeKind": "runtime"
         },
         {
+          "path": "apps/observer/src/reconcile/sessionGroupRepairAuthority.ts",
+          "declaration": "decideSessionGroupRepairAuthority",
+          "kind": "function",
+          "role": "POLICY",
+          "edgeKind": "runtime"
+        },
+        {
           "path": "apps/observer/src/reconcile/sessionGroups.ts",
           "declaration": "reconcileSessionGroups",
           "kind": "function",
@@ -15587,6 +15678,14 @@
           "edgeKind": "runtime"
         }
       ]
+    },
+    {
+      "path": "apps/observer/src/reconcile/sessionGroupRepairAuthority.ts",
+      "declaration": "decideSessionGroupRepairAuthority",
+      "kind": "function",
+      "role": "POLICY",
+      "purpose": "Decides which configured projects have enough provider evidence to prune absent Group members. Terminal or harness uncertainty blocks absence pruning globally because assignments retain no provider provenance; positive identity corruption remains repairable by persistence.",
+      "dependencies": []
     },
     {
       "path": "apps/observer/src/reconcile/sessionGroups.ts",
@@ -15601,7 +15700,7 @@
       "declaration": "reconcileSessionGroups",
       "kind": "function",
       "role": "USE CASE",
-      "purpose": "Repairs durable Group membership and parentage against canonical state, then projects configured Groups with reason-specific diagnostics.",
+      "purpose": "Repairs durable Group identity and parentage against canonical state, prunes absent membership only for explicitly authoritative projects, then projects configured Groups with reason-specific diagnostics.",
       "dependencies": [
         {
           "path": "apps/observer/src/persistence/ports.ts",

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -252,15 +252,15 @@ No single layer owns all truth.
 | State | Authority and lifetime |
 | --- | --- |
 | Loaded config | Authoritative for managed projects, defaults, provider choices, feature policy, and configured hooks. Durable in TOML; loaded into process memory at startup and updated through explicit config operations. |
-| Provider observations | Each provider is authoritative only for external facts it can prove. Live reads and normalized ingress observations may be persisted with retention, but cached evidence does not outrank a newer provider read. |
+| Provider observations | Each provider is authoritative only for external facts it can prove. Every worktree-project, terminal-provider, and harness-provider read records `complete` or `indeterminate` evidence for the reconcile that consumed it. Live reads and normalized ingress observations may be persisted with retention, but cached evidence does not outrank a newer provider read. |
 | Provider-owned identity | Worktree, target, harness-run, native execution, and external endpoint identity stays owned by the provider that minted it. Application code may carry opaque IDs but must not reconstruct their format. |
 | Observer-minted state | Command, event, error, report, session, Session Group, correlation, readiness, and recovery identities are legitimate internal facts minted by the observer. The observer does not invent external facts. |
-| Observer SQLite | Durable observer memory for commands, events, ingress dedupe, observations, correlations, explicitly admitted Station sessions, project-local Session Groups, canonical worktree display titles, native-execution bindings, metadata caches, recovery handles, and readiness. Group membership is exclusive per session, while Group deletion changes only organizational rows. Display-title authority is keyed by `(projectId, worktreeId)` and survives transient provider observation gaps; it is not branch or provider identity. Raw provider observations remain live graph evidence and do not mint durable Station sessions. |
+| Observer SQLite | Durable observer memory for commands, events, ingress dedupe, observations, correlations, explicitly admitted Station sessions, project-local Session Groups, canonical worktree display titles, native-execution bindings, metadata caches, recovery handles, and readiness. Group membership is exclusive per session, while Group deletion changes only organizational rows. An incomplete provider scan preserves uncertain assignments without advancing Group versions; a later complete scan can project them again or authoritatively prune confirmed absence. Display-title authority is keyed by `(projectId, worktreeId)` and survives transient provider observation gaps; it is not branch or provider identity. Raw provider observations remain live graph evidence and do not mint durable Station sessions. |
 | Local Git metadata evidence | Local Git is authoritative only for checkout-local `HEAD`, refs, merge-base, and numstat at read time. Command failures retain cached evidence through the TTL and mark it stale, while a matching checkout reported unavailable clears its local-change row; superseded identities cannot mutate either row. Ref-watch notifications are hints that request reconcile, never metadata or UI mutations themselves. |
 | Observer boot claim | `dirname(resolvedSocket)/observer.claim.sqlite` is a persistent private transport-lifecycle file. Only its active SQLite write transaction owns boot exclusion; file or sidecar existence is never authority. It has no Observer migrations or application persistence role. |
 | Observer process identity | `<resolved socketPath>.pid` is the strict, socket-specific `{pid, osStartTime, processToken, version, socketPath}` identity published by the process that successfully bound the socket. The UUID v4 `processToken` identifies one launch and `version` is the Observer selector: display SemVer plus reserved `station.<sha256>` build metadata. They corroborate process and immutable-build identity for later handoff and diagnostics; `lsof` remains primary socket-ownership evidence, and the file alone is never liveness authority. |
 | In-memory persistence adapter | Process-local test state that preserves the eight persistence ports' observable transaction semantics. It is neither restart-durable nor selectable by production runtime composition. |
-| `StationSnapshot` | Current normalized graph held in memory. `rows` is configured worktree inventory; `sessions` is canonical session membership; and required `sessionGroups` carries normalized organizational state for configured projects. Reconcile replaces the base projection; recorded Group mutations refresh only their project through the same serialized writer, and accepted harness reports can project status and readiness between reconciles. It is derived and not a durable replay log. |
+| `StationSnapshot` | Current normalized graph held in memory. `rows` is configured worktree inventory; `sessions` is canonical session membership; and required `sessionGroups` carries normalized organizational state for configured projects. Reconcile replaces the base projection; unavailable sessions remain absent during degraded reads even when their durable Group assignments are preserved. Recorded Group mutations refresh only their project through the same serialized writer, and accepted harness reports can project status and readiness between reconciles. It is derived and not a durable replay log. |
 | Current provider context | The exact correlated worktree and terminal arrays from the last committed reconcile generation, held only in Observer core for harness-hook normalization. It commits with the snapshot, is never reconstructed from durable observation history, and strips terminal-private provider data before crossing the provider boundary. |
 | Live event bus | Future-only, process-local delivery. Subscriber queues are currently unbounded, events have no sequence numbers, and reconnects cannot request replay. |
 | Persisted event rows | Historical and diagnostic observer memory. They are not currently the source for live subscription replay. |
@@ -496,13 +496,21 @@ target agents.
 
 ### Reconciliation
 
-Reconcile reads worktree and terminal actors, derives the worktree context for
-harness reads, applies cached metadata and durable overlays, resolves one effective display title
-per current worktree, and correlates canonical sessions. It then atomically repairs durable Group
-membership and parent relationships, excludes but retains definitions for unconfigured projects,
+Reconcile reads worktree and terminal actors, records a complete or indeterminate outcome for each
+worktree project and terminal provider, derives the worktree context for harness reads, and records
+the same outcome for each harness provider. It applies cached metadata and durable overlays, resolves
+one effective display title per current worktree, and correlates canonical sessions. It then derives
+explicit project-level Group absence authority: a complete worktree scan authorizes its configured
+project, while any terminal or harness discovery failure blocks absence pruning globally because
+assignments retain no provider provenance. It atomically repairs durable Group membership and parent
+relationships, pruning absence only for authoritative projects while always repairing positive
+cross-project identity, assignment corruption, and invalid parentage. It excludes but retains definitions for unconfigured projects,
 projects configured Groups as a flat deterministic parent-before-child array, insert-initializes
 missing canonical title records with the result, and replaces the in-memory snapshot. Reason-specific relationship
 repair and excluded definitions contribute provider-neutral errors to the reconcile timing record.
+`lastReconcile.sessionGroupRepair` and the structured `Reconcile finished.` log report whether repair
+was `applied`, `partially_scoped`, or `skipped`, the authoritative and preserved project IDs, and the
+provider-read blockers. Existing provider errors remain the degradation signal.
 Existing canonical titles win; missing authority initializes from
 the best non-ended custom session evidence before branch fallback, using insert-only reconcile
 persistence so stale evidence cannot overwrite a concurrent rename. It then
@@ -800,7 +808,7 @@ expires.
 | Command timeout and cancellation | Handlers receive a signal combining the runtime timeout and queue shutdown. Concrete provider adapters own bounded external settlement; command use cases pass cancellation and normalize failures without starting another provider-operation timer. A handler with a non-cancellable durable section calls `beginCommit` after read-only validation and immediately before its first write; cancellation may prevent entry, but the queue drains a begun commit to one completion. Other cancellation remains cooperative, and the process shutdown backstop handles ignored signals. |
 | Snapshot writer ordering | Full reconciles, Group mutation commits, and harness-report authorization plus base projection share a non-poisoning promise chain. A Group mutation projects only its command project and never scans providers, repairs other durable state, or publishes a reconcile event. Readiness persistence revalidates the live snapshot after its write. Scheduled reconcile requests coalesce; queued work after a run receives a later flush. |
 | Persisted harness compatibility | A harness adapter may use a provider-local strict schema to reject recognizable observations accepted by an earlier build. Unparseable legacy data remains admitted. Reconcile excludes only provider-rejected observations, then atomically replaces the affected session's derived native binding and readiness from the remaining admitted history; a succeeded acknowledgement remains authoritative. |
-| Provider reads | Reads are timeboxed, retried at the runtime boundary, and concurrency-limited. Failures become provider health and reconcile errors. |
+| Provider reads | Reads are timeboxed, retried at the runtime boundary, and concurrency-limited. Every worktree-project, terminal-provider, and harness-provider read produces explicit completeness evidence. Failures become provider health and reconcile errors; worktree failures scope Group absence authority by project, while terminal or harness failures block it globally. |
 | Harness ingress | First-party hook transports delegate delivery and spooling to `stn-ingress`. Known build/schema/handoff incompatibility rejects without spooling. One Observer worker processes a bounded pending map; new reports can replace pending work for the same key, and a full map rejects unrelated work with a backpressure error. |
 | Spool drain | One configured drain runs at a time and processes stable filename order through direct durable ingress. Stable spool IDs survive legacy records without hook IDs; completion is idempotent after primary dedupe, and failed records remain on disk with attempt/error evidence. |
 | Hook auto-start throttle | `hook-autostart.lock` limits provider-hook spawn attempts only around the canonical CLI Observer lifecycle. It is never Observer ownership; each child still enters the socket-relative SQLite boot claim. |
@@ -867,7 +875,9 @@ when it changes several tables:
   updates roll back before cwd, execution correlation, or liveness timestamps can refresh.
 - `SessionGroupStore` owns recorded Group definitions, exclusive direct membership, parent changes,
   deletion-to-ungroup with child reparenting, and atomic reconcile repair of parseable membership
-  and parent relationships. Stale versions and expected assignments return conflicts without
+  and parent relationships. Its reconcile repair requires explicit project-level absence authority,
+  preserves uncertain assignments and versions, and still removes positive project mismatches or
+  corrupt assignment/group relationships regardless of absence authority. Stale versions and expected assignments return conflicts without
   throwing; invariant or storage failures roll back the complete conversation. Empty definitions
   remain durable. Fresh-session placement intentionally stays in `SessionStore` so session and
   membership cannot commit through separate ports.

--- a/packages/contracts/src/observer.ts
+++ b/packages/contracts/src/observer.ts
@@ -135,6 +135,40 @@ export const ObserverSqliteHealthSummarySchema = z
   })
   .passthrough();
 
+export const SessionGroupRepairBlockerSchema = z.discriminatedUnion("scope", [
+  z
+    .object({
+      scope: z.literal("project"),
+      providerType: z.literal("worktree"),
+      providerId: ProviderIdSchema,
+      projectId: ProjectIdSchema,
+      code: nonEmptyStringSchema,
+    })
+    .strict(),
+  z
+    .object({
+      scope: z.literal("global"),
+      providerType: z.enum(["terminal", "harness"]),
+      providerId: ProviderIdSchema,
+      code: nonEmptyStringSchema,
+    })
+    .strict(),
+]);
+
+export type SessionGroupRepairBlocker = z.infer<typeof SessionGroupRepairBlockerSchema>;
+
+/** Public diagnostic summary of the provider authority used for one durable Group repair. */
+export const SessionGroupRepairSummarySchema = z
+  .object({
+    status: z.enum(["applied", "partially_scoped", "skipped"]),
+    absenceAuthorityProjectIds: z.array(ProjectIdSchema),
+    preservedProjectIds: z.array(ProjectIdSchema),
+    blockers: z.array(SessionGroupRepairBlockerSchema),
+  })
+  .strict();
+
+export type SessionGroupRepairSummary = z.infer<typeof SessionGroupRepairSummarySchema>;
+
 export const ObserverReconcileTimingSchema = z
   .object({
     reason: nonEmptyStringSchema,
@@ -147,6 +181,7 @@ export const ObserverReconcileTimingSchema = z
     harnessRunsObserved: z.number().int().nonnegative().optional(),
     eventsEmitted: z.number().int().nonnegative().optional(),
     errors: z.array(SafeErrorSchema).optional(),
+    sessionGroupRepair: SessionGroupRepairSummarySchema.optional(),
   })
   .strict();
 

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -2109,6 +2109,30 @@ describe("contract schemas", () => {
       },
       "Session Group repair blocker with an unknown field",
     );
+    const globalSessionGroupRepair = {
+      status: "skipped",
+      absenceAuthorityProjectIds: [],
+      preservedProjectIds: ["web", "api"],
+      blockers: [
+        {
+          scope: "global",
+          providerType: "harness",
+          providerId: "codex",
+          code: "HARNESS_DISCOVER_FAILED",
+        },
+      ],
+    } as const;
+    expect(SessionGroupRepairSummarySchema.parse(globalSessionGroupRepair)).toEqual(
+      globalSessionGroupRepair,
+    );
+    expectFails(
+      SessionGroupRepairSummarySchema,
+      {
+        ...globalSessionGroupRepair,
+        blockers: [{ ...globalSessionGroupRepair.blockers[0], extra: true }],
+      },
+      "global Session Group repair blocker with an unknown field",
+    );
 
     expectParses(
       ObserverHealthSchema,

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -52,6 +52,7 @@ import {
   RepositoryPullRequestRequestSchema,
   RepositoryRemoteSchema,
   SafeErrorSchema,
+  SessionGroupRepairSummarySchema,
   SessionGroupViewSchema,
   SessionMigrationJournalEntrySchema,
   SessionMigrationLockSchema,
@@ -2080,6 +2081,35 @@ describe("contract schemas", () => {
       "harness event report spool record",
     );
 
+    const sessionGroupRepair = {
+      status: "partially_scoped",
+      absenceAuthorityProjectIds: ["web"],
+      preservedProjectIds: ["api"],
+      blockers: [
+        {
+          scope: "project",
+          providerType: "worktree",
+          providerId: "worktrunk",
+          projectId: "api",
+          code: "PROVIDER_TIMEOUT",
+        },
+      ],
+    } as const;
+    expect(SessionGroupRepairSummarySchema.parse(sessionGroupRepair)).toEqual(sessionGroupRepair);
+    expectFails(
+      SessionGroupRepairSummarySchema,
+      { ...sessionGroupRepair, extra: true },
+      "Session Group repair summary with an unknown field",
+    );
+    expectFails(
+      SessionGroupRepairSummarySchema,
+      {
+        ...sessionGroupRepair,
+        blockers: [{ ...sessionGroupRepair.blockers[0], extra: true }],
+      },
+      "Session Group repair blocker with an unknown field",
+    );
+
     expectParses(
       ObserverHealthSchema,
       {
@@ -2091,6 +2121,13 @@ describe("contract schemas", () => {
         socketPath: "/tmp/station/observer.sock",
         stateDir: "/tmp/station/state",
         hookSpoolDepth: 0,
+        lastReconcile: {
+          reason: "scheduled",
+          startedAt: "2026-05-20T12:00:00.000Z",
+          finishedAt: "2026-05-20T12:00:01.000Z",
+          durationMs: 1_000,
+          sessionGroupRepair,
+        },
         harnessIngressQueue: {
           depth: 0,
           enqueued: 10,


### PR DESCRIPTION
## What this fixes

Session Groups are durable organization over canonical Station session IDs. A degraded provider scan could previously treat missing sessions as authoritative deletion, remove their saved memberships, and advance Group versions. This matters because sessions that returned after provider recovery or Observer restart were permanently Ungrouped.

Closes #689.

## What changed

- Record complete or indeterminate outcomes for each worktree-project, terminal-provider, and harness-provider read.
- Derive explicit project-level absence-pruning authority; terminal or harness failures conservatively block absence pruning for every project.
- Preserve uncertain durable assignments and Group versions while still repairing positive cross-project identity, assignment, and parent corruption.
- Keep degraded snapshots provider-truthful, allowing preserved memberships to project automatically when sessions become visible again.
- Expose the repair status, authoritative and preserved projects, and strict provider blockers in Observer health and the structured reconcile-finished log.
- Document the authority boundary and regenerate the Observer architecture manifest.

## Testing

- Added pure policy coverage for applied, partially scoped, terminal-blocked, harness-blocked, and all-worktree-indeterminate outcomes.
- Extended the shared SQLite and in-memory persistence contract for authoritative pruning, uncertain preservation, and positive mismatch repair.
- Added SQLite reopen/recovery, isolated terminal-only preservation, harness-only failure/recovery, and mixed-project reconcile regressions.
- Validated the final test changes with typecheck, lint, 157 contract tests, 742 integration tests, and 174 focused policy/persistence tests.
- Ran `env -u STATION_OPENCODE_PLUGIN_BODY_PATH pnpm test:all` for the implementation commit.
- Ran `pnpm architecture:observer:generate` and `pnpm architecture:observer:check`.

## User-visible behavior

During a provider outage, unavailable sessions may temporarily disappear from the live snapshot. After provider recovery or Observer restart, they return to their original Groups without manual reorganization.