### PR TITLE
test(ci): make release gates deterministic

### DIFF
--- a/integrations/worktree/worktrunk/test/unit/provider.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/provider.test.ts
@@ -1268,6 +1268,7 @@ describe("WorktrunkProvider", () => {
     let activeScans = 0;
     let maxActiveScans = 0;
     let completedScans = 0;
+    const firstBatchSaturated = Promise.withResolvers<void>();
     const provider = testProvider({
       command: "wt",
       useLifecycleHooks: false,
@@ -1276,7 +1277,8 @@ describe("WorktrunkProvider", () => {
         if (input.args?.includes("list")) {
           activeScans += 1;
           maxActiveScans = Math.max(maxActiveScans, activeScans);
-          await new Promise((resolve) => setTimeout(resolve, 5));
+          if (activeScans === 4) firstBatchSaturated.resolve();
+          await firstBatchSaturated.promise;
           activeScans -= 1;
           completedScans += 1;
           return result(input, "[]");

--- a/tests/e2e/observer-lifecycle.test.ts
+++ b/tests/e2e/observer-lifecycle.test.ts
@@ -1540,9 +1540,13 @@ async function expectSingleObserver(
   await waitFor(async () => (await observerProcessesForSocket(socketPath)).length === 1, 3000);
   expect(await observerProcessesForSocket(socketPath)).toEqual([pid]);
 
-  // Process discovery can precede Linux /proc socket-holder visibility.
-  await waitFor(async () => (await socketHolders(socketPath)).includes(pid), 3000);
-  expect(await socketHolders(socketPath)).toEqual([pid]);
+  // Reuse the successful socket-holder snapshot because a second scan can race socket activity.
+  let holders: number[] = [];
+  await waitFor(async () => {
+    holders = await socketHolders(socketPath);
+    return holders.includes(pid);
+  }, 3000);
+  expect(holders).toEqual([pid]);
 }
 
 async function socketHolders(socketPath: string): Promise<number[]> {


### PR DESCRIPTION
## What this fixes

Station standard CI had two test-only races that could reject unchanged release source: the Worktrunk concurrency proof depended on four filesystem preflights overlapping a 5 ms timer, and the Observer singleton proof discarded a successful socket-holder sample before taking a second racy sample. Both recurred while preparing pre-alpha.8.1, making an immutable tag unnecessarily risky.

## What changed

- Gates the first Worktrunk scan batch until all four bounded workers are active, proving saturation and the upper bound without wall-clock timing.
- Retains the successful Observer socket-holder snapshot and asserts that exact sample instead of rescanning.
- Leaves Worktrunk and Observer production behavior unchanged.

## Testing

- Installed with Bun 1.4.0 using the frozen lockfile; bun.lock remained unchanged.
- Passed the full Worktrunk provider suite (35/35) and full Observer E2E suite (27/27).
- Passed 100/100 focused Worktrunk stress iterations and 20/20 focused Observer iterations on Darwin arm64.
- Passed lint and Observer architecture validation.

## Safety and scope

This changes two tests only. Hosted Linux CI remains the required proof for the /proc socket-holder path before the pre-alpha.8.1 tag is created.