### PR TITLE
fix(protocol): remove owned Unix socket after close

### DIFF
--- a/packages/protocol/src/transport.ts
+++ b/packages/protocol/src/transport.ts
@@ -234,6 +234,13 @@ export async function listenUnixSocket(
 
   await bindWithStaleReclaim(server, options.socketPath);
 
+  const boundSocket = await readUnixSocketMetadata(options.socketPath);
+  if (boundSocket === undefined || !boundSocket.isSocket) {
+    abandonServer(server, sockets);
+    throw inaccessibleSocket("path-changed", undefined, boundSocket).error;
+  }
+  const boundSocketIdentity = socketIdentity(boundSocket);
+
   try {
     await chmod(options.socketPath, 0o600);
   } catch {
@@ -242,7 +249,7 @@ export async function listenUnixSocket(
 
   return {
     socketPath: options.socketPath,
-    close: () => closeServer(server, options.socketPath, sockets),
+    close: () => closeServer(server, options.socketPath, sockets, boundSocketIdentity),
     abandon: () => abandonServer(server, sockets),
   };
 }
@@ -544,8 +551,9 @@ function inMemoryEndpoint(incoming: PassThrough, outgoing: PassThrough): NdjsonC
 
 async function closeServer(
   server: Server,
-  _socketPath: string,
+  socketPath: string,
   sockets: Set<Socket>,
+  boundSocketIdentity: SocketIdentity,
 ): Promise<void> {
   const closed = new Promise<void>((resolve, reject) => {
     server.close((error) => {
@@ -561,6 +569,12 @@ async function closeServer(
     socket.destroySoon();
   }
   await closed;
+
+  // Bun may leave the Unix pathname after close; remove only the exact socket this server bound.
+  const current = await readUnixSocketMetadata(socketPath);
+  if (current?.isSocket && socketIdentitiesMatch(boundSocketIdentity, current)) {
+    await unlink(socketPath);
+  }
 }
 
 function abandonServer(server: Server, sockets: Set<Socket>): void {

--- a/packages/protocol/test/unit/transport.test.ts
+++ b/packages/protocol/test/unit/transport.test.ts
@@ -259,7 +259,7 @@ describe("Unix socket NDJSON transport", () => {
     await expect(server.closed).resolves.toBeUndefined();
   });
 
-  it("closes even when a client connection is still open", async () => {
+  it("closes open clients and removes the exact owned socket pathname", async () => {
     const { socketPath } = await createTempSocketPath();
     const server = await listenUnixSocket({
       socketPath,
@@ -269,6 +269,7 @@ describe("Unix socket NDJSON transport", () => {
 
     await expect(server.close()).resolves.toBeUndefined();
     await expect(client.closed).resolves.toBeUndefined();
+    await expect(access(socketPath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 });
 


### PR DESCRIPTION
## What this fixes

Station’s protocol transport owns the Unix socket pathname used by the Observer. In the `v0.0.0-pre-alpha.6` release workflow, both attempts of the macOS x64 compiled-binary smoke left that pathname behind after the incumbent exited, so the successor correctly refused an unprovable handoff and blocked draft creation.

## What changed

- Capture the exact inode and birth-time identity of the socket immediately after binding.
- After server close, remove a surviving pathname only when it is still the exact socket this server bound.
- Preserve the existing fail-closed behavior when the pathname changes or belongs to a successor.
- Extend transport coverage to require open-client shutdown to remove the owned pathname.

## Testing

- `bun run test:unit -- packages/protocol/test/unit/transport.test.ts` — 15 tests
- `bun run test:integration -- apps/observer/test/integration/protocol-server.test.ts` — 12 tests
- `bun run typecheck` — 46 tasks
- `bun run build:binary -- --version 0.0.0-pre-alpha.6`
- `bun run smoke:binary -- --expected-version 0.0.0-pre-alpha.6`
- Full lint and Observer architecture checks

## Safety and scope

Cleanup is authorized only by the socket identity captured at bind time. A missing, replaced, or non-socket pathname is preserved; displaced listeners continue to use the existing abandon path. This does not weaken holder evidence or Observer handoff admission.

## User-visible behavior

Compiled Observer replacement no longer fails solely because Bun leaves the incumbent’s already-closed Unix socket pathname behind. Manually verify by running the two-artifact binary smoke on macOS x64 and confirming same-version handoff completes.
