### PR TITLE
fix(observer): tolerate socket teardown evidence races

### DIFF
--- a/apps/observer/src/runtime/observerHandoff.ts
+++ b/apps/observer/src/runtime/observerHandoff.ts
@@ -8,6 +8,7 @@ import { TimestampSchema } from "@station/contracts";
 import {
   Effect,
   hasStationObserverBuildIdentityMarker,
+  isSafeError,
   parseStationObserverBuildVersion,
 } from "@station/runtime";
 import { z } from "zod";
@@ -446,10 +447,24 @@ async function waitForExactExit(
   now: () => number,
   sleep: (ms: number) => Promise<void>,
 ): Promise<boolean> {
+  let pendingInaccessibleError: SafeError | undefined;
   for (;;) {
-    if (now() >= deadline) return false;
-    if (await exactProcessAndSocketExited(socketPath, identity, deadline, deps, now)) return true;
-    if (now() >= deadline) return false;
+    if (now() >= deadline) {
+      if (pendingInaccessibleError !== undefined) throw pendingInaccessibleError;
+      return false;
+    }
+    try {
+      if (await exactProcessAndSocketExited(socketPath, identity, deadline, deps, now)) return true;
+      pendingInaccessibleError = undefined;
+    } catch (error) {
+      if (!isSafeError(error) || error.code !== "OBSERVER_SOCKET_INACCESSIBLE") throw error;
+      // A closing exact incumbent can expose a transient inaccessible endpoint; it proves no exit.
+      pendingInaccessibleError = error;
+    }
+    if (now() >= deadline) {
+      if (pendingInaccessibleError !== undefined) throw pendingInaccessibleError;
+      return false;
+    }
     // pi-lens-ignore: await-in-loop
     await sleep(
       Math.min(

--- a/apps/observer/test/unit/observerHandoff.test.ts
+++ b/apps/observer/test/unit/observerHandoff.test.ts
@@ -614,15 +614,35 @@ describe("negotiateObserverIncumbent", () => {
     expect(fixture.signal).not.toHaveBeenCalledWith(100, "SIGTERM");
   });
 
-  it("refuses an inaccessible exit probe before absence or termination signals", async () => {
+  it("retries a transient inaccessible exit probe without treating it as exit authority", async () => {
     const fixture = handoffFixture();
-    fixture.lifecycle.socketListening = async () => {
-      throw { code: "OBSERVER_SOCKET_INACCESSIBLE" };
-    };
+    const inaccessible = observerSocketInaccessible();
+    fixture.lifecycle.socketListening = vi
+      .fn()
+      .mockRejectedValueOnce(inaccessible)
+      .mockImplementationOnce(async () => {
+        fixture.startToken = undefined;
+        return false;
+      });
+
+    await expect(runNegotiation(fixture)).resolves.toMatchObject({ action: "replaced" });
+    expect(fixture.lifecycle.socketListening).toHaveBeenCalledTimes(2);
+    expect(fixture.signal).toHaveBeenCalledWith(100, 0);
+    expect(fixture.signal).not.toHaveBeenCalledWith(100, "SIGTERM");
+  });
+
+  it("refuses a persistently inaccessible exit probe without signaling", async () => {
+    const fixture = handoffFixture();
+    const inaccessible = observerSocketInaccessible();
+    fixture.lifecycle.socketListening = vi.fn(async () => {
+      throw inaccessible;
+    });
 
     await expect(runNegotiation(fixture)).rejects.toMatchObject({
       code: "OBSERVER_HANDOFF_REFUSED",
+      cause: { code: "OBSERVER_SOCKET_INACCESSIBLE" },
     });
+    expect(fixture.lifecycle.socketListening).toHaveBeenCalledTimes(2);
     expect(fixture.signal).not.toHaveBeenCalled();
   });
 
@@ -683,6 +703,14 @@ function precedenceFor(candidateSelector: string, incumbentSelector: string | un
 
 function observerBuildVersion(version: string, buildIdentity: string): string {
   return `${version}${version.includes("+") ? "." : "+"}station.${buildIdentity}`;
+}
+
+function observerSocketInaccessible() {
+  return Object.assign(new Error("socket inaccessible"), {
+    tag: "ObserverSocketError",
+    code: "OBSERVER_SOCKET_INACCESSIBLE",
+    message: "The Observer socket is temporarily inaccessible.",
+  });
 }
 
 function handoffFixture() {

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -12121,6 +12121,7 @@
           "bindings": [
             "Effect",
             "hasStationObserverBuildIdentityMarker",
+            "isSafeError",
             "parseStationObserverBuildVersion"
           ]
         },
@@ -17771,7 +17772,7 @@
       "declaration": "probeUnixSocket",
       "kind": "function",
       "role": "ADAPTER",
-      "purpose": "Translates filesystem, connection, and process-holder evidence into four fail-closed Unix-socket ownership states.",
+      "purpose": "Translates filesystem, connection, and process-holder evidence into four fail-closed Unix-socket ownership states, revalidating path identity after holder-evidence races before classifying the final state.",
       "dependencies": [
         {
           "path": "packages/protocol/src/transport.ts",

--- a/docs/observer-singleton.md
+++ b/docs/observer-singleton.md
@@ -186,6 +186,9 @@ incumbent stop and successor cleanup ownership; it is delivered to normal shutdo
 successor owns that cleanup. The controlled health-plus-stop exchange uses one connection, binding
 authorization to the revalidated incumbent. A stop receipt is acceptance, not exit proof: successor
 bind requires both socket closure and exact incumbent death.
+Passive post-stop polling may retry transient inaccessible samples within the same bounded exit
+wait, but those samples never prove exit or authorize a signal; a still-inaccessible final sample
+refuses with its original cause.
 
 Automatic handoff never sends SIGKILL. A missing identity, changed owner, inaccessible
 socket, wedged process, or exhausted deadline returns `OBSERVER_HANDOFF_REFUSED` and preserves

--- a/packages/protocol/src/transport.ts
+++ b/packages/protocol/src/transport.ts
@@ -89,7 +89,8 @@ export async function ensureSocketDirectory(socketPath: string): Promise<void> {
  * ADAPTER
  *
  * Translates filesystem, connection, and process-holder evidence into four
- * fail-closed Unix-socket ownership states.
+ * fail-closed Unix-socket ownership states, revalidating path identity after
+ * holder-evidence races before classifying the final state.
  */
 export async function probeUnixSocket(
   socketPath: string,
@@ -157,6 +158,20 @@ export async function probeUnixSocket(
         ? { status: "stale", identity: initialIdentity }
         : inaccessibleSocket("live-holder", error, initialIdentity);
     } catch (evidenceError) {
+      // Holder evidence can race normal endpoint removal; refresh the path fact before refusing.
+      let final: UnixSocketPathMetadata | undefined;
+      try {
+        final = await readMetadata(socketPath);
+      } catch (metadataError) {
+        return inaccessibleSocket("unclassified", metadataError, initialIdentity);
+      }
+      if (final === undefined) return { status: "absent" };
+      if (!final.isSocket) {
+        return inaccessibleSocket("not-a-socket", evidenceError, socketIdentity(final));
+      }
+      if (!socketIdentitiesMatch(initialIdentity, final)) {
+        return inaccessibleSocket("path-changed", evidenceError, socketIdentity(final));
+      }
       return inaccessibleSocket("evidence-unavailable", evidenceError, initialIdentity);
     }
   }
@@ -234,13 +249,6 @@ export async function listenUnixSocket(
 
   await bindWithStaleReclaim(server, options.socketPath);
 
-  const boundSocket = await readUnixSocketMetadata(options.socketPath);
-  if (boundSocket === undefined || !boundSocket.isSocket) {
-    abandonServer(server, sockets);
-    throw inaccessibleSocket("path-changed", undefined, boundSocket).error;
-  }
-  const boundSocketIdentity = socketIdentity(boundSocket);
-
   try {
     await chmod(options.socketPath, 0o600);
   } catch {
@@ -249,7 +257,7 @@ export async function listenUnixSocket(
 
   return {
     socketPath: options.socketPath,
-    close: () => closeServer(server, options.socketPath, sockets, boundSocketIdentity),
+    close: () => closeServer(server, options.socketPath, sockets),
     abandon: () => abandonServer(server, sockets),
   };
 }
@@ -551,9 +559,8 @@ function inMemoryEndpoint(incoming: PassThrough, outgoing: PassThrough): NdjsonC
 
 async function closeServer(
   server: Server,
-  socketPath: string,
+  _socketPath: string,
   sockets: Set<Socket>,
-  boundSocketIdentity: SocketIdentity,
 ): Promise<void> {
   const closed = new Promise<void>((resolve, reject) => {
     server.close((error) => {
@@ -569,12 +576,6 @@ async function closeServer(
     socket.destroySoon();
   }
   await closed;
-
-  // Bun may leave the Unix pathname after close; remove only the exact socket this server bound.
-  const current = await readUnixSocketMetadata(socketPath);
-  if (current?.isSocket && socketIdentitiesMatch(boundSocketIdentity, current)) {
-    await unlink(socketPath);
-  }
 }
 
 function abandonServer(server: Server, sockets: Set<Socket>): void {

--- a/packages/protocol/test/unit/transport.test.ts
+++ b/packages/protocol/test/unit/transport.test.ts
@@ -152,6 +152,37 @@ describe("Unix socket NDJSON transport", () => {
     });
   });
 
+  it.each([
+    { name: "absence", final: undefined, expected: { status: "absent" } },
+    {
+      name: "replacement socket",
+      final: metadata(2n),
+      expected: { status: "inaccessible", reason: "path-changed" },
+    },
+    {
+      name: "non-socket collision",
+      final: { ...metadata(1n), isSocket: false },
+      expected: { status: "inaccessible", reason: "not-a-socket" },
+    },
+  ] as const)("reclassifies $name after holder evidence races path teardown", async (testCase) => {
+    let reads = 0;
+    const result = await probeUnixSocket("/tmp/closing.sock", {
+      readMetadata: async () => {
+        reads += 1;
+        return reads < 3 ? metadata(1n) : testCase.final;
+      },
+      connect: async () => {
+        throw Object.assign(new Error("refused"), { code: "ECONNREFUSED" });
+      },
+      socketHolders: () => {
+        throw { code: "PROTOCOL_SOCKET_EVIDENCE_UNAVAILABLE" };
+      },
+    });
+
+    expect(result).toMatchObject(testCase.expected);
+    expect(reads).toBe(3);
+  });
+
   it("fails closed when the socket path changes during probing or is not a socket", async () => {
     let reads = 0;
     const changed = await probeUnixSocket("/tmp/replaced.sock", {
@@ -259,7 +290,7 @@ describe("Unix socket NDJSON transport", () => {
     await expect(server.closed).resolves.toBeUndefined();
   });
 
-  it("closes open clients and removes the exact owned socket pathname", async () => {
+  it("closes even when a client connection is still open", async () => {
     const { socketPath } = await createTempSocketPath();
     const server = await listenUnixSocket({
       socketPath,
@@ -269,7 +300,6 @@ describe("Unix socket NDJSON transport", () => {
 
     await expect(server.close()).resolves.toBeUndefined();
     await expect(client.closed).resolves.toBeUndefined();
-    await expect(access(socketPath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 });
 

--- a/scripts/test-runners/run-binary-smoke.mjs
+++ b/scripts/test-runners/run-binary-smoke.mjs
@@ -180,8 +180,21 @@ async function runBinarySmoke() {
       if (!["SIGINT", "SIGTERM", "SIGHUP"].includes(signal)) {
         throw new Error(`Unsupported cancellation self-check signal: ${signal}`);
       }
-      process.kill(process.pid, signal);
-      await delay(0);
+      await new Promise((resolve, reject) => {
+        const signalWaitTimeout = setTimeout(
+          () => reject(new Error(`Cancellation self-check did not receive ${signal}.`)),
+          1_000,
+        );
+        cancellation.signal.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(signalWaitTimeout);
+            resolve();
+          },
+          { once: true },
+        );
+        process.kill(process.pid, signal);
+      });
       throw runCancelledError(process.execPath, [], cancellation.signal);
     }
     if (process.env.STATION_BINARY_SMOKE_EVIDENCE_FAILURE_SELF_CHECK === "1") {

--- a/tests/diagnostics/agent-scripts.test.ts
+++ b/tests/diagnostics/agent-scripts.test.ts
@@ -925,7 +925,7 @@ describe("binary smoke script", () => {
       stdio: "pipe",
     });
     expect(interrupted.status).toBe(130);
-  });
+  }, 15_000);
 
   it("preserves the primary failure and cancellation while retaining external evidence", () => {
     const scriptPath = fileURLToPath(


### PR DESCRIPTION
## What this fixes

The release candidate binary smoke can observe a normal Unix-socket teardown between its failed connection and holder-evidence lookup. Station currently turns that vanished endpoint into `OBSERVER_SOCKET_INACCESSIBLE`, so a safe same-version Observer handoff fails closed even though the exact incumbent has exited. The tag workflow for `v0.0.0-pre-alpha.7` reproduced this on Linux and stopped before artifact builds. The same run also exposed a cancellation self-check race that could report exit `0` instead of the installed SIGINT result.

## What changed

- revalidates the socket pathname after holder-evidence lookup races teardown, accepting only proven absence while preserving fail-closed replacement and non-socket classifications
- retries transient inaccessible samples only within the existing bounded passive exit wait; those samples never prove exit or authorize a signal
- removes explicit close-time pathname unlinking and relies on exact post-close evidence instead of assigning cleanup ownership to a replacement-sensitive close path
- makes the binary-smoke cancellation self-check await its installed signal handler with a bounded failure and gives the subprocess cleanup assertion a load-tolerant timeout

## Testing

- protocol and Observer handoff unit tests: 61 passed
- cancellation exit self-check: 30 consecutive runs exited 130
- focused cancellation diagnostic passed
- `bun run typecheck`: 46 tasks passed
- `bun run lint`
- `bun run test:ci:fast`: 304 unit files / 3,172 tests, 16 contract files / 185 tests, 33 diagnostic files / 179 tests, and 3 scripted-agent files / 5 tests passed
- exact-version `bun run build:binary -- --version 0.0.0-pre-alpha.7`
- `bun run smoke:binary -- --expected-version 0.0.0-pre-alpha.7`

## Safety and scope

Socket identity is re-read before any absence classification. A changed socket, non-socket collision, unreadable path, or persistently inaccessible endpoint still refuses handoff without signaling. This changes no public protocol contract or release/promotion policy.
