### PR TITLE
test(release): preserve predecessor update smoke compatibility

### DIFF
--- a/scripts/test-runners/composed-update-report.mjs
+++ b/scripts/test-runners/composed-update-report.mjs
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import {
+  SafeErrorSchema,
+  UpdateArtifactSchema,
+  UpdateChannelIdSchema,
+  UpdateCommandArgvSchema,
+  UpdateCommandReportSchema,
+} from "../../packages/contracts/dist/index.js";
+
+const legacySafeTextSchema = z
+  .string()
+  .min(1)
+  .refine((value) => !/\n\s*at\s+\S+/u.test(value), "must not contain stack trace frames");
+const legacyUpdateStepSchema = z
+  .object({
+    id: z.enum(["detect", "plan", "apply", "observer-restart", "host-handoff"]),
+    status: z.enum(["completed", "planned", "deferred", "skipped", "failed"]),
+    detail: legacySafeTextSchema,
+    command: UpdateCommandArgvSchema.optional(),
+  })
+  .strict();
+
+// The release smoke composes the current target with the newest complete immutable predecessor.
+const legacyV1UpdateCommandReportSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    channel: UpdateChannelIdSchema,
+    status: z.enum(["current", "planned", "updated", "deferred", "failed"]),
+    current: UpdateArtifactSchema,
+    target: UpdateArtifactSchema,
+    steps: z.array(legacyUpdateStepSchema),
+    warnings: z.array(SafeErrorSchema),
+    recoveryCommands: z.array(UpdateCommandArgvSchema),
+    error: SafeErrorSchema.optional(),
+  })
+  .strict();
+
+const composedUpdateReportSchema = z.union([
+  legacyV1UpdateCommandReportSchema,
+  UpdateCommandReportSchema,
+]);
+const legacyV1IncumbentVersion = "0.0.0-pre-alpha.5.16";
+
+export function parseComposedUpdateReport(value, incumbentVersion) {
+  const report = composedUpdateReportSchema.parse(value);
+  const expectedSchemaVersion = incumbentVersion === legacyV1IncumbentVersion ? 1 : 4;
+  if (report.schemaVersion !== expectedSchemaVersion) {
+    throw new Error(
+      `Expected update report schema ${expectedSchemaVersion} from incumbent ${incumbentVersion}, received ${report.schemaVersion}.`,
+    );
+  }
+  return report;
+}

