### PR TITLE
refactor(cli): execute typed Observer commands without reparsing

### DIFF
--- a/apps/cli/src/commands/command.ts
+++ b/apps/cli/src/commands/command.ts
@@ -1,11 +1,15 @@
 import type { StationConfig } from "@station/config";
 import type {
+  AcceptedCommandReceipt,
+  CommandExecutionOutcome,
   CommandId,
   CommandReceipt,
   CommandRecord,
+  FailedCommandRecord,
   ObserverApi,
   SafeError,
   StationCommand,
+  SucceededCommandRecord,
 } from "@station/contracts";
 import { CommandIdSchema, StationCommandSchema } from "@station/contracts";
 import { createObserverClient, type ObserverClient } from "@station/protocol";
@@ -23,6 +27,13 @@ export type CommandCommandOptions = {
   configPath?: string;
   stdin?: string;
   timeoutMs?: number;
+};
+
+export type TypedObserverCommandOptions = {
+  config?: StationConfig;
+  configPath?: string;
+  timeoutMs?: number;
+  waitForCompletion?: boolean;
 };
 
 export type CommandDispatchAcceptedResult = {
@@ -58,6 +69,57 @@ type ParsedCommandArgs =
       timeoutMs?: number;
     };
 
+/**
+ * ADAPTER
+ *
+ * Starts or selects the pinned Observer, dispatches one typed Station command, and optionally
+ * reloads its durable terminal outcome through the race-safe protocol completion wait.
+ */
+export async function executeTypedObserverCommand<TCommand extends StationCommand>(
+  command: TCommand,
+  options: TypedObserverCommandOptions = {},
+  deps: ObserverProcessDeps = {},
+): Promise<CommandExecutionOutcome<TCommand>> {
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  const client = await createCommandObserverClient(options, timeoutMs, deps);
+  const receipt = await dispatchCommand(client, command, timeoutMs);
+  if (!receipt.accepted) {
+    return {
+      status: "rejected",
+      receipt,
+    };
+  }
+  if (options.waitForCompletion !== true) {
+    return {
+      status: "accepted",
+      receipt,
+    };
+  }
+
+  const record = await waitForCommand(client, receipt.commandId, timeoutMs);
+  if (record.status !== "succeeded" && record.status !== "failed") {
+    throw commandWaitTimeoutError();
+  }
+  assertMatchingCommandCompletion(command, receipt, record);
+  if (record.status === "succeeded") {
+    return {
+      status: "succeeded",
+      receipt,
+      record,
+    };
+  }
+  return {
+    status: "failed",
+    receipt,
+    record,
+  };
+}
+
+/**
+ * ADAPTER
+ *
+ * Translates raw CLI argv and stdin JSON into typed Observer command execution or record lookup.
+ */
 export async function runCommandCommand(
   args: string[],
   options: CommandCommandOptions = {},
@@ -65,44 +127,25 @@ export async function runCommandCommand(
 ): Promise<CommandCommandResult> {
   const parsed = parseCommandArgs(args);
   const timeoutMs = parsed.timeoutMs ?? options.timeoutMs ?? 30_000;
-  const paths = resolveObserverPaths(options.config);
-  const status = await startObserver({ ...options, paths, timeoutMs }, deps);
-  assertObserverRunning(status);
-  const client =
-    deps.clientFactory?.(paths.socketPath) ??
-    createObserverClient({
-      socketPath: paths.socketPath,
-      timeoutMs,
-      ...(status.health.version === undefined
-        ? {}
-        : { expectedBuildVersion: status.health.version }),
-    });
 
   if (parsed.action === "get") {
+    const client = await createCommandObserverClient(options, timeoutMs, deps);
     return getCommand(client, parsed.commandId);
   }
 
   const command = parseCommandFromStdin(options.stdin, parsed.stdin);
-  const receipt = await dispatchCommand(client, command, timeoutMs);
-  if (!parsed.wait || !receipt.accepted) {
+  const executionOptions = typedObserverCommandOptions(options, timeoutMs, parsed.wait);
+  const outcome = await executeTypedObserverCommand(command, executionOptions, deps);
+  if (outcome.status === "accepted" || outcome.status === "rejected") {
     return {
-      status: receipt.status,
-      receipt,
-    };
-  }
-
-  const record = await waitForCommand(client, receipt.commandId, timeoutMs);
-  if (record.status !== "succeeded" && record.status !== "failed") {
-    throw {
-      tag: "TimeoutError",
-      code: "COMMAND_WAIT_TIMEOUT",
-      message: "Command did not finish before the timeout.",
+      status: outcome.status,
+      receipt: outcome.receipt,
     };
   }
   return {
-    status: record.status,
-    receipt,
-    command: record,
+    status: outcome.status,
+    receipt: outcome.receipt,
+    command: outcome.record,
   };
 }
 
@@ -124,6 +167,40 @@ async function getCommand(client: ObserverApi, commandId: CommandId): Promise<Co
   return {
     command,
   };
+}
+
+async function createCommandObserverClient(
+  options: Pick<TypedObserverCommandOptions, "config" | "configPath">,
+  timeoutMs: number,
+  deps: ObserverProcessDeps,
+): Promise<ObserverClient> {
+  const paths = resolveObserverPaths(options.config);
+  const status = await startObserver({ ...options, paths, timeoutMs }, deps);
+  assertObserverRunning(status);
+  return (
+    deps.clientFactory?.(paths.socketPath) ??
+    createObserverClient({
+      socketPath: paths.socketPath,
+      timeoutMs,
+      ...(status.health.version === undefined
+        ? {}
+        : { expectedBuildVersion: status.health.version }),
+    })
+  );
+}
+
+function typedObserverCommandOptions(
+  options: CommandCommandOptions,
+  timeoutMs: number,
+  waitForCompletion: boolean,
+): TypedObserverCommandOptions {
+  const executionOptions: TypedObserverCommandOptions = {
+    timeoutMs,
+    waitForCompletion,
+  };
+  if (options.config !== undefined) executionOptions.config = options.config;
+  if (options.configPath !== undefined) executionOptions.configPath = options.configPath;
+  return executionOptions;
 }
 
 function missingCommandRecordError(commandId: CommandId): SafeError {
@@ -178,11 +255,7 @@ async function waitForCommand(
         code: "COMMAND_WAIT_FAILED",
         message: "Command wait could not load the observer command record.",
       },
-      timeoutError: {
-        tag: "TimeoutError",
-        code: "COMMAND_WAIT_TIMEOUT",
-        message: "Command did not finish before the timeout.",
-      },
+      timeoutError: commandWaitTimeoutError(),
     },
     async () => client.waitForCommand(commandId, { timeoutMs }).catch(mapCommandWaitError),
   );
