### PR TITLE
fix(doctor): report detached terminal topology truthfully

### DIFF
--- a/apps/observer/src/diagnostics/environmentCheck.ts
+++ b/apps/observer/src/diagnostics/environmentCheck.ts
@@ -6,32 +6,26 @@ import type {
 } from "@station/contracts";
 
 /**
- * Readable `stn doctor` summary of session terminal topology. Detached/stale
- * sessions or orphans warn; full per-session detail remains in the JSON snapshot.
+ * Readable `stn doctor` summary of session terminal topology. Stale sessions or
+ * orphans warn; detached targets remain visible in the provider/state tally.
  */
 export function buildSessionEnvironmentCheck(
   snapshot: Pick<StationSnapshot, "sessions" | "orphans">,
 ): DoctorCheck {
   const sessions = snapshot.sessions;
   const orphans = snapshot.orphans ?? [];
-  const detached = sessions.filter(isDetachedOrStale);
+  const stale = sessions.filter((session) => session.terminal?.state === "stale");
 
   const parts = [`${sessions.length} session(s)${summarizeProviders(sessions)}.`];
-  if (detached.length > 0) {
-    parts.push(
-      `${detached.length} detached/stale (running, not attachable here): ${describeSessions(detached)}.`,
-    );
+  if (stale.length > 0) {
+    parts.push(`${stale.length} stale terminal target(s): ${describeSessions(stale)}.`);
   }
   if (orphans.length > 0) {
     parts.push(`${orphans.length} orphaned runtime state(s)${summarizeOrphans(orphans)}.`);
   }
 
-  const status: DoctorCheck["status"] = detached.length > 0 || orphans.length > 0 ? "warn" : "ok";
+  const status: DoctorCheck["status"] = stale.length > 0 || orphans.length > 0 ? "warn" : "ok";
   return { name: "sessions", status, message: parts.join(" ") };
-}
-
-function isDetachedOrStale(session: SessionView): boolean {
-  return session.terminal?.state === "detached" || session.terminal?.state === "stale";
 }
 
 /** ` — station: 4 open · tmux: 3 detached` (empty for zero sessions). */

--- a/apps/observer/test/unit/environmentCheck.test.ts
+++ b/apps/observer/test/unit/environmentCheck.test.ts
@@ -42,7 +42,7 @@ describe("buildSessionEnvironmentCheck", () => {
     expect(check.message).toBe("1 session(s) — no terminal: 1.");
   });
 
-  it("warns and names detached sessions with their provider (the silent-click case)", () => {
+  it("reports detached sessions without claiming they are unreachable", () => {
     const check = buildSessionEnvironmentCheck({
       sessions: [
         session("adc0a0", "native", "open"),
@@ -51,20 +51,18 @@ describe("buildSessionEnvironmentCheck", () => {
       ],
       orphans: [],
     });
-    expect(check.status).toBe("warn");
+    expect(check.status).toBe("ok");
     expect(check.message).toContain("native: 1 open · tmux: 2 detached");
-    expect(check.message).toContain("2 detached/stale (running, not attachable here):");
-    expect(check.message).toContain("b83b75 [tmux]");
-    expect(check.message).toContain("ui-explore [tmux]");
+    expect(check.message).not.toContain("not attachable here");
   });
 
-  it("treats stale terminals as detached/stale too", () => {
+  it("warns and names stale terminals", () => {
     const check = buildSessionEnvironmentCheck({
       sessions: [session("x", "native", "stale")],
       orphans: [],
     });
     expect(check.status).toBe("warn");
-    expect(check.message).toContain("1 detached/stale");
+    expect(check.message).toContain("1 stale terminal target(s): x [native].");
   });
 
   it("warns on orphaned runtime states and counts them by kind", () => {
@@ -76,10 +74,10 @@ describe("buildSessionEnvironmentCheck", () => {
     expect(check.message).toContain("2 orphaned runtime state(s) (1 session, 1 terminal_target).");
   });
 
-  it("truncates the detached list past four with a +N more suffix", () => {
-    const detached = ["a", "b", "c", "d", "e", "f"].map((t) => session(t, "tmux", "detached"));
-    const check = buildSessionEnvironmentCheck({ sessions: detached, orphans: [] });
-    expect(check.message).toContain("6 detached/stale");
+  it("truncates the stale list past four with a +N more suffix", () => {
+    const stale = ["a", "b", "c", "d", "e", "f"].map((t) => session(t, "tmux", "stale"));
+    const check = buildSessionEnvironmentCheck({ sessions: stale, orphans: [] });
+    expect(check.message).toContain("6 stale terminal target(s)");
     expect(check.message).toContain("+2 more");
   });
 });

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -518,7 +518,7 @@ When Station "does nothing" or panes read "exited", inspect the `cli`, `tui`, an
 Other Station diagnostics:
 
 - A pane reading "terminal exited 1" on every local shell in a source checkout can indicate the node-pty `spawn-helper` exec-bit issue; see [Limitations and workarounds](limitations.md#source-checkout-panes-exit-immediately).
-- `stn doctor` includes a session/terminal check that reports a per-provider session breakdown (e.g. `station: 7 open · tmux: 4 detached`) and flags detached, stale, or orphaned sessions — useful when a row cannot be focused from Station.
+- `stn doctor` includes a session/terminal check that reports a per-provider session breakdown (e.g. `station: 7 open · tmux: 4 detached`) and flags stale terminal targets or orphaned runtime state. Detached targets remain visible in the tally without degrading health because Doctor has no active-renderer context.
 - Station persists its pane layout to `<state_dir>/station/layout.json` (override `STATION_LAYOUT_PATH`); a malformed or absent snapshot falls back to a single fresh shell.
 
 Station runtime files (alongside the observer state directory):


### PR DESCRIPTION
## What this fixes

The Observer Doctor session check owns a topology summary, but it treated every detached terminal as unreachable and degraded health. A detached tmux target can still be live and externally focusable, while Doctor has no active-renderer context with which to decide whether a user can land there.

This correction was split from #631; #729 owns that issue's narrowed reconciled-evidence contract.

## What changed

- Keep detached targets visible in the provider/state tally without warning on detachment alone.
- Warn and list stale terminal targets and orphaned runtime state.
- Remove the renderer-relative `not attachable here` claim.
- Update focused coverage and debugging guidance to match the corrected boundary.

## Testing

- Standard CI passed on current `main`, including static, fast, integration, setup E2E, Observer E2E, Station, SQLite cross-runtime, and binary-smoke lanes.
- `npx --yes bun@1.4.0 run typecheck`
- `npx --yes bun@1.4.0 run lint`
- Focused Doctor unit and previously flaky protocol-server integration suites passed after rebase.

## Safety and scope

This changes only Doctor interpretation and wording. It does not infer renderer-local openability, add terminal attachment evidence, change canonical session topology, or alter any TUI action.

## User-visible behavior

`stn doctor` still reports detached sessions in provider/state totals, but detached state alone no longer changes the sessions check to warning or claims the session is unreachable. Stale targets and orphans remain warnings.

Manual verification: run `stn doctor` with a detached tmux target, then with a stale target; only the stale topology should warn.
