### PR TITLE
fix(test): make guided setup PTY gate progress-aware

### DIFF
--- a/config/vitest/vitest.setup-e2e.config.ts
+++ b/config/vitest/vitest.setup-e2e.config.ts
@@ -13,6 +13,6 @@ export default defineConfig({
       "tests/e2e/setup-guided-tty.test.ts",
     ],
     fileParallelism: false,
-    testTimeout: 60_000,
+    testTimeout: 90_000,
   },
 });

--- a/tests/e2e/setup-guided-tty.test.ts
+++ b/tests/e2e/setup-guided-tty.test.ts
@@ -65,6 +65,38 @@ describe("guided setup real TTY", () => {
     expect(result.stdout).not.toContain("selected:claude");
   });
 
+  it("delivers each prompt answer when raw mode remains enabled between prompts", async () => {
+    const result = await runGuidedPty({
+      command: process.execPath,
+      args: ["--input-type=module", "--eval", uninterruptedRawModeScript],
+      cwd: process.cwd(),
+      env: process.env,
+      inputs: [{ raw: "a" }, { raw: "b" }],
+      timeoutMs: 5_000,
+    });
+
+    expect(result.timedOut, `${result.stdout}\n${result.stderr}`).toBe(false);
+    expect(result.exitCode, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.answersSent).toBe(2);
+    expect(result.stdout).toContain("answers:a,b");
+  });
+
+  it("allows progressive PTY work to exceed the inactivity timeout", async () => {
+    const result = await runGuidedPty({
+      command: process.execPath,
+      args: ["--input-type=module", "--eval", progressiveOutputScript],
+      cwd: process.cwd(),
+      env: process.env,
+      inputs: [],
+      timeoutMs: 500,
+      hardTimeoutMs: 5_000,
+    });
+
+    expect(result.timedOut, `${result.stdout}\n${result.stderr}`).toBe(false);
+    expect(result.exitCode, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain("progress:done");
+  });
+
   it("keeps the fifth agent navigable in a constrained terminal", async () => {
     const result = await runPresenterScenario({
       scenario: "multi",
@@ -174,4 +206,39 @@ if (scenario === "confirm") {
     process.stdout.write("raw-mode-after:" + String(process.stdin.isRaw === true) + "\n");
   }
 }
+`;
+
+const uninterruptedRawModeScript = String.raw`
+const cursorHide = "\u001b[?25l";
+const cursorShow = "\u001b[?25h";
+const answers = [];
+process.stdin.on("data", (chunk) => {
+  for (const answer of chunk.toString("utf8")) {
+    answers.push(answer);
+    if (answers.length === 1) {
+      process.stdout.write(cursorShow + "first:" + answer + "\n" + cursorHide);
+      continue;
+    }
+    if (answers.length === 2) {
+      process.stdout.write(cursorShow + "answers:" + answers.join(",") + "\n");
+      process.stdin.setRawMode(false);
+      process.stdin.pause();
+    }
+  }
+});
+process.stdin.setRawMode(true);
+process.stdin.resume();
+process.stdout.write(cursorHide);
+`;
+
+const progressiveOutputScript = String.raw`
+let progress = 0;
+const timer = setInterval(() => {
+  progress += 1;
+  process.stdout.write("progress:" + String(progress) + "\n");
+  if (progress === 7) {
+    clearInterval(timer);
+    process.stdout.write("progress:done\n");
+  }
+}, 100);
 `;

--- a/tests/support/setup-guided.ts
+++ b/tests/support/setup-guided.ts
@@ -29,16 +29,21 @@ export type RunGuidedPtyOptions = {
   readonly inputs: readonly GuidedPtyInput[];
   readonly rows?: number;
   readonly columns?: number;
+  /** Maximum PTY inactivity before the child is terminated. */
   readonly timeoutMs?: number;
+  /** Absolute ceiling for a child that keeps producing output. */
+  readonly hardTimeoutMs?: number;
   readonly sendSigtermOnFirstRawMode?: boolean;
 };
 
 const rawModeMarker = "__STATION_GUIDED_PTY_RAW__\n";
+const promptReadySequence = "\u001b[?25l";
 
 export function runGuidedPty(options: RunGuidedPtyOptions): Promise<GuidedPtyResult> {
   const rows = options.rows ?? 24;
   const columns = options.columns ?? 100;
   const timeoutMs = options.timeoutMs ?? 20_000;
+  const hardTimeoutMs = Math.max(options.hardTimeoutMs ?? 60_000, timeoutMs);
   const bridge = spawn(
     "python3",
     ["-c", pythonPtyBridge, String(rows), String(columns), options.command, ...options.args],
@@ -51,13 +56,46 @@ export function runGuidedPty(options: RunGuidedPtyOptions): Promise<GuidedPtyRes
   const output: Buffer[] = [];
   let bridgeStderr = "";
   let markerBuffer = "";
+  let promptBuffer = "";
   let answerIndex = 0;
   let timedOut = false;
   let sigtermAttempted = false;
   let sigtermSent = false;
+  let idleTimer: ReturnType<typeof setTimeout> | undefined;
 
-  bridge.stdout.on("data", (chunk: Buffer) => output.push(chunk));
+  const terminateForTimeout = () => {
+    if (timedOut) return;
+    timedOut = true;
+    bridge.kill("SIGTERM");
+    setTimeout(() => bridge.kill("SIGKILL"), 500).unref();
+  };
+  const resetIdleTimer = () => {
+    if (idleTimer !== undefined) clearTimeout(idleTimer);
+    idleTimer = setTimeout(terminateForTimeout, timeoutMs);
+  };
+
+  bridge.stdout.on("data", (chunk: Buffer) => {
+    resetIdleTimer();
+    output.push(chunk);
+    promptBuffer += chunk.toString("utf8");
+    let promptIndex = promptBuffer.indexOf(promptReadySequence);
+    while (promptIndex >= 0) {
+      promptBuffer = promptBuffer.slice(promptIndex + promptReadySequence.length);
+      const input = options.inputs[answerIndex];
+      if (options.sendSigtermOnFirstRawMode !== true && input !== undefined) {
+        // Clack hides the cursor only after its keypress listener is attached. Sampled raw-mode
+        // transitions can disappear between immediate prompts, but this rendered boundary cannot.
+        bridge.stdin.write(encodeGuidedInput(input));
+        answerIndex += 1;
+      }
+      promptIndex = promptBuffer.indexOf(promptReadySequence);
+    }
+    if (promptBuffer.length >= promptReadySequence.length) {
+      promptBuffer = promptBuffer.slice(-(promptReadySequence.length - 1));
+    }
+  });
   bridge.stderr.on("data", (chunk: Buffer) => {
+    resetIdleTimer();
     markerBuffer += chunk.toString("utf8");
     let markerIndex = markerBuffer.indexOf(rawModeMarker);
     while (markerIndex >= 0) {
@@ -66,25 +104,17 @@ export function runGuidedPty(options: RunGuidedPtyOptions): Promise<GuidedPtyRes
       if (options.sendSigtermOnFirstRawMode === true && !sigtermAttempted) {
         sigtermAttempted = true;
         sigtermSent = bridge.kill("SIGTERM");
-      } else {
-        const input = options.inputs[answerIndex];
-        if (input !== undefined) {
-          bridge.stdin.write(encodeGuidedInput(input));
-          answerIndex += 1;
-        }
       }
       markerIndex = markerBuffer.indexOf(rawModeMarker);
     }
   });
 
   return new Promise((resolve) => {
-    const timer = setTimeout(() => {
-      timedOut = true;
-      bridge.kill("SIGTERM");
-      setTimeout(() => bridge.kill("SIGKILL"), 500).unref();
-    }, timeoutMs);
+    resetIdleTimer();
+    const hardTimer = setTimeout(terminateForTimeout, hardTimeoutMs);
     bridge.on("close", (exitCode) => {
-      clearTimeout(timer);
+      if (idleTimer !== undefined) clearTimeout(idleTimer);
+      clearTimeout(hardTimer);
       bridgeStderr += markerBuffer;
       const rawOutput = Buffer.concat(output).toString("utf8");
       resolve({


### PR DESCRIPTION
## What this fixes

The guided setup E2E driver owns scripted interaction with Station's real terminal prompts. It sampled terminal raw-mode edges every 10 ms and treated each child timeout as an absolute wall-clock deadline. An immediate reprompt could hide a cooked-to-raw transition and leave the next answer unsent; a progressing setup could also exceed the deadline under load. Those two failure modes blocked both immutable `.8` release attempts on different tests even though the exact release tree had passed PR CI.

## What changed

- Deliver each scripted answer from Clack's rendered prompt boundary, which occurs after the keypress listener is attached.
- Reserve sampled raw-mode evidence for the process-interruption scenario instead of prompt synchronization.
- Treat the existing timeout as an inactivity budget while retaining a separate absolute hard stop and a bounded Vitest ceiling.
- Add deterministic coverage for back-to-back prompts that remain continuously raw and for progressive output that outlives its inactivity budget.

## Testing

- Bun 1.4.0 frozen install; build, typecheck, lint, and Observer architecture checks.
- Focused prompt-readiness and progressive-output regressions passed.
- Full all-shell guided setup E2E passed twice: 26/26 each run.
- Unit 3,172/3,172; contracts 185/185; diagnostics 179/179; scripted-agent 5/5; setup E2E 30/30; Observer E2E 27/27; installer smoke passed.
- The first broad integration pass completed 837/837 assertions but exposed an unrelated existing delayed `process.exit` test timer; the exact integration lane rerun passed 837/837 cleanly.

## Safety and scope

This changes only test configuration, PTY test support, and PTY regression coverage. Production setup and user-visible behavior are unchanged.