@@ -192,13 +265,41 @@ async function waitForCommand(
   return result.value;
 }
 
+function assertMatchingCommandCompletion<TCommand extends StationCommand>(
+  command: TCommand,
+  receipt: AcceptedCommandReceipt,
+  record: CommandRecord,
+): asserts record is SucceededCommandRecord<TCommand> | FailedCommandRecord<TCommand> {
+  if (
+    record.id !== receipt.commandId ||
+    record.type !== command.type ||
+    record.command.type !== command.type
+  ) {
+    throw commandCompletionMismatchError(receipt.commandId);
+  }
+}
+
+function commandCompletionMismatchError(commandId: CommandId): SafeError {
+  return {
+    tag: "CommandCliError",
+    code: "COMMAND_COMPLETION_MISMATCH",
+    message: "The observer returned completion that did not match the dispatched command.",
+    hint: `Inspect the durable record with \`stn command get ${commandId}\` before retrying.`,
+    commandId,
+  };
+}
+
+function commandWaitTimeoutError(): SafeError {
+  return {
+    tag: "TimeoutError",
+    code: "COMMAND_WAIT_TIMEOUT",
+    message: "Command did not finish before the timeout.",
+  };
+}
+
 function mapCommandWaitError(error: unknown): never {
   if (isSafeError(error) && error.tag === "TimeoutError") {
-    throw {
-      tag: "TimeoutError",
-      code: "COMMAND_WAIT_TIMEOUT",
-      message: "Command did not finish before the timeout.",
-    };
+    throw commandWaitTimeoutError();
   }
   throw error;
 }

--- a/apps/cli/src/commands/project.ts
+++ b/apps/cli/src/commands/project.ts
@@ -1,8 +1,15 @@
 import { doctorProject, loadConfig, type ProjectConfig, type StationConfig } from "@station/config";
-import type { CommandReceipt, CommandRecord, StationCommand } from "@station/contracts";
+import type {
+  AcceptedCommandReceipt,
+  FailedCommandRecord,
+  RejectedCommandReceipt,
+  SafeError,
+  StationCommand,
+  SucceededCommandRecord,
+} from "@station/contracts";
 import { parsePositiveIntegerOption, parseRequiredOptionValue } from "../args.js";
 import type { ObserverProcessDeps } from "../observerProcess.js";
