### PR TITLE
test(tmux): isolate real popup acceptance

### DIFF
--- a/apps/cli/test/unit/real-station-config-support.test.ts
+++ b/apps/cli/test/unit/real-station-config-support.test.ts
@@ -1,23 +1,38 @@
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { writeRealStationConfig } from "../../../../tests/support/real-station/config.js";
 import type { RealE2eEnvironment } from "../../../../tests/support/real-station/env.js";
 import type { RealTempRepo } from "../../../../tests/support/real-station/repo.js";
 
 describe("real Station config support", () => {
   let root: string | undefined;
+  const endpointRoots: string[] = [];
 
   afterEach(async () => {
+    vi.unstubAllEnvs();
     if (root !== undefined) {
       await rm(root, { recursive: true, force: true });
       root = undefined;
     }
+    await Promise.all(
+      endpointRoots.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+    );
   });
 
   it("creates private Observer directories and writes scripted harness config", async () => {
     root = await mkdtemp(join(tmpdir(), "station-real-config-support-"));
+    const tmuxBin = join(root, "tmux path's");
+    await writeFile(
+      tmuxBin,
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: These are shell parameter expansions.
+      '#!/bin/sh\nprintf \'%s\\n\' "$@" > "$0.args"\nprintf \'%s\\n\' "${TMUX-unset}" "${TMUX_PANE-unset}" > "$0.env"\n',
+      "utf8",
+    );
+    await chmod(tmuxBin, 0o700);
+    vi.stubEnv("TMUX", "/ambient/hostile.sock,99,0");
+    vi.stubEnv("TMUX_PANE", "%99");
     const repo: RealTempRepo = {
       root,
       repoPath: join(root, "repo"),
@@ -29,6 +44,7 @@ describe("real Station config support", () => {
       repoRoot: "/station",
       stationBin: "/station/bin/stn",
       stationIngressBin: "/station/bin/stn-ingress",
+      tmuxBin,
       worktrunkBin: "/usr/local/bin/wt",
     };
 
@@ -38,15 +54,35 @@ describe("real Station config support", () => {
       harnessProvider: "scripted",
       scriptedCommand: "/usr/local/bin/node",
     });
+    endpointRoots.push(fixture.tmuxEndpoint.rootPath);
 
     await expect(directoryMode(fixture.stateDir)).resolves.toBe(0o700);
     await expect(directoryMode(join(root, "run"))).resolves.toBe(0o700);
-    await expect(readFile(fixture.configPath, "utf8")).resolves.toContain(
-      '[harness.scripted]\nenabled = true\ncommand = "/usr/local/bin/node"',
+    await expect(directoryMode(fixture.tmuxEndpoint.rootPath)).resolves.toBe(0o700);
+    await expect(directoryMode(fixture.tmuxEndpoint.wrapperPath)).resolves.toBe(0o700);
+    await expect(readFile(fixture.tmuxEndpoint.wrapperPath, "utf8")).resolves.toBe(
+      `#!/bin/sh\nexec '${tmuxBin.replaceAll("'", "'\\''")}' -f /dev/null "$@"\n`,
     );
+    await expect(readFile(`${tmuxBin}.args`, "utf8")).resolves.toBe(
+      `-f\n/dev/null\n-S\n${fixture.tmuxEndpoint.socketPath}\nnew-session\n-d\n-s\n_station-real-endpoint\nsleep 86400\n`,
+    );
+    await expect(readFile(`${tmuxBin}.env`, "utf8")).resolves.toBe("unset\nunset\n");
+    const config = await readFile(fixture.configPath, "utf8");
+    expect(config).toContain(
+      `[terminal.tmux]\ncommand = ${JSON.stringify(fixture.tmuxEndpoint.wrapperPath)}\nworkbench_socket_path = ${JSON.stringify(fixture.tmuxEndpoint.socketPath)}`,
+    );
+    expect(config).toContain('[harness.scripted]\nenabled = true\ncommand = "/usr/local/bin/node"');
+
+    const second = await writeRealStationConfig({
+      env,
+      repo,
+      harnessProvider: "scripted",
+      scriptedCommand: "/usr/local/bin/node",
+      tmuxSession: "station-real-second",
+    });
+    endpointRoots.push(second.tmuxEndpoint.rootPath);
+    expect(second.tmuxEndpoint.rootPath).not.toBe(fixture.tmuxEndpoint.rootPath);
   });
 });
 
-async function directoryMode(path: string): Promise<number> {
-  return (await stat(path)).mode & 0o777;
-}
+const directoryMode = async (path: string): Promise<number> => (await stat(path)).mode & 0o777;

--- a/apps/cli/test/unit/real-station-tmux-support.test.ts
+++ b/apps/cli/test/unit/real-station-tmux-support.test.ts
@@ -1,52 +1,436 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { appendFile, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RealE2eEnvironment } from "../../../../tests/support/real-station/env.js";
 
-const execFile = vi.hoisted(() => vi.fn());
+const execFileAsync = vi.hoisted(() => vi.fn());
+const spawn = vi.hoisted(() => vi.fn());
 
-vi.mock("node:child_process", () => ({
-  execFile: (
-    file: string,
-    args: string[],
-    options: unknown,
-    callback: (error: Error | null, stdout: string, stderr: string) => void,
-  ) => {
-    execFile(file, args, options);
-    callback(null, "", "");
-  },
-  spawn: vi.fn(),
-}));
+vi.mock("node:child_process", () => {
+  const execFile = (): never => {
+    throw new Error("Unexpected callback-form execFile invocation.");
+  };
+  Object.defineProperty(execFile, Symbol.for("nodejs.util.promisify.custom"), {
+    value: (file: string, args: string[], options: unknown) => execFileAsync(file, args, options),
+  });
+  return { execFile, spawn: (...args: unknown[]) => spawn(...args) };
+});
 
-import { startStationTuiInTmux } from "../../../../tests/support/real-station/tmux.js";
+import {
+  closeRealTmuxEndpoint,
+  createRealTmuxEndpoint,
+  displayStationPopupAndSendKey,
+  killTmuxSession,
+  launchNativeStationInTmux,
+  type RealTmuxEndpoint,
+  startAttachedTmuxPtyClient,
+  startStationTuiInTmux,
+} from "../../../../tests/support/real-station/tmux.js";
 
 describe("real Station tmux support", () => {
+  const roots: string[] = [];
+
   beforeEach(() => {
-    execFile.mockClear();
+    execFileAsync.mockReset();
+    spawn.mockReset();
+    mockTmux(() => succeed());
+    process.env.TMUX = "/ambient,1,0";
+    process.env.TMUX_PANE = "%99";
   });
 
-  it("launches the dashboard entry in the captured tmux viewport", async () => {
-    const env: RealE2eEnvironment = {
-      repoRoot: "/repo",
-      stationBin: "/repo/bin/stn",
-      stationIngressBin: "/repo/bin/stn-ingress",
-      tmuxBin: "/opt/homebrew/bin/tmux",
-    };
+  afterEach(async () => {
+    delete process.env.TMUX;
+    delete process.env.TMUX_PANE;
+    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  });
 
+  it("launches the dashboard through the exact private endpoint", async () => {
+    const endpoint = testEndpoint();
     await startStationTuiInTmux({
-      env,
+      env: TEST_ENVIRONMENT,
+      endpoint,
       configPath: "/tmp/station config.toml",
       sessionName: "station-real-tui",
     });
+    const [file, args, options] = execFileAsync.mock.calls[0] as DirectCall;
+    expect(file).toBe(endpoint.wrapperPath);
+    expect(args).toEqual([
+      "-S",
+      endpoint.socketPath,
+      "new-session",
+      "-d",
+      "-s",
+      "station-real-tui",
+      "'/repo/bin/stn' --config '/tmp/station config.toml' tui --popup",
+    ]);
+    expect(options.env).not.toHaveProperty("TMUX");
+    expect(options.env).not.toHaveProperty("TMUX_PANE");
+  });
 
-    expect(execFile).toHaveBeenCalledWith(
-      "/opt/homebrew/bin/tmux",
-      [
-        "new-session",
-        "-d",
-        "-s",
-        "station-real-tui",
-        "'/repo/bin/stn' --config '/tmp/station config.toml' tui --popup",
-      ],
-      { timeout: 10_000 },
+  it("uses the private endpoint for spawned clients and retains spawn failure", async () => {
+    const endpoint = testEndpoint();
+    spawn.mockReturnValue(fakeChild());
+    let polls = 0;
+    mockTmux((args) => {
+      if (!args.includes("list-clients")) return succeed();
+      return succeed(++polls === 1 ? BASELINE_CLIENTS : MULTIPLE_CLIENTS);
+    });
+
+    await expect(
+      startAttachedTmuxPtyClient({ endpoint, sessionName: "workbench" }),
+    ).rejects.toMatchObject(failureErrors('"name":"new-b"'));
+    const spawnedArgs = spawn.mock.calls[0]?.[1] as string[];
+    const spawnedOptions = spawn.mock.calls[0]?.[2] as { env: NodeJS.ProcessEnv };
+    expect(spawnedArgs.slice(4, 7)).toEqual([endpoint.wrapperPath, "-S", endpoint.socketPath]);
+    expect(spawnedOptions.env).not.toHaveProperty("TMUX");
+    expect(spawnedOptions.env).not.toHaveProperty("TMUX_PANE");
+
+    spawn.mockImplementation(() => fakeChild(undefined, null, new Error("spawn ENOENT")));
+    mockTmux((args) => succeed(args.includes("list-clients") ? BASELINE_CLIENTS : ""));
+    await expect(
+      startAttachedTmuxPtyClient({ endpoint, sessionName: "workbench" }),
+    ).rejects.toMatchObject(failureErrors("did not expose a process id", "spawn ENOENT"));
+  });
+
+  it("retains detach failure and PTY data emitted between exit and close", async () => {
+    const endpoint = testEndpoint();
+    const child = fakeChild("final-close-evidence");
+    const closeEvents = vi.fn();
+    child.on("close", closeEvents);
+    spawn.mockReturnValue(child);
+    let polls = 0;
+    mockTmux((args) => {
+      if (args.includes("list-clients"))
+        return succeed(++polls === 1 ? BASELINE_CLIENTS : ONE_CLIENT);
+      if (args.includes("display-message")) return succeed("new\t20\tworkbench\tagent\t%7\n");
+      if (args.includes("detach-client")) return fail(1, "detach denied\n");
+      return succeed();
+    });
+
+    const client = await startAttachedTmuxPtyClient({ endpoint, sessionName: "workbench" });
+    const firstClose = client.close();
+    const concurrentClose = client.close();
+    await expect(firstClose).rejects.toMatchObject({
+      errors: [expect.objectContaining({ message: expect.stringContaining("detach denied") })],
+      message: expect.stringContaining("final-close-evidence"),
+    });
+    await expect(concurrentClose).resolves.toBeUndefined();
+    await expect(client.close()).resolves.toBeUndefined();
+    expect(commandCalls("display-message")).toHaveLength(1);
+    expect(commandCalls("detach-client")).toHaveLength(1);
+    expect(closeEvents).toHaveBeenCalledOnce();
+  });
+
+  it("classifies exact absence, aggregates partial initialization, and retains uncertain roots", async () => {
+    const endpoint = testEndpoint();
+    mockTmux(() => fail(1, "can't find session: missing\n"));
+    await expect(killTmuxSession(endpoint, "missing")).resolves.toBeUndefined();
+
+    mockTmux(() => fail(1, "can't find session: other\n"));
+    await expect(killTmuxSession(endpoint, "missing")).rejects.toThrow("other");
+
+    const removed = testEndpoint(await temporaryRoot());
+    mockTmux((args) =>
+      args.includes("kill-server")
+        ? succeed()
+        : fail(1, `error connecting to ${removed.socketPath} (No such file or directory)\n`),
+    );
+    await closeRealTmuxEndpoint(removed);
+    await expect(stat(removed.rootPath)).rejects.toMatchObject({ code: "ENOENT" });
+
+    const retained = testEndpoint(await temporaryRoot());
+    mockTmux((args) => (args.includes("kill-server") ? succeed() : fail(1, "permission denied\n")));
+    await expect(closeRealTmuxEndpoint(retained)).rejects.toThrow("permission denied");
+    await expect(stat(retained.rootPath)).resolves.toBeDefined();
+
+    let initializationRoot: string | undefined;
+    mockTmux((args, file) => {
+      initializationRoot = dirname(file);
+      return args.includes("new-session")
+        ? fail(1, "initialization failed\n")
+        : fail(1, "cleanup failed\n");
+    });
+    await expect(createRealTmuxEndpoint(TEST_ENVIRONMENT)).rejects.toMatchObject(
+      failureErrors("initialization failed", "cleanup failed"),
+    );
+    if (initializationRoot === undefined) throw new Error("Initialization did not invoke tmux.");
+    roots.push(initializationRoot);
+    await expect(stat(initializationRoot)).resolves.toBeDefined();
+  });
+
+  it("performs zero writes after tuple drift or popup settlement", async () => {
+    await expectNoPopupWrite(
+      await popupHarness({
+        drainOnClose: true,
+        views: [CLIENT_VIEW, "new\t20\tworkbench\twrong\t%7\n", CLIENT_VIEW],
+      }),
+      "before input",
+    );
+    await expectNoPopupWrite(await popupHarness({ settleOnOpen: true }), "settled");
+  });
+
+  it("waits for the current nonced start despite stale popup artifacts", async () => {
+    const start = Promise.withResolvers<void>();
+    const current = await popupHarness({ startGate: start.promise });
+    const oldStartMarker = `${POPUP_START}:${OLD_POPUP_NONCE}`;
+    const oldReleasePath = `${current.markerPath}.${OLD_POPUP_NONCE}.release`;
+    await writeFile(current.markerPath, `${oldStartMarker}\n`, "utf8");
+    await writeFile(oldReleasePath, "release\n", "utf8");
+    const opening = current.open();
+    await vi.waitFor(() => expect(current.state.startMarker).toBeDefined());
+    expect(current.state.startMarker).not.toBe(oldStartMarker);
+    expect(current.state.releasePath).not.toBe(oldReleasePath);
+    expect(current.write).not.toHaveBeenCalled();
+    start.resolve();
+    const popup = await opening;
+    expect(current.write).toHaveBeenCalledOnce();
+    await appendFile(current.markerPath, "child-exit:0\n", "utf8");
+    current.settle({ code: 0 });
+    await popup.release(true);
+    await expect(readFile(current.state.releasePath as string, "utf8")).resolves.toBe("release\n");
+  });
+
+  it("writes once and accepts only exact child-zero, empty signal-free 129 evidence", async () => {
+    const accepted = await popupHarness();
+    const popup = await accepted.open();
+    expect(accepted.write).toHaveBeenCalledExactlyOnceWith(Buffer.from("1", "utf8"));
+    await appendFile(accepted.markerPath, "child-exit:0\n", "utf8");
+    accepted.settle({ code: 129 });
+    const release = popup.release(true);
+    expect(popup.release(false)).toBe(release);
+    await release;
+
+    for (const invalid of [
+      { child: "child-exit:1\n", settlement: { code: 0 } },
+      { child: "child-exit:0\n", settlement: { code: 129, stderr: "dismissed\n" } },
+      { child: "child-exit:0\n", settlement: { code: 129, signal: "SIGTERM" as const } },
+    ]) {
+      const rejected = await popupHarness();
+      const rejectedPopup = await rejected.open();
+      await appendFile(rejected.markerPath, invalid.child, "utf8");
+      rejected.settle(invalid.settlement);
+      await expect(rejectedPopup.release(true)).rejects.toThrow();
+    }
+  });
+
+  it("closes and drains the exact popup after rejected key delivery", async () => {
+    const rejected = await popupHarness(
+      { drainOnClose: true },
+      vi.fn().mockRejectedValue(new Error("key rejected")),
+    );
+    await expect(rejected.open()).rejects.toMatchObject({
+      errors: [expect.objectContaining({ message: "key rejected" })],
+      message: expect.stringContaining("PTY evidence"),
+    });
+    expect(rejected.state.closes).toBe(1);
+    await expect(readFile(rejected.state.releasePath as string, "utf8")).resolves.toBe("release\n");
+  });
+
+  it("kills only a successfully created native session and aggregates cleanup failure", async () => {
+    const input = {
+      env: TEST_ENVIRONMENT,
+      endpoint: testEndpoint(),
+      configPath: "/tmp/config.toml",
+      observerSocketPath: "/tmp/observer.sock",
+      stateDir: "/tmp/state",
+      sessionName: "native",
+    };
+    mockTmux((args) =>
+      args.includes("new-session") ? fail(1, "new-session failed\n") : succeed(),
+    );
+    await expect(launchNativeStationInTmux(input)).rejects.toThrow("new-session failed");
+    expect(execFileAsync.mock.calls.some((call) => call[1].includes("kill-session"))).toBe(false);
+
+    execFileAsync.mockClear();
+    mockTmux((args) => {
+      if (args.includes("new-session")) return succeed();
+      if (args.includes("set-option")) return fail(1, "mouse setup failed\n");
+      if (args.includes("kill-session")) return fail(1, "native cleanup failed\n");
+      return succeed();
+    });
+    await expect(launchNativeStationInTmux(input)).rejects.toMatchObject(
+      failureErrors("mouse setup failed", "native cleanup failed"),
     );
   });
+
+  async function temporaryRoot(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), "station-tmux-unit-"));
+    roots.push(root);
+    return root;
+  }
+
+  async function popupHarness(options: PopupOptions = {}, write = vi.fn(async () => undefined)) {
+    const markerPath = join(await temporaryRoot(), "marker");
+    const settlement = Promise.withResolvers<ExecResult>();
+    const state = {
+      closes: 0,
+      releasePath: undefined as string | undefined,
+      settled: false,
+      startMarker: undefined as string | undefined,
+    };
+    const settle = (result: PopupSettlement): void => {
+      if (state.settled) throw new Error("popup settlement repeated");
+      state.settled = true;
+      if (result.code === 0) settlement.resolve({ stderr: "", stdout: "" });
+      else settlement.reject(tmuxError(result.code, result.stderr ?? "", result.signal ?? null));
+    };
+    let viewIndex = 0;
+    mockTmux((args) => {
+      if (args.includes("display-message"))
+        return succeed(options.views?.[viewIndex++] ?? CLIENT_VIEW);
+      if (args.includes("display-popup") && args.includes("-C")) {
+        expect(args.slice(2)).toEqual(["display-popup", "-c", "new", "-C"]);
+        state.closes += 1;
+        if (options.drainOnClose === true && !state.settled) settle({ code: 0 });
+        return succeed();
+      }
+      if (!args.includes("display-popup")) return succeed();
+      expect(args.slice(2, 7)).toEqual(["display-popup", "-c", "new", "-t", "workbench:agent.0"]);
+      const match = POPUP_START_PATTERN.exec(args.at(-1) ?? "");
+      if (match === null) throw new Error("popup invocation did not include its nonce");
+      state.startMarker = match[0];
+      state.releasePath = `${markerPath}.${match[1]}.release`;
+      void Promise.resolve(options.startGate)
+        .then(() => writeFile(markerPath, `${state.startMarker}\n`, "utf8"))
+        .then(() => {
+          if (options.settleOnOpen === true) settle({ code: 0 });
+        }, settlement.reject);
+      return settlement.promise;
+    });
+    const client = {
+      clientName: "new",
+      clientPid: 20,
+      processId: 77,
+      sessionName: "workbench",
+      write,
+      outputTail: () => "\nPTY evidence",
+      close: async () => undefined,
+    };
+    const input: Parameters<typeof displayStationPopupAndSendKey>[0] = {
+      env: TEST_ENVIRONMENT,
+      endpoint: testEndpoint(),
+      client,
+      configPath: "/tmp/config.toml",
+      target: "workbench:agent.0",
+      expectedWindowName: "agent",
+      expectedPaneId: "%7",
+      key: "1",
+      markerPath,
+      delaySeconds: 0,
+    };
+    return { markerPath, open: () => displayStationPopupAndSendKey(input), settle, state, write };
+  }
+
+  async function expectNoPopupWrite(
+    popup: Awaited<ReturnType<typeof popupHarness>>,
+    message: string,
+  ): Promise<void> {
+    await expect(popup.open()).rejects.toMatchObject(failureErrors(message));
+    expect(popup.write).not.toHaveBeenCalled();
+  }
 });
+
+const POPUP_START = "popup-started:new:20:workbench:agent.0";
+const POPUP_START_PATTERN = /popup-started:new:20:workbench:agent\.0:([\da-f-]{36})/u;
+const OLD_POPUP_NONCE = "11111111-1111-4111-8111-111111111111";
+const CLIENT_VIEW = "new\t20\tworkbench\tagent\t%7\n";
+const BASELINE_CLIENTS = "old\t10\tworkbench\n";
+const ONE_CLIENT = `${BASELINE_CLIENTS}new\t20\tworkbench\n`;
+const MULTIPLE_CLIENTS = `${BASELINE_CLIENTS}new-a\t20\tworkbench\nnew-b\t21\tworkbench\n`;
+
+type DirectCall = [string, string[], { env: NodeJS.ProcessEnv }];
+type ExecResult = { stderr: string; stdout: string };
+type PopupOptions = {
+  drainOnClose?: boolean;
+  settleOnOpen?: boolean;
+  startGate?: Promise<void>;
+  views?: string[];
+};
+type PopupSettlement = { code: number; stderr?: string; signal?: NodeJS.Signals };
+
+function testEndpoint(rootPath = "/private"): RealTmuxEndpoint {
+  return {
+    rootPath,
+    socketPath: join(rootPath, "server.sock"),
+    wrapperPath: join(rootPath, "tmux"),
+  };
+}
+
+const commandCalls = (command: string) =>
+  execFileAsync.mock.calls.filter((call) => call[1].includes(command));
+
+const TEST_ENVIRONMENT: RealE2eEnvironment = {
+  repoRoot: "/repo",
+  stationBin: "/repo/bin/stn",
+  stationIngressBin: "/repo/bin/stn-ingress",
+  tmuxBin: "/opt/homebrew/bin/tmux",
+};
+
+function mockTmux(handler: (args: string[], file: string) => Promise<ExecResult>): void {
+  execFileAsync.mockImplementation(
+    (file: string, args: string[], options: { env: NodeJS.ProcessEnv }) => {
+      expect(args.slice(0, 2)).toEqual(["-S", join(dirname(file), "server.sock")]);
+      expect(options.env).not.toHaveProperty("TMUX");
+      expect(options.env).not.toHaveProperty("TMUX_PANE");
+      return handler(args, file);
+    },
+  );
+}
+
+const fail = (code: number, stderr: string) => Promise.reject(tmuxError(code, stderr));
+
+function tmuxError(code: number, stderr: string, signal: NodeJS.Signals | null = null) {
+  return Object.assign(new Error(stderr || `tmux exited ${code}`), {
+    code,
+    killed: false,
+    signal,
+    stderr,
+    stdout: "",
+  });
+}
+
+const succeed = (stdout = "", stderr = "") => Promise.resolve({ stderr, stdout });
+
+const failureErrors = (...messages: string[]) => ({
+  errors: messages.map((message) =>
+    expect.objectContaining({ message: expect.stringContaining(message) }),
+  ),
+});
+
+function fakeChild(
+  finalEvidence?: string,
+  pid: number | null = 77,
+  spawnFailure?: Error,
+): ChildProcess {
+  const child = Object.assign(new EventEmitter(), {
+    exitCode: null,
+    kill: vi.fn(),
+    pid: pid ?? undefined,
+    signalCode: null,
+    stderr: new PassThrough(),
+    stdin: new PassThrough(),
+    stdout: new PassThrough(),
+  }) as unknown as ChildProcess;
+  let closed = false;
+  const close = (): void => {
+    if (closed) return;
+    closed = true;
+    child.emit("close", spawnFailure === undefined ? 0 : 1, null);
+  };
+  child.stdin?.once("finish", () => {
+    child.emit("exit", 0, null);
+    if (finalEvidence !== undefined) child.stderr?.write(finalEvidence);
+    queueMicrotask(close);
+  });
+  if (spawnFailure !== undefined) {
+    queueMicrotask(() => {
+      child.emit("error", spawnFailure);
+      close();
+    });
+  }
+  return child;
+}

--- a/tests/e2e/real/README.md
+++ b/tests/e2e/real/README.md
@@ -54,9 +54,9 @@ bun run test:e2e:real:local tests/e2e/real/real-native-tui-mouse.test.ts
 
 ## Isolation
 
-Each test uses a temporary local clone of this repository, a temporary station config, a temporary Worktrunk config, unique private tmux sessions, a unique observer socket, and a temporary SQLite state directory. Observer state and socket directories are created with exact `0700` permissions. Codex scenarios additionally own a private `CODEX_HOME`, and the native mouse test owns its attached PTY client and native Station process.
+Each generated config owns a separate short `0700` tmux endpoint root outside its temporary repository clone. Its wrapper adds only `-f /dev/null`; the config and fixture helpers select the private socket. Tests also use a temporary station config, Worktrunk config, observer socket, SQLite state directory, and local clone. Codex scenarios additionally own a private `CODEX_HOME`, and the native mouse test owns its attached PTY client and native Station process.
 
-The active checkout is never passed to Worktrunk as the project root. Cleanup kills the unique tmux sessions, stops the observer, removes created Worktrunk branches/worktrees where possible, and removes the temp clone. Product cleanup treats an already-absent terminal as retired while preserving unrelated provider failures; the scripted stale-pane scenario exercises both stale replacement and terminal-absent session close.
+The active checkout is never passed to Worktrunk as the project root. Cleanup kills only the explicit private tmux server, proves that endpoint unreachable, and then removes its root (including retained socket pathnames); uncertain endpoint failures retain the root for diagnosis. Observer, Worktrunk, and clone cleanup remain independent. Product cleanup treats an already-absent terminal as retired while preserving unrelated provider failures; the scripted stale-pane scenario exercises both stale replacement and terminal-absent session close.
 
 Set `STATION_REAL_E2E_KEEP_TEMP=1` while debugging a failure to leave the observer, tmux session, Worktrunk state, and temp clone in place. Clean those resources manually after inspection.
 

--- a/tests/e2e/real/real-claude-hooks.test.ts
+++ b/tests/e2e/real/real-claude-hooks.test.ts
@@ -19,7 +19,8 @@ import { createRealTempRepo, uniqueBranch } from "../../support/real-station/rep
 import {
   activeTmuxPane,
   captureTmuxPane,
-  killTmuxSession,
+  closeRealTmuxEndpoint,
+  type RealTmuxEndpoint,
   sendTmuxKeys,
 } from "../../support/real-station/tmux";
 import { removeRealWorktrunkWorktree } from "../../support/real-station/worktrunk";
@@ -55,6 +56,7 @@ describeReal("real Claude hook ingestion", () => {
       harnessProvider: "claude",
       installClaudeHooks: true,
     });
+    cleanup.defer(() => closeRealTmuxEndpoint(config.tmuxEndpoint));
     await installClaudeHookProjectConfig({
       env,
       repo,
@@ -64,12 +66,8 @@ describeReal("real Claude hook ingestion", () => {
       await runStationJson(env, {
         configPath: config.configPath,
         args: ["observer", "stop"],
-      }).catch(() => undefined);
+      });
     });
-    cleanup.defer(async () => {
-      await killTmuxSession(env, config.tmuxSession);
-    });
-
     const branch = uniqueBranch("claude-hooks");
     cleanup.defer(async () => {
       await removeRealWorktrunkWorktree({ env, config, repo, branch });
@@ -109,7 +107,7 @@ describeReal("real Claude hook ingestion", () => {
         branch,
         timeoutMs: 90_000,
       });
-      await continuePastClaudeTrustDialog(env, config.tmuxSession, row);
+      await continuePastClaudeTrustDialog(config.tmuxEndpoint, config.tmuxSession, row);
       await waitForClaudeSentinel(sentinel, { rootPath: row.path, timeoutMs: 240_000 });
       const idleRow = await waitForRowAgentState({
         env,
@@ -210,12 +208,12 @@ async function waitForRowTerminalAttachment(input: {
 }
 
 async function continuePastClaudeTrustDialog(
-  env: RealE2eEnvironment,
+  endpoint: RealTmuxEndpoint,
   tmuxSession: string,
   row: StationSnapshot["rows"][number],
 ): Promise<void> {
   const target = await activeTmuxPane(
-    env,
+    endpoint,
     `${tmuxSession}:${buildWorkbenchWindowName({
       projectId: row.projectId,
       branch: row.branch,
@@ -225,9 +223,9 @@ async function continuePastClaudeTrustDialog(
   );
   const deadline = Date.now() + 30_000;
   while (Date.now() <= deadline) {
-    const captured = await captureTmuxPane({ env, target });
+    const captured = await captureTmuxPane({ endpoint, target });
     if (captured.includes("Yes, I trust this folder")) {
-      await sendTmuxKeys({ env, target, keys: ["Enter"] });
+      await sendTmuxKeys({ endpoint, target, keys: ["Enter"] });
       return;
     }
     await new Promise((resolve) => setTimeout(resolve, 500));

--- a/tests/e2e/real/real-codex-hooks.test.ts
+++ b/tests/e2e/real/real-codex-hooks.test.ts
@@ -25,7 +25,8 @@ import { createRealTempRepo, uniqueBranch } from "../../support/real-station/rep
 import {
   activeTmuxPane,
   captureTmuxPane,
-  killTmuxSession,
+  closeRealTmuxEndpoint,
+  type RealTmuxEndpoint,
   sendTmuxKeys,
 } from "../../support/real-station/tmux";
 import { removeRealWorktrunkWorktree } from "../../support/real-station/worktrunk";
@@ -67,17 +68,14 @@ describeReal("real Codex hook ingestion", () => {
         args: notify.args,
       },
     });
+    cleanup.defer(() => closeRealTmuxEndpoint(config.tmuxEndpoint));
     await codex.installHooks(config);
     cleanup.defer(async () => {
       await runStationJson(testEnv, {
         configPath: config.configPath,
         args: ["observer", "stop"],
-      }).catch(() => undefined);
+      });
     });
-    cleanup.defer(async () => {
-      await killTmuxSession(testEnv, config.tmuxSession);
-    });
-
     const branch = uniqueBranch("codex-hooks");
     cleanup.defer(async () => {
       await removeRealWorktrunkWorktree({ env: testEnv, config, repo, branch });
@@ -117,7 +115,7 @@ describeReal("real Codex hook ingestion", () => {
         branch,
         timeoutMs: 90_000,
       });
-      await continuePastCodexStartupPrompts(testEnv, config.tmuxSession, row);
+      await continuePastCodexStartupPrompts(config.tmuxEndpoint, config.tmuxSession, row);
       await waitForCodexSentinel(sentinel, { rootPath: row.path, timeoutMs: 240_000 });
       const idleRow = await waitForRowAgentState({
         env: testEnv,
@@ -234,12 +232,12 @@ async function waitForRowTerminalAttachment(input: {
 }
 
 async function continuePastCodexStartupPrompts(
-  env: RealE2eEnvironment,
+  endpoint: RealTmuxEndpoint,
   tmuxSession: string,
   row: StationSnapshot["rows"][number],
 ): Promise<void> {
   const target = await activeTmuxPane(
-    env,
+    endpoint,
     `${tmuxSession}:${buildWorkbenchWindowName({
       projectId: row.projectId,
       branch: row.branch,
@@ -249,12 +247,12 @@ async function continuePastCodexStartupPrompts(
   );
   const deadline = Date.now() + 30_000;
   while (Date.now() <= deadline) {
-    const captured = await captureTmuxPane({ env, target });
+    const captured = await captureTmuxPane({ endpoint, target });
     if (captured.includes("Do you trust the contents of this directory?")) {
-      await sendTmuxKeys({ env, target, keys: ["1", "Enter"] });
+      await sendTmuxKeys({ endpoint, target, keys: ["1", "Enter"] });
     }
     if (captured.includes("hooks need review") && captured.includes("Press t to trust all")) {
-      await sendTmuxKeys({ env, target, keys: ["t"] });
+      await sendTmuxKeys({ endpoint, target, keys: ["t"] });
       return;
     }
     await new Promise((resolve) => setTimeout(resolve, 500));

--- a/tests/e2e/real/real-existing-worktree-start-agent.test.ts
+++ b/tests/e2e/real/real-existing-worktree-start-agent.test.ts
@@ -15,7 +15,7 @@ import {
 } from "../../support/real-station/env";
 import { CleanupStack, runStationJson } from "../../support/real-station/process";
 import { createRealTempRepo, uniqueBranch } from "../../support/real-station/repo";
-import { killTmuxSession } from "../../support/real-station/tmux";
+import { closeRealTmuxEndpoint } from "../../support/real-station/tmux";
 import {
   createRealWorktrunkWorktree,
   removeRealWorktrunkWorktree,
@@ -53,17 +53,14 @@ describeReal("real existing Worktrunk worktree start-agent", () => {
       codexCommand: codex.codexCommand,
       installCodexHooks: true,
     });
+    cleanup.defer(() => closeRealTmuxEndpoint(config.tmuxEndpoint));
     await codex.installHooks(config);
     cleanup.defer(async () => {
       await runStationJson(testEnv, {
         configPath: config.configPath,
         args: ["observer", "stop"],
-      }).catch(() => undefined);
+      });
     });
-    cleanup.defer(async () => {
-      await killTmuxSession(testEnv, config.tmuxSession);
-    });
-
     const branch = uniqueBranch("existing");
     cleanup.defer(async () => {
       await removeRealWorktrunkWorktree({ env: testEnv, config, repo, branch });

--- a/tests/e2e/real/real-native-tui-mouse.test.ts
+++ b/tests/e2e/real/real-native-tui-mouse.test.ts
@@ -38,10 +38,10 @@ import { createRealTempRepo } from "../../support/real-station/repo";
 import {
   type AttachedTmuxPtyClient,
   captureTmuxPane,
+  closeRealTmuxEndpoint,
   killTmuxSession,
   launchNativeStationInTmux,
   startAttachedTmuxPtyClient,
-  tmuxSessionExists,
 } from "../../support/real-station/tmux";
 import { removeRealWorktrunkWorktree } from "../../support/real-station/worktrunk";
 
@@ -85,6 +85,7 @@ describeReal("real native Station mouse input", () => {
       codexCommand: codex.codexCommand,
       installCodexHooks: true,
     });
+    cleanup.defer(() => closeRealTmuxEndpoint(config.tmuxEndpoint));
     await writeFile(
       config.configPath,
       `${(await readFile(config.configPath, "utf8")).replace(
@@ -106,10 +107,7 @@ describeReal("real native Station mouse input", () => {
         configPath: config.configPath,
         args: ["observer", "stop"],
         env: isolatedStationEnv(config),
-      }).catch(() => undefined);
-    });
-    cleanup.defer(async () => {
-      await killTmuxSession(testEnv, config.tmuxSession);
+      });
     });
     cleanup.defer(async () => {
       await removeRealWorktrunkWorktree({ env: testEnv, config, repo, branch });
@@ -158,7 +156,7 @@ describeReal("real native Station mouse input", () => {
       );
       const createdRow = findRowByBranch(created, branch);
       await waitForCodexSentinel(sentinel, { rootPath: createdRow.path, timeoutMs: 180_000 });
-      await killTmuxSession(testEnv, config.tmuxSession);
+      await killTmuxSession(config.tmuxEndpoint, config.tmuxSession);
       const dormant = await waitForSnapshot(
         client,
         (snapshot: StationSnapshot) => {
@@ -203,6 +201,7 @@ describeReal("real native Station mouse input", () => {
 
       const launched = await launchNativeStationInTmux({
         env: testEnv,
+        endpoint: config.tmuxEndpoint,
         configPath: config.configPath,
         observerSocketPath: config.socketPath,
         stateDir: config.stateDir,
@@ -210,11 +209,8 @@ describeReal("real native Station mouse input", () => {
         cwd: repo.repoPath,
         dimensions: NATIVE_DIMENSIONS,
       });
-      cleanup.defer(async () => {
-        await killTmuxSession(testEnv, nativeSession);
-      });
       const ptyClient = await startAttachedTmuxPtyClient({
-        env: testEnv,
+        endpoint: config.tmuxEndpoint,
         sessionName: nativeSession,
         dimensions: NATIVE_DIMENSIONS,
       });
@@ -232,7 +228,7 @@ describeReal("real native Station mouse input", () => {
         runtime,
         (frame) =>
           frame.includes("[shell]") &&
-          frame.includes(`╭ ▼ ${groupName} 1 session`) &&
+          frame.includes(`▼ ${groupName} 1 session`) &&
           hasDashboardSessionRow(frame, branch),
         "The native-only Station overlay did not render its Group and real session.",
       );
@@ -274,7 +270,7 @@ describeReal("real native Station mouse input", () => {
         (frame) => frame.includes(`▶ ${groupName}`) && !hasDashboardSessionRow(frame, branch),
         "The deliberate native Group click did not collapse exactly once.",
       );
-      await writeSgrClick(ptyClient, groupCell);
+      await writeSgrClick(ptyClient, cellForText(await captureNativeFrame(runtime), groupName));
       await waitForNativeFrame(
         runtime,
         (frame) => frame.includes(`▼ ${groupName}`) && hasDashboardSessionRow(frame, branch),
@@ -466,8 +462,6 @@ describeReal("real native Station mouse input", () => {
         expect(await waitForPidExit(nativePid, 10_000)).toBe(true);
         expect(await waitForPidExit(attachedClientPid, 10_000)).toBe(true);
         expect(await waitForPidExit(observerPid, 10_000)).toBe(true);
-        expect(await tmuxSessionExists(testEnv, nativeSession)).toBe(false);
-        expect(await tmuxSessionExists(testEnv, config.tmuxSession)).toBe(false);
         expect(await pathExists(worktreePath)).toBe(false);
         expect(await pathExists(repo.root)).toBe(false);
       }
@@ -603,7 +597,7 @@ async function waitForSnapshotWithDiagnostics(
 
 async function captureNativeFrame(runtime: NativeRuntime, styled = false): Promise<string> {
   return captureTmuxPane({
-    env: runtime.env,
+    endpoint: runtime.config.tmuxEndpoint,
     target: runtime.target,
     styled,
     preserveTrailingSpaces: true,

--- a/tests/e2e/real/real-popup-navigation.test.ts
+++ b/tests/e2e/real/real-popup-navigation.test.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import type { StationSnapshot } from "@station/contracts";
+import type { StationEvent, StationSnapshot } from "@station/contracts";
 import { buildWorkbenchWindowName } from "@station/tmux";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import { findRowByBranch } from "../../support/real-station/assertions";
@@ -20,9 +20,10 @@ import {
 import { createRealTempRepo, uniqueBranch } from "../../support/real-station/repo";
 import {
   activeTmuxPane,
-  activeTmuxWindow,
+  closeRealTmuxEndpoint,
   displayStationPopupAndSendKey,
-  killTmuxSession,
+  inspectTmuxClient,
+  startAttachedTmuxPtyClient,
 } from "../../support/real-station/tmux";
 import {
   createRealWorktrunkWorktree,
@@ -55,17 +56,14 @@ describeReal("real tmux popup navigation", () => {
       codexCommand: codex.codexCommand,
       installCodexHooks: true,
     });
+    cleanup.defer(() => closeRealTmuxEndpoint(config.tmuxEndpoint));
     await codex.installHooks(config);
     cleanup.defer(async () => {
       await runStationJson(testEnv, {
         configPath: config.configPath,
         args: ["observer", "stop"],
-      }).catch(() => undefined);
+      });
     });
-    cleanup.defer(async () => {
-      await killTmuxSession(testEnv, config.tmuxSession);
-    });
-
     const branch = uniqueBranch("popup");
     cleanup.defer(async () => {
       await removeRealWorktrunkWorktree({ env: testEnv, config, repo, branch });
@@ -109,28 +107,144 @@ describeReal("real tmux popup navigation", () => {
       120_000,
     );
     const agentRow = findRowByBranch(agentSnapshot, branch);
+    const sessionId = agentRow.agent?.sessionId;
+    if (sessionId === undefined) throw new Error("Popup agent did not expose a session id.");
     const windowName = expectedWindowName(config.projectId, branch, agentRow.id, agentRow.path);
-    const paneId = await activeTmuxPane(testEnv, `${config.tmuxSession}:${windowName}.0`);
+    const target = `${config.tmuxSession}:${windowName}.0`;
+    const paneId = await activeTmuxPane(config.tmuxEndpoint, target);
     const markerPath = join(repo.root, "popup-navigation.marker");
+    const tmuxClient = await startAttachedTmuxPtyClient({
+      endpoint: config.tmuxEndpoint,
+      sessionName: config.tmuxSession,
+    });
+    cleanup.defer(tmuxClient.close);
+    const events = client.subscribe({ type: ["command.accepted"] })[Symbol.asyncIterator]();
+    const startRead = (): Promise<IteratorResult<StationEvent>> => {
+      const read = events.next();
+      // Attach a handler immediately while preserving the original rejecting promise for the waiter.
+      void read.catch(() => undefined);
+      return read;
+    };
+    let pendingRead = startRead();
+    const waitForAccepted = async (
+      matches: (event: AcceptedEvent) => boolean,
+      timeoutMs: number,
+    ): Promise<AcceptedEvent | undefined> => {
+      const deadline = Date.now() + timeoutMs;
+      for (let seen = 0; seen < 32; seen += 1) {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const next = await Promise.race([
+          pendingRead,
+          new Promise<undefined>((resolve) => {
+            timer = setTimeout(resolve, Math.max(1, deadline - Date.now()));
+          }),
+        ]).finally(() => clearTimeout(timer));
+        if (next === undefined) return undefined;
+        pendingRead = startRead();
+        if (next.done) throw new Error("Popup accepted-event stream ended.");
+        if (next.value.type === "command.accepted" && matches(next.value)) return next.value;
+        if (Date.now() >= deadline) return undefined;
+      }
+      return undefined;
+    };
+    cleanup.defer(async () => {
+      const returning = events.return?.();
+      if (returning === undefined) return;
+      void returning.catch(() => undefined);
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      await Promise.race([
+        returning,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => reject(new Error("Popup event iterator did not close.")), 5_000);
+        }),
+      ]).finally(() => clearTimeout(timer));
+    });
+    const correlation = `${process.pid}-${Date.now().toString(36)}`;
+    const readinessDeadline = Date.now() + 15_000;
+    let subscriptionReady = false;
+    for (let attempt = 1; attempt <= 3 && !subscriptionReady; attempt += 1) {
+      const reason = `real-popup-subscription-ready-${correlation}-${attempt}`;
+      const readiness = await client.dispatch({
+        type: "observer.reconcile",
+        payload: { reason },
+      });
+      subscriptionReady =
+        (await waitForAccepted(
+          (event) =>
+            event.commandId === readiness.commandId &&
+            event.command.type === "observer.reconcile" &&
+            event.command.payload.reason === reason,
+          Math.min(5_000, Math.max(1, readinessDeadline - Date.now())),
+        )) !== undefined;
+    }
+    if (!subscriptionReady) throw new Error("Popup subscription missed three readiness commands.");
+    const focusAccepted = waitForAccepted(
+      (event) =>
+        event.command.type === "terminal.focus" &&
+        event.command.payload.sessionId === sessionId &&
+        event.command.payload.origin?.provider === "tmux" &&
+        event.command.payload.origin.clientId === tmuxClient.clientName,
+      60_000,
+    ).then((event) => {
+      if (event === undefined) {
+        throw new Error("Popup did not emit the correlated terminal.focus acceptance event.");
+      }
+      return event;
+    });
+    void focusAccepted.catch(() => undefined);
 
-    await displayStationPopupAndSendKey({
+    const popup = await displayStationPopupAndSendKey({
       env: testEnv,
+      endpoint: config.tmuxEndpoint,
+      client: tmuxClient,
       configPath: config.configPath,
-      target: `${config.tmuxSession}:${windowName}.0`,
+      target,
+      expectedWindowName: windowName,
+      expectedPaneId: paneId,
       key: "1",
       markerPath,
     });
+    cleanup.defer(() => popup.release(false));
 
-    await expect(readFile(markerPath, "utf8")).resolves.toContain("popup-started");
-    await expect(readFile(markerPath, "utf8")).resolves.toContain("key-sent");
-    await expect(activeTmuxWindow(testEnv, config.tmuxSession)).resolves.toBe(windowName);
-    await expect(activeTmuxPane(testEnv, config.tmuxSession)).resolves.toBe(paneId);
+    let causalSuccess = false;
+    let primaryFailure: unknown;
+    try {
+      const accepted = await focusAccepted;
+      await expect(
+        waitForCommandRecord(client, accepted.commandId, { timeoutMs: 60_000 }),
+      ).resolves.toMatchObject({ status: "succeeded" });
+      await expect(inspectTmuxClient(config.tmuxEndpoint, tmuxClient.clientName)).resolves.toBe(
+        `${tmuxClient.clientName}\t${tmuxClient.clientPid}\t${config.tmuxSession}\t${windowName}\t${paneId}`,
+      );
+      causalSuccess = true;
+    } catch (error) {
+      primaryFailure = error;
+    }
+    try {
+      await popup.release(causalSuccess);
+    } catch (cleanupFailure) {
+      if (primaryFailure !== undefined) {
+        throw new AggregateError(
+          [primaryFailure, cleanupFailure],
+          "popup proof and release failed",
+        );
+      }
+      throw cleanupFailure;
+    }
+    if (primaryFailure !== undefined) throw primaryFailure;
+
+    const marker = await readFile(markerPath, "utf8");
+    expect(marker).toContain("popup-started");
+    expect(marker).toContain("key-sent");
+    expect(marker).toContain("child-exit:0");
   }, 240_000);
 });
 
 function findMaybeRow(snapshot: StationSnapshot, branch: string) {
   return snapshot.rows.find((row) => row.branch === branch);
 }
+
+type AcceptedEvent = Extract<StationEvent, { type: "command.accepted" }>;
 
 function expectedWindowName(
   projectId: string,

--- a/tests/e2e/real/real-recovery.test.ts
+++ b/tests/e2e/real/real-recovery.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../../support/real-station/env";
 import { CleanupStack, runStationJson } from "../../support/real-station/process";
 import { createRealTempRepo, uniqueBranch } from "../../support/real-station/repo";
-import { killTmuxSession } from "../../support/real-station/tmux";
+import { closeRealTmuxEndpoint, killTmuxSession } from "../../support/real-station/tmux";
 import {
   createRealWorktrunkWorktree,
   removeRealWorktrunkWorktree,
@@ -49,16 +49,13 @@ describeReal("real observer recovery", () => {
       repo,
       codexCommand: codex.codexCommand,
     });
+    cleanup.defer(() => closeRealTmuxEndpoint(config.tmuxEndpoint));
     cleanup.defer(async () => {
       await runStationJson(testEnv, {
         configPath: config.configPath,
         args: ["observer", "stop"],
-      }).catch(() => undefined);
+      });
     });
-    cleanup.defer(async () => {
-      await killTmuxSession(testEnv, config.tmuxSession);
-    });
-
     const branch = uniqueBranch("recovery");
     cleanup.defer(async () => {
       await removeRealWorktrunkWorktree({ env: testEnv, config, repo, branch });
@@ -100,17 +97,14 @@ describeReal("real observer recovery", () => {
       codexCommand: codex.codexCommand,
       installCodexHooks: true,
     });
+    cleanup.defer(() => closeRealTmuxEndpoint(config.tmuxEndpoint));
     await codex.installHooks(config);
     cleanup.defer(async () => {
       await runStationJson(testEnv, {
         configPath: config.configPath,
         args: ["observer", "stop"],
-      }).catch(() => undefined);
+      });
     });
-    cleanup.defer(async () => {
-      await killTmuxSession(testEnv, config.tmuxSession);
-    });
-
     const branch = uniqueBranch("stale-tmux");
     cleanup.defer(async () => {
       await removeRealWorktrunkWorktree({ env: testEnv, config, repo, branch });
@@ -143,7 +137,7 @@ describeReal("real observer recovery", () => {
     });
     expect(started.status).toBe("succeeded");
 
-    await killTmuxSession(testEnv, config.tmuxSession);
+    await killTmuxSession(config.tmuxEndpoint, config.tmuxSession);
     await runStationJson(testEnv, {
       configPath: config.configPath,
       args: ["reconcile", "--reason", "real-stale-tmux-after-kill"],

--- a/tests/e2e/real/real-session-lifecycle-claude.test.ts
+++ b/tests/e2e/real/real-session-lifecycle-claude.test.ts
@@ -17,7 +17,7 @@ import {
   waitForSnapshot,
 } from "../../support/real-station/protocol";
 import { createRealTempRepo, uniqueBranch } from "../../support/real-station/repo";
-import { killTmuxSession, listTmuxWindows } from "../../support/real-station/tmux";
+import { closeRealTmuxEndpoint, listTmuxWindows } from "../../support/real-station/tmux";
 import { removeRealWorktrunkWorktree } from "../../support/real-station/worktrunk";
 
 const describeReal =
@@ -46,16 +46,13 @@ describeReal("real Claude session lifecycle", () => {
     const repo = await createRealTempRepo(env);
     cleanup.defer(repo.cleanup);
     const config = await writeRealStationConfig({ env, repo, harnessProvider: "claude" });
+    cleanup.defer(() => closeRealTmuxEndpoint(config.tmuxEndpoint));
     cleanup.defer(async () => {
       await runStationJson(env, {
         configPath: config.configPath,
         args: ["observer", "stop"],
-      }).catch(() => undefined);
+      });
     });
-    cleanup.defer(async () => {
-      await killTmuxSession(env, config.tmuxSession);
-    });
-
     const branch = uniqueBranch("claude-lifecycle-session-observability-rollout");
     cleanup.defer(async () => {
       await removeRealWorktrunkWorktree({ env, config, repo, branch });
@@ -122,7 +119,7 @@ describeReal("real Claude session lifecycle", () => {
         focusable: true,
         hasPrimaryAgentEndpoint: true,
       });
-      await expect(listTmuxWindows(env, config.tmuxSession)).resolves.toContain(
+      await expect(listTmuxWindows(config.tmuxEndpoint, config.tmuxSession)).resolves.toContain(
         expectedWindowName(config.projectId, branch, row.id, row.path),
       );
 

--- a/tests/e2e/real/real-session-lifecycle-codex.test.ts
+++ b/tests/e2e/real/real-session-lifecycle-codex.test.ts
@@ -21,7 +21,7 @@ import {
   waitForSnapshot,
 } from "../../support/real-station/protocol";
 import { createRealTempRepo, uniqueBranch } from "../../support/real-station/repo";
-import { killTmuxSession, listTmuxWindows } from "../../support/real-station/tmux";
+import { closeRealTmuxEndpoint, listTmuxWindows } from "../../support/real-station/tmux";
 import { removeRealWorktrunkWorktree } from "../../support/real-station/worktrunk";
 
 const describeReal = realE2eEnabled() ? describe : describe.skip;
@@ -56,17 +56,14 @@ describeReal("real Codex session lifecycle", () => {
       codexCommand: codex.codexCommand,
       installCodexHooks: true,
     });
+    cleanup.defer(() => closeRealTmuxEndpoint(config.tmuxEndpoint));
     await codex.installHooks(config);
     cleanup.defer(async () => {
       await runStationJson(testEnv, {
         configPath: config.configPath,
         args: ["observer", "stop"],
-      }).catch(() => undefined);
+      });
     });
-    cleanup.defer(async () => {
-      await killTmuxSession(testEnv, config.tmuxSession);
-    });
-
     const branch = uniqueBranch(
       "codex-lifecycle-customer-account-permissions-rollout-for-enterprise-alpha",
     );
@@ -135,7 +132,7 @@ describeReal("real Codex session lifecycle", () => {
         focusable: true,
         hasPrimaryAgentEndpoint: true,
       });
-      await expect(listTmuxWindows(testEnv, config.tmuxSession)).resolves.toContain(
+      await expect(listTmuxWindows(config.tmuxEndpoint, config.tmuxSession)).resolves.toContain(
         expectedWindowName(config.projectId, branch, row.id, row.path),
       );
 

--- a/tests/e2e/real/real-session-title-branch-change.test.ts
+++ b/tests/e2e/real/real-session-title-branch-change.test.ts
@@ -20,7 +20,7 @@ import {
 import { CleanupStack, runStationJson } from "../../support/real-station/process";
 import { createRealObserverClient, waitForSnapshot } from "../../support/real-station/protocol";
 import { createRealTempRepo, uniqueBranch } from "../../support/real-station/repo";
-import { killTmuxSession } from "../../support/real-station/tmux";
+import { closeRealTmuxEndpoint } from "../../support/real-station/tmux";
 import { removeRealWorktrunkWorktree } from "../../support/real-station/worktrunk";
 
 const describeReal = realE2eEnabled() ? describe : describe.skip;
@@ -55,17 +55,14 @@ describeReal("real session title branch change", () => {
       codexCommand: codex.codexCommand,
       installCodexHooks: true,
     });
+    cleanup.defer(() => closeRealTmuxEndpoint(config.tmuxEndpoint));
     await codex.installHooks(config);
     cleanup.defer(async () => {
       await runStationJson(testEnv, {
         configPath: config.configPath,
         args: ["observer", "stop"],
-      }).catch(() => undefined);
+      });
     });
-    cleanup.defer(async () => {
-      await killTmuxSession(testEnv, config.tmuxSession);
-    });
-
     const originalBranch = uniqueBranch("title-original");
     const agentBranch = uniqueBranch("title-agent");
     cleanup.defer(async () => {

--- a/tests/e2e/real/real-station-process.test.ts
+++ b/tests/e2e/real/real-station-process.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../../support/real-station/env";
 import { CleanupStack, runStationJson } from "../../support/real-station/process";
 import { createRealTempRepo } from "../../support/real-station/repo";
-import { killTmuxSession } from "../../support/real-station/tmux";
+import { closeRealTmuxEndpoint } from "../../support/real-station/tmux";
 
 const describeReal = realE2eEnabled() ? describe : describe.skip;
 
@@ -33,16 +33,13 @@ describeReal("real station process", () => {
     const repo = await createRealTempRepo(env);
     cleanup.defer(repo.cleanup);
     const config = await writeRealStationConfig({ env, repo });
+    cleanup.defer(() => closeRealTmuxEndpoint(config.tmuxEndpoint));
     cleanup.defer(async () => {
       await runStationJson(env, {
         configPath: config.configPath,
         args: ["observer", "stop"],
-      }).catch(() => undefined);
+      });
     });
-    cleanup.defer(async () => {
-      await killTmuxSession(env, config.tmuxSession);
-    });
-
     await expect(
       runStationJson(env, {
         configPath: config.configPath,

--- a/tests/e2e/real/real-tui-control.test.ts
+++ b/tests/e2e/real/real-tui-control.test.ts
@@ -20,9 +20,10 @@ import {
 import { createRealTempRepo, uniqueBranch } from "../../support/real-station/repo";
 import {
   captureTmuxPane,
-  killTmuxSession,
+  closeRealTmuxEndpoint,
   killTmuxWindow,
   listTmuxWindows,
+  type RealTmuxEndpoint,
   sendTmuxKeys,
   startStationTuiInTmux,
 } from "../../support/real-station/tmux";
@@ -55,20 +56,15 @@ describeReal("real TUI stale-terminal recovery", () => {
       harnessProvider: "scripted",
       scriptedCommand: process.execPath,
     });
+    const endpoint = config.tmuxEndpoint;
+    cleanup.defer(() => closeRealTmuxEndpoint(endpoint));
     const tuiSession = uniqueTmuxSession("station-real-stale-tui");
     cleanup.defer(async () => {
       await runStationJson(env, {
         configPath: config.configPath,
         args: ["observer", "stop"],
-      }).catch(() => undefined);
+      });
     });
-    cleanup.defer(async () => {
-      await killTmuxSession(env, tuiSession);
-    });
-    cleanup.defer(async () => {
-      await killTmuxSession(env, config.tmuxSession);
-    });
-
     const branch = uniqueBranch("stale-tui");
     cleanup.defer(async () => {
       await removeRealWorktrunkWorktree({ env, config, repo, branch });
@@ -150,17 +146,18 @@ describeReal("real TUI stale-terminal recovery", () => {
       throw new Error("Grouped stale-session baseline was incomplete.");
     }
     const windowName = expectedWindowName(config.projectId, branch, staleRow.id, staleRow.path);
-    await expect(listTmuxWindows(env, config.tmuxSession)).resolves.toEqual([windowName]);
+    await expect(listTmuxWindows(endpoint, config.tmuxSession)).resolves.toEqual([windowName]);
 
     await startStationTuiInTmux({
       env,
+      endpoint,
       configPath: config.configPath,
       sessionName: tuiSession,
     });
-    await waitForTuiText(env, tuiSession, "Stale recovery");
-    await sendTmuxKeys({ env, target: tuiSession, keys: ["1"] });
-    await waitForTuiText(env, tuiSession, "Start fresh (Y)");
-    await sendTmuxKeys({ env, target: tuiSession, keys: ["y"] });
+    await waitForTuiText(endpoint, tuiSession, "Stale recovery");
+    await sendTmuxKeys({ endpoint, target: tuiSession, keys: ["1"] });
+    await waitForTuiText(endpoint, tuiSession, "Start fresh (Y)");
+    await sendTmuxKeys({ endpoint, target: tuiSession, keys: ["y"] });
     await waitForScriptedLaunchCount(config.stateDir, 2);
 
     const restarted = await waitForSnapshot(
@@ -195,10 +192,10 @@ describeReal("real TUI stale-terminal recovery", () => {
     expect(restarted.sessions.filter((session) => session.worktreeId === staleRow.id)).toHaveLength(
       1,
     );
-    await expect(listTmuxWindows(env, config.tmuxSession)).resolves.toEqual([windowName]);
+    await expect(listTmuxWindows(endpoint, config.tmuxSession)).resolves.toEqual([windowName]);
     await expect(scriptedLaunchCount(config.stateDir)).resolves.toBe(2);
 
-    await killTmuxWindow(env, `${config.tmuxSession}:${windowName}`);
+    await killTmuxWindow(endpoint, `${config.tmuxSession}:${windowName}`);
     await waitForSnapshot(
       client,
       (snapshot) => findMaybeRow(snapshot, branch)?.terminal === undefined,
@@ -236,14 +233,14 @@ describeReal("real TUI stale-terminal recovery", () => {
 });
 
 async function waitForTuiText(
-  env: RealE2eEnvironment,
+  endpoint: RealTmuxEndpoint,
   target: string,
   expected: string,
 ): Promise<void> {
   const deadline = Date.now() + 30_000;
   let captured = "";
   while (Date.now() <= deadline) {
-    captured = await captureTmuxPane({ env, target });
+    captured = await captureTmuxPane({ endpoint, target });
     if (captured.includes(expected)) {
       return;
     }

--- a/tests/e2e/real/real-worktrunk-hooks.test.ts
+++ b/tests/e2e/real/real-worktrunk-hooks.test.ts
@@ -13,7 +13,7 @@ import {
 } from "../../support/real-station/env";
 import { CleanupStack, runStationJson } from "../../support/real-station/process";
 import { createRealTempRepo } from "../../support/real-station/repo";
-import { killTmuxSession } from "../../support/real-station/tmux";
+import { closeRealTmuxEndpoint } from "../../support/real-station/tmux";
 
 const describeReal = realE2eEnabled() ? describe : describe.skip;
 
@@ -39,16 +39,13 @@ describeReal("real Worktrunk hook ingestion", () => {
     const repo = await createRealTempRepo(env);
     cleanup.defer(repo.cleanup);
     const config = await writeRealStationConfig({ env, repo, useLifecycleHooks: true });
+    cleanup.defer(() => closeRealTmuxEndpoint(config.tmuxEndpoint));
     cleanup.defer(async () => {
       await runStationJson(env, {
         configPath: config.configPath,
         args: ["hooks", "uninstall", "worktrunk", "--yes"],
-      }).catch(() => undefined);
+      });
     });
-    cleanup.defer(async () => {
-      await killTmuxSession(env, config.tmuxSession);
-    });
-
     await expect(
       runStationJson(env, {
         configPath: config.configPath,
@@ -75,16 +72,13 @@ describeReal("real Worktrunk hook ingestion", () => {
     const repo = await createRealTempRepo(env);
     cleanup.defer(repo.cleanup);
     const config = await writeRealStationConfig({ env, repo });
+    cleanup.defer(() => closeRealTmuxEndpoint(config.tmuxEndpoint));
     cleanup.defer(async () => {
       await runStationJson(env, {
         configPath: config.configPath,
         args: ["observer", "stop"],
-      }).catch(() => undefined);
+      });
     });
-    cleanup.defer(async () => {
-      await killTmuxSession(env, config.tmuxSession);
-    });
-
     await runStationJson(env, {
       configPath: config.configPath,
       args: ["observer", "start", "--timeout-ms", "30000"],
@@ -111,16 +105,13 @@ describeReal("real Worktrunk hook ingestion", () => {
       repo: spoolRepo,
       autoStartFromHooks: false,
     });
+    cleanup.defer(() => closeRealTmuxEndpoint(spoolConfig.tmuxEndpoint));
     cleanup.defer(async () => {
       await runStationJson(env, {
         configPath: spoolConfig.configPath,
         args: ["observer", "stop"],
-      }).catch(() => undefined);
+      });
     });
-    cleanup.defer(async () => {
-      await killTmuxSession(env, spoolConfig.tmuxSession);
-    });
-
     const spooled = await runWorktrunkIngress(env, spoolConfig, {
       event: "post-create",
       stdin: JSON.stringify({ branch: "station/hook-spooled" }),

--- a/tests/support/real-station/config.ts
+++ b/tests/support/real-station/config.ts
@@ -3,12 +3,14 @@ import { dirname, join } from "node:path";
 import type { RealE2eEnvironment } from "./env";
 import { requireToolPath } from "./env";
 import type { RealTempRepo } from "./repo";
+import { closeRealTmuxEndpoint, createRealTmuxEndpoint, type RealTmuxEndpoint } from "./tmux";
 
 export type RealStationConfigFixture = {
   configPath: string;
   stateDir: string;
   socketPath: string;
   worktrunkConfigPath: string;
+  tmuxEndpoint: RealTmuxEndpoint;
   tmuxSession: string;
   projectId: string;
 };
@@ -45,9 +47,12 @@ export async function writeRealStationConfig(
   const worktrunkConfigPath = join(options.repo.root, "worktrunk", "config.toml");
   const configPath = join(options.repo.root, "station.config.toml");
   const tmuxSession = options.tmuxSession ?? uniqueTmuxSession();
+  const worktrunkCommand = requireToolPath(options.env, "worktrunk");
+  const harnessLines = harnessConfigLines(options, harnessProvider);
   await ensurePrivateDirectory(stateDir);
   await ensurePrivateDirectory(dirname(socketPath));
   await mkdir(join(options.repo.root, "worktrunk"), { recursive: true });
+  const tmuxEndpoint = await createRealTmuxEndpoint(options.env);
 
   const lines = [
     "schema_version = 1",
@@ -64,15 +69,17 @@ export async function writeRealStationConfig(
     'layout = "agent-shell"',
     "",
     "[worktree.worktrunk]",
-    `command = ${tomlString(requireToolPath(options.env, "worktrunk"))}`,
+    `command = ${tomlString(worktrunkCommand)}`,
     `config_path = ${tomlString(worktrunkConfigPath)}`,
     `use_lifecycle_hooks = ${options.useLifecycleHooks === true ? "true" : "false"}`,
     `hook_mode = ${tomlString(options.useLifecycleHooks === true ? "required-for-mvp" : "disabled")}`,
     "",
     "[terminal.tmux]",
+    `command = ${tomlString(tmuxEndpoint.wrapperPath)}`,
+    `workbench_socket_path = ${tomlString(tmuxEndpoint.socketPath)}`,
     `workbench_session = ${tomlString(tmuxSession)}`,
     "",
-    ...harnessConfigLines(options, harnessProvider),
+    ...harnessLines,
     ...eventHookConfigLines(options),
     "[[projects]]",
     `id = ${tomlString(projectId)}`,
@@ -93,12 +100,22 @@ export async function writeRealStationConfig(
     "include_external = false",
     "",
   ];
-  await writeFile(configPath, lines.join("\n"), "utf8");
+  try {
+    await writeFile(configPath, lines.join("\n"), "utf8");
+  } catch (error) {
+    try {
+      await closeRealTmuxEndpoint(tmuxEndpoint);
+    } catch (cleanupError) {
+      throw new AggregateError([error, cleanupError], "config write and tmux cleanup failed");
+    }
+    throw error;
+  }
 
   return {
     configPath,
     stateDir,
     socketPath,
+    tmuxEndpoint,
     worktrunkConfigPath,
     tmuxSession,
     projectId,

--- a/tests/support/real-station/tmux.ts
+++ b/tests/support/real-station/tmux.ts
@@ -1,5 +1,7 @@
-import { type ChildProcess, execFile, spawn } from "node:child_process";
-import { appendFile, readFile } from "node:fs/promises";
+import { type ChildProcess, type ExecFileException, execFile, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { appendFile, chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 import type { RealE2eEnvironment } from "./env";
@@ -55,13 +57,62 @@ export type TmuxPtyDimensions = {
   rows: number;
 };
 
+export type RealTmuxEndpoint = { rootPath: string; socketPath: string; wrapperPath: string };
+
+type TmuxClientRecord = { name: string; pid: number; session: string };
+
+export async function createRealTmuxEndpoint(env: RealE2eEnvironment): Promise<RealTmuxEndpoint> {
+  const rootPath = await mkdtemp(join(tmpdir(), "stn-real-tmux-"));
+  const socketPath = join(rootPath, "server.sock");
+  const wrapperPath = join(rootPath, "tmux");
+  const endpoint = { rootPath, socketPath, wrapperPath };
+  let wrapperReady = false;
+  try {
+    await chmod(rootPath, 0o700);
+    const wrapper = `#!/bin/sh\nexec ${shellQuote(requireToolPath(env, "tmux"))} -f /dev/null "$@"\n`;
+    await writeFile(endpoint.wrapperPath, wrapper, "utf8");
+    await chmod(endpoint.wrapperPath, 0o700);
+    wrapperReady = true;
+    const args = ["new-session", "-d", "-s", "_station-real-endpoint", "sleep 86400"];
+    await runTmuxCommand(endpoint, args);
+    return endpoint;
+  } catch (error) {
+    try {
+      await (wrapperReady
+        ? closeRealTmuxEndpoint(endpoint)
+        : rm(rootPath, { recursive: true, force: true }));
+    } catch (cleanupError) {
+      throw new AggregateError([error, cleanupError], "tmux endpoint creation and cleanup failed");
+    }
+    throw error;
+  }
+}
+
+export async function closeRealTmuxEndpoint(endpoint: RealTmuxEndpoint): Promise<void> {
+  try {
+    await runTmuxCommand(endpoint, ["kill-server"]);
+  } catch (error) {
+    if (!isExactEndpointAbsence(error, endpoint)) throw error;
+  }
+  try {
+    await runTmuxCommand(endpoint, ["list-sessions"]);
+  } catch (error) {
+    if (!isExactEndpointAbsence(error, endpoint)) throw error;
+    await rm(endpoint.rootPath, { recursive: true });
+    return;
+  }
+  throw new Error(`tmux endpoint remained reachable after kill-server: ${endpoint.socketPath}`);
+}
 /**
  * An attached tmux client whose keyboard and mouse bytes cross a real PTY rather
- * than `tmux send-keys` or OpenTUI's test-renderer dispatch.
+ * than `tmux send-keys` or OpenTUI's test-renderer dispatch. `processId` is the
+ * Python bridge PID, not tmux client identity.
  */
 export type AttachedTmuxPtyClient = {
   clientName: string;
+  clientPid: number;
   processId: number;
+  sessionName: string;
   write(bytes: Uint8Array): Promise<void>;
   outputTail(): string;
   close(): Promise<void>;
@@ -72,66 +123,48 @@ export type NativeStationTmuxLaunch = {
   target: string;
 };
 
-export async function killTmuxSession(env: RealE2eEnvironment, sessionName: string): Promise<void> {
-  await execFileAsync(requireToolPath(env, "tmux"), ["kill-session", "-t", sessionName], {
-    timeout: 10_000,
-  }).catch(() => undefined);
-}
-
-export async function killTmuxWindow(env: RealE2eEnvironment, target: string): Promise<void> {
-  await execFileAsync(requireToolPath(env, "tmux"), ["kill-window", "-t", target], {
-    timeout: 10_000,
-  });
-}
-
-export async function tmuxSessionExists(
-  env: RealE2eEnvironment,
+export async function killTmuxSession(
+  endpoint: RealTmuxEndpoint,
   sessionName: string,
-): Promise<boolean> {
+): Promise<void> {
   try {
-    await execFileAsync(requireToolPath(env, "tmux"), ["has-session", "-t", sessionName], {
-      timeout: 10_000,
-    });
-    return true;
-  } catch {
-    return false;
+    await runTmuxCommand(endpoint, ["kill-session", "-t", sessionName]);
+  } catch (error) {
+    const absent =
+      isExactEndpointAbsence(error, endpoint) ||
+      isExactTmuxFailure(error, 1, `can't find session: ${sessionName}`);
+    if (!absent) throw error;
   }
 }
 
+export async function killTmuxWindow(endpoint: RealTmuxEndpoint, target: string): Promise<void> {
+  await runTmuxCommand(endpoint, ["kill-window", "-t", target]);
+}
+
 export async function listTmuxWindows(
-  env: RealE2eEnvironment,
+  endpoint: RealTmuxEndpoint,
   sessionName: string,
 ): Promise<string[]> {
-  const output = await execFileAsync(
-    requireToolPath(env, "tmux"),
-    ["list-windows", "-t", sessionName, "-F", "#{window_name}"],
-    { timeout: 10_000 },
-  );
+  const args = ["list-windows", "-t", sessionName, "-F", "#{window_name}"];
+  const output = await runTmuxCommand(endpoint, args);
   return output.stdout
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
 }
 
-export async function activeTmuxWindow(
-  env: RealE2eEnvironment,
-  sessionName: string,
-): Promise<string> {
-  const output = await execFileAsync(
-    requireToolPath(env, "tmux"),
-    ["display-message", "-p", "-t", sessionName, "#{window_name}"],
-    { timeout: 10_000 },
-  );
-  return output.stdout.trim();
+export async function activeTmuxPane(endpoint: RealTmuxEndpoint, target: string): Promise<string> {
+  const args = ["display-message", "-p", "-t", target, "#{pane_id}"];
+  return (await runTmuxCommand(endpoint, args)).stdout.trim();
 }
 
-export async function activeTmuxPane(env: RealE2eEnvironment, target: string): Promise<string> {
-  const output = await execFileAsync(
-    requireToolPath(env, "tmux"),
-    ["display-message", "-p", "-t", target, "#{pane_id}"],
-    { timeout: 10_000 },
-  );
-  return output.stdout.trim();
+export async function inspectTmuxClient(
+  endpoint: RealTmuxEndpoint,
+  clientName: string,
+): Promise<string> {
+  const format = "#{client_name}\t#{client_pid}\t#{session_name}\t#{window_name}\t#{pane_id}";
+  const args = ["display-message", "-p", "-c", clientName, format];
+  return (await runTmuxCommand(endpoint, args)).stdout.replace(/\r?\n$/u, "");
 }
 
 /**
@@ -140,6 +173,7 @@ export async function activeTmuxPane(env: RealE2eEnvironment, target: string): P
  */
 export async function launchNativeStationInTmux(input: {
   env: RealE2eEnvironment;
+  endpoint: RealTmuxEndpoint;
   configPath: string;
   observerSocketPath: string;
   stateDir: string;
@@ -147,7 +181,6 @@ export async function launchNativeStationInTmux(input: {
   cwd?: string;
   dimensions?: TmuxPtyDimensions;
 }): Promise<NativeStationTmuxLaunch> {
-  const tmux = requireToolPath(input.env, "tmux");
   const dimensions = input.dimensions ?? DEFAULT_PTY_DIMENSIONS;
   assertDimensions(dimensions);
   const command = [
@@ -186,17 +219,14 @@ export async function launchNativeStationInTmux(input: {
   }
   args.push(command);
 
+  let sessionCreated = false;
   try {
-    await execFileAsync(tmux, args, { timeout: 10_000 });
+    await runTmuxCommand(input.endpoint, args);
+    sessionCreated = true;
     // Tmux must decode and forward the attached client's SGR stream before native OpenTUI can receive it.
-    await execFileAsync(tmux, ["set-option", "-t", input.sessionName, "mouse", "on"], {
-      timeout: 10_000,
-    });
-    const pane = await execFileAsync(
-      tmux,
-      ["display-message", "-p", "-t", input.sessionName, "#{pane_pid}\t#{pane_id}"],
-      { timeout: 10_000 },
-    );
+    await runTmuxCommand(input.endpoint, ["set-option", "-t", input.sessionName, "mouse", "on"]);
+    const paneArgs = ["display-message", "-p", "-t", input.sessionName, "#{pane_pid}\t#{pane_id}"];
+    const pane = await runTmuxCommand(input.endpoint, paneArgs);
     const [panePidText, paneId] = pane.stdout.trim().split("\t");
     const panePid = Number(panePidText);
     if (!Number.isInteger(panePid) || panePid <= 0 || paneId === undefined) {
@@ -204,13 +234,19 @@ export async function launchNativeStationInTmux(input: {
     }
     return { panePid, target: paneId };
   } catch (error) {
-    await killTmuxSession(input.env, input.sessionName);
+    if (!sessionCreated) throw error;
+    try {
+      await killTmuxSession(input.endpoint, input.sessionName);
+    } catch (cleanupError) {
+      throw new AggregateError([error, cleanupError], "native tmux launch and cleanup failed");
+    }
     throw error;
   }
 }
 
 export async function startStationTuiInTmux(input: {
   env: RealE2eEnvironment;
+  endpoint: RealTmuxEndpoint;
   configPath: string;
   sessionName: string;
 }): Promise<void> {
@@ -221,33 +257,46 @@ export async function startStationTuiInTmux(input: {
     "tui",
     "--popup",
   ].join(" ");
-  await execFileAsync(
-    requireToolPath(input.env, "tmux"),
-    ["new-session", "-d", "-s", input.sessionName, command],
-    { timeout: 10_000 },
-  );
+  await runTmuxCommand(input.endpoint, ["new-session", "-d", "-s", input.sessionName, command]);
 }
 
 export async function displayStationPopupAndSendKey(input: {
   env: RealE2eEnvironment;
+  endpoint: RealTmuxEndpoint;
+  client: AttachedTmuxPtyClient;
   configPath: string;
   target: string;
+  expectedWindowName: string;
+  expectedPaneId: string;
   key: string;
   markerPath: string;
   delaySeconds?: number;
-}): Promise<void> {
-  const delaySeconds = input.delaySeconds ?? 3;
-  const ptyClient = await startAttachedTmuxPtyClient({
-    env: input.env,
-    sessionName: tmuxSessionFromTarget(input.target),
-  });
+}): Promise<{ release(causalSuccess: boolean): Promise<void> }> {
+  const { client, endpoint } = input;
+  const invocationNonce = randomUUID();
+  const releasePath = `${input.markerPath}.${invocationNonce}.release`;
+  if (client.sessionName !== (input.target.split(":")[0] ?? input.target)) {
+    throw new Error(
+      `popup client ${client.clientName}/${client.clientPid}/${client.sessionName} is not in target ${input.target} on ${endpoint.socketPath}${client.outputTail()}`,
+    );
+  }
+  const expectedView = `${client.clientName}\t${client.clientPid}\t${client.sessionName}\t${input.expectedWindowName}\t${input.expectedPaneId}`;
+  const checkView = async (phase: string): Promise<void> => {
+    const actual = await inspectTmuxClient(endpoint, client.clientName);
+    if (actual !== expectedView) {
+      throw new Error(
+        `popup client changed ${phase} endpoint=${endpoint.socketPath} expected=${JSON.stringify(expectedView)} actual=${JSON.stringify(actual)}${client.outputTail()}`,
+      );
+    }
+  };
+  await checkView("before display");
+  const startMarker = `popup-started:${client.clientName}:${client.clientPid}:${input.target}:${invocationNonce}`;
   const popupCommand = [
-    "exec",
     "env",
     `PATH=${shellQuote(dirname(process.execPath))}:$PATH`,
     "STATION_TUI_POPUP=1",
     "STATION_FOCUS_PROVIDER=tmux",
-    `STATION_FOCUS_CLIENT_ID=${shellQuote(ptyClient.clientName)}`,
+    `STATION_FOCUS_CLIENT_ID=${shellQuote(client.clientName)}`,
     shellQuote(input.env.stationBin),
     "--config",
     shellQuote(input.configPath),
@@ -255,68 +304,172 @@ export async function displayStationPopupAndSendKey(input: {
     "--popup",
   ].join(" ");
   const popupScript = [
-    `printf '%s\\n' popup-started > ${shellQuote(input.markerPath)}`,
+    `printf '%s\\n' ${shellQuote(startMarker)} > ${shellQuote(input.markerPath)}`,
     popupCommand,
+    "child_status=$?",
+    `printf 'child-exit:%s\\n' "$child_status" >> ${shellQuote(input.markerPath)}`,
+    `while [ ! -e ${shellQuote(releasePath)} ]; do sleep 0.05; done`,
+    'exit "$child_status"',
   ].join("; ");
-  let sendKeyDone: Promise<void> | undefined;
-  const keyTimer = setTimeout(() => {
-    sendKeyDone = ptyClient
-      .write(Buffer.from(input.key, "utf8"))
-      .then(() => appendFile(input.markerPath, "key-sent\n", "utf8"));
-  }, delaySeconds * 1000);
-  try {
-    await execFileAsync(requireToolPath(input.env, "tmux"), ["select-pane", "-t", input.target], {
-      timeout: 10_000,
+  const popupArgs = [
+    "display-popup",
+    "-c",
+    client.clientName,
+    "-t",
+    input.target,
+    "-w",
+    "50%",
+    "-h",
+    "50%",
+    "-E",
+    `sh -lc ${shellQuote(popupScript)}`,
+  ];
+  let settlementError: unknown;
+  let settled = false;
+  const settlement = runTmuxCommand(endpoint, popupArgs, 120_000)
+    .catch((error: unknown) => {
+      settlementError = error;
+    })
+    .finally(() => {
+      settled = true;
     });
-    await execFileAsync(
-      requireToolPath(input.env, "tmux"),
-      [
-        "display-popup",
-        "-t",
-        ptyClient.clientName,
-        "-w",
-        "50%",
-        "-h",
-        "50%",
-        "-E",
-        `sh -lc ${shellQuote(popupScript)}`,
-      ],
-      { timeout: 120_000 },
+  let keyAttempted = false;
+  let markerEvidence = "<unread>";
+  let releaseEvidence = "release=not-attempted";
+  let releasePromise: Promise<void> | undefined;
+  const release = (causalSuccess: boolean): Promise<void> => {
+    releasePromise ??= (async () => {
+      const failures: unknown[] = [];
+      let closeState = "not-attempted";
+      const closePopup = async (): Promise<void> => {
+        closeState = "failed";
+        try {
+          await runTmuxCommand(endpoint, ["display-popup", "-c", client.clientName, "-C"]);
+          closeState = "ok";
+        } catch (error) {
+          failures.push(error);
+        }
+      };
+      if (!causalSuccess) await closePopup();
+      let gateWritten = false;
+      try {
+        await writeFile(releasePath, "release\n", { encoding: "utf8", flag: "wx" });
+        gateWritten = true;
+      } catch (error) {
+        failures.push(error);
+      }
+      if (!gateWritten && closeState === "not-attempted") await closePopup();
+      await settlement;
+      try {
+        markerEvidence = await readMarker(input.markerPath);
+      } catch (error) {
+        failures.push(error);
+        markerEvidence = "<unreadable>";
+      }
+      const markerExact =
+        markerEvidence === `${startMarker}\nkey-sent\nchild-exit:0\n` ||
+        markerEvidence === `${startMarker}\nchild-exit:0\nkey-sent\n`;
+      if (causalSuccess && !markerExact) {
+        failures.push(new Error(`popup marker or child exit was not exact: ${markerEvidence}`));
+      }
+      let viewExact = false;
+      try {
+        await checkView("after release");
+        viewExact = true;
+      } catch (error) {
+        failures.push(error);
+      }
+      const causalEvidence =
+        causalSuccess && gateWritten && closeState === "not-attempted" && markerExact && viewExact;
+      if (
+        settlementError !== undefined &&
+        !(causalEvidence && isExactTmuxFailure(settlementError, 129, ""))
+      ) {
+        failures.push(settlementError);
+      }
+      if (failures.length > 0 && closeState === "not-attempted") await closePopup();
+      releaseEvidence = `gate=${gateWritten ? "ok" : "failed"} close=${closeState} settlement=${settlementError === undefined ? "ok" : "failed"}`;
+      if (failures.length > 0) {
+        throw new AggregateError(
+          failures,
+          `real tmux popup release failed ${releaseEvidence} marker=${JSON.stringify(markerEvidence)}${client.outputTail()}`,
+        );
+      }
+    })();
+    return releasePromise;
+  };
+  try {
+    await waitForPopupStart(input.markerPath, startMarker, () => settled);
+    await waitForPopupDelay(
+      input.markerPath,
+      startMarker,
+      (input.delaySeconds ?? 3) * 1000,
+      () => settled,
     );
-    await waitForFileText(input.markerPath, "key-sent", delaySeconds * 1000 + 10_000);
-  } finally {
-    clearTimeout(keyTimer);
-    await sendKeyDone?.catch(() => undefined);
-    await ptyClient.close();
+    if ((await readMarker(input.markerPath)) !== `${startMarker}\n`) {
+      throw new Error("popup Station child exited before delayed input");
+    }
+    await checkView("before input");
+    if (settled) throw new Error("popup settled immediately before input");
+    keyAttempted = true;
+    await client.write(Buffer.from(input.key, "utf8"));
+    await appendFile(input.markerPath, "key-sent\n", "utf8");
+  } catch (error) {
+    const failures: unknown[] = [error];
+    await release(false).catch((releaseError: unknown) => {
+      failures.push(releaseError);
+    });
+    throw new AggregateError(
+      failures,
+      `real tmux popup failed endpoint=${endpoint.socketPath} client=${client.clientName}/${client.clientPid}/${client.sessionName} target=${input.target} key=${keyAttempted ? "attempting" : "not-attempted"} ${releaseEvidence} marker=${JSON.stringify(markerEvidence)}${client.outputTail()}`,
+    );
   }
+
+  return { release };
 }
 
-async function waitForFileText(path: string, expected: string, timeoutMs: number): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() <= deadline) {
-    const content = await readFile(path, "utf8").catch(() => "");
-    if (content.includes(expected)) return;
-    await delay(100);
+async function waitForPopupStart(
+  markerPath: string,
+  startMarker: string,
+  settled: () => boolean,
+): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  let marker = "";
+  while (Date.now() < deadline) {
+    marker = await readMarker(markerPath);
+    if (marker === `${startMarker}\n`) return;
+    if (settled()) throw new Error(`popup settled before its start marker: ${marker}`);
+    await delay(Math.min(50, deadline - Date.now()));
   }
-  throw new Error(`Timed out waiting for ${expected} in ${path}.`);
+  throw new Error(`popup start marker timed out: ${markerPath} marker=${JSON.stringify(marker)}`);
+}
+
+async function waitForPopupDelay(
+  markerPath: string,
+  startMarker: string,
+  delayMs: number,
+  settled: () => boolean,
+): Promise<void> {
+  const deadline = Date.now() + delayMs;
+  while (Date.now() < deadline) {
+    if (settled()) throw new Error("popup settled during the post-start delay");
+    const marker = await readMarker(markerPath);
+    if (marker !== `${startMarker}\n`)
+      throw new Error(`popup marker changed before input: ${marker}`);
+    await delay(Math.min(50, deadline - Date.now()));
+  }
 }
 
 export async function sendTmuxKeys(input: {
-  env: RealE2eEnvironment;
+  endpoint: RealTmuxEndpoint;
   target: string;
   keys: string[];
 }): Promise<void> {
-  await execFileAsync(
-    requireToolPath(input.env, "tmux"),
-    ["send-keys", "-t", input.target, ...input.keys],
-    {
-      timeout: 10_000,
-    },
-  );
+  await runTmuxCommand(input.endpoint, ["send-keys", "-t", input.target, ...input.keys]);
 }
 
 export async function captureTmuxPane(input: {
-  env: RealE2eEnvironment;
+  endpoint: RealTmuxEndpoint;
   target: string;
   styled?: boolean;
   preserveTrailingSpaces?: boolean;
@@ -327,9 +480,7 @@ export async function captureTmuxPane(input: {
   if (input.preserveTrailingSpaces === true) args.push("-N");
   args.push("-t", input.target);
   if (input.visibleOnly !== true) args.push("-S", "-80");
-  const output = await execFileAsync(requireToolPath(input.env, "tmux"), args, {
-    timeout: 10_000,
-  });
+  const output = await runTmuxCommand(input.endpoint, args);
   return output.stdout;
 }
 
@@ -342,14 +493,15 @@ function shellQuote(value: string): string {
  * bounded output tails for real keyboard/mouse acceptance diagnostics.
  */
 export async function startAttachedTmuxPtyClient(input: {
-  env: RealE2eEnvironment;
+  endpoint: RealTmuxEndpoint;
   sessionName: string;
   dimensions?: TmuxPtyDimensions;
   processEnv?: NodeJS.ProcessEnv;
 }): Promise<AttachedTmuxPtyClient> {
-  const tmux = requireToolPath(input.env, "tmux");
+  const { endpoint, sessionName } = input;
   const dimensions = input.dimensions ?? DEFAULT_PTY_DIMENSIONS;
   assertDimensions(dimensions);
+  const baseline = await listTmuxClients(endpoint, sessionName);
   const child = spawn(
     "python3",
     [
@@ -357,27 +509,25 @@ export async function startAttachedTmuxPtyClient(input: {
       ptyBridgeScript,
       String(dimensions.rows),
       String(dimensions.columns),
-      tmux,
+      endpoint.wrapperPath,
+      "-S",
+      endpoint.socketPath,
       "attach-session",
       "-t",
-      input.sessionName,
+      sessionName,
     ],
     {
-      env: {
+      env: controllerEnvironment({
         ...(input.processEnv ?? process.env),
         TERM: "xterm-256color",
-      },
+      }),
       stdio: ["pipe", "pipe", "pipe"],
     },
   );
-  const processId = child.pid;
-  if (processId === undefined) {
-    child.kill("SIGTERM");
-    throw new Error("tmux PTY client did not expose a process id.");
-  }
   let stdoutTail: Buffer = Buffer.alloc(0);
   let stderrTail: Buffer = Buffer.alloc(0);
   let spawnError: Error | undefined;
+  const childClose = new Promise<void>((resolve) => child.once("close", () => resolve()));
   child.once("error", (error) => {
     spawnError = error;
   });
@@ -387,77 +537,109 @@ export async function startAttachedTmuxPtyClient(input: {
   child.stderr.on("data", (chunk: Buffer) => {
     stderrTail = appendOutputTail(stderrTail, chunk);
   });
+  const outputTail = () =>
+    `\nPTY stdout tail:\n${stdoutTail.toString("utf8")}\nPTY stderr tail:\n${stderrTail.toString("utf8")}`;
+  const processId = child.pid;
 
   try {
-    const clientName = await waitForTmuxClient({
-      env: input.env,
-      sessionName: input.sessionName,
+    if (processId === undefined) {
+      throw new Error("tmux PTY client did not expose a process id.");
+    }
+    const client = await waitForTmuxClient(
+      endpoint,
+      sessionName,
+      baseline,
       child,
-      output: () => stdoutTail,
-      stderr: () => stderrTail,
-      spawnError: () => spawnError,
-    });
+      () => spawnError,
+      outputTail,
+    );
     let closed = false;
     return {
-      clientName,
+      clientName: client.name,
+      clientPid: client.pid,
       processId,
+      sessionName: client.session,
       write: (bytes) => writeChildInput(child, bytes),
-      outputTail: () =>
-        `\nPTY stdout tail:\n${stdoutTail.toString("utf8")}\nPTY stderr tail:\n${stderrTail.toString("utf8")}`,
+      outputTail,
       close: async () => {
         if (closed) return;
         closed = true;
-        await execFileAsync(tmux, ["detach-client", "-t", clientName], {
-          timeout: 2_000,
-        }).catch(() => undefined);
+        const failures: unknown[] = [];
+        try {
+          const view = await inspectTmuxClient(endpoint, client.name);
+          if (!view.startsWith(`${client.name}\t${client.pid}\t${client.session}\t`)) {
+            throw new Error(
+              `tmux PTY client identity changed before detach expected=${JSON.stringify(client)} actual=${JSON.stringify(view)}`,
+            );
+          }
+          await runTmuxCommand(endpoint, ["detach-client", "-t", client.name], 2_000);
+        } catch (error) {
+          failures.push(error);
+        }
         child.stdin?.end();
-        await terminateChild(child, 2_000);
+        try {
+          await terminateChild(child, childClose, 2_000);
+        } catch (error) {
+          failures.push(error);
+        }
+        if (failures.length > 0) {
+          throw new AggregateError(
+            failures,
+            `tmux PTY client cleanup failed endpoint=${endpoint.socketPath} client=${client.name}/${client.pid}/${client.session}${outputTail()}`,
+          );
+        }
       },
     };
   } catch (error) {
+    const failures: unknown[] = [error];
     child.stdin?.end();
-    await terminateChild(child, 1_000).catch(() => undefined);
-    throw error;
+    await terminateChild(child, childClose, 1_000).catch((cleanupError: unknown) => {
+      failures.push(cleanupError);
+    });
+    if (spawnError !== undefined) failures.push(spawnError);
+    throw new AggregateError(
+      failures,
+      `tmux PTY client attachment failed endpoint=${endpoint.socketPath} session=${sessionName}${outputTail()}`,
+    );
   }
 }
 
-async function waitForTmuxClient(input: {
-  env: RealE2eEnvironment;
-  sessionName: string;
-  child: ChildProcess;
-  output: () => Buffer;
-  stderr: () => Buffer;
-  spawnError: () => Error | undefined;
-}): Promise<string> {
+async function waitForTmuxClient(
+  endpoint: RealTmuxEndpoint,
+  sessionName: string,
+  baseline: TmuxClientRecord[],
+  child: ChildProcess,
+  spawnError: () => Error | undefined,
+  evidence: () => string,
+): Promise<TmuxClientRecord> {
+  const baselineByName = new Map(baseline.map((record) => [record.name, record.pid]));
   const deadline = Date.now() + 5_000;
   while (Date.now() <= deadline) {
+    if (spawnError() !== undefined || child.exitCode !== null || child.signalCode !== null) {
+      throw new Error(
+        `tmux PTY client exited before attaching: ${spawnError()?.message ?? ""}${evidence()}`,
+      );
+    }
+    const current = await listTmuxClients(endpoint, sessionName);
     if (
-      input.spawnError() !== undefined ||
-      input.child.exitCode !== null ||
-      input.child.signalCode !== null
+      current.filter((record) => baselineByName.get(record.name) === record.pid).length !==
+      baseline.length
     ) {
       throw new Error(
-        `tmux PTY client exited before attaching: ${input.spawnError()?.message ?? ""}${input.output().toString("utf8")}${input.stderr().toString("utf8")}`,
+        `tmux client baseline changed during PTY attach baseline=${JSON.stringify(baseline).slice(0, 4096)} current=${JSON.stringify(current).slice(0, 4096)}`,
       );
     }
-    try {
-      const output = await execFileAsync(
-        requireToolPath(input.env, "tmux"),
-        ["list-clients", "-t", input.sessionName, "-F", "#{client_name}"],
-        { timeout: 2_000 },
+    const candidates = current.filter((record) => !baselineByName.has(record.name));
+    if (candidates.length > 1) {
+      throw new Error(
+        `tmux PTY attach admitted multiple clients: ${JSON.stringify(candidates).slice(0, 4096)}`,
       );
-      const clientName = output.stdout.trim().split(/\r?\n/).find(Boolean);
-      if (clientName !== undefined) {
-        return clientName;
-      }
-    } catch {
-      // Keep polling until the PTY client appears or exits.
     }
+    const candidate = candidates[0];
+    if (candidate !== undefined) return candidate;
     await delay(100);
   }
-  throw new Error(
-    `tmux PTY client did not attach before popup launch.\nstdout tail:\n${input.output().toString("utf8")}\nstderr tail:\n${input.stderr().toString("utf8")}`,
-  );
+  throw new Error(`tmux PTY client did not attach before popup launch.${evidence()}`);
 }
 
 async function writeChildInput(child: ChildProcess, bytes: Uint8Array): Promise<void> {
@@ -466,37 +648,32 @@ async function writeChildInput(child: ChildProcess, bytes: Uint8Array): Promise<
     throw new Error("tmux PTY client is not writable.");
   }
   await new Promise<void>((resolve, reject) => {
-    stdin.write(bytes, (error) => {
-      if (error === null || error === undefined) {
-        resolve();
-      } else {
-        reject(error);
-      }
-    });
+    stdin.write(bytes, (error) => (error == null ? resolve() : reject(error)));
   });
 }
 
-async function terminateChild(child: ChildProcess, timeoutMs: number): Promise<void> {
-  if (await waitForChildExit(child, timeoutMs)) return;
+async function terminateChild(
+  child: ChildProcess,
+  childClose: Promise<void>,
+  timeoutMs: number,
+): Promise<void> {
+  if (await waitForChildClose(childClose, timeoutMs)) return;
   child.kill("SIGTERM");
-  if (await waitForChildExit(child, timeoutMs)) return;
+  if (await waitForChildClose(childClose, timeoutMs)) return;
   child.kill("SIGKILL");
-  if (!(await waitForChildExit(child, timeoutMs))) {
+  if (!(await waitForChildClose(childClose, timeoutMs))) {
     throw new Error(`tmux PTY client ${child.pid ?? "<unknown>"} survived SIGKILL.`);
   }
 }
 
-async function waitForChildExit(child: ChildProcess, timeoutMs: number): Promise<boolean> {
-  if (child.exitCode !== null || child.signalCode !== null) {
-    return true;
-  }
-  return new Promise<boolean>((resolve) => {
-    const timer = setTimeout(() => resolve(false), timeoutMs);
-    child.once("exit", () => {
-      clearTimeout(timer);
-      resolve(true);
-    });
-  });
+async function waitForChildClose(childClose: Promise<void>, timeoutMs: number): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return Promise.race([
+    childClose.then(() => true),
+    new Promise<boolean>((resolve) => {
+      timer = setTimeout(() => resolve(false), timeoutMs);
+    }),
+  ]).finally(() => clearTimeout(timer));
 }
 
 function appendOutputTail(current: Buffer, chunk: Buffer): Buffer {
@@ -523,6 +700,67 @@ async function delay(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function tmuxSessionFromTarget(target: string): string {
-  return target.split(":")[0] ?? target;
+async function runTmuxCommand(
+  endpoint: RealTmuxEndpoint,
+  args: string[],
+  timeoutMs = 10_000,
+): Promise<{ stderr: string; stdout: string }> {
+  return execFileAsync(endpoint.wrapperPath, ["-S", endpoint.socketPath, ...args], {
+    encoding: "utf8",
+    env: controllerEnvironment(process.env),
+    timeout: timeoutMs,
+  });
+}
+
+function controllerEnvironment(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env = { ...source };
+  delete env.TMUX;
+  delete env.TMUX_PANE;
+  return env;
+}
+
+async function listTmuxClients(
+  endpoint: RealTmuxEndpoint,
+  sessionName: string,
+): Promise<TmuxClientRecord[]> {
+  const format = "#{client_name}\t#{client_pid}\t#{session_name}";
+  const args = ["list-clients", "-t", sessionName, "-F", format];
+  const serialized = (await runTmuxCommand(endpoint, args, 2_000)).stdout.replace(/\r?\n$/u, "");
+  if (serialized.length === 0) return [];
+  return serialized.split("\n").map((line) => {
+    const match = /^([^\t\n]+)\t([1-9]\d*)\t([^\t\n]+)$/u.exec(line);
+    if (match === null || match[3] !== sessionName) {
+      throw new Error(`Malformed tmux client record for ${sessionName}: ${line}`);
+    }
+    return { name: match[1] as string, pid: Number(match[2]), session: match[3] };
+  });
+}
+
+async function readMarker(path: string): Promise<string> {
+  try {
+    return (await readFile(path, "utf8")).slice(-OUTPUT_TAIL_BYTES);
+  } catch (error) {
+    if (error instanceof Error && (error as NodeJS.ErrnoException).code === "ENOENT") return "";
+    throw error;
+  }
+}
+
+function isExactEndpointAbsence(error: unknown, endpoint: RealTmuxEndpoint): boolean {
+  return [
+    `no server running on ${endpoint.socketPath}`,
+    `error connecting to ${endpoint.socketPath} (No such file or directory)`,
+  ].some((diagnostic) => isExactTmuxFailure(error, 1, diagnostic));
+}
+
+function isExactTmuxFailure(error: unknown, code: number, diagnostic: string): boolean {
+  if (!(error instanceof Error)) return false;
+  const failure = error as ExecFileException;
+  const stderr = String(failure.stderr ?? "");
+  return (
+    failure.code === code &&
+    failure.signal == null &&
+    failure.killed !== true &&
+    String(failure.stdout ?? "") === "" &&
+    (diagnostic === "" ? stderr === "" : stderr.replace(/\r?\n$/u, "") === diagnostic)
+  );
 }


### PR DESCRIPTION
## What this fixes

Real Station acceptance fixtures could inherit ambient tmux authority, conflate popup client and pane targets, suppress delivery failures, and lack causal cleanup evidence. That made the lane unable to prove it exercised the intended client and target. The isolated acceptance boundary makes the lane trustworthy and unblocks downstream update-convergence work without product changes.

## What changed

- Creates one explicit private tmux endpoint per fixture and routes every fixture operation through it.
- Uses a dedicated PTY client, with `display-popup -c` client authority kept separate from `-t` pane authority.
- Adds nonced current-invocation popup-start and release handshakes around one correlated key write.
- Preserves actionable primary and cleanup failures with aggregate evidence, then requires strict client, popup, process, endpoint, and teardown proof.
- Migrates the real callers and adds hostile-`TMUX` isolation plus causal unit coverage.

## Testing

- Focused real-Station config and tmux support units: 10/10 passed.
- Direct E2E TypeScript no-emit passed.
- Build: 24 tasks; typecheck: 46 tasks; lint: 1,861 files; architecture: 159 modules. The generated Observer manifest remained byte-identical and `git diff --check` passed.
- Full `test:all`: 3,191 unit, 185 contract, 852 integration, 184 diagnostic, 5 scripted-agent, 30 setup E2E, and 27 Observer/session E2E tests; install smoke passed.
- Full `test:ci:station` passed, including 104 bridge PTY, 69 Bun PTY, and 10 Host upgrade tests.
- Hostile inherited-`TMUX`: 1/1 passed; popup navigation passed twice from fresh fixtures; real Codex hook and lifecycle passed 2/2; remaining non-native migrated callers passed 7/7.
- `claude` was unavailable, so Claude real lanes were not claimed. Native real TUI crossed the exact dormant `agent-resume` recovery boundary, then reproduced the unchanged later line-366 assertion: “Native condition click-away did not return to filter text editing.”

## Safety and scope

Exactly 17 existing test/support/doc paths changed: +1,118/-372, net +746. There are no production, contracts, workflows, packages, generated, or new-file changes. Private-prefix leak checks found no fixture root or process, and validation issued no ambient/default tmux query.

Closes #711.