### PR TITLE
test(observer): await Linux socket holder visibility

### DIFF
--- a/apps/observer/src/runtime/main.ts
+++ b/apps/observer/src/runtime/main.ts
@@ -636,7 +636,7 @@ async function runClaimedObserverRuntime(input: {
           }
         }
         ownership?.stop();
-        // close() unlinks the bound pathname, so ownership is revalidated with no await
+        // Runtime close may unlink the bound pathname, so ownership is revalidated with no await
         // between this check and close; a stale check could remove a successor's socket.
         const identityAtClose = stillOwnsSocket ? await readSocketIdentity(socketPath) : undefined;
         const ownsSocketAtClose =

--- a/tests/e2e/observer-lifecycle.test.ts
+++ b/tests/e2e/observer-lifecycle.test.ts
@@ -1540,6 +1540,8 @@ async function expectSingleObserver(
   await waitFor(async () => (await observerProcessesForSocket(socketPath)).length === 1, 3000);
   expect(await observerProcessesForSocket(socketPath)).toEqual([pid]);
 
+  // Process discovery can precede Linux /proc socket-holder visibility.
+  await waitFor(async () => (await socketHolders(socketPath)).includes(pid), 3000);
   expect(await socketHolders(socketPath)).toEqual([pid]);
 }
 


### PR DESCRIPTION
## What this fixes

The Observer lifecycle E2E helper confirms a converged process and then immediately samples Linux `/proc` for its Unix-socket holder. Health and process discovery can precede socket-holder visibility, producing an empty one-shot sample even though the healthy listener remains live. The identical failure has occurred on three unrelated CI runs and can block an otherwise valid release correction.

## What changed

- Wait up to the existing three-second convergence budget for the expected holder PID before asserting the exact holder set.
- Keep the exact final assertion so unexpected extra owners still fail.
- Clarify that runtime server close may unlink its pathname; the ownership revalidation remains required across runtimes.

## Testing

- `bun run build`: 24 tasks passed.
- `bun run test:e2e:observer`: 3 files / 27 tests passed.
- The affected stale-start case passed 5/5 focused repetitions before the wait was added.
- `bun run lint` and Observer architecture validation passed in commit/push hooks.

## Safety and scope

This changes only E2E observation timing and a lifecycle comment. It does not weaken the exact single-holder assertion or alter runtime behavior.