-import { runCommandCommand } from "./command.js";
+import { executeTypedObserverCommand, type TypedObserverCommandOptions } from "./command.js";
 
 export type ProjectCommandOptions = {
   config?: StationConfig;
@@ -16,6 +23,8 @@ export type ProjectSummary = {
   root: string;
 };
 
+type ProjectMutationCommand = Extract<StationCommand, { type: "project.add" | "project.remove" }>;
+
 export type ProjectCommandResult =
   | {
       action: "list";
@@ -23,9 +32,22 @@ export type ProjectCommandResult =
     }
   | {
       action: "add" | "remove";
-      status: "succeeded" | "failed";
-      receipt: CommandReceipt;
-      command: CommandRecord;
+      status: "succeeded";
+      receipt: AcceptedCommandReceipt;
+      command: SucceededCommandRecord<ProjectMutationCommand>;
+      projects: ProjectSummary[];
+    }
+  | {
+      action: "add" | "remove";
+      status: "failed";
+      receipt: AcceptedCommandReceipt;
+      command: FailedCommandRecord<ProjectMutationCommand>;
+      projects: ProjectSummary[];
+    }
+  | {
+      action: "add" | "remove";
+      status: "rejected";
+      receipt: RejectedCommandReceipt;
       projects: ProjectSummary[];
     }
   | {
@@ -59,6 +81,11 @@ type ParsedProjectArgs =
       projectId: string;
     };
 
+/**
+ * ADAPTER
+ *
+ * Translates project CLI intent into configuration reads or typed Observer project commands.
+ */
 export async function runProjectCommand(
   args: string[],
   options: ProjectCommandOptions = {},
@@ -87,35 +114,73 @@ export async function runProjectCommand(
 
   const command = commandForParsedArgs(parsed);
   const timeoutMs = parsed.timeoutMs ?? options.timeoutMs ?? 30_000;
-  const dispatched = await runCommandCommand(
-    ["dispatch", "--stdin", "--wait", "--timeout-ms", String(timeoutMs)],
-    { ...options, stdin: JSON.stringify(command), timeoutMs },
-    deps,
-  );
-  if (!("receipt" in dispatched) || !("command" in dispatched)) {
-    throw new Error("Project command dispatch did not return a completed command record.");
-  }
+  const executionOptions = projectExecutionOptions(options, timeoutMs);
+  const outcome = await executeTypedObserverCommand(command, executionOptions, deps);
+  if (outcome.status === "accepted") throw missingProjectCompletionError(outcome.receipt.commandId);
   const loaded =
     options.configPath === undefined
       ? await loadConfig()
       : await loadConfig({ configPath: options.configPath });
+  const projects = summarizeProjects(loaded.projects);
+  if (outcome.status === "rejected") {
+    return {
+      action: parsed.action,
+      status: "rejected",
+      receipt: outcome.receipt,
+      projects,
+    };
+  }
+  if (outcome.status === "succeeded") {
+    return {
+      action: parsed.action,
+      status: "succeeded",
+      receipt: outcome.receipt,
+      command: outcome.record,
+      projects,
+    };
+  }
   return {
     action: parsed.action,
-    status: dispatched.status,
-    receipt: dispatched.receipt,
-    command: dispatched.command,
-    projects: summarizeProjects(loaded.projects),
+    status: "failed",
+    receipt: outcome.receipt,
+    command: outcome.record,
+    projects,
   };
 }
 
 export function projectCommandExitCode(result: ProjectCommandResult): number {
-  if ((result.action === "add" || result.action === "remove") && result.status === "failed") {
+  if (
+    (result.action === "add" || result.action === "remove") &&
+    (result.status === "rejected" || result.status === "failed")
+  ) {
     return 1;
   }
   if (result.action === "doctor" && result.status === "warn") {
     return 1;
   }
   return 0;
+}
+
+function projectExecutionOptions(
+  options: ProjectCommandOptions,
+  timeoutMs: number,
+): TypedObserverCommandOptions {
+  const executionOptions: TypedObserverCommandOptions = {
+    timeoutMs,
+    waitForCompletion: true,
+  };
+  if (options.config !== undefined) executionOptions.config = options.config;
+  if (options.configPath !== undefined) executionOptions.configPath = options.configPath;
+  return executionOptions;
+}
+
+function missingProjectCompletionError(commandId: string): SafeError {
+  return {
+    tag: "ProjectCliError",
+    code: "PROJECT_COMMAND_COMPLETION_MISSING",
+    message: "The project command returned before its durable completion was available.",
+    commandId,
+  };
 }
 
 function parseProjectArgs(args: string[]): ParsedProjectArgs {
@@ -214,7 +279,7 @@ function parseDoctorArgs(args: string[]): Extract<ParsedProjectArgs, { action: "
 
 function commandForParsedArgs(
   parsed: Extract<ParsedProjectArgs, { action: "add" | "remove" }>,
-): StationCommand {
+): ProjectMutationCommand {
   if (parsed.action === "remove") {
     return {
       type: "project.remove",

--- a/apps/cli/test/integration/command-command.test.ts
+++ b/apps/cli/test/integration/command-command.test.ts
@@ -1,13 +1,18 @@
 import { runCli } from "@station/cli";
-import { runCommandCommand } from "@station/cli/internal";
+import { executeTypedObserverCommand, runCommandCommand } from "@station/cli/internal";
 import type { CommandReceipt, CommandRecord, StationCommand } from "@station/contracts";
+import { StationCommandSchema } from "@station/contracts";
 import type { TerminalCommandRecord } from "@station/protocol";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTempState, writeConfigToml } from "../../../../tests/support/temp-projects";
 
 const now = "2026-05-22T12:00:00.000Z";
 const incumbentBuildVersion = `1.2.3+station.${"a".repeat(64)}`;
 const replacementBuildVersion = `1.2.3+station.${"b".repeat(64)}`;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("CLI command dispatch/get", () => {
   it("dispatches typed command JSON from stdin through the observer protocol", async () => {
@@ -15,6 +20,7 @@ describe("CLI command dispatch/get", () => {
     const configPath = await writeConfigToml(fixture.root, fixture.config);
     const command = reconcileCommand("cli-command-dispatch");
     const dispatched: StationCommand[] = [];
+    const parseCommand = vi.spyOn(StationCommandSchema, "safeParse");
 
     const result = await runCli(["--config", configPath, "command", "dispatch", "--stdin"], {
       stdin: JSON.stringify(command),
@@ -27,6 +33,10 @@ describe("CLI command dispatch/get", () => {
       }),
     });
 
+    expect(parseCommand).toHaveBeenCalledTimes(1);
+    const parsed = parseCommand.mock.results[0]?.value;
+    expect(parsed?.success).toBe(true);
+    if (parsed?.success !== true) throw new Error("Expected command input to parse.");
     expect(result).toEqual({
       code: 0,
       output: {
@@ -35,6 +45,60 @@ describe("CLI command dispatch/get", () => {
       },
     });
     expect(dispatched).toEqual([command]);
+    expect(dispatched[0]).toBe(parsed.data);
+  });
+
+  it("dispatches an already-typed command without re-entering command parsing", async () => {
+    const fixture = await createTempState();
+    const command = reconcileCommand("typed-command-dispatch");
+    const dispatched: StationCommand[] = [];
+    const parseCommand = vi.spyOn(StationCommandSchema, "safeParse");
+
+    const outcome = await executeTypedObserverCommand(
+      command,
+      { config: fixture.config, timeoutMs: 1000 },
+      runningObserverDeps({
+        socketPath: fixture.socketPath,
+        dispatch: async (input) => {
+          dispatched.push(input);
+          return receipt("cmd_typed");
+        },
+      }),
+    );
+
+    expect(outcome).toEqual({ status: "accepted", receipt: receipt("cmd_typed") });
+    expect(parseCommand).not.toHaveBeenCalled();
+    expect(dispatched).toEqual([command]);
+    expect(dispatched[0]).toBe(command);
+  });
+
+  it("preserves a rejected receipt and returns a nonzero raw CLI outcome", async () => {
+    const fixture = await createTempState();
+    const configPath = await writeConfigToml(fixture.root, fixture.config);
+    const command = reconcileCommand("cli-command-rejected");
+    const rejected = rejectedReceipt("cmd_rejected");
+
+    const result = await runCli(
+      ["--config", configPath, "command", "dispatch", "--stdin", "--wait"],
+      {
+        stdin: JSON.stringify(command),
+        observerDeps: runningObserverDeps({
+          socketPath: fixture.socketPath,
+          dispatch: async () => rejected,
+          waitForCommand: async () => {
+            throw new Error("rejected commands must not wait for completion");
+          },
+        }),
+      },
+    );
+
+    expect(result).toEqual({
+      code: 1,
+      output: {
+        status: "rejected",
+        receipt: rejected,
+      },
+    });
   });
 
   it("dispatches Cursor session.create JSON from stdin without rewriting the payload", async () => {
@@ -85,6 +149,34 @@ describe("CLI command dispatch/get", () => {
       status: "succeeded",
       receipt: receipt("cmd_wait"),
       command: completed,
+    });
+  });
+
+  it("preserves a failed terminal record and returns a nonzero raw CLI outcome", async () => {
+    const fixture = await createTempState();
+    const configPath = await writeConfigToml(fixture.root, fixture.config);
+    const command = reconcileCommand("cli-command-failed");
+    const failed = commandRecord("cmd_failed", command, "failed");
+
+    const result = await runCli(
+      ["--config", configPath, "command", "dispatch", "--stdin", "--wait"],
+      {
+        stdin: JSON.stringify(command),
+        observerDeps: runningObserverDeps({
+          socketPath: fixture.socketPath,
+          dispatch: async () => receipt("cmd_failed"),
+          waitForCommand: async () => failed as TerminalCommandRecord,
+        }),
+      },
+    );
+
+    expect(result).toEqual({
+      code: 1,
+      output: {
+        status: "failed",
+        receipt: receipt("cmd_failed"),
+        command: failed,
+      },
     });
   });
 
@@ -191,6 +283,50 @@ describe("CLI command dispatch/get", () => {
       ),
     ).rejects.toMatchObject({
       code: "COMMAND_WAIT_TIMEOUT",
+    });
+  });
+
+  it("preserves the dispatch timeout code before a receipt exists", async () => {
+    const fixture = await createTempState();
+    const command = reconcileCommand("cli-command-dispatch-timeout");
+
+    await expect(
+      executeTypedObserverCommand(
+        command,
+        { config: fixture.config, timeoutMs: 5 },
+        runningObserverDeps({
+          socketPath: fixture.socketPath,
+          dispatch: async () => new Promise<CommandReceipt>(() => undefined),
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: "COMMAND_DISPATCH_TIMEOUT",
+    });
+  });
+
+  it("rejects a terminal record that does not match the dispatched command", async () => {
+    const fixture = await createTempState();
+    const command = reconcileCommand("cli-command-mismatch");
+    const mismatched = commandRecord(
+      "cmd_other",
+      reconcileCommand("different-command"),
+      "succeeded",
+    );
+
+    await expect(
+      executeTypedObserverCommand(
+        command,
+        { config: fixture.config, timeoutMs: 1000, waitForCompletion: true },
+        runningObserverDeps({
+          socketPath: fixture.socketPath,
+          dispatch: async () => receipt("cmd_expected"),
+          waitForCommand: async () => mismatched as TerminalCommandRecord,
+        }),
+      ),
+    ).rejects.toMatchObject({
+      tag: "CommandCliError",
+      code: "COMMAND_COMPLETION_MISMATCH",
+      commandId: "cmd_expected",
     });
   });
 
@@ -326,6 +462,21 @@ function receipt(commandId: string): CommandReceipt {
     spanId: "spn_cli",
     accepted: true,
     status: "accepted",
+  };
+}
+
+function rejectedReceipt(commandId: string): CommandReceipt {
+  return {
+    commandId,
+    traceId: "trc_cli",
+    spanId: "spn_cli",
+    accepted: false,
+    status: "rejected",
+    error: {
+      tag: "CommandRejectedError",
+      code: "COMMAND_REJECTED_FOR_TEST",
+      message: "Observer rejected the command before execution.",
+    },
   };
 }
 

--- a/apps/cli/test/integration/project-command.test.ts
+++ b/apps/cli/test/integration/project-command.test.ts
@@ -5,12 +5,17 @@ import { promisify } from "node:util";
 import { runCli } from "@station/cli";
 import { addProjectToConfig, removeProjectFromConfig } from "@station/config";
 import type { CommandReceipt, CommandRecord, StationCommand } from "@station/contracts";
+import { StationCommandSchema } from "@station/contracts";
 import { environmentWithoutGitLocals } from "@station/runtime";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTempState, writeConfigToml } from "../../../../tests/support/temp-projects";
 
 const now = "2026-05-20T12:00:00.000Z";
 const execFileAsync = promisify(execFile);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("CLI project commands", () => {
   it("lists configured projects", async () => {
@@ -33,6 +38,7 @@ describe("CLI project commands", () => {
     const configPath = await writeConfigToml(fixture.root, fixture.config);
     const repo = await makeRepo(fixture.root, "web");
     const dispatched: StationCommand[] = [];
+    const parseCommand = vi.spyOn(StationCommandSchema, "safeParse");
 
     const result = await runCli(["--config", configPath, "project", "add", repo], {
       observerDeps: runningObserverDeps({
@@ -48,11 +54,14 @@ describe("CLI project commands", () => {
     });
 
     expect(dispatched).toEqual([projectAddCommand(repo)]);
-    expect(result).toMatchObject({
+    expect(parseCommand).not.toHaveBeenCalled();
+    expect(result).toEqual({
       code: 0,
       output: {
         action: "add",
         status: "succeeded",
+        receipt: receipt("cmd_project_add"),
+        command: commandRecord("cmd_project_add", projectAddCommand(repo), "succeeded"),
         projects: [{ id: "web", label: "web", root: repo }],
       },
     });
@@ -64,6 +73,7 @@ describe("CLI project commands", () => {
     const repo = await makeRepo(fixture.root, "web");
     await addProjectToConfig({ path: repo, configPath, homeDir: fixture.root });
     const dispatched: StationCommand[] = [];
+    const parseCommand = vi.spyOn(StationCommandSchema, "safeParse");
 
     const result = await runCli(["--config", configPath, "project", "remove", "web"], {
       observerDeps: runningObserverDeps({
@@ -83,11 +93,70 @@ describe("CLI project commands", () => {
     });
 
     expect(dispatched).toEqual([projectRemoveCommand("web")]);
-    expect(result).toMatchObject({
+    expect(parseCommand).not.toHaveBeenCalled();
+    expect(result).toEqual({
       code: 0,
       output: {
         action: "remove",
         status: "succeeded",
+        receipt: receipt("cmd_project_remove"),
+        command: commandRecord("cmd_project_remove", projectRemoveCommand("web"), "succeeded"),
+        projects: [],
+      },
+    });
+  });
+
+  it("returns the original project rejection as structured nonzero output", async () => {
+    const fixture = await createTempState();
+    const configPath = await writeConfigToml(fixture.root, fixture.config);
+    const repo = await makeRepo(fixture.root, "web");
+    const rejected = rejectedReceipt("cmd_project_rejected");
+    const parseCommand = vi.spyOn(StationCommandSchema, "safeParse");
+
+    const result = await runCli(["--config", configPath, "project", "add", repo], {
+      observerDeps: runningObserverDeps({
+        socketPath: fixture.socketPath,
+        dispatch: async () => rejected,
+        waitForCommand: async () => {
+          throw new Error("rejected project commands must not wait for completion");
+        },
+      }),
+    });
+
+    expect(parseCommand).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      code: 1,
+      output: {
+        action: "add",
+        status: "rejected",
+        receipt: rejected,
+        projects: [],
+      },
+    });
+  });
+
+  it("returns a failed project record as structured nonzero output", async () => {
+    const fixture = await createTempState();
+    const configPath = await writeConfigToml(fixture.root, fixture.config);
+    const repo = await makeRepo(fixture.root, "web");
+    const command = projectAddCommand(repo);
+    const failed = commandRecord("cmd_project_failed", command, "failed");
+
+    const result = await runCli(["--config", configPath, "project", "add", repo], {
+      observerDeps: runningObserverDeps({
+        socketPath: fixture.socketPath,
+        dispatch: async () => receipt("cmd_project_failed"),
+        waitForCommand: async () => failed,
+      }),
+    });
+
+    expect(result).toEqual({
+      code: 1,
+      output: {
+        action: "add",
+        status: "failed",
+        receipt: receipt("cmd_project_failed"),
+        command: failed,
         projects: [],
       },
     });
@@ -182,6 +251,22 @@ function receipt(commandId: string): CommandReceipt {
   };
 }
 
+function rejectedReceipt(commandId: string): CommandReceipt {
+  return {
+    commandId,
+    traceId: "trc_project",
+    spanId: "spn_project",
+    accepted: false,
+    status: "rejected",
+    error: {
+      tag: "CommandRejectedError",
+      code: "PROJECT_ALREADY_CONFIGURED",
+      message: "The project is already configured.",
+      hint: "Use `stn project list` to inspect configured projects.",
+    },
+  };
+}
+
 function commandRecord(
   id: string,
   command: StationCommand,
@@ -201,6 +286,13 @@ function commandRecord(
   }
   if (status === "succeeded" || status === "failed") {
     record.finishedAt = now;
+  }
+  if (status === "failed") {
+    record.error = {
+      tag: "CommandExecutionError",
+      code: "PROJECT_CONFIG_WRITE_FAILED",
+      message: "The project configuration could not be updated.",
+    };
   }
   return record;
 }

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -13545,6 +13545,73 @@
   ],
   "controlledDeclarations": [
     {
+      "path": "apps/cli/src/commands/command.ts",
+      "declaration": "executeTypedObserverCommand",
+      "kind": "function",
+      "role": "ADAPTER",
+      "purpose": "Starts or selects the pinned Observer, dispatches one typed Station command, and optionally reloads its durable terminal outcome through the race-safe protocol completion wait.",
+      "dependencies": [
+        {
+          "path": "apps/cli/src/observerProcess.ts",
+          "declaration": "startObserver",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "packages/contracts/src/observer.ts",
+          "declaration": "ObserverApi",
+          "kind": "type",
+          "role": "DRIVING PORT",
+          "edgeKind": "type-only"
+        },
+        {
+          "path": "packages/protocol/src/client.ts",
+          "declaration": "createObserverClient",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        }
+      ]
+    },
+    {
+      "path": "apps/cli/src/commands/command.ts",
+      "declaration": "runCommandCommand",
+      "kind": "function",
+      "role": "ADAPTER",
+      "purpose": "Translates raw CLI argv and stdin JSON into typed Observer command execution or record lookup.",
+      "dependencies": [
+        {
+          "path": "apps/cli/src/commands/command.ts",
+          "declaration": "executeTypedObserverCommand",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/cli/src/observerProcess.ts",
+          "declaration": "startObserver",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "packages/contracts/src/observer.ts",
+          "declaration": "ObserverApi",
+          "kind": "type",
+          "role": "DRIVING PORT",
+          "edgeKind": "type-only"
+        },
+        {
+          "path": "packages/protocol/src/client.ts",
+          "declaration": "createObserverClient",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        }
+      ]
+    },
+    {
       "path": "apps/cli/src/commands/debugLogs.ts",
       "declaration": "runDebugLogsCommand",
       "kind": "function",
@@ -13688,6 +13755,22 @@
         {
           "path": "packages/protocol/src/client.ts",
           "declaration": "createObserverClient",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        }
+      ]
+    },
+    {
+      "path": "apps/cli/src/commands/project.ts",
+      "declaration": "runProjectCommand",
+      "kind": "function",
+      "role": "ADAPTER",
+      "purpose": "Translates project CLI intent into configuration reads or typed Observer project commands.",
+      "dependencies": [
+        {
+          "path": "apps/cli/src/commands/command.ts",
+          "declaration": "executeTypedObserverCommand",
           "kind": "function",
           "role": "ADAPTER",
           "edgeKind": "runtime"

--- a/packages/contracts/src/commandLifecycle.ts
+++ b/packages/contracts/src/commandLifecycle.ts
@@ -80,13 +80,28 @@ export type CommandRecordFor<TCommand extends StationCommand> = TCommand extends
   : never;
 
 export type CommandRecord = CommandRecordFor<StationCommand>;
-export type SucceededCommandRecord = CommandRecord & { status: "succeeded" };
-export type FailedCommandRecord = CommandRecord & { status: "failed" };
-export type CommandExecutionOutcome =
+type CommandSubtypeFor<TCommand extends StationCommand> = Extract<
+  StationCommand,
+  { type: TCommand["type"] }
+>;
+
+export type SucceededCommandRecord<TCommand extends StationCommand = StationCommand> =
+  CommandRecordFor<CommandSubtypeFor<TCommand>> & { status: "succeeded" };
+export type FailedCommandRecord<TCommand extends StationCommand = StationCommand> =
+  CommandRecordFor<CommandSubtypeFor<TCommand>> & { status: "failed" };
+export type CommandExecutionOutcome<TCommand extends StationCommand = StationCommand> =
   | { status: "accepted"; receipt: AcceptedCommandReceipt }
   | { status: "rejected"; receipt: RejectedCommandReceipt }
-  | { status: "succeeded"; receipt: AcceptedCommandReceipt; record: SucceededCommandRecord }
-  | { status: "failed"; receipt: AcceptedCommandReceipt; record: FailedCommandRecord };
+  | {
+      status: "succeeded";
+      receipt: AcceptedCommandReceipt;
+      record: SucceededCommandRecord<TCommand>;
+    }
+  | {
+      status: "failed";
+      receipt: AcceptedCommandReceipt;
+      record: FailedCommandRecord<TCommand>;
+    };
 
 export const CommandRecordSchema = CommandRecordBaseSchema.superRefine((record, context) => {
   if (record.type !== record.command.type) {

--- a/packages/contracts/test/type/commandLifecycle.typecheck.ts
+++ b/packages/contracts/test/type/commandLifecycle.typecheck.ts
@@ -1,4 +1,9 @@
-import type { CommandRecord, FailedCommandRecord, StationCommand } from "../../src/index.js";
+import type {
+  CommandExecutionOutcome,
+  CommandRecord,
+  FailedCommandRecord,
+  StationCommand,
+} from "../../src/index.js";
 
 const command = {
   type: "worktree.create",
@@ -26,6 +31,63 @@ const successWithResult: CommandRecord = {
   },
 };
 
+const typedSuccess = {
+  status: "succeeded",
+  receipt: {
+    commandId: "cmd_typed_success",
+    accepted: true,
+    status: "accepted",
+  },
+  record: {
+    id: "cmd_typed_success",
+    type: command.type,
+    command,
+    status: "succeeded",
+    createdAt: "2026-05-20T12:00:00.000Z",
+    result: {
+      type: "worktree.create",
+      projectId: "web",
+      worktreeId: "wt_typed",
+    },
+  },
+} satisfies CommandExecutionOutcome<typeof command>;
+
+type TypedWorktreeResult = NonNullable<
+  Extract<CommandExecutionOutcome<typeof command>, { status: "succeeded" }>["record"]["result"]
+>;
+
+const mismatchedTypedResult = {
+  // @ts-expect-error The generic outcome accepts only the submitted command subtype's result.
+  type: "session.create",
+  projectId: "web",
+  worktreeId: "wt_mismatched",
+  sessionId: "ses_mismatched",
+} satisfies TypedWorktreeResult;
+
+const projectCommand = {
+  type: "project.add",
+  payload: { path: "/tmp/station/web" },
+} as const satisfies StationCommand;
+
+type ProjectSuccessRecord = Extract<
+  CommandExecutionOutcome<typeof projectCommand>,
+  { status: "succeeded" }
+>["record"];
+
+const projectSuccessWithInventedResult = {
+  id: "cmd_project",
+  type: projectCommand.type,
+  command: projectCommand,
+  status: "succeeded",
+  createdAt: "2026-05-20T12:00:00.000Z",
+  // @ts-expect-error Result-less project commands cannot invent a success result.
+  result: {
+    type: "worktree.create",
+    projectId: "web",
+    worktreeId: "wt_impossible",
+  },
+} satisfies ProjectSuccessRecord;
+
 const failureWithoutResult: FailedCommandRecord = {
   id: "cmd_failed_without_result",
   type: command.type,
@@ -52,5 +114,8 @@ const failedWithResult: CommandRecord = {
 
 void legacySuccess;
 void successWithResult;
+void typedSuccess;
+void mismatchedTypedResult;
+void projectSuccessWithInventedResult;
 void failureWithoutResult;
 void failedWithResult;


### PR DESCRIPTION
## What this fixes

Station resource commands should enter the Observer through typed application contracts. `stn project add/remove` currently rebuilds raw CLI argv/stdin around an already-typed command, reparses it, and turns Observer rejection into an internal result-shape failure.

This separates the raw CLI trust boundary from typed command execution so resource commands preserve the durable correlated outcome introduced by #650. Closes #651.

## What changed

- Add one internal typed executor that owns pinned Observer startup, dispatch timeouts, optional race-safe protocol completion waits, and shared outcome shaping.
- Keep `stn command` as the raw adapter: parse stdin once through the shared command schema, delegate, and preserve existing dispatch/get output.
- Route project add/remove directly through typed execution without JSON, stdin, or synthetic argv round-trips.
- Preserve rejected receipts and SafeErrors as structured nonzero project outcomes.
- Complete the shared generic `CommandExecutionOutcome<TCommand>` type correlation and reject mismatched terminal completion identity.
- Mark the CLI/Observer adapters and regenerate the architecture manifest.

## Testing

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- Focused CLI integration tests: 21 passed
- Unit: 3,133 passed
- Contracts: 167 passed
- Integration: 772 passed
- Diagnostics: 161 passed on a full-lane rerun after aggregate load-related timeouts
- Scripted agent: 5 passed
- Setup E2E: 28 passed
- Observer E2E: 27 passed
- `pnpm smoke:install` passed on rerun after an installer-smoke PID-file race

## User-visible behavior

Raw command output remains compatible. Rejected `stn project add/remove` commands now return the original receipt/error with exit code 1 instead of an internal shape error.