--- a/scripts/test-runners/run-update-smoke.mjs
+++ b/scripts/test-runners/run-update-smoke.mjs
@@ -22,7 +22,6 @@ import {
 import { tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { UpdateCommandReportSchema } from "../../packages/contracts/dist/index.js";
 import {
   createObserverClient,
   readUnixSocketHolderPids,
@@ -41,6 +40,7 @@ import {
   releaseBinarySmokeEvidenceReservation,
   reserveBinarySmokeEvidenceDestination,
 } from "./binary-smoke-evidence.mjs";
+import { parseComposedUpdateReport } from "./composed-update-report.mjs";
 
 const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
 const runnerPath = fileURLToPath(import.meta.url);
@@ -468,13 +468,11 @@ async function runScenario(input) {
             [installedBinary, "update", "--dry-run", "--json"],
             scenarioRoot,
           );
-    const dryRunReport = UpdateCommandReportSchema.parse(
+    const dryRunReport = parseComposedUpdateReport(
       parseJson(dryRunResult.stdout, `${input.name} compiled dry-run report`),
+      input.options.incumbentVersion,
     );
-    assertDryUpdateReport(dryRunReport, input);
-    const expectedDryRunCode = ["blocked", "reap-required"].includes(dryRunReport.plan.outcome)
-      ? 1
-      : 0;
+    const expectedDryRunCode = assertDryUpdateReport(dryRunReport, input);
     assertEqual(dryRunResult.code, expectedDryRunCode, `${input.name} dry-run outcome exit code`);
     assertDeepEqual(
       await captureDryRunState(dryRunStateInput),
@@ -515,8 +513,9 @@ async function runScenario(input) {
             scenarioRoot,
           );
     assertEqual(updateResult.code, expectedUpdateCode, `${input.name} update exit code`);
-    const report = UpdateCommandReportSchema.parse(
+    const report = parseComposedUpdateReport(
       parseJson(updateResult.stdout, `${input.name} update report`),
+      input.options.incumbentVersion,
     );
     assertUpdateReport(report, input, installedBinary, configPath);
     if (expectedUpdateCode === 0) {
@@ -953,7 +952,7 @@ async function captureDryRunState(input) {
     socketPath: observerHealth.socketPath,
     stateDir: observerHealth.stateDir,
   };
-  const recoveryInventory = await observer.getSessionRecoveryInventory();
+  const recoveryReadiness = await observer.getSessionRecoveryReadiness();
   let host;
   if (input.busyHost) {
     const client = createStationHostClient({
@@ -988,7 +987,7 @@ async function captureDryRunState(input) {
       ]),
       holders: readUnixSocketHolderPids(input.socketPath),
       identity: observerIdentity,
-      recoveryInventory,
+      recoveryReadiness,
     },
     host: {
       socket: await snapshotEntry(input.hostSocketPath),
@@ -1514,6 +1513,10 @@ async function verifyBareLaunches(input) {
 }
 
 function assertUpdateReport(report, input, installedBinary, configPath) {
+  if (report.schemaVersion === 1) {
+    assertLegacyUpdateReport(report, input, installedBinary, configPath);
+    return;
+  }
   assertEqual(report.schemaVersion, 4, `${input.name} update schema`);
   assertEqual(report.kind, "result", `${input.name} update result kind`);
   assertEqual(report.channel, "installer-binary", `${input.name} update channel`);
@@ -1573,7 +1576,77 @@ function assertUpdateReport(report, input, installedBinary, configPath) {
   );
 }
 
+function assertLegacyUpdateReport(report, input, installedBinary, configPath) {
+  assertEqual(report.schemaVersion, 1, `${input.name} legacy update schema`);
+  assertEqual(report.channel, "installer-binary", `${input.name} legacy update channel`);
+  const refusal = input.busyHost && input.options.busyHostOutcome === "preserved-refusal";
+  assertEqual(report.status, refusal ? "failed" : "updated", `${input.name} legacy update status`);
+  assertEqual(
+    report.current?.version,
+    input.options.incumbentVersion,
+    `${input.name} legacy current`,
+  );
+  assertEqual(report.target?.version, input.target.version, `${input.name} legacy target`);
+  assertDeepEqual(report.warnings, [], `${input.name} legacy update warnings`);
+  const expectedRecovery = refusal
+    ? [[installedBinary, "--config", configPath, "host", "handoff", "--fidelity", "processes"]]
+    : [];
+  assertDeepEqual(
+    report.recoveryCommands,
+    expectedRecovery,
+    `${input.name} legacy recovery commands (${JSON.stringify({
+      error: report.error,
+      steps: report.steps,
+    })})`,
+  );
+  assertEqual(
+    report.error?.code,
+    refusal ? "UPDATE_RUNTIME_CROSSOVER_FAILED" : undefined,
+    `${input.name} legacy update error`,
+  );
+  assertDeepEqual(
+    report.steps.map((step) => step.id),
+    ["detect", "plan", "apply", "observer-restart", "host-handoff"],
+    `${input.name} exact ordered legacy update steps`,
+  );
+  assertDeepEqual(
+    report.steps.map((step) => step.status),
+    [
+      "completed",
+      "completed",
+      "completed",
+      "completed",
+      refusal ? "failed" : input.busyHost ? "completed" : "skipped",
+    ],
+    `${input.name} exact legacy update step outcomes`,
+  );
+}
+
 function assertDryUpdateReport(report, input) {
+  if (report.schemaVersion === 1) {
+    assertEqual(report.status, "planned", `${input.name} legacy dry-run status`);
+    assertEqual(report.channel, "installer-binary", `${input.name} legacy dry-run channel`);
+    assertEqual(
+      report.current?.version,
+      input.options.incumbentVersion,
+      `${input.name} legacy dry current`,
+    );
+    assertEqual(report.target?.version, input.target.version, `${input.name} legacy dry target`);
+    assertDeepEqual(report.warnings, [], `${input.name} legacy dry-run warnings`);
+    assertDeepEqual(report.recoveryCommands, [], `${input.name} legacy dry-run recovery commands`);
+    assertEqual(report.error, undefined, `${input.name} legacy dry-run error`);
+    assertDeepEqual(
+      report.steps.map((step) => step.id),
+      ["detect", "plan", "apply", "observer-restart", "host-handoff"],
+      `${input.name} exact ordered legacy dry-run steps`,
+    );
+    assertDeepEqual(
+      report.steps.map((step) => step.status),
+      ["completed", "completed", "planned", "planned", input.busyHost ? "planned" : "skipped"],
+      `${input.name} exact legacy dry-run step outcomes`,
+    );
+    return 0;
+  }
   assertEqual(report.schemaVersion, 4, `${input.name} dry-run schema`);
   assertEqual(report.kind, "preview", `${input.name} dry-run kind`);
   assertEqual(report.channel, "installer-binary", `${input.name} dry-run channel`);
@@ -1582,6 +1655,7 @@ function assertDryUpdateReport(report, input) {
   assertEqual(report.initial?.boundary.authorization, "none", `${input.name} dry authorization`);
   assertEqual(report.plan?.authorization, "none", `${input.name} dry plan authorization`);
   assertEqual("recoveryPreflight" in report, false, `${input.name} dry omits nested preflight`);
+  return ["blocked", "reap-required"].includes(report.plan.outcome) ? 1 : 0;
 }
 
 function assertVisibleRefusal(result, label) {

--- a/tests/diagnostics/composed-update-report.test.ts
+++ b/tests/diagnostics/composed-update-report.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+async function loadReportModule() {
+  return import("../../scripts/test-runners/composed-update-report.mjs");
+}
+
+function legacyReport() {
+  return {
+    schemaVersion: 1,
+    channel: "installer-binary",
+    status: "planned",
+    current: { version: "0.0.0-pre-alpha.5.16" },
+    target: { version: "0.0.1-local" },
+    steps: [
+      { id: "detect", status: "completed", detail: "Detected installer ownership." },
+      { id: "plan", status: "completed", detail: "Resolved the target." },
+      { id: "apply", status: "planned", detail: "Would install the target." },
+      { id: "observer-restart", status: "planned", detail: "Would restart the Observer." },
+      { id: "host-handoff", status: "skipped", detail: "No Host is running." },
+    ],
+    warnings: [],
+    recoveryCommands: [],
+  };
+}
+
+function currentReport() {
+  return {
+    schemaVersion: 4,
+    kind: "result",
+    channel: "installer-binary",
+    status: "updated",
+    current: { version: "0.0.0-local" },
+    target: { version: "0.0.1-local" },
+    steps: [],
+    warnings: [],
+    recoveryCommands: [],
+  };
+}
+
+describe("composed update report parsing", () => {
+  it("accepts the strict published-predecessor report", async () => {
+    const { parseComposedUpdateReport } = await loadReportModule();
+    const report = legacyReport();
+
+    expect(parseComposedUpdateReport(report, "0.0.0-pre-alpha.5.16")).toEqual(report);
+    expect(() =>
+      parseComposedUpdateReport({ ...report, unknown: true }, "0.0.0-pre-alpha.5.16"),
+    ).toThrow();
+    expect(() =>
+      parseComposedUpdateReport(
+        {
+          ...report,
+          steps: [{ ...report.steps[0], detail: "Unsafe detail.\n    at legacy-frame" }],
+        },
+        "0.0.0-pre-alpha.5.16",
+      ),
+    ).toThrow();
+  });
+
+  it("delegates current reports to the current shared contract", async () => {
+    const { parseComposedUpdateReport } = await loadReportModule();
+    const report = currentReport();
+
+    expect(parseComposedUpdateReport(report, "0.0.0-local")).toEqual(report);
+    expect(() =>
+      parseComposedUpdateReport({ ...report, status: "planned" }, "0.0.0-local"),
+    ).toThrow();
+  });
+
+  it.each([2, 3])("rejects unsupported report schema %i", async (schemaVersion) => {
+    const { parseComposedUpdateReport } = await loadReportModule();
+
+    expect(() =>
+      parseComposedUpdateReport({ ...legacyReport(), schemaVersion }, "0.0.0-pre-alpha.5.16"),
+    ).toThrow();
+  });
+
+  it("requires the report contract owned by the exact incumbent", async () => {
+    const { parseComposedUpdateReport } = await loadReportModule();
+
+    expect(() => parseComposedUpdateReport(legacyReport(), "0.0.0-local")).toThrow(
+      /Expected update report schema 4/u,
+    );
+    expect(() => parseComposedUpdateReport(currentReport(), "0.0.0-pre-alpha.5.16")).toThrow(
+      /Expected update report schema 1/u,
+    );
+  });
+});


### PR DESCRIPTION
## What this fixes

Station's release smoke must prove that the newest complete immutable predecessor can update to the candidate without mutating runtime state during preview. The published `.5.16` predecessor predates the current recovery-inventory method and emits update report schema v1, so the gate rejected its valid protocol/report surface before it could exercise the release candidate.

## What changed

- Snapshot recovery readiness, which is strict and unchanged across `.5.16` and the current Observer, during dry-run immutability checks.
- Parse the published predecessor's report v1 through a strict runner-local schema while keeping production contracts current-only.
- Allow v1 only for exact incumbent `0.0.0-pre-alpha.5.16`; every other incumbent must still emit current report v4.
- Preserve the exact legacy and current dry-run/result assertions, step ordering, recovery commands, and exit outcomes.
- Add focused coverage for both contracts, strict unknown-field rejection, unsupported versions, unsafe text, and incumbent/schema mismatches.

## Testing

- `bun run test:diagnostics -- tests/diagnostics/composed-update-report.test.ts` (5 passed)
- `bun run test:ci:binary` (native binary smoke plus current v4 update smoke; 3 update scenarios passed)
- Exact `.5.16 → .8.1` draft-asset update smoke with `--scenarios full --busy-host-outcome preserved-refusal` (3 scenarios passed)
- `bun run typecheck`
- `bun run lint`
- `bun run test:diagnostics` (184 passed)

## Safety and scope

This changes only release-test orchestration and diagnostics coverage. It does not widen production update contracts or alter runtime behavior.
