### PR TITLE
feat(tui): add homebaked inset scrollbars to Help and the dashboard

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -649,7 +649,17 @@ inert. Native composition hosts the result in a managed pane, while standalone c
 Observer-backed capability.
 
 All bottom-sheet text uses the shared non-selectable sheet text primitive. Dragging inside any sheet
-therefore remains pointer interaction and never starts OpenTUI terminal text selection.
+therefore remains pointer interaction and never starts OpenTUI terminal text selection. Help overlay
+copy, `▲`/`▼` overflow chrome, and both inset scrollbar tracks are also non-selectable: OpenTUI
+starts a selection on left-down before renderable handlers run, so a drag on a selectable thumb
+would paint a selection across session copy. Track down/drag maps through the inclusive cell
+formula and never activates dashboard cells. The dashboard gutter paints `▲`/`▼` beside the
+overflow rows whenever the tree can scroll that way, not only when sessions are clipped.
+Session counts stay in the label when sessions are off-screen; otherwise the copy is
+`more above` / `more below`. Those arrows page like the labels and stay off the proportional
+thumb. Thumb length follows Blink/WebKit
+`round(visible/content × track)` (one-cell minimum, never longer than the track); leftover
+track cells keep a thin `▕` rail so the unused range still shows how much remains.
 
 Real native mouse acceptance lives in
 `tests/e2e/real/real-native-tui-mouse.test.ts`. It launches bare `stn` with `TMUX` and `TMUX_PANE`

--- a/packages/dashboard-core/src/components/Dashboard/content.ts
+++ b/packages/dashboard-core/src/components/Dashboard/content.ts
@@ -115,14 +115,21 @@ function plural(count: number, noun: string): string {
 
 export const FIRST_RUN_BODY_LABEL = "Add your first project";
 
+/** Copy for a tree-overflow row. Session counts stay when sessions are clipped. */
 export function scrollIndicatorLabel(
   direction: "above" | "below",
   overflow: DashboardSessionOverflow,
 ): string {
   if (direction === "above") {
-    return `▲ ${overflow.above} ${plural(overflow.above, "session")} above`;
+    if (overflow.above > 0) {
+      return `▲ ${overflow.above} ${plural(overflow.above, "session")} above`;
+    }
+    return "▲ more above";
   }
-  return `▼ ${overflow.below} below · showing ${overflow.visible} of ${overflow.total}`;
+  if (overflow.below > 0) {
+    return `▼ ${overflow.below} below · showing ${overflow.visible} of ${overflow.total}`;
+  }
+  return "▼ more below";
 }
 
 export type SnapshotLoadingLine = {

--- a/packages/dashboard-core/src/components/Dashboard/layout.ts
+++ b/packages/dashboard-core/src/components/Dashboard/layout.ts
@@ -21,12 +21,22 @@ export function dashboardFixedRows(): number {
 
 /** Shared absolute offset from the dashboard surface to its first projected tree row. */
 export function dashboardBodyTop(): number {
-  return (
+  return dashboardScrollGutterChrome({ hasFleetBar: true }).top;
+}
+
+/** Chrome rows above/below the body column, matching DashboardView's child list. */
+export function dashboardScrollGutterChrome(options: { hasFleetBar: boolean }): {
+  top: number;
+  bottom: number;
+} {
+  const top =
     DASHBOARD_FIXED_ROW_HEIGHTS.topSpacer +
-    DASHBOARD_FIXED_ROW_HEIGHTS.fleetBar +
+    (options.hasFleetBar ? DASHBOARD_FIXED_ROW_HEIGHTS.fleetBar : 0) +
     DASHBOARD_FIXED_ROW_HEIGHTS.topDivider +
-    DASHBOARD_FIXED_ROW_HEIGHTS.topScrollIndicator
-  );
+    DASHBOARD_FIXED_ROW_HEIGHTS.topScrollIndicator;
+  const bottom =
+    DASHBOARD_FIXED_ROW_HEIGHTS.bottomScrollIndicator + DASHBOARD_FIXED_ROW_HEIGHTS.bottomDivider;
+  return { top, bottom };
 }
 
 export function dashboardBodyRows(totalRows: number): number {

--- a/packages/dashboard-core/src/components/Dashboard/tableHeader.ts
+++ b/packages/dashboard-core/src/components/Dashboard/tableHeader.ts
@@ -44,11 +44,13 @@ export type DashboardTableHeaderModel =
 export function dashboardTableHeaderModel({
   layout,
   overflow,
+  hiddenAbove,
   columns = 80,
   persistentFilter,
 }: {
   layout: RowGridLayout | undefined;
   overflow: DashboardSessionOverflow;
+  hiddenAbove: number;
   columns?: number;
   persistentFilter?: DashboardPersistentFilterProjection;
 }): DashboardTableHeaderModel {
@@ -62,8 +64,8 @@ export function dashboardTableHeaderModel({
       }),
     };
   }
-  // The position cue owns the shared row whenever sessions are hidden above.
-  if (overflow.above > 0) {
+  // The position cue owns the shared row whenever the tree can scroll up.
+  if (hiddenAbove > 0) {
     return { kind: "aboveOverflow", overflow };
   }
   if (layout !== undefined) {

--- a/packages/dashboard-core/src/components/HelpOverlay/content.ts
+++ b/packages/dashboard-core/src/components/HelpOverlay/content.ts
@@ -1,0 +1,90 @@
+import { DASHBOARD_FILTER_CONDITION_KEYS } from "../../selectors/dashboardFilterConditions.js";
+import {
+  dashboardBindingHelp,
+  type TuiDashboardBindingId,
+  type TuiHelpContentLine,
+} from "../../state/keymap.js";
+
+const FILTER_CONDITION_KEY_HINT = DASHBOARD_FILTER_CONDITION_KEYS.join("/");
+
+function dashboardHelp(id: TuiDashboardBindingId): { key: string; description: string } {
+  const help = dashboardBindingHelp(id);
+  if (help === undefined) throw new Error(`Dashboard binding ${id} has no Help metadata.`);
+  return {
+    key: help.panelKeys ?? help.keys,
+    description: help.panelLabel ?? help.label,
+  };
+}
+
+function dashboardHelpGroup(ids: readonly TuiDashboardBindingId[]): {
+  key: string;
+  description: string;
+} {
+  const entries = ids.map(dashboardHelp);
+  return {
+    key: entries.map(({ key }) => key).join("/"),
+    description: [...new Set(entries.map(({ description }) => description))].join("/"),
+  };
+}
+
+function dashboardKeys(ids: readonly TuiDashboardBindingId[]): string {
+  return ids.map((id) => dashboardHelp(id).key).join(" ");
+}
+
+function dashboardProjectViewHelpLines(): TuiHelpContentLine[] {
+  const navigation = dashboardHelpGroup(["tui.dashboard.focusUp", "tui.dashboard.focusDown"]);
+  const helpAliases = dashboardHelpGroup(["tui.dashboard.help", "tui.dashboard.helpAlias"]);
+  const refresh = dashboardHelp("tui.dashboard.refresh");
+  return [
+    { key: navigation.key, description: `${navigation.description} · wheel scroll` },
+    dashboardHelp("tui.dashboard.focusActivate"),
+    dashboardHelp("tui.dashboard.nextNeedsMe"),
+    dashboardHelpGroup(["tui.dashboard.quickGroup", "tui.dashboard.moveToGroup"]),
+    {
+      key: dashboardKeys([
+        "tui.dashboard.filter",
+        "tui.dashboard.focusActivate",
+        "tui.dashboard.dismissEsc",
+        "tui.dashboard.quit",
+      ]),
+      description: "edit/apply/cancel-clear/retain-close filter",
+    },
+    {
+      key: `Tab ${FILTER_CONDITION_KEY_HINT}`,
+      description: "build filter conditions · F applies builder",
+    },
+    dashboardHelp("tui.dashboard.slotActivate"),
+    dashboardHelpGroup([
+      "tui.dashboard.newSession",
+      "tui.dashboard.addProject",
+      "tui.dashboard.rename",
+      "tui.dashboard.collapse",
+      "tui.dashboard.fork",
+      "tui.dashboard.projectSettings",
+    ]),
+    dashboardHelp("tui.dashboard.widgetSettings"),
+    dashboardHelp("tui.dashboard.remove"),
+    {
+      key: helpAliases.key,
+      description: `${helpAliases.description} · ${refresh.key} ${refresh.description}`,
+    },
+  ];
+}
+
+const DASHBOARD_PROJECT_VIEW_HELP_LINE_COUNT = dashboardProjectViewHelpLines().length;
+
+/** Full Help overlay copy: Station keymap lines, then the dashboard project-view bindings. */
+export function helpOverlayContent(
+  keymapHelp: readonly TuiHelpContentLine[],
+): TuiHelpContentLine[] {
+  return [
+    { text: "station help", align: "center" },
+    ...keymapHelp,
+    { text: "station project view", align: "center" },
+    ...dashboardProjectViewHelpLines(),
+  ];
+}
+
+export function helpOverlayLineCount(keymapHelpCount: number): number {
+  return 2 + Math.max(0, Math.floor(keymapHelpCount)) + DASHBOARD_PROJECT_VIEW_HELP_LINE_COUNT;
+}

--- a/packages/dashboard-core/src/components/HelpOverlay/helpPanel.ts
+++ b/packages/dashboard-core/src/components/HelpOverlay/helpPanel.ts
@@ -1,10 +1,34 @@
 import type { TuiHelpContentLine } from "../../state/keymap.js";
+import { scrollbarOffsetForTrackIndex, verticalScrollbarCells } from "../scrollbar.js";
 
 export type HelpPanelLayout = {
   left: number;
   top: number;
   width: number;
   height: number;
+};
+
+export type HelpPanelBorderLine = {
+  kind: "border";
+  text: string;
+};
+
+export type HelpPanelBodyLine = {
+  kind: "body";
+  prefix: string;
+  bar: string;
+  suffix: string;
+  trackIndex: number;
+  offset: number;
+};
+
+export type HelpPanelLine = HelpPanelBorderLine | HelpPanelBodyLine;
+
+export type HelpPanelModel = {
+  lines: HelpPanelLine[];
+  overflow: boolean;
+  bodyRows: number;
+  scrollOffset: number;
 };
 
 export type { TuiHelpContentLine };
@@ -22,9 +46,7 @@ export function helpPanelLayout(
   const availableRows = Math.max(1, rows);
   const desiredWidth = Math.max(MIN_PANEL_WIDTH, Math.min(MAX_PANEL_WIDTH, availableColumns - 4));
   const width = Math.min(availableColumns, desiredWidth);
-  const desiredHeight = content.length + 2;
-  const maxHeight = availableRows >= 8 ? availableRows - 4 : availableRows;
-  const height = Math.min(maxHeight, desiredHeight);
+  const height = helpPanelHeight(availableRows, content.length);
   return {
     left: Math.max(0, Math.floor((availableColumns - width) / 2)),
     top: Math.max(0, Math.floor((availableRows - height) / 2)),
@@ -33,24 +55,93 @@ export function helpPanelLayout(
   };
 }
 
+export function helpPanelHeight(terminalRows: number, contentLength: number): number {
+  const availableRows = Math.max(1, terminalRows);
+  const desiredHeight = Math.max(0, Math.floor(contentLength)) + 2;
+  const maxHeight = availableRows >= 8 ? availableRows - 4 : availableRows;
+  return Math.min(maxHeight, desiredHeight);
+}
+
+export function helpPanelBodyRows(terminalRows: number, contentLength: number): number {
+  return Math.max(0, helpPanelHeight(terminalRows, contentLength) - 2);
+}
+
+export function clampHelpScrollOffset(
+  contentLength: number,
+  bodyRows: number,
+  offset: number,
+): number {
+  const viewport = Math.max(0, Math.floor(bodyRows));
+  const maxOffset = Math.max(0, Math.floor(contentLength) - viewport);
+  const requested = Number.isFinite(offset) ? Math.floor(offset) : 0;
+  return Math.min(Math.max(0, requested), maxOffset);
+}
+
+export function helpPanelModel(
+  width: number,
+  height: number,
+  content: readonly TuiHelpContentLine[],
+  scrollOffset = 0,
+): HelpPanelModel {
+  const panelWidth = Math.max(1, width);
+  const panelHeight = Math.max(1, height);
+  if (panelHeight === 1) {
+    return {
+      lines: [{ kind: "border", text: horizontalBorder(panelWidth) }],
+      overflow: content.length > 0,
+      bodyRows: 0,
+      scrollOffset: 0,
+    };
+  }
+
+  const bodyRows = Math.max(0, panelHeight - 2);
+  const overflow = content.length > bodyRows;
+  const offset = clampHelpScrollOffset(content.length, bodyRows, scrollOffset);
+  const bars = verticalScrollbarCells({
+    trackHeight: bodyRows,
+    contentLength: content.length,
+    viewportLength: bodyRows,
+    offset,
+  });
+  const lines: HelpPanelLine[] = [{ kind: "border", text: horizontalBorder(panelWidth) }];
+  for (let index = 0; index < bodyRows; index += 1) {
+    const bar = bars[index] ?? " ";
+    const parts = contentLineParts(panelWidth, content[offset + index], bar);
+    lines.push({
+      kind: "body",
+      prefix: parts.prefix,
+      bar: parts.bar,
+      suffix: parts.suffix,
+      trackIndex: index,
+      offset: scrollbarOffsetForTrackIndex({
+        trackHeight: bodyRows,
+        contentLength: content.length,
+        viewportLength: bodyRows,
+        offset,
+        trackIndex: index,
+      }),
+    });
+  }
+  lines.push({ kind: "border", text: bottomBorder(panelWidth) });
+  return {
+    lines,
+    overflow,
+    bodyRows,
+    scrollOffset: offset,
+  };
+}
+
 export function helpPanelLines(
   width: number,
   height: number,
   content: readonly TuiHelpContentLine[],
+  scrollOffset = 0,
 ): string[] {
-  const panelWidth = Math.max(1, width);
-  const panelHeight = Math.max(1, height);
-  if (panelHeight === 1) {
-    return [horizontalBorder(panelWidth)];
-  }
+  return helpPanelModel(width, height, content, scrollOffset).lines.map(joinHelpPanelLine);
+}
 
-  const bodyRows = Math.max(0, panelHeight - 2);
-  const lines = [horizontalBorder(panelWidth)];
-  for (let index = 0; index < bodyRows; index += 1) {
-    lines.push(contentLine(panelWidth, content[index]));
-  }
-  lines.push(bottomBorder(panelWidth));
-  return lines;
+export function joinHelpPanelLine(line: HelpPanelLine): string {
+  return line.kind === "border" ? line.text : `${line.prefix}${line.bar}${line.suffix}`;
 }
 
 function horizontalBorder(width: number): string {
@@ -73,15 +164,32 @@ function bottomBorder(width: number): string {
   return `╰${"─".repeat(width - 2)}╯`;
 }
 
-function contentLine(width: number, content: TuiHelpContentLine | undefined): string {
+function contentLineParts(
+  width: number,
+  content: TuiHelpContentLine | undefined,
+  barGlyph: string,
+): { prefix: string; bar: string; suffix: string } {
   if (width === 1) {
-    return "│";
+    return { prefix: "│", bar: "", suffix: "" };
+  }
+  if (width === 2) {
+    return { prefix: "│", bar: "", suffix: "│" };
   }
   const innerWidth = width - 2;
   const padding = horizontalPaddingFor(innerWidth);
   const contentWidth = Math.max(0, innerWidth - padding * 2);
   const body = formatContent(content, contentWidth);
-  return `│${" ".repeat(padding)}${body}${" ".repeat(padding)}│`;
+  const leftPad = " ".repeat(padding);
+  // The thumb lives in the last inner pad cell so ╭╮│╰╯ stay rounded chrome.
+  if (padding === 0) {
+    return { prefix: `│${body}`, bar: "", suffix: "│" };
+  }
+  const rightPad = " ".repeat(padding - 1);
+  return {
+    prefix: `│${leftPad}${body}${rightPad}`,
+    bar: barGlyph,
+    suffix: "│",
+  };
 }
 
 function formatContent(content: TuiHelpContentLine | undefined, width: number): string {

--- a/packages/dashboard-core/src/components/scrollbar.ts
+++ b/packages/dashboard-core/src/components/scrollbar.ts
@@ -1,4 +1,6 @@
 export const VERTICAL_SCROLLBAR_THUMB = "▐";
+/** Thin right rail for leftover track; same cell as the thumb, not a second column. */
+export const VERTICAL_SCROLLBAR_TRACK = "▕";
 export const VERTICAL_SCROLLBAR_EMPTY = " ";
 
 export type VerticalScrollbarInput = {
@@ -8,15 +10,15 @@ export type VerticalScrollbarInput = {
   offset: number;
 };
 
-/** Whole-cell thumb; empty when content fits. Track cells are spaces, not a second rail. */
+/** Whole-cell thumb. Hidden when content fits. Overflowing leftover cells keep a rail. */
 export function verticalScrollbarCells(input: VerticalScrollbarInput): string[] {
   const trackHeight = Math.max(0, Math.floor(input.trackHeight));
-  const cells = Array.from({ length: trackHeight }, () => VERTICAL_SCROLLBAR_EMPTY);
   const metrics = scrollbarThumbMetrics(input, trackHeight);
   if (metrics === undefined) {
-    return cells;
+    return Array.from({ length: trackHeight }, () => VERTICAL_SCROLLBAR_EMPTY);
   }
   const { thumbStart, thumbSize } = metrics;
+  const cells = Array.from({ length: trackHeight }, () => VERTICAL_SCROLLBAR_TRACK);
   for (let index = thumbStart; index < thumbStart + thumbSize; index += 1) {
     cells[index] = VERTICAL_SCROLLBAR_THUMB;
   }
@@ -47,7 +49,13 @@ function scrollbarThumbMetrics(
   if (trackHeight === 0 || contentLength <= viewportLength) {
     return undefined;
   }
-  const thumbSize = Math.max(1, Math.round((viewportLength * trackHeight) / contentLength));
+  // Blink cc::ScrollUtils::CalculateScrollbarThumbLength (WebKit Composite
+  // matches the round + min). Min is one cell = bar thickness. Firefox sizes
+  // from page-increment instead of visible/content; do not copy that.
+  const thumbSize = Math.min(
+    trackHeight,
+    Math.max(1, Math.round((viewportLength * trackHeight) / contentLength)),
+  );
   const maxThumbStart = Math.max(0, trackHeight - thumbSize);
   const maxOffset = Math.max(1, contentLength - viewportLength);
   const offset = Math.min(Math.max(0, Math.floor(input.offset)), contentLength - viewportLength);

--- a/packages/dashboard-core/src/components/scrollbar.ts
+++ b/packages/dashboard-core/src/components/scrollbar.ts
@@ -1,0 +1,56 @@
+export const VERTICAL_SCROLLBAR_THUMB = "▐";
+export const VERTICAL_SCROLLBAR_EMPTY = " ";
+
+export type VerticalScrollbarInput = {
+  trackHeight: number;
+  contentLength: number;
+  viewportLength: number;
+  offset: number;
+};
+
+/** Whole-cell thumb; empty when content fits. Track cells are spaces, not a second rail. */
+export function verticalScrollbarCells(input: VerticalScrollbarInput): string[] {
+  const trackHeight = Math.max(0, Math.floor(input.trackHeight));
+  const cells = Array.from({ length: trackHeight }, () => VERTICAL_SCROLLBAR_EMPTY);
+  const metrics = scrollbarThumbMetrics(input, trackHeight);
+  if (metrics === undefined) {
+    return cells;
+  }
+  const { thumbStart, thumbSize } = metrics;
+  for (let index = thumbStart; index < thumbStart + thumbSize; index += 1) {
+    cells[index] = VERTICAL_SCROLLBAR_THUMB;
+  }
+  return cells;
+}
+
+/** Maps a track cell to a clamped content offset for click-to-scroll. */
+export function scrollbarOffsetForTrackIndex(
+  input: VerticalScrollbarInput & { trackIndex: number },
+): number {
+  const trackHeight = Math.max(0, Math.floor(input.trackHeight));
+  const contentLength = Math.max(0, Math.floor(input.contentLength));
+  const viewportLength = Math.max(1, Math.floor(input.viewportLength));
+  const maxOffset = Math.max(0, contentLength - viewportLength);
+  if (maxOffset === 0 || trackHeight <= 1) {
+    return 0;
+  }
+  const trackIndex = Math.min(Math.max(0, Math.floor(input.trackIndex)), trackHeight - 1);
+  return Math.round((trackIndex * maxOffset) / (trackHeight - 1));
+}
+
+function scrollbarThumbMetrics(
+  input: VerticalScrollbarInput,
+  trackHeight: number,
+): { thumbStart: number; thumbSize: number } | undefined {
+  const contentLength = Math.max(0, Math.floor(input.contentLength));
+  const viewportLength = Math.max(1, Math.floor(input.viewportLength));
+  if (trackHeight === 0 || contentLength <= viewportLength) {
+    return undefined;
+  }
+  const thumbSize = Math.max(1, Math.round((viewportLength * trackHeight) / contentLength));
+  const maxThumbStart = Math.max(0, trackHeight - thumbSize);
+  const maxOffset = Math.max(1, contentLength - viewportLength);
+  const offset = Math.min(Math.max(0, Math.floor(input.offset)), contentLength - viewportLength);
+  const thumbStart = Math.round((offset * maxThumbStart) / maxOffset);
+  return { thumbStart, thumbSize };
+}

--- a/packages/dashboard-core/src/entrypoints/selectors.ts
+++ b/packages/dashboard-core/src/entrypoints/selectors.ts
@@ -84,6 +84,7 @@ export {
   scrollbarOffsetForTrackIndex,
   VERTICAL_SCROLLBAR_EMPTY,
   VERTICAL_SCROLLBAR_THUMB,
+  VERTICAL_SCROLLBAR_TRACK,
   verticalScrollbarCells,
 } from "../components/scrollbar.js";
 

--- a/packages/dashboard-core/src/entrypoints/selectors.ts
+++ b/packages/dashboard-core/src/entrypoints/selectors.ts
@@ -33,7 +33,7 @@ export type {
   DashboardFooterModel,
 } from "../components/Dashboard/footer.js";
 export { dashboardFooterModel } from "../components/Dashboard/footer.js";
-export { dashboardBodyTop } from "../components/Dashboard/layout.js";
+export { dashboardBodyTop, dashboardScrollGutterChrome } from "../components/Dashboard/layout.js";
 export { dashboardRowGridInput } from "../components/Dashboard/rowGridInput.js";
 export type {
   DashboardFilterHeaderModel,
@@ -57,19 +57,35 @@ export type {
 export { createGroupSheetContent } from "../components/GroupCreateSheet/content.js";
 
 export {
+  helpOverlayContent,
+  helpOverlayLineCount,
+} from "../components/HelpOverlay/content.js";
+export type {
+  HelpPanelBodyLine,
+  HelpPanelLine,
+  HelpPanelModel,
+} from "../components/HelpOverlay/helpPanel.js";
+export {
+  clampHelpScrollOffset,
+  helpPanelBodyRows,
   helpPanelLayout,
   helpPanelLines,
+  helpPanelModel,
+  joinHelpPanelLine,
 } from "../components/HelpOverlay/helpPanel.js";
-
 export {
   newSessionEditGroupDraftContent,
   newSessionEditNameContent,
   newSessionReviewContent,
 } from "../components/NewSessionBottomSheet/content.js";
-
 export { newSessionContentRowCount } from "../components/NewSessionBottomSheet/layout.js";
-
 export { projectSettingsPanelLayout } from "../components/ProjectSettingsPanel/layout.js";
+export {
+  scrollbarOffsetForTrackIndex,
+  VERTICAL_SCROLLBAR_EMPTY,
+  VERTICAL_SCROLLBAR_THUMB,
+  verticalScrollbarCells,
+} from "../components/scrollbar.js";
 
 export { textMatchSegments } from "../components/TextMatch/segments.js";
 export type { ToastBorderColorName } from "../components/ToastOverlay/content.js";

--- a/packages/dashboard-core/src/selectors/dashboardViewport.ts
+++ b/packages/dashboard-core/src/selectors/dashboardViewport.ts
@@ -28,7 +28,7 @@ export type DashboardViewport = {
   readonly persistentFilter?: DashboardPersistentFilterProjection;
 };
 
-/** Session-row counts (not raw tree-row counts) for the scroll-overflow labels. */
+/** Session-row counts for overflow-label copy. Visibility uses hiddenAbove/hiddenBelow. */
 export type DashboardSessionOverflow = {
   readonly above: number;
   readonly below: number;

--- a/packages/dashboard-core/src/state/actions.ts
+++ b/packages/dashboard-core/src/state/actions.ts
@@ -5,7 +5,7 @@ import type { NewSessionActionId } from "../flows/newSession.js";
 import type { DashboardCellId, DashboardRowId } from "../selectors/dashboardTree.js";
 import type { ClientNotice } from "../services/types.js";
 import { activateDashboardCell } from "./dashboardCells.js";
-import { scrollDashboard } from "./dashboardScroll.js";
+import { scrollDashboard, scrollDashboardTo } from "./dashboardScroll.js";
 import type { TuiKey } from "./keys.js";
 import { openDashboardRowShell } from "./rowActivation.js";
 import { tuiScreenBehavior } from "./screenBehavior.js";
@@ -16,6 +16,7 @@ import {
   handleForkSessionAction,
   openForkDetailsForRow,
 } from "./screens/fork.js";
+import { scrollHelpTo } from "./screens/help.js";
 import {
   openMoveToGroupCreate,
   openMoveToGroupForRow,
@@ -130,6 +131,8 @@ export type TuiSemanticAction =
 /** State-only dashboard events for focus, screen, selection, scrolling, and widget transitions. */
 export type DashboardStateAction =
   | { type: "dashboard.scroll"; delta: number }
+  | { type: "dashboard.scrollTo"; offset: number }
+  | { type: "help.scrollTo"; offset: number }
   | { type: "newSession.open"; projectId?: ProjectId; groupId?: SessionGroupId }
   | { type: "projectSettings.focusItem"; itemId: ProjectSettingsItemId }
   | { type: "addProject.selectRow"; index: number }
@@ -219,6 +222,10 @@ function handleDashboardStateAction(
   switch (action.type) {
     case "dashboard.scroll":
       return stateTransition(scrollDashboard(state, action.delta));
+    case "dashboard.scrollTo":
+      return stateTransition(scrollDashboardTo(state, action.offset));
+    case "help.scrollTo":
+      return stateTransition(scrollHelpTo(state, action.offset));
     case "newSession.open":
       return openNewSession(state, {
         ...(action.projectId === undefined ? {} : { projectId: action.projectId }),

--- a/packages/dashboard-core/src/state/dashboardScroll.ts
+++ b/packages/dashboard-core/src/state/dashboardScroll.ts
@@ -3,10 +3,18 @@ import { selectDashboardTree } from "../selectors/dashboardTree.js";
 import type { DashboardState } from "./types.js";
 
 export function scrollDashboard(state: DashboardState, delta: number): DashboardState {
-  return clampDashboardStateScroll({
+  return scrollDashboardTo(state, state.scrollOffset + delta);
+}
+
+export function scrollDashboardTo(state: DashboardState, offset: number): DashboardState {
+  const next = clampDashboardStateScroll({
     ...state,
-    scrollOffset: state.scrollOffset + delta,
+    scrollOffset: offset,
   });
+  if (next.scrollOffset === state.scrollOffset) {
+    return state;
+  }
+  return next;
 }
 
 export function clampDashboardStateScroll(state: DashboardState): DashboardState {

--- a/packages/dashboard-core/src/state/runtime.ts
+++ b/packages/dashboard-core/src/state/runtime.ts
@@ -21,7 +21,7 @@ import { applyAddProjectFolderRefreshed } from "./screens/addProjectScreen.js";
 import { applySnapshotSourceState } from "./sourceBridge.js";
 import { ADD_PROJECT_DIRECTORY_POLL_INTERVAL_MS } from "./timing.js";
 import { addTuiToast, expireTuiToasts, refreshActiveTuiToastExpiry } from "./toasts.js";
-import { handleTuiKey, type TuiTransition } from "./transition.js";
+import { handleTuiKey, type TuiRuntimeContext, type TuiTransition } from "./transition.js";
 import type { CreateInitialTuiStateOptions, DashboardState, DashboardStateView } from "./types.js";
 
 /**
@@ -50,6 +50,8 @@ export type DashboardRuntimeOptions = {
   initialState?: Omit<CreateInitialTuiStateOptions, "initialSnapshot">;
   folderService?: TuiFolderService;
   clientLabel?: string;
+  /** Station keymap Help lines prepended to the dashboard Help overlay copy. */
+  helpKeymapLineCount?: number;
 };
 
 /**
@@ -78,6 +80,7 @@ export function createDashboardRuntime(options: DashboardRuntimeOptions): Dashbo
   const folderService = options.folderService ?? createNodeFolderService();
   const source = options.source;
   const clientLabel = options.clientLabel ?? "TUI";
+  const helpKeymapLineCount = options.helpKeymapLineCount;
   const effectScope = createDashboardRuntimeEffectScope();
   let store: StoreApi<DashboardState>;
   const operations = createTuiLocalOperationRunner({
@@ -106,10 +109,11 @@ export function createDashboardRuntime(options: DashboardRuntimeOptions): Dashbo
         clientLabel,
         operations,
         effectScope,
-        handleTuiKey(store.getState(), key, {
-          cwd: folderService.cwd(),
-          homeDir: folderService.homeDir(),
-        }),
+        handleTuiKey(
+          store.getState(),
+          key,
+          dashboardRuntimeContext(folderService, helpKeymapLineCount),
+        ),
       );
     },
     dispatch: (action): void => {
@@ -120,10 +124,11 @@ export function createDashboardRuntime(options: DashboardRuntimeOptions): Dashbo
         clientLabel,
         operations,
         effectScope,
-        handleTuiAction(store.getState(), action, {
-          cwd: folderService.cwd(),
-          homeDir: folderService.homeDir(),
-        }),
+        handleTuiAction(
+          store.getState(),
+          action,
+          dashboardRuntimeContext(folderService, helpKeymapLineCount),
+        ),
       );
     },
     setTerminalRows: (rows): void => {
@@ -355,4 +360,18 @@ async function reconcileSnapshot(
       store.setState({ loading: false });
     });
   }
+}
+
+function dashboardRuntimeContext(
+  folderService: TuiFolderService,
+  helpKeymapLineCount: number | undefined,
+): TuiRuntimeContext {
+  const context: TuiRuntimeContext = {
+    cwd: folderService.cwd(),
+    homeDir: folderService.homeDir(),
+  };
+  if (helpKeymapLineCount !== undefined) {
+    context.helpKeymapLineCount = helpKeymapLineCount;
+  }
+  return context;
 }

--- a/packages/dashboard-core/src/state/screens/dashboard.ts
+++ b/packages/dashboard-core/src/state/screens/dashboard.ts
@@ -17,6 +17,7 @@ import { addTuiToast } from "../toasts.js";
 import type { TuiRuntimeContext, TuiTransition } from "../transition.js";
 import type { DashboardState } from "../types.js";
 import { openAddProject } from "./addProjectScreen.js";
+import { openHelp } from "./help.js";
 import {
   clearDashboardPersistentFilter,
   openDashboardPersistentFilter,
@@ -82,10 +83,7 @@ function handleDashboardAction(
       };
     case "tui.help.open":
       return {
-        state: {
-          ...state,
-          screen: { name: "help" },
-        },
+        state: openHelp(state, context),
       };
     case "tui.exit":
       return exitDashboardRenderer(state);

--- a/packages/dashboard-core/src/state/screens/help.ts
+++ b/packages/dashboard-core/src/state/screens/help.ts
@@ -1,5 +1,10 @@
+import { helpOverlayLineCount } from "../../components/HelpOverlay/content.js";
+import {
+  clampHelpScrollOffset,
+  helpPanelBodyRows,
+} from "../../components/HelpOverlay/helpPanel.js";
 import type { TuiKey } from "../keys.js";
-import type { TuiTransition } from "../transition.js";
+import type { TuiRuntimeContext, TuiTransition } from "../transition.js";
 import type { DashboardState } from "../types.js";
 
 export const helpScreenBehavior = {
@@ -13,9 +18,63 @@ export function handleHelpKey(state: DashboardState, key: TuiKey): TuiTransition
       state: closeHelp(state),
     };
   }
+  const delta = helpScrollDeltaForKey(key);
+  if (delta !== 0) {
+    return { state: scrollHelp(state, delta) };
+  }
   return { state };
+}
+
+export function openHelp(state: DashboardState, context: TuiRuntimeContext): DashboardState {
+  return {
+    ...state,
+    screen: {
+      name: "help",
+      scrollOffset: 0,
+      contentLength: helpOverlayLineCount(context.helpKeymapLineCount ?? 0),
+    },
+  };
+}
+
+export function scrollHelpTo(state: DashboardState, offset: number): DashboardState {
+  if (state.screen.name !== "help") {
+    return state;
+  }
+  const scrollOffset = clampHelpScrollOffset(
+    state.screen.contentLength,
+    helpPanelBodyRows(state.terminalRows, state.screen.contentLength),
+    offset,
+  );
+  if (scrollOffset === state.screen.scrollOffset) {
+    return state;
+  }
+  return {
+    ...state,
+    screen: {
+      name: "help",
+      scrollOffset,
+      contentLength: state.screen.contentLength,
+    },
+  };
+}
+
+function scrollHelp(state: DashboardState, delta: number): DashboardState {
+  if (state.screen.name !== "help") {
+    return state;
+  }
+  return scrollHelpTo(state, state.screen.scrollOffset + delta);
 }
 
 function closeHelp(state: DashboardState): DashboardState {
   return { ...state, screen: { name: "dashboard" } };
+}
+
+function helpScrollDeltaForKey(key: TuiKey): -1 | 0 | 1 {
+  if (key.upArrow === true || key.mouseScroll === "up") {
+    return -1;
+  }
+  if (key.downArrow === true || key.mouseScroll === "down") {
+    return 1;
+  }
+  return 0;
 }

--- a/packages/dashboard-core/src/state/transition.ts
+++ b/packages/dashboard-core/src/state/transition.ts
@@ -28,6 +28,8 @@ export type TuiTransition = {
 export type TuiRuntimeContext = {
   cwd: string;
   homeDir: string;
+  /** Station keymap Help lines prepended to the dashboard Help overlay copy. */
+  helpKeymapLineCount?: number;
 };
 
 export function handleTuiKey(

--- a/packages/dashboard-core/src/state/types.ts
+++ b/packages/dashboard-core/src/state/types.ts
@@ -139,7 +139,7 @@ export type TuiObserverConnectionStatus =
 
 export type TuiScreen =
   | { name: "dashboard" }
-  | { name: "help" }
+  | { name: "help"; scrollOffset: number; contentLength: number }
   | { name: "projectMenu"; projectId: ProjectId; focus: ProjectMenuActionId }
   | {
       name: "createGroup";

--- a/packages/dashboard-core/test/fixtures/snapshots.ts
+++ b/packages/dashboard-core/test/fixtures/snapshots.ts
@@ -102,6 +102,41 @@ export function createManySlotDashboardSnapshot(): StationSnapshot {
   ]);
 }
 
+/** One project with `sessionCount` idle sessions, for scrollbar / windowing stress. */
+export function createCrowdedDashboardSnapshot(sessionCount: number): StationSnapshot {
+  return snapshotFromRows(
+    Array.from({ length: Math.max(0, Math.floor(sessionCount)) }, (_, index) =>
+      row({
+        id: `wt_web_crowd_${index}`,
+        projectId: "web",
+        branch: `crowd-${String(index).padStart(4, "0")}`,
+        state: "idle",
+      }),
+    ),
+  );
+}
+
+/** Crowded web sessions inside one Group, so the tree has inert frame-end rows. */
+export function createCrowdedGroupedDashboardSnapshot(sessionCount: number): StationSnapshot {
+  const snapshot = createCrowdedDashboardSnapshot(sessionCount);
+  return {
+    ...snapshot,
+    sessionGroups: [
+      {
+        id: "group_crowd",
+        projectId: "web",
+        name: "Crowd",
+        sessionIds: snapshot.sessions
+          .filter((session) => session.projectId === "web")
+          .map((session) => session.id),
+        version: 1,
+        createdAt: fixtureNow,
+        updatedAt: fixtureNow,
+      },
+    ],
+  };
+}
+
 export function createCommandSnapshot(
   state: "none" | "idle" = "idle",
   options: { dirty?: boolean } = {},

--- a/packages/dashboard-core/test/fixtures/snapshots.ts
+++ b/packages/dashboard-core/test/fixtures/snapshots.ts
@@ -116,6 +116,45 @@ export function createCrowdedDashboardSnapshot(sessionCount: number): StationSna
   );
 }
 
+/** Crowded empty Groups after one session Group, so the tree can scroll with no sessions clipped. */
+export function createCrowdedEmptyGroupsSnapshot(groupCount: number): StationSnapshot {
+  const snapshot = snapshotFromRows([
+    row({
+      id: "wt_web_only",
+      projectId: "web",
+      branch: "only-session",
+      state: "idle",
+    }),
+  ]);
+  const sessionId = snapshot.sessions[0]?.id;
+  if (sessionId === undefined) {
+    throw new Error("crowded empty-group fixture requires a session");
+  }
+  return {
+    ...snapshot,
+    sessionGroups: [
+      {
+        id: "group_active",
+        projectId: "web",
+        name: "Active",
+        sessionIds: [sessionId],
+        version: 1,
+        createdAt: fixtureNow,
+        updatedAt: fixtureNow,
+      },
+      ...Array.from({ length: Math.max(0, Math.floor(groupCount)) }, (_, index) => ({
+        id: `group_empty_${String(index).padStart(2, "0")}`,
+        projectId: "web",
+        name: `Empty ${String(index).padStart(2, "0")}`,
+        sessionIds: [],
+        version: 1,
+        createdAt: fixtureNow,
+        updatedAt: fixtureNow,
+      })),
+    ],
+  };
+}
+
 /** Crowded web sessions inside one Group, so the tree has inert frame-end rows. */
 export function createCrowdedGroupedDashboardSnapshot(sessionCount: number): StationSnapshot {
   const snapshot = createCrowdedDashboardSnapshot(sessionCount);

--- a/packages/dashboard-core/test/unit/components/dashboardTableHeader.test.ts
+++ b/packages/dashboard-core/test/unit/components/dashboardTableHeader.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { scrollIndicatorLabel } from "../../../src/components/Dashboard/content.js";
 import {
   dashboardPersistentFilterHeaderModel,
   dashboardTableHeaderModel,
@@ -45,6 +46,7 @@ describe("dashboard table header model", () => {
     const model = dashboardTableHeaderModel({
       layout: HEADER_LAYOUT,
       overflow: { ...NO_OVERFLOW, above: 2 },
+      hiddenAbove: 2,
       persistentFilter: projection(),
     });
 
@@ -54,23 +56,57 @@ describe("dashboard table header model", () => {
   it("gives above overflow precedence over the available column layout", () => {
     const overflow = { ...NO_OVERFLOW, above: 2, total: 6 };
 
-    expect(dashboardTableHeaderModel({ layout: HEADER_LAYOUT, overflow })).toEqual({
+    expect(dashboardTableHeaderModel({ layout: HEADER_LAYOUT, overflow, hiddenAbove: 2 })).toEqual({
       kind: "aboveOverflow",
       overflow,
     });
   });
 
+  it("uses above overflow when only tree chrome is hidden above", () => {
+    expect(
+      dashboardTableHeaderModel({
+        layout: HEADER_LAYOUT,
+        overflow: NO_OVERFLOW,
+        hiddenAbove: 3,
+      }),
+    ).toEqual({
+      kind: "aboveOverflow",
+      overflow: NO_OVERFLOW,
+    });
+  });
+
   it("uses column headers when the viewport is at the top", () => {
-    expect(dashboardTableHeaderModel({ layout: HEADER_LAYOUT, overflow: NO_OVERFLOW })).toEqual({
+    expect(
+      dashboardTableHeaderModel({
+        layout: HEADER_LAYOUT,
+        overflow: NO_OVERFLOW,
+        hiddenAbove: 0,
+      }),
+    ).toEqual({
       kind: "columns",
       layout: HEADER_LAYOUT,
     });
   });
 
   it("uses one empty header row when no layout exists", () => {
-    expect(dashboardTableHeaderModel({ layout: undefined, overflow: NO_OVERFLOW })).toEqual({
+    expect(
+      dashboardTableHeaderModel({ layout: undefined, overflow: NO_OVERFLOW, hiddenAbove: 0 }),
+    ).toEqual({
       kind: "empty",
     });
+  });
+});
+
+describe("scrollIndicatorLabel", () => {
+  it("keeps session copy when sessions are clipped", () => {
+    const overflow = { above: 2, below: 3, visible: 4, total: 9 };
+    expect(scrollIndicatorLabel("above", overflow)).toBe("▲ 2 sessions above");
+    expect(scrollIndicatorLabel("below", overflow)).toBe("▼ 3 below · showing 4 of 9");
+  });
+
+  it("uses generic copy when only tree chrome is clipped", () => {
+    expect(scrollIndicatorLabel("above", NO_OVERFLOW)).toBe("▲ more above");
+    expect(scrollIndicatorLabel("below", NO_OVERFLOW)).toBe("▼ more below");
   });
 });
 

--- a/packages/dashboard-core/test/unit/components/helpPanel.test.ts
+++ b/packages/dashboard-core/test/unit/components/helpPanel.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  helpOverlayContent,
+  helpOverlayLineCount,
+} from "../../../src/components/HelpOverlay/content.js";
+import {
+  clampHelpScrollOffset,
+  helpPanelBodyRows,
+  helpPanelLines,
+  helpPanelModel,
+  joinHelpPanelLine,
+} from "../../../src/components/HelpOverlay/helpPanel.js";
+import { VERTICAL_SCROLLBAR_THUMB } from "../../../src/components/scrollbar.js";
+import type { TuiHelpContentLine } from "../../../src/state/keymap.js";
+
+const FITTING: readonly TuiHelpContentLine[] = [
+  { text: "title", align: "center" },
+  { key: "H", description: "help" },
+];
+
+const OVERFLOW: readonly TuiHelpContentLine[] = Array.from({ length: 8 }, (_, index) => ({
+  key: String(index),
+  description: `line ${index}`,
+}));
+
+describe("help overlay content", () => {
+  it("counts dashboard copy plus keymap lines", () => {
+    const empty = helpOverlayContent([]);
+    expect(helpOverlayLineCount(0)).toBe(empty.length);
+    expect(helpOverlayLineCount(9)).toBe(empty.length + 9);
+    expect(helpOverlayContent([{ key: "Ctrl-O", description: "open" }])[1]).toEqual({
+      key: "Ctrl-O",
+      description: "open",
+    });
+  });
+});
+
+describe("helpPanelLines", () => {
+  it("keeps inner padding as spaces when content fits", () => {
+    const lines = helpPanelLines(64, 4, FITTING, 0);
+    expect(lines[0]?.startsWith("╭")).toBe(true);
+    expect(lines[0]?.endsWith("╮")).toBe(true);
+    expect(lines.at(-1)?.startsWith("╰")).toBe(true);
+    expect(lines.join("")).not.toContain(VERTICAL_SCROLLBAR_THUMB);
+    expect(lines[1]?.endsWith("│")).toBe(true);
+    expect(lines[1]?.at(-2)).toBe(" ");
+  });
+
+  it("windows overflowing copy and paints an inset thumb inside the box", () => {
+    const top = helpPanelLines(64, 5, OVERFLOW, 0);
+    const scrolled = helpPanelLines(64, 5, OVERFLOW, 2);
+    expect(top[1]).toContain("line 0");
+    expect(top.join("")).not.toContain("line 5");
+    expect(scrolled[1]).toContain("line 2");
+    expect(top[1]?.at(-1)).toBe("│");
+    expect(top[1]?.at(-2)).toBe(VERTICAL_SCROLLBAR_THUMB);
+    expect(top[0]).toMatch(/^╭.+╮$/);
+    expect(top.at(-1)).toMatch(/^╰.+╯$/);
+  });
+
+  it("clamps a past-the-end offset to the last window", () => {
+    const last = helpPanelLines(64, 5, OVERFLOW, 99);
+    expect(last[1]).toContain("line 5");
+    expect(last[3]).toContain("line 7");
+  });
+});
+
+describe("helpPanelModel", () => {
+  it("splits the inset bar cell for pointer targets", () => {
+    const model = helpPanelModel(64, 5, OVERFLOW, 0);
+    expect(model.overflow).toBe(true);
+    expect(model.bodyRows).toBe(3);
+    const body = model.lines[1];
+    if (body === undefined || body.kind !== "body") {
+      throw new Error("expected a body line");
+    }
+    expect(joinHelpPanelLine(body)).toHaveLength(64);
+    expect(body.bar).toBe(VERTICAL_SCROLLBAR_THUMB);
+    expect(body.suffix).toBe("│");
+  });
+});
+
+describe("clampHelpScrollOffset", () => {
+  it("clamps to the last fully visible window", () => {
+    expect(clampHelpScrollOffset(22, 18, -3)).toBe(0);
+    expect(clampHelpScrollOffset(22, 18, 4)).toBe(4);
+    expect(clampHelpScrollOffset(22, 18, 9)).toBe(4);
+    expect(helpPanelBodyRows(24, 22)).toBe(18);
+  });
+});

--- a/packages/dashboard-core/test/unit/components/helpPanel.test.ts
+++ b/packages/dashboard-core/test/unit/components/helpPanel.test.ts
@@ -10,7 +10,10 @@ import {
   helpPanelModel,
   joinHelpPanelLine,
 } from "../../../src/components/HelpOverlay/helpPanel.js";
-import { VERTICAL_SCROLLBAR_THUMB } from "../../../src/components/scrollbar.js";
+import {
+  VERTICAL_SCROLLBAR_THUMB,
+  VERTICAL_SCROLLBAR_TRACK,
+} from "../../../src/components/scrollbar.js";
 import type { TuiHelpContentLine } from "../../../src/state/keymap.js";
 
 const FITTING: readonly TuiHelpContentLine[] = [
@@ -54,6 +57,7 @@ describe("helpPanelLines", () => {
     expect(scrolled[1]).toContain("line 2");
     expect(top[1]?.at(-1)).toBe("│");
     expect(top[1]?.at(-2)).toBe(VERTICAL_SCROLLBAR_THUMB);
+    expect(top[2]?.at(-2)).toBe(VERTICAL_SCROLLBAR_TRACK);
     expect(top[0]).toMatch(/^╭.+╮$/);
     expect(top.at(-1)).toMatch(/^╰.+╯$/);
   });

--- a/packages/dashboard-core/test/unit/components/scrollbar.stress.test.ts
+++ b/packages/dashboard-core/test/unit/components/scrollbar.stress.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  scrollbarOffsetForTrackIndex,
+  VERTICAL_SCROLLBAR_THUMB,
+  verticalScrollbarCells,
+} from "../../../src/components/scrollbar.js";
+
+const STRESS_CASES = [
+  { trackHeight: 17, contentLength: 300, viewportLength: 17 },
+  { trackHeight: 17, contentLength: 301, viewportLength: 17 },
+  { trackHeight: 18, contentLength: 300, viewportLength: 18 },
+  { trackHeight: 9, contentLength: 300, viewportLength: 9 },
+  { trackHeight: 17, contentLength: 3000, viewportLength: 17 },
+  { trackHeight: 4, contentLength: 20, viewportLength: 1 },
+  { trackHeight: 18, contentLength: 22, viewportLength: 18 },
+  { trackHeight: 17, contentLength: 18, viewportLength: 17 },
+] as const;
+
+describe("vertical scrollbar stress", () => {
+  it.each(STRESS_CASES)("maps the first and last track cells to 0 and maxOffset (%o)", (input) => {
+    const maxOffset = input.contentLength - input.viewportLength;
+    expect(scrollbarOffsetForTrackIndex({ ...input, offset: 0, trackIndex: 0 })).toBe(0);
+    expect(
+      scrollbarOffsetForTrackIndex({
+        ...input,
+        offset: 0,
+        trackIndex: input.trackHeight - 1,
+      }),
+    ).toBe(maxOffset);
+  });
+
+  it.each(STRESS_CASES)("click offsets are monotone and stay in range (%o)", (input) => {
+    const maxOffset = input.contentLength - input.viewportLength;
+    let previous = 0;
+    for (let trackIndex = 0; trackIndex < input.trackHeight; trackIndex += 1) {
+      const offset = scrollbarOffsetForTrackIndex({ ...input, offset: 0, trackIndex });
+      expect(offset).toBeGreaterThanOrEqual(previous);
+      expect(offset).toBeGreaterThanOrEqual(0);
+      expect(offset).toBeLessThanOrEqual(maxOffset);
+      previous = offset;
+    }
+  });
+
+  it.each(
+    STRESS_CASES,
+  )("keeps a thumb at the start when offset is 0 and at the end at maxOffset (%o)", (input) => {
+    const maxOffset = input.contentLength - input.viewportLength;
+    const top = verticalScrollbarCells({ ...input, offset: 0 });
+    const bottom = verticalScrollbarCells({ ...input, offset: maxOffset });
+    expect(top[0]).toBe(VERTICAL_SCROLLBAR_THUMB);
+    expect(bottom.at(-1)).toBe(VERTICAL_SCROLLBAR_THUMB);
+  });
+
+  it.each(
+    STRESS_CASES,
+  )("advances offset by 1 even when the painted thumb stays put (%o)", (input) => {
+    const maxOffset = input.contentLength - input.viewportLength;
+    let stuck = 0;
+    let moved = 0;
+    let previous = verticalScrollbarCells({ ...input, offset: 0 }).join("");
+    for (let offset = 1; offset <= maxOffset; offset += 1) {
+      const next = verticalScrollbarCells({ ...input, offset }).join("");
+      if (next === previous) {
+        stuck += 1;
+      } else {
+        moved += 1;
+      }
+      previous = next;
+    }
+    expect(stuck + moved).toBe(maxOffset);
+    expect(moved).toBeGreaterThan(0);
+    if (maxOffset > input.trackHeight) {
+      expect(stuck).toBeGreaterThan(0);
+    }
+  });
+
+  it("a one-cell track cannot encode both ends, so clicks collapse to 0", () => {
+    expect(
+      scrollbarOffsetForTrackIndex({
+        trackHeight: 1,
+        contentLength: 300,
+        viewportLength: 1,
+        offset: 0,
+        trackIndex: 0,
+      }),
+    ).toBe(0);
+  });
+
+  it.each(STRESS_CASES)("clicking the painted end thumbs returns 0 and maxOffset (%o)", (input) => {
+    const maxOffset = input.contentLength - input.viewportLength;
+    const top = verticalScrollbarCells({ ...input, offset: 0 });
+    const bottom = verticalScrollbarCells({ ...input, offset: maxOffset });
+    expect(
+      scrollbarOffsetForTrackIndex({
+        ...input,
+        offset: 0,
+        trackIndex: top.indexOf(VERTICAL_SCROLLBAR_THUMB),
+      }),
+    ).toBe(0);
+    expect(
+      scrollbarOffsetForTrackIndex({
+        ...input,
+        offset: 0,
+        trackIndex: bottom.lastIndexOf(VERTICAL_SCROLLBAR_THUMB),
+      }),
+    ).toBe(maxOffset);
+  });
+
+  it("clicking a middle thumb cell can jump away from the current offset", () => {
+    const input = { trackHeight: 17, contentLength: 300, viewportLength: 17, offset: 100 };
+    const thumb = verticalScrollbarCells(input).indexOf(VERTICAL_SCROLLBAR_THUMB);
+    expect(scrollbarOffsetForTrackIndex({ ...input, trackIndex: thumb })).not.toBe(input.offset);
+  });
+});
+
+describe("OpenTUI cell-ratio exclusive end (why we snap last cell)", () => {
+  it("maps the last cell through height, not height-1, so it misses maxOffset", () => {
+    const height = 17;
+    const maxOffset = 283;
+    const lastCell = height - 1;
+    const clicked = Math.round((lastCell / height) * maxOffset);
+    expect(clicked).toBe(266);
+    expect(clicked).not.toBe(maxOffset);
+  });
+
+  it("maps integer-cell thumb drag through *2 virtual coords, so an odd maxThumbStart is unreachable", () => {
+    const height = 17;
+    const maxOffset = 283;
+    const virtualTrack = height * 2;
+    const virtualThumb = 1;
+    const maxThumbStart = virtualTrack - virtualThumb;
+    const lastCellVirtual = lastCellVirtualPos(height);
+    const ratio = lastCellVirtual / maxThumbStart;
+    const dragged = Math.round(ratio * maxOffset);
+    expect(maxThumbStart).toBe(33);
+    expect(lastCellVirtual).toBe(32);
+    expect(dragged).toBe(274);
+    expect(dragged).not.toBe(maxOffset);
+  });
+});
+
+function lastCellVirtualPos(height: number): number {
+  return (height - 1) * 2;
+}

--- a/packages/dashboard-core/test/unit/components/scrollbar.stress.test.ts
+++ b/packages/dashboard-core/test/unit/components/scrollbar.stress.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   scrollbarOffsetForTrackIndex,
   VERTICAL_SCROLLBAR_THUMB,
+  VERTICAL_SCROLLBAR_TRACK,
   verticalScrollbarCells,
 } from "../../../src/components/scrollbar.js";
 
@@ -49,6 +50,10 @@ describe("vertical scrollbar stress", () => {
     const bottom = verticalScrollbarCells({ ...input, offset: maxOffset });
     expect(top[0]).toBe(VERTICAL_SCROLLBAR_THUMB);
     expect(bottom.at(-1)).toBe(VERTICAL_SCROLLBAR_THUMB);
+    expect(
+      top.every((cell) => cell === VERTICAL_SCROLLBAR_THUMB || cell === VERTICAL_SCROLLBAR_TRACK),
+    ).toBe(true);
+    expect(top).toContain(VERTICAL_SCROLLBAR_TRACK);
   });
 
   it.each(

--- a/packages/dashboard-core/test/unit/components/scrollbar.test.ts
+++ b/packages/dashboard-core/test/unit/components/scrollbar.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  scrollbarOffsetForTrackIndex,
+  VERTICAL_SCROLLBAR_EMPTY,
+  VERTICAL_SCROLLBAR_THUMB,
+  verticalScrollbarCells,
+} from "../../../src/components/scrollbar.js";
+
+describe("verticalScrollbarCells", () => {
+  it("fills the track with spaces when content fits", () => {
+    expect(
+      verticalScrollbarCells({
+        trackHeight: 5,
+        contentLength: 5,
+        viewportLength: 5,
+        offset: 0,
+      }),
+    ).toEqual(Array.from({ length: 5 }, () => VERTICAL_SCROLLBAR_EMPTY));
+  });
+
+  it("places a proportional thumb at the top, middle, and bottom", () => {
+    const input = {
+      trackHeight: 18,
+      contentLength: 22,
+      viewportLength: 18,
+    };
+    const top = verticalScrollbarCells({ ...input, offset: 0 }).join("");
+    const bottom = verticalScrollbarCells({ ...input, offset: 4 }).join("");
+
+    expect(top.startsWith(VERTICAL_SCROLLBAR_THUMB.repeat(15))).toBe(true);
+    expect(top.endsWith(VERTICAL_SCROLLBAR_EMPTY.repeat(3))).toBe(true);
+    expect(bottom.startsWith(VERTICAL_SCROLLBAR_EMPTY.repeat(3))).toBe(true);
+    expect(bottom.endsWith(VERTICAL_SCROLLBAR_THUMB.repeat(15))).toBe(true);
+    expect(verticalScrollbarCells({ ...input, offset: 2 }).join("")).toContain(
+      VERTICAL_SCROLLBAR_THUMB,
+    );
+  });
+
+  it("keeps a one-cell thumb for a tiny viewport", () => {
+    expect(
+      verticalScrollbarCells({
+        trackHeight: 4,
+        contentLength: 20,
+        viewportLength: 1,
+        offset: 0,
+      }),
+    ).toEqual([
+      VERTICAL_SCROLLBAR_THUMB,
+      VERTICAL_SCROLLBAR_EMPTY,
+      VERTICAL_SCROLLBAR_EMPTY,
+      VERTICAL_SCROLLBAR_EMPTY,
+    ]);
+  });
+});
+
+describe("scrollbarOffsetForTrackIndex", () => {
+  it("maps the first and last track cells to the scroll range", () => {
+    const input = {
+      trackHeight: 18,
+      contentLength: 22,
+      viewportLength: 18,
+      offset: 0,
+    };
+    expect(scrollbarOffsetForTrackIndex({ ...input, trackIndex: 0 })).toBe(0);
+    expect(scrollbarOffsetForTrackIndex({ ...input, trackIndex: 17 })).toBe(4);
+  });
+
+  it("returns 0 when content fits", () => {
+    expect(
+      scrollbarOffsetForTrackIndex({
+        trackHeight: 10,
+        contentLength: 5,
+        viewportLength: 10,
+        offset: 0,
+        trackIndex: 7,
+      }),
+    ).toBe(0);
+  });
+});

--- a/packages/dashboard-core/test/unit/components/scrollbar.test.ts
+++ b/packages/dashboard-core/test/unit/components/scrollbar.test.ts
@@ -3,8 +3,19 @@ import {
   scrollbarOffsetForTrackIndex,
   VERTICAL_SCROLLBAR_EMPTY,
   VERTICAL_SCROLLBAR_THUMB,
+  VERTICAL_SCROLLBAR_TRACK,
   verticalScrollbarCells,
 } from "../../../src/components/scrollbar.js";
+
+function thumbSize(input: {
+  trackHeight: number;
+  contentLength: number;
+  viewportLength: number;
+}): number {
+  return verticalScrollbarCells({ ...input, offset: 0 }).filter(
+    (cell) => cell === VERTICAL_SCROLLBAR_THUMB,
+  ).length;
+}
 
 describe("verticalScrollbarCells", () => {
   it("fills the track with spaces when content fits", () => {
@@ -28,8 +39,8 @@ describe("verticalScrollbarCells", () => {
     const bottom = verticalScrollbarCells({ ...input, offset: 4 }).join("");
 
     expect(top.startsWith(VERTICAL_SCROLLBAR_THUMB.repeat(15))).toBe(true);
-    expect(top.endsWith(VERTICAL_SCROLLBAR_EMPTY.repeat(3))).toBe(true);
-    expect(bottom.startsWith(VERTICAL_SCROLLBAR_EMPTY.repeat(3))).toBe(true);
+    expect(top.endsWith(VERTICAL_SCROLLBAR_TRACK.repeat(3))).toBe(true);
+    expect(bottom.startsWith(VERTICAL_SCROLLBAR_TRACK.repeat(3))).toBe(true);
     expect(bottom.endsWith(VERTICAL_SCROLLBAR_THUMB.repeat(15))).toBe(true);
     expect(verticalScrollbarCells({ ...input, offset: 2 }).join("")).toContain(
       VERTICAL_SCROLLBAR_THUMB,
@@ -46,10 +57,18 @@ describe("verticalScrollbarCells", () => {
       }),
     ).toEqual([
       VERTICAL_SCROLLBAR_THUMB,
-      VERTICAL_SCROLLBAR_EMPTY,
-      VERTICAL_SCROLLBAR_EMPTY,
-      VERTICAL_SCROLLBAR_EMPTY,
+      VERTICAL_SCROLLBAR_TRACK,
+      VERTICAL_SCROLLBAR_TRACK,
+      VERTICAL_SCROLLBAR_TRACK,
     ]);
+  });
+
+  it("shrinks the thumb as content grows, using Blink visible/content * track", () => {
+    const track = { trackHeight: 17, viewportLength: 17 };
+    expect(thumbSize({ ...track, contentLength: 17 })).toBe(0);
+    expect(thumbSize({ ...track, contentLength: 18 })).toBe(16);
+    expect(thumbSize({ ...track, contentLength: 34 })).toBe(9);
+    expect(thumbSize({ ...track, contentLength: 300 })).toBe(1);
   });
 });
 

--- a/packages/dashboard-core/test/unit/selectors/dashboardViewport.test.ts
+++ b/packages/dashboard-core/test/unit/selectors/dashboardViewport.test.ts
@@ -3,6 +3,7 @@ import { dashboardRowIds } from "../../../src/selectors/dashboardTree.js";
 import { selectDashboardViewport } from "../../../src/selectors/dashboardViewport.js";
 import { createInitialTuiState } from "../../../src/state/screen.js";
 import {
+  createCrowdedEmptyGroupsSnapshot,
   createDashboardSnapshot,
   createGroupedDashboardSnapshot,
 } from "../../fixtures/snapshots.js";
@@ -172,6 +173,22 @@ describe("dashboard viewport selector", () => {
       below: 5,
       visible: 2,
       total: 7,
+    });
+  });
+
+  it("can hide group chrome below while every session stays in the window", () => {
+    const snapshot = createCrowdedEmptyGroupsSnapshot(20);
+    const viewport = selectDashboardViewport(
+      snapshot,
+      createInitialTuiState({ initialSnapshot: snapshot, terminalRows: 12 }),
+    );
+
+    expect(viewport.hiddenBelow).toBeGreaterThan(0);
+    expect(viewport.sessionOverflow).toEqual({
+      above: 0,
+      below: 0,
+      visible: 1,
+      total: 1,
     });
   });
 

--- a/packages/dashboard-core/test/unit/state/actions.test.ts
+++ b/packages/dashboard-core/test/unit/state/actions.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { dashboardRowIds } from "../../../src/selectors/dashboardTree.js";
 import type { DashboardStateAction } from "../../../src/state/actions.js";
 import { handleTuiAction } from "../../../src/state/actions.js";
-import { scrollDashboard } from "../../../src/state/dashboardScroll.js";
+import { scrollDashboard, scrollDashboardTo } from "../../../src/state/dashboardScroll.js";
 import { createInitialTuiState } from "../../../src/state/screen.js";
 import { tuiScreenBehavior } from "../../../src/state/screenBehavior.js";
 import {
@@ -10,6 +10,7 @@ import {
   openAddProject,
   selectAddProjectRow,
 } from "../../../src/state/screens/addProjectScreen.js";
+import { scrollHelpTo } from "../../../src/state/screens/help.js";
 import { openProjectDefaultAgentPicker } from "../../../src/state/screens/projectDefaultAgent.js";
 import {
   focusProjectSettingsItem,
@@ -49,6 +50,18 @@ const STATE_ACTION_CASES: readonly StateActionCase[] = [
     action: { type: "dashboard.scroll", delta: 5 },
     state: scrollingDashboardState,
     reduce: (state) => scrollDashboard(state, 5),
+  },
+  {
+    name: "dashboard.scrollTo",
+    action: { type: "dashboard.scrollTo", offset: 3 },
+    state: scrollingDashboardState,
+    reduce: (state) => scrollDashboardTo(state, 3),
+  },
+  {
+    name: "help.scrollTo",
+    action: { type: "help.scrollTo", offset: 2 },
+    state: helpOverflowState,
+    reduce: (state) => scrollHelpTo(state, 2),
   },
   {
     name: "projectSettings.focusItem",
@@ -129,6 +142,8 @@ const STATE_ACTION_CASES: readonly StateActionCase[] = [
 ];
 
 const STALE_STATE_ACTIONS: readonly DashboardStateAction[] = [
+  { type: "dashboard.scrollTo", offset: 4 },
+  { type: "help.scrollTo", offset: 2 },
   { type: "projectSettings.focusItem", itemId: "agent" },
   { type: "addProject.selectRow", index: 0 },
   { type: "screen.clickAway" },
@@ -535,6 +550,14 @@ function dashboardState(): DashboardState {
 
 function scrollingDashboardState(): DashboardState {
   return { ...dashboardState(), terminalRows: 8 };
+}
+
+function helpOverflowState(): DashboardState {
+  return {
+    ...dashboardState(),
+    terminalRows: 8,
+    screen: { name: "help", scrollOffset: 0, contentLength: 20 },
+  };
 }
 
 function projectSettingsState(): DashboardState {

--- a/packages/dashboard-core/test/unit/state/dashboardScroll.stress.test.ts
+++ b/packages/dashboard-core/test/unit/state/dashboardScroll.stress.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it } from "vitest";
+import {
+  helpPanelBodyRows,
+  helpPanelLines,
+} from "../../../src/components/HelpOverlay/helpPanel.js";
+import { verticalScrollbarCells } from "../../../src/components/scrollbar.js";
+import { dashboardRowIds, selectDashboardTree } from "../../../src/selectors/dashboardTree.js";
+import { selectDashboardViewport } from "../../../src/selectors/dashboardViewport.js";
+import { focusDashboardSession } from "../../../src/state/dashboardFocus.js";
+import {
+  clampDashboardStateScroll,
+  scrollDashboard,
+  scrollDashboardTo,
+} from "../../../src/state/dashboardScroll.js";
+import type { TuiHelpContentLine } from "../../../src/state/keymap.js";
+import { createInitialTuiState } from "../../../src/state/screen.js";
+import { handleTuiKey } from "../../../src/state/transition.js";
+import {
+  createCrowdedDashboardSnapshot,
+  createCrowdedGroupedDashboardSnapshot,
+} from "../../fixtures/snapshots.js";
+
+const TERMINAL_ROWS = 24;
+const SESSION_COUNT = 300;
+
+describe("dashboard windowing stress", () => {
+  it("every offset shows tree[offset], including when the thumb would not move", () => {
+    const snapshot = createCrowdedDashboardSnapshot(SESSION_COUNT);
+    const initial = createInitialTuiState({
+      initialSnapshot: snapshot,
+      terminalRows: TERMINAL_ROWS,
+    });
+    const tree = selectDashboardTree(snapshot, initial, initial.screen);
+    const start = selectDashboardViewport(snapshot, initial);
+    const maxOffset = tree.visibleRows.length - start.bodyRows;
+    expect(maxOffset).toBeGreaterThan(SESSION_COUNT - start.bodyRows);
+
+    for (let offset = 0; offset <= maxOffset; offset += 1) {
+      const state = scrollDashboardTo(initial, offset);
+      const viewport = selectDashboardViewport(snapshot, state);
+      expect(state.scrollOffset).toBe(offset);
+      expect(viewport.clampedScrollOffset).toBe(offset);
+      expect(viewport.hiddenAbove).toBe(offset);
+      expect(viewport.hiddenBelow).toBe(maxOffset - offset);
+      expect(viewport.rows[0]?.id).toBe(tree.visibleRows[offset]?.id);
+      expect(viewport.rows.at(-1)?.id).toBe(
+        tree.visibleRows[offset + viewport.rows.length - 1]?.id,
+      );
+    }
+  });
+
+  it("wheels one tree row at a time down to the last window and refuses to overshoot", () => {
+    const snapshot = createCrowdedDashboardSnapshot(SESSION_COUNT);
+    let state = createInitialTuiState({
+      initialSnapshot: snapshot,
+      terminalRows: TERMINAL_ROWS,
+    });
+    const maxOffset = maxScrollOffset(snapshot, state);
+
+    for (let step = 0; step < maxOffset; step += 1) {
+      const next = handleTuiKey(state, { input: "", mouseScroll: "down" }).state;
+      expect(next.scrollOffset).toBe(state.scrollOffset + 1);
+      state = next;
+    }
+
+    expect(handleTuiKey(state, { input: "", mouseScroll: "down" }).state).toBe(state);
+    expect(selectDashboardViewport(snapshot, state).hiddenBelow).toBe(0);
+  });
+
+  it("wheels one tree row at a time up from the last window", () => {
+    const snapshot = createCrowdedDashboardSnapshot(SESSION_COUNT);
+    const initial = createInitialTuiState({
+      initialSnapshot: snapshot,
+      terminalRows: TERMINAL_ROWS,
+    });
+    const maxOffset = maxScrollOffset(snapshot, initial);
+    let state = scrollDashboardTo(initial, maxOffset);
+    const lastId = firstRowId(selectDashboardViewport(snapshot, state));
+
+    const next = handleTuiKey(state, { input: "", mouseScroll: "up" }).state;
+    expect(next.scrollOffset).toBe(maxOffset - 1);
+    expect(firstRowId(selectDashboardViewport(snapshot, next))).not.toBe(lastId);
+
+    state = scrollDashboardTo(initial, 0);
+    expect(handleTuiKey(state, { input: "", mouseScroll: "up" }).state).toBe(state);
+  });
+
+  it("arrow-down never skips more tree rows than the cursor moved, and reaches the last window", () => {
+    const snapshot = createCrowdedDashboardSnapshot(SESSION_COUNT);
+    let state = createInitialTuiState({
+      initialSnapshot: snapshot,
+      terminalRows: TERMINAL_ROWS,
+    });
+    const tree = selectDashboardTree(snapshot, state, state.screen);
+    const maxOffset = maxScrollOffset(snapshot, state);
+    const budget = tree.visibleRows.length + 8;
+
+    for (let step = 0; step < budget; step += 1) {
+      const previous = state;
+      const previousIndex = focusedIndex(tree, previous);
+      state = handleTuiKey(state, { input: "", downArrow: true }).state;
+      const nextIndex = focusedIndex(tree, state);
+      expect(state.scrollOffset).toBeGreaterThanOrEqual(previous.scrollOffset);
+      expect(state.scrollOffset - previous.scrollOffset).toBeLessThanOrEqual(
+        Math.max(1, nextIndex - previousIndex),
+      );
+      if (state.scrollOffset === maxOffset && nextIndex === previousIndex) {
+        break;
+      }
+    }
+
+    expect(state.scrollOffset).toBe(maxOffset);
+    expect(selectDashboardViewport(snapshot, state).hiddenBelow).toBe(0);
+  });
+
+  it("scrollTo(max) and a past-the-end offset both land on the last window", () => {
+    const snapshot = createCrowdedDashboardSnapshot(SESSION_COUNT);
+    const state = createInitialTuiState({
+      initialSnapshot: snapshot,
+      terminalRows: TERMINAL_ROWS,
+    });
+    const maxOffset = maxScrollOffset(snapshot, state);
+    const atMax = scrollDashboardTo(state, maxOffset);
+    const pastEnd = scrollDashboardTo(atMax, maxOffset + 50);
+    expect(atMax.scrollOffset).toBe(maxOffset);
+    expect(pastEnd).toBe(atMax);
+    expect(selectDashboardViewport(snapshot, atMax).hiddenBelow).toBe(0);
+  });
+
+  it("pages by 5 near the end clamp to max instead of overshooting", () => {
+    const snapshot = createCrowdedDashboardSnapshot(SESSION_COUNT);
+    const state = createInitialTuiState({
+      initialSnapshot: snapshot,
+      terminalRows: TERMINAL_ROWS,
+    });
+    const maxOffset = maxScrollOffset(snapshot, state);
+    expect(scrollDashboard(scrollDashboardTo(state, maxOffset - 2), 5).scrollOffset).toBe(
+      maxOffset,
+    );
+    expect(scrollDashboard(state, -5).scrollOffset).toBe(0);
+  });
+
+  it("widening the terminal while pinned at the bottom keeps the last window, not a hole", () => {
+    const snapshot = createCrowdedDashboardSnapshot(SESSION_COUNT);
+    const compact = createInitialTuiState({
+      initialSnapshot: snapshot,
+      terminalRows: TERMINAL_ROWS,
+    });
+    const maxOffset = maxScrollOffset(snapshot, compact);
+    const pinned = scrollDashboardTo(compact, maxOffset);
+    const widened = clampDashboardStateScroll({ ...pinned, terminalRows: 40 });
+    const viewport = selectDashboardViewport(snapshot, widened);
+    expect(widened.scrollOffset).toBeLessThan(maxOffset);
+    expect(viewport.hiddenBelow).toBe(0);
+    expect(viewport.rows.at(-1)?.id).toBe(
+      selectDashboardTree(snapshot, widened, widened.screen).visibleRows.at(-1)?.id,
+    );
+  });
+
+  it("shrinking the terminal while at the tall bottom keeps a valid offset that is no longer the last window", () => {
+    const snapshot = createCrowdedDashboardSnapshot(SESSION_COUNT);
+    const tall = createInitialTuiState({
+      initialSnapshot: snapshot,
+      terminalRows: 40,
+    });
+    const pinned = scrollDashboardTo(tall, maxScrollOffset(snapshot, tall));
+    const shrunk = clampDashboardStateScroll({ ...pinned, terminalRows: TERMINAL_ROWS });
+    expect(shrunk.scrollOffset).toBe(pinned.scrollOffset);
+    expect(selectDashboardViewport(snapshot, shrunk).hiddenBelow).toBeGreaterThan(0);
+  });
+
+  it("arrow-down walks the cursor through the first window before the offset moves", () => {
+    const snapshot = createCrowdedDashboardSnapshot(SESSION_COUNT);
+    let state = createInitialTuiState({
+      initialSnapshot: snapshot,
+      terminalRows: TERMINAL_ROWS,
+    });
+    const bodyRows = selectDashboardViewport(snapshot, state).bodyRows;
+    const entered = handleTuiKey(state, { input: "", downArrow: true }).state;
+    expect(entered.scrollOffset).toBe(0);
+    expect(entered.dashboardFocus).toBeDefined();
+    state = entered;
+    let downs = 1;
+    while (state.scrollOffset === 0 && downs < bodyRows + 8) {
+      state = handleTuiKey(state, { input: "", downArrow: true }).state;
+      downs += 1;
+    }
+    expect(downs).toBeGreaterThan(2);
+    expect(state.scrollOffset).toBe(1);
+  });
+
+  it("a one-row wheel still changes the window when the painted thumb does not", () => {
+    const snapshot = createCrowdedDashboardSnapshot(SESSION_COUNT);
+    const initial = createInitialTuiState({
+      initialSnapshot: snapshot,
+      terminalRows: TERMINAL_ROWS,
+    });
+    const tree = selectDashboardTree(snapshot, initial, initial.screen);
+    const viewportLength = selectDashboardViewport(snapshot, initial).bodyRows;
+    const paint = {
+      trackHeight: viewportLength,
+      contentLength: tree.visibleRows.length,
+      viewportLength,
+    };
+    expect(verticalScrollbarCells({ ...paint, offset: 0 }).join("")).toBe(
+      verticalScrollbarCells({ ...paint, offset: 1 }).join(""),
+    );
+    const after = handleTuiKey(initial, { input: "", mouseScroll: "down" }).state;
+    expect(after.scrollOffset).toBe(1);
+    expect(firstRowId(selectDashboardViewport(snapshot, after))).not.toBe(
+      firstRowId(selectDashboardViewport(snapshot, initial)),
+    );
+  });
+
+  it("arrow-up from the last window focuses a visible row before the offset moves", () => {
+    const snapshot = createCrowdedDashboardSnapshot(SESSION_COUNT);
+    const initial = createInitialTuiState({
+      initialSnapshot: snapshot,
+      terminalRows: TERMINAL_ROWS,
+    });
+    const maxOffset = maxScrollOffset(snapshot, initial);
+    const pinned = scrollDashboardTo(initial, maxOffset);
+    const entered = handleTuiKey(pinned, { input: "", upArrow: true }).state;
+    expect(entered.scrollOffset).toBe(maxOffset);
+    expect(entered.dashboardFocus).toBeDefined();
+    let state = entered;
+    let ups = 1;
+    while (state.scrollOffset === maxOffset && ups < 40) {
+      state = handleTuiKey(state, { input: "", upArrow: true }).state;
+      ups += 1;
+    }
+    expect(ups).toBeGreaterThan(2);
+    expect(state.scrollOffset).toBe(maxOffset - 1);
+  });
+
+  it("collapsing a crowded group while pinned at the bottom keeps a valid last window", () => {
+    const snapshot = createCrowdedGroupedDashboardSnapshot(80);
+    const initial = createInitialTuiState({
+      initialSnapshot: snapshot,
+      terminalRows: TERMINAL_ROWS,
+    });
+    const maxBefore = maxScrollOffset(snapshot, initial);
+    const pinned = scrollDashboardTo(initial, maxBefore);
+    const collapsed = clampDashboardStateScroll({
+      ...pinned,
+      collapsedGroupIds: new Set(["group_crowd"]),
+    });
+    const viewport = selectDashboardViewport(snapshot, collapsed);
+    expect(maxBefore).toBeGreaterThan(0);
+    expect(collapsed.scrollOffset).toBeLessThan(maxBefore);
+    expect(viewport.hiddenBelow).toBe(0);
+    expect(collapsed.scrollOffset).toBeGreaterThanOrEqual(0);
+  });
+
+  it("wheels one tree row through inert group chrome that arrows skip", () => {
+    const snapshot = createCrowdedGroupedDashboardSnapshot(40);
+    const initial = createInitialTuiState({
+      initialSnapshot: snapshot,
+      terminalRows: TERMINAL_ROWS,
+    });
+    const lastSessionId = snapshot.sessions
+      .filter((session) => session.projectId === "web")
+      .at(-1)?.id;
+    if (lastSessionId === undefined) {
+      throw new Error("expected a crowded web session");
+    }
+    const focused = focusDashboardSession(initial, lastSessionId);
+    expect(focused.dashboardFocus?.rowId).toBe(dashboardRowIds.session(lastSessionId));
+    const wheeled = handleTuiKey(focused, { input: "", mouseScroll: "down" }).state;
+    const arrowed = handleTuiKey(focused, { input: "", downArrow: true }).state;
+    expect(wheeled.scrollOffset).toBe(focused.scrollOffset + 1);
+    expect(wheeled.dashboardFocus).toEqual(focused.dashboardFocus);
+    expect(arrowed.dashboardFocus?.rowId).not.toBe(focused.dashboardFocus?.rowId);
+    expect(arrowed.scrollOffset - focused.scrollOffset).toBeGreaterThan(1);
+  });
+});
+
+describe("help windowing stress", () => {
+  it("arrows one line at a time through a 300-line panel, including stuck-thumb offsets", () => {
+    const content = crowdedHelpContent(300);
+    const bodyRows = helpPanelBodyRows(TERMINAL_ROWS, content.length);
+    const maxOffset = content.length - bodyRows;
+    const height = bodyRows + 2;
+
+    let state = createInitialTuiState({ terminalRows: TERMINAL_ROWS });
+    state = { ...state, screen: { name: "help", scrollOffset: 0, contentLength: content.length } };
+
+    for (let offset = 0; offset <= maxOffset; offset += 1) {
+      const lines = helpPanelLines(64, height, content, offset);
+      expect(lines[1]).toContain(`line-${offset}`);
+      expect(lines[bodyRows]).toContain(`line-${offset + bodyRows - 1}`);
+    }
+
+    for (let step = 0; step < maxOffset; step += 1) {
+      const next = handleTuiKey(state, { input: "", downArrow: true }).state;
+      expect(next.screen).toMatchObject({ name: "help", scrollOffset: step + 1 });
+      state = next;
+    }
+    expect(handleTuiKey(state, { input: "", downArrow: true }).state).toBe(state);
+
+    const up = handleTuiKey(state, { input: "", upArrow: true }).state;
+    expect(up.screen).toMatchObject({ name: "help", scrollOffset: maxOffset - 1 });
+    expect(handleTuiKey(up, { input: "", escape: true }).state.screen).toEqual({
+      name: "dashboard",
+    });
+  });
+
+  it("a one-line help wheel still changes the window when the painted thumb does not", () => {
+    const content = crowdedHelpContent(300);
+    const bodyRows = helpPanelBodyRows(TERMINAL_ROWS, content.length);
+    const paint = {
+      trackHeight: bodyRows,
+      contentLength: content.length,
+      viewportLength: bodyRows,
+    };
+    expect(verticalScrollbarCells({ ...paint, offset: 0 }).join("")).toBe(
+      verticalScrollbarCells({ ...paint, offset: 1 }).join(""),
+    );
+    let state = createInitialTuiState({ terminalRows: TERMINAL_ROWS });
+    state = {
+      ...state,
+      screen: { name: "help", scrollOffset: 0, contentLength: content.length },
+      scrollOffset: 12,
+    };
+    const next = handleTuiKey(state, { input: "", mouseScroll: "down" }).state;
+    expect(next.scrollOffset).toBe(12);
+    expect(next.screen).toMatchObject({ name: "help", scrollOffset: 1 });
+  });
+});
+
+function maxScrollOffset(
+  snapshot: ReturnType<typeof createCrowdedDashboardSnapshot>,
+  state: ReturnType<typeof createInitialTuiState>,
+): number {
+  const viewport = selectDashboardViewport(snapshot, state);
+  return viewport.hiddenAbove + viewport.hiddenBelow;
+}
+
+function firstRowId(viewport: ReturnType<typeof selectDashboardViewport>): string {
+  const id = viewport.rows[0]?.id;
+  if (id === undefined) {
+    throw new Error("expected a visible dashboard row");
+  }
+  return id;
+}
+
+function focusedIndex(
+  tree: ReturnType<typeof selectDashboardTree>,
+  state: ReturnType<typeof createInitialTuiState>,
+): number {
+  if (state.dashboardFocus === undefined) {
+    return 0;
+  }
+  return tree.visibleIndexById.get(state.dashboardFocus.rowId) ?? 0;
+}
+
+function crowdedHelpContent(lineCount: number): TuiHelpContentLine[] {
+  return Array.from({ length: lineCount }, (_, index) => ({
+    key: String(index),
+    description: `line-${index}`,
+  }));
+}

--- a/packages/dashboard-core/test/unit/state/screenBehavior.test.ts
+++ b/packages/dashboard-core/test/unit/state/screenBehavior.test.ts
@@ -86,7 +86,7 @@ const screenBehaviorCases: readonly [
     },
     "present",
   ],
-  ["help", { name: "help" }, "present"],
+  ["help", { name: "help", scrollOffset: 0, contentLength: 0 }, "present"],
   ["project menu", { name: "projectMenu", projectId: "web", focus: "quickGroup" }, "present"],
   [
     "create group",

--- a/packages/dashboard-core/test/unit/state/transition.test.ts
+++ b/packages/dashboard-core/test/unit/state/transition.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { helpOverlayLineCount } from "../../../src/components/HelpOverlay/content.js";
 import { dashboardRowIds } from "../../../src/selectors/dashboardTree.js";
 import { selectDashboardViewport } from "../../../src/selectors/dashboardViewport.js";
 import { deriveTuiInputMode } from "../../../src/state/keymap.js";
@@ -77,6 +78,54 @@ describe("TUI screen transitions", () => {
 
     const dismissedError = handleTuiKey(closedHelp.state, { input: "", escape: true });
     expect(dismissedError.state.toasts).toEqual([]);
+  });
+
+  it("scrolls and clamps the help overlay without closing it", () => {
+    const state = createInitialTuiState({
+      initialSnapshot: createDashboardSnapshot(),
+      terminalRows: 8,
+    });
+    const opened = handleTuiKey(state, { input: "H" }).state;
+    expect(opened.screen).toEqual({
+      name: "help",
+      scrollOffset: 0,
+      contentLength: helpOverlayLineCount(0),
+    });
+
+    const down = handleTuiKey(opened, { input: "", downArrow: true }).state;
+    expect(down.screen).toMatchObject({ name: "help", scrollOffset: 1 });
+    const wheel = handleTuiKey(down, { input: "", mouseScroll: "down" }).state;
+    expect(wheel.screen).toMatchObject({ name: "help", scrollOffset: 2 });
+    const up = handleTuiKey(wheel, { input: "", upArrow: true }).state;
+    expect(up.screen).toMatchObject({ name: "help", scrollOffset: 1 });
+
+    let clamped = opened;
+    for (let index = 0; index < 40; index += 1) {
+      clamped = handleTuiKey(clamped, { input: "", downArrow: true }).state;
+    }
+    expect(clamped.screen).toMatchObject({ name: "help" });
+    if (clamped.screen.name !== "help") {
+      throw new Error("expected help screen");
+    }
+    const stillClamped = handleTuiKey(clamped, { input: "", downArrow: true }).state;
+    expect(stillClamped.screen).toEqual(clamped.screen);
+
+    expect(handleTuiKey(clamped, { input: "", escape: true }).state.screen).toEqual({
+      name: "dashboard",
+    });
+  });
+
+  it("counts Station keymap lines when opening Help through runtime context", () => {
+    const opened = handleTuiKey(
+      createInitialTuiState({ initialSnapshot: createDashboardSnapshot() }),
+      { input: "H" },
+      { cwd: "/workspace", homeDir: "/home", helpKeymapLineCount: 9 },
+    ).state;
+    expect(opened.screen).toEqual({
+      name: "help",
+      scrollOffset: 0,
+      contentLength: helpOverlayLineCount(9),
+    });
   });
 
   it("opens remove session slot selection from the dashboard", () => {

--- a/station/src/dashboardRenderer/FullscreenDashboard.test.tsx
+++ b/station/src/dashboardRenderer/FullscreenDashboard.test.tsx
@@ -457,7 +457,7 @@ describe("FullscreenDashboard mouse composition", () => {
     const help = cellFor(setup.captureCharFrame(), "station help");
 
     await actOn(() => setup.mockMouse.click(help.col, help.row, MouseButtons.LEFT));
-    expect(fixture.runtime.state.getState().screen).toEqual({ name: "help" });
+    expect(fixture.runtime.state.getState().screen).toMatchObject({ name: "help" });
 
     await actOn(() => setup.mockMouse.click(0, 0, MouseButtons.LEFT));
     expect(fixture.runtime.state.getState().screen).toEqual({ name: "dashboard" });

--- a/station/src/dashboardRenderer/main.tsx
+++ b/station/src/dashboardRenderer/main.tsx
@@ -16,6 +16,7 @@ import { copyToClipboard, DEFAULT_COPY_SINKS } from "../copy/clipboard.js";
 import { createOpenTuiSelectionCopyHandler } from "../copy/openTuiSelection.js";
 import { createRuntimeClipboardEffects } from "../copy/runtimeClipboard.js";
 import { STATION_KEYBOARD_PROTOCOL } from "../input/keyboardProtocol.js";
+import { stationKeymapHelp } from "../input/keymap/stationBindings.js";
 import { DecMode } from "../terminal/protocol/decset.js";
 import { CsiCommand } from "../terminal/protocol/identifiers.js";
 import { VtPrefix } from "../terminal/protocol/syntax.js";
@@ -112,6 +113,7 @@ export async function runDashboardMain(): Promise<void> {
     service: client.service,
     capabilities,
     clientLabel: "station",
+    helpKeymapLineCount: stationKeymapHelp().length,
     initialState: {
       widgets: tuiConfig.config?.widgets ?? [],
       widgetsPersisted: tuiConfig.configPath !== undefined,

--- a/station/src/input/stationIntegration.test.ts
+++ b/station/src/input/stationIntegration.test.ts
@@ -115,7 +115,7 @@ describe("station overlay layer in the keymap stack", () => {
     const keymap = createStationKeymap(view);
 
     expect(routeKey("H", station.getState(), keymap)).toEqual({ kind: "swallowed" });
-    expect(view.state.getState().screen).toEqual({ name: "help" });
+    expect(view.state.getState().screen).toMatchObject({ name: "help" });
 
     // Esc in help mode closes the MODE, not the overlay.
     expect(routeKey("\x1b", station.getState(), keymap)).toEqual({ kind: "swallowed" });
@@ -412,7 +412,7 @@ describe("station input through the station runtime", () => {
       },
       LEFT_DOWN,
     );
-    expect(view.state.getState().screen).toEqual({ name: "help" });
+    expect(view.state.getState().screen).toMatchObject({ name: "help" });
     expect(view.state.getState().persistentFilter).toEqual({ query: "working" });
 
     runtime.handleSequence("\x1b");
@@ -538,7 +538,7 @@ describe("station input through the station runtime", () => {
     for (const target of [{ kind: "screenBackdrop" }, { kind: "sheetBackdrop" }] as const) {
       expect(runtime.dispatchMouse({ kind: "station", target }, RIGHT_DOWN)).toBe(true);
       expect(runtime.dispatchMouse({ kind: "station", target }, WHEEL_UP)).toBe(true);
-      expect(view.state.getState().screen).toEqual({ name: "help" });
+      expect(view.state.getState().screen).toMatchObject({ name: "help" });
       expect(station.getState().input.contextMenu).toBeNull();
     }
 

--- a/station/src/station/StationOverlay.test.tsx
+++ b/station/src/station/StationOverlay.test.tsx
@@ -214,7 +214,7 @@ describe("StationOverlay", () => {
 
     await setup.mockMouse.click(titleAction.col, titleAction.row, MouseButtons.RIGHT);
 
-    expect(store.state.getState().screen).toEqual({ name: "help" });
+    expect(store.state.getState().screen).toMatchObject({ name: "help" });
     expect(calls.at(-1)).toMatchObject({
       target: { kind: "station", target: { kind: "screenBackdrop" } },
       event: { type: "down", button: "right", rawButton: 2 },

--- a/station/src/station/input/stationMouse.test.ts
+++ b/station/src/station/input/stationMouse.test.ts
@@ -39,6 +39,11 @@ const LEFT_UP: StationMouseEvent = {
   type: "up",
 };
 
+const LEFT_DRAG: StationMouseEvent = {
+  ...LEFT_DOWN,
+  type: "drag",
+};
+
 const MIDDLE_DOWN: StationMouseEvent = {
   ...LEFT_DOWN,
   button: "middle",
@@ -677,6 +682,37 @@ describe("routeStationMouse", () => {
     const store = makeStore();
     routeStationMouse({ kind: "scrollbar", surface: "dashboard", offset: 4 }, LEFT_DOWN, store);
     expect(store.state.getState().scrollOffset).toBeGreaterThan(0);
+  });
+
+  it("scrolls from gutter drags without treating cell drags as activation", () => {
+    const store = makeStore();
+    routeStationMouse({ kind: "scrollbar", surface: "dashboard", offset: 4 }, LEFT_DRAG, store);
+    expect(store.state.getState().scrollOffset).toBeGreaterThan(0);
+
+    store.actions.dispatch({ type: "dashboard.scrollTo", offset: 0 });
+    const session = store.state.getState().snapshot?.sessions[0];
+    if (session === undefined) {
+      throw new Error("expected a session");
+    }
+    const focusBefore = store.state.getState().dashboardFocus;
+    routeStationMouse(
+      {
+        kind: "dashboardCell",
+        rowId: dashboardRowIds.session(session.id),
+        cellId: "identity",
+      },
+      LEFT_DRAG,
+      store,
+    );
+    expect(store.state.getState().scrollOffset).toBe(0);
+    expect(store.state.getState().dashboardFocus).toEqual(focusBefore);
+  });
+
+  it("scrolls Help from bar drags without closing it", () => {
+    const store = makeStore();
+    store.actions.handleKey({ input: "H" });
+    routeStationMouse({ kind: "scrollbar", surface: "help", offset: 3 }, LEFT_DRAG, store);
+    expect(store.state.getState().screen).toMatchObject({ name: "help", scrollOffset: 3 });
   });
 
   it("keeps stale screen and sheet backdrop wheel events from scrolling after dismissal", () => {

--- a/station/src/station/input/stationMouse.test.ts
+++ b/station/src/station/input/stationMouse.test.ts
@@ -400,7 +400,7 @@ describe("routeStationMouse", () => {
       LEFT_DOWN,
       store,
     );
-    expect(store.state.getState().screen).toEqual({ name: "help" });
+    expect(store.state.getState().screen).toMatchObject({ name: "help" });
     expect(store.state.getState().persistentFilter).toEqual({ query: "working" });
 
     store.actions.handleKey({ input: "", escape: true });
@@ -649,13 +649,34 @@ describe("routeStationMouse", () => {
       expect(routeStationMouse({ kind: "screenBackdrop" }, event, store)).toEqual({
         kind: "handled",
       });
-      expect(store.state.getState().screen).toEqual({ name: "help" });
+      expect(store.state.getState().screen).toMatchObject({ name: "help" });
     }
 
     expect(routeStationMouse({ kind: "screenBackdrop" }, LEFT_DOWN, store)).toEqual({
       kind: "handled",
     });
     expect(store.state.getState().screen).toEqual({ name: "dashboard" });
+  });
+
+  it("scrolls help on wheel over the panel and on help-scrollbar clicks", () => {
+    const store = makeStore();
+    store.actions.handleKey({ input: "H" });
+
+    routeStationMouse({ kind: "sheetBackdrop" }, SCROLL_DOWN, store);
+    expect(store.state.getState().screen).toMatchObject({ name: "help", scrollOffset: 1 });
+
+    routeStationMouse({ kind: "scrollbar", surface: "help", offset: 3 }, LEFT_DOWN, store);
+    expect(store.state.getState().screen).toMatchObject({ name: "help", scrollOffset: 3 });
+
+    routeStationMouse({ kind: "scrollbar", surface: "dashboard", offset: 4 }, LEFT_DOWN, store);
+    expect(store.state.getState().screen).toMatchObject({ name: "help", scrollOffset: 3 });
+    expect(store.state.getState().scrollOffset).toBe(0);
+  });
+
+  it("scrolls the dashboard from the outside-group gutter", () => {
+    const store = makeStore();
+    routeStationMouse({ kind: "scrollbar", surface: "dashboard", offset: 4 }, LEFT_DOWN, store);
+    expect(store.state.getState().scrollOffset).toBeGreaterThan(0);
   });
 
   it("keeps stale screen and sheet backdrop wheel events from scrolling after dismissal", () => {
@@ -974,7 +995,7 @@ describe("routeStationMouse", () => {
         modal,
       ),
     ).toEqual({ kind: "handled" });
-    expect(modal.state.getState().screen).toEqual({ name: "help" });
+    expect(modal.state.getState().screen).toMatchObject({ name: "help" });
     expect(modal.state.getState().dashboardFocus).toBeUndefined();
   });
 

--- a/station/src/station/input/stationMouse.ts
+++ b/station/src/station/input/stationMouse.ts
@@ -70,7 +70,7 @@ export type StationMouseTarget =
   | { kind: "screenBackdrop" }
   | { kind: "sheetBackdrop" };
 
-export type StationMouseEventKind = "down" | "scroll-up" | "scroll-down";
+export type StationMouseEventKind = "down" | "drag" | "scroll-up" | "scroll-down";
 export type StationMouseOutcome = { kind: "handled" } | { kind: "open-url"; url: string };
 
 const SCROLL_PAGE_ROWS = 5;
@@ -100,8 +100,14 @@ export function routeStationMouse(
     return { kind: "handled" };
   }
   const mode = deriveTuiInputMode(runtime.state.getState());
-  if (eventKind !== "down") {
+  if (eventKind === "scroll-up" || eventKind === "scroll-down") {
     routeStationWheel(target, eventKind, runtime, mode);
+    return { kind: "handled" };
+  }
+  if (eventKind === "drag") {
+    if (target.kind === "scrollbar") {
+      routeScrollbar(target, runtime, mode);
+    }
     return { kind: "handled" };
   }
 
@@ -161,11 +167,7 @@ export function routeStationMouse(
       }
       return { kind: "handled" };
     case "scrollbar":
-      if (target.surface === "help" && mode === "help") {
-        runtime.actions.dispatch({ type: "help.scrollTo", offset: target.offset });
-      } else if (target.surface === "dashboard" && ROW_INTERACTIVE_MODES.has(mode)) {
-        runtime.actions.dispatch({ type: "dashboard.scrollTo", offset: target.offset });
-      }
+      routeScrollbar(target, runtime, mode);
       return { kind: "handled" };
     case "toast":
       dismissStationToasts(runtime);
@@ -254,7 +256,28 @@ export function stationMouseEventKind(event: StationMouseEvent): StationMouseEve
     if (event.scrollDirection === "down") return "scroll-down";
     return undefined;
   }
-  return event.type === "down" && event.button === "left" ? "down" : undefined;
+  if (event.button !== "left") {
+    return undefined;
+  }
+  if (event.type === "down") {
+    return "down";
+  }
+  if (event.type === "drag") {
+    return "drag";
+  }
+  return undefined;
+}
+
+function routeScrollbar(
+  target: Extract<StationMouseTarget, { kind: "scrollbar" }>,
+  runtime: DashboardMouseRuntime,
+  mode: TuiInputMode,
+): void {
+  if (target.surface === "help" && mode === "help") {
+    runtime.actions.dispatch({ type: "help.scrollTo", offset: target.offset });
+  } else if (target.surface === "dashboard" && ROW_INTERACTIVE_MODES.has(mode)) {
+    runtime.actions.dispatch({ type: "dashboard.scrollTo", offset: target.offset });
+  }
 }
 
 function routePersistentFilterConditionAction(

--- a/station/src/station/input/stationMouse.ts
+++ b/station/src/station/input/stationMouse.ts
@@ -48,6 +48,7 @@ export type StationMouseTarget =
     }
   | { kind: "body" }
   | { kind: "scrollIndicator"; direction: "up" | "down" }
+  | { kind: "scrollbar"; surface: "help" | "dashboard"; offset: number }
   | { kind: "toast" }
   | { kind: "sheetChoice"; choiceKey: string }
   | { kind: "removeWorktreeAction"; actionId: RemoveWorktreeActionId }
@@ -157,6 +158,13 @@ export function routeStationMouse(
           type: "dashboard.scroll",
           delta: target.direction === "up" ? -SCROLL_PAGE_ROWS : SCROLL_PAGE_ROWS,
         });
+      }
+      return { kind: "handled" };
+    case "scrollbar":
+      if (target.surface === "help" && mode === "help") {
+        runtime.actions.dispatch({ type: "help.scrollTo", offset: target.offset });
+      } else if (target.surface === "dashboard" && ROW_INTERACTIVE_MODES.has(mode)) {
+        runtime.actions.dispatch({ type: "dashboard.scrollTo", offset: target.offset });
       }
       return { kind: "handled" };
     case "toast":
@@ -293,6 +301,18 @@ function routeStationWheel(
   runtime: DashboardMouseRuntime,
   mode: TuiInputMode,
 ): void {
+  if (mode === "help") {
+    if (
+      target.kind === "sheetBackdrop" ||
+      (target.kind === "scrollbar" && target.surface === "help")
+    ) {
+      runtime.actions.handleKey({
+        input: "",
+        mouseScroll: eventKind === "scroll-up" ? "up" : "down",
+      });
+    }
+    return;
+  }
   if (
     target.kind === "screenBackdrop" ||
     target.kind === "sheetBackdrop" ||

--- a/station/src/station/store/dashboardRuntime.ts
+++ b/station/src/station/store/dashboardRuntime.ts
@@ -7,6 +7,7 @@ import { createDashboardRuntime } from "@station/dashboard-core/runtime";
 import type { DashboardCapabilities, DashboardRuntime, TuiFolderService } from "@station/dashboard-core/runtime";
 import type { DashboardGroupHeaderActionVisibility } from "@station/dashboard-core/state";
 import type { TuiWidgetConfig } from "@station/dashboard-core/widgets";
+import { stationKeymapHelp } from "../../input/keymap/stationBindings.js";
 import type { StationClient } from "../../sources/types.js";
 
 export type StationDashboardRuntime = DashboardRuntime & {
@@ -55,6 +56,9 @@ export function createStationDashboardRuntime(
     initialState.groupHeaderActionVisibility = options.groupHeaderActionVisibility;
   }
   runtimeOptions.initialState = initialState;
-  const runtime = createDashboardRuntime(runtimeOptions);
+  const runtime = createDashboardRuntime({
+    ...runtimeOptions,
+    helpKeymapLineCount: stationKeymapHelp().length,
+  });
   return { ...runtime, clientState: client.state };
 }

--- a/station/src/station/test/support/makeStationTestRuntime.ts
+++ b/station/src/station/test/support/makeStationTestRuntime.ts
@@ -14,6 +14,7 @@ import type {
   TuiFolderService,
  } from "@station/dashboard-core/runtime";
 import { manyProjectsSnapshot } from "../../fixtures/scenarios.js";
+import { stationKeymapHelp } from "../../../input/keymap/stationBindings.js";
 import { FakeStationSource } from "./fakeStationSource.js";
 import { FakeTuiObserverService } from "./fakeObserverService.js";
 
@@ -83,6 +84,7 @@ export function createStationTestDashboardRuntime(
     ...runtimeOptions,
     source: clientState,
     capabilities: resolvedCapabilities,
+    helpKeymapLineCount: runtimeOptions.helpKeymapLineCount ?? stationKeymapHelp().length,
   });
   return { ...runtime, clientState };
 }

--- a/station/src/station/view/ActiveScreenOverlayView.tsx
+++ b/station/src/station/view/ActiveScreenOverlayView.tsx
@@ -104,7 +104,7 @@ function renderActiveScreenOverlay({
       );
     }
     case "help":
-      return <HelpOverlayView columns={columns} rows={rows} />;
+      return <HelpOverlayView screen={screen} columns={columns} rows={rows} />;
     case "projectMenu":
       return (
         <ProjectMenuView

--- a/station/src/station/view/DashboardTableHeaderView.test.tsx
+++ b/station/src/station/view/DashboardTableHeaderView.test.tsx
@@ -79,6 +79,15 @@ describe("DashboardTableHeaderView", () => {
     expect(setup.captureCharFrame().split("\n")[0]?.trimEnd()).toBe("▲ 3 sessions above");
   });
 
+  it("renders generic above overflow when no sessions are clipped", async () => {
+    const setup = await renderHeader({
+      kind: "aboveOverflow",
+      overflow: { above: 0, below: 0, visible: 1, total: 1 },
+    });
+
+    expect(setup.captureCharFrame().split("\n")[0]?.trimEnd()).toBe("▲ more above");
+  });
+
   it("keeps the upward scroll pointer target", async () => {
     const targets: StationMouseTarget[] = [];
     const setup = await renderHeader(

--- a/station/src/station/view/DashboardTableHeaderView.tsx
+++ b/station/src/station/view/DashboardTableHeaderView.tsx
@@ -12,7 +12,7 @@ export function DashboardTableHeaderView({ model }: { model: DashboardTableHeade
     case "columns":
       return <ColumnHeaderRow layout={model.layout} />;
     case "aboveOverflow":
-      return <DashboardScrollIndicatorView direction="above" overflow={model.overflow} />;
+      return <DashboardScrollIndicatorView direction="above" overflow={model.overflow} visible />;
     case "empty":
       return <box height={1} />;
     default:
@@ -27,18 +27,20 @@ function assertNeverDashboardTableHeaderModel(_model: never): never {
 export function DashboardScrollIndicatorView({
   direction,
   overflow,
+  visible,
 }: {
   direction: "above" | "below";
   overflow: DashboardSessionOverflow;
+  visible: boolean;
 }) {
   const theme = useStationTheme();
   const dispatch = useStationMouse();
-  const hiddenSessions = direction === "above" ? overflow.above : overflow.below;
   return (
-    <box height={1}>
-      {hiddenSessions > 0 ? (
+    <box height={1} flexShrink={0}>
+      {visible ? (
         <text
           fg={toOpenTuiColor(theme.text.muted)}
+          selectable={false}
           {...stationMouseProps(dispatch, {
             kind: "scrollIndicator",
             direction: direction === "above" ? "up" : "down",
@@ -54,7 +56,7 @@ export function DashboardScrollIndicatorView({
 function ColumnHeaderRow({ layout }: { layout: RowGridLayout }) {
   const theme = useStationTheme();
   return (
-    <box height={1} width="100%" overflow="hidden">
+    <box height={1} width="100%" flexShrink={0} overflow="hidden">
       <text fg={toOpenTuiColor(theme.text.muted)}>
         <Segments segments={layout.segments} />
       </text>

--- a/station/src/station/view/DashboardView.tsx
+++ b/station/src/station/view/DashboardView.tsx
@@ -1,7 +1,8 @@
 // Render layer for the dashboard: one <text> per line, sized by the shared
 // viewport selector. Mouse targets report through the station mouse context;
 // hover is component-local and color-only so golden frames stay layout-stable.
-import { TextAttributes } from "@opentui/core";
+import { TextAttributes, type BoxRenderable } from "@opentui/core";
+import { useRef } from "react";
 import {
   dashboardTableHeaderModel,
   dashboardRowGridInput,
@@ -13,7 +14,6 @@ import { layoutWorktreeRowGrid, textSegment, truncateCells } from "@station/dash
 import type { RowGridLayout, RowGridRowInput } from "@station/dashboard-core/selectors";
 import {
   dashboardScrollGutterChrome,
-  scrollbarOffsetForTrackIndex,
   selectDashboardViewport,
   selectFleetSummary,
   verticalScrollbarCells,
@@ -39,7 +39,12 @@ import { SegmentLinkTargets, Segments } from "./segments.js";
 import { Throbber } from "./Throbber.js";
 import { FLEET_STATUS_ORDER, STATION_STATUS_UI } from "../statusUi.js";
 import { toOpenTuiColor, useStationTheme } from "../../theme/index.js";
-import { useStationHoverState, useStationMouse, stationMouseProps } from "./stationMouseContext.js";
+import {
+  useStationHoverState,
+  useStationMouse,
+  stationMouseProps,
+  stationScrollbarPointerProps,
+} from "./stationMouseContext.js";
 
 export type DashboardViewProps = {
   snapshot: DashboardSnapshotView;
@@ -69,6 +74,7 @@ export function DashboardView({ snapshot, viewState, screen, columns = 80 }: Das
   const tableHeader = dashboardTableHeaderModel({
     layout: headerLayout,
     overflow: viewport.sessionOverflow,
+    hiddenAbove: viewport.hiddenAbove,
     columns: contentColumns,
     ...(viewport.persistentFilter === undefined
       ? {}
@@ -84,7 +90,7 @@ export function DashboardView({ snapshot, viewState, screen, columns = 80 }: Das
         overflow="hidden"
         onMouseScroll={stationMouseProps(dispatch, { kind: "body" }).onMouseScroll}
       >
-        <text> </text>
+        <text flexShrink={0}> </text>
         {firstRun ? null : (
           <FleetBar summary={fleet} counts={snapshot.counts} columns={contentColumns} />
         )}
@@ -102,7 +108,11 @@ export function DashboardView({ snapshot, viewState, screen, columns = 80 }: Das
             layoutByItem={layoutByItem}
           />
         )}
-        <DashboardScrollIndicatorView direction="below" overflow={viewport.sessionOverflow} />
+        <DashboardScrollIndicatorView
+          direction="below"
+          overflow={viewport.sessionOverflow}
+          visible={viewport.hiddenBelow > 0}
+        />
         <Divider columns={contentColumns} />
       </box>
       <DashboardScrollGutter
@@ -112,6 +122,8 @@ export function DashboardView({ snapshot, viewState, screen, columns = 80 }: Das
         contentLength={treeRowCount}
         viewportLength={viewport.bodyRows}
         offset={viewport.clampedScrollOffset}
+        hiddenAbove={viewport.hiddenAbove}
+        hiddenBelow={viewport.hiddenBelow}
       />
     </box>
   );
@@ -119,7 +131,11 @@ export function DashboardView({ snapshot, viewState, screen, columns = 80 }: Das
 
 export function Divider({ columns }: { columns: number }) {
   const theme = useStationTheme();
-  return <text fg={toOpenTuiColor(theme.text.muted)}>{"─".repeat(Math.max(1, columns))}</text>;
+  return (
+    <text flexShrink={0} fg={toOpenTuiColor(theme.text.muted)}>
+      {"─".repeat(Math.max(1, columns))}
+    </text>
+  );
 }
 
 // Pinned fleet triage bar: glyph + colour reinforce each status lane. ready/
@@ -157,7 +173,7 @@ function FleetBar({
     Math.max(0, columns - lanesWidth - 2),
   );
   return (
-    <box height={1} width="100%" flexDirection="row" overflow="hidden">
+    <box height={1} width="100%" flexShrink={0} flexDirection="row" overflow="hidden">
       <text flexGrow={1} fg={toOpenTuiColor(theme.text.muted)}>
         <span attributes={TextAttributes.BOLD}>FLEET</span>
         {parts.map((part) => (
@@ -225,6 +241,8 @@ function DashboardScrollGutter({
   contentLength,
   viewportLength,
   offset,
+  hiddenAbove,
+  hiddenBelow,
 }: {
   chromeTop: number;
   chromeBottom: number;
@@ -232,9 +250,12 @@ function DashboardScrollGutter({
   contentLength: number;
   viewportLength: number;
   offset: number;
+  hiddenAbove: number;
+  hiddenBelow: number;
 }) {
   const dispatch = useStationMouse();
   const theme = useStationTheme();
+  const trackRef = useRef<BoxRenderable | null>(null);
   const overflow = contentLength > viewportLength && trackHeight > 0;
   const cells = verticalScrollbarCells({
     trackHeight,
@@ -242,38 +263,72 @@ function DashboardScrollGutter({
     viewportLength,
     offset,
   });
+  const pointer = overflow
+    ? stationScrollbarPointerProps(dispatch, {
+        surface: "dashboard",
+        contentLength,
+        viewportLength,
+        trackHeight,
+        trackTop: () => trackRef.current?.y ?? 0,
+      })
+    : undefined;
   return (
-    <box width={1} flexDirection="column" flexShrink={0}>
+    <box width={1} flexDirection="column" flexShrink={0} selectable={false}>
       {Array.from({ length: chromeTop }, (_, index) => (
-        <text key={`top-${index}`}> </text>
+        <GutterOverflowArrow
+          key={`top-${index}`}
+          glyph={index === chromeTop - 1 && hiddenAbove > 0 ? "▲" : " "}
+          direction="up"
+        />
       ))}
-      <box flexGrow={1} flexDirection="column">
+      <box
+        ref={trackRef}
+        width={1}
+        height={trackHeight}
+        flexShrink={0}
+        flexDirection="column"
+        selectable={false}
+        {...pointer}
+      >
         {cells.map((glyph, index) => (
-          <text
-            key={index}
-            fg={toOpenTuiColor(theme.text.muted)}
-            {...(overflow
-              ? stationMouseProps(dispatch, {
-                  kind: "scrollbar",
-                  surface: "dashboard",
-                  offset: scrollbarOffsetForTrackIndex({
-                    trackHeight,
-                    contentLength,
-                    viewportLength,
-                    offset,
-                    trackIndex: index,
-                  }),
-                })
-              : {})}
-          >
+          <text key={index} fg={toOpenTuiColor(theme.text.muted)} selectable={false}>
             {glyph}
           </text>
         ))}
       </box>
       {Array.from({ length: chromeBottom }, (_, index) => (
-        <text key={`bottom-${index}`}> </text>
+        <GutterOverflowArrow
+          key={`bottom-${index}`}
+          glyph={index === 0 && hiddenBelow > 0 ? "▼" : " "}
+          direction="down"
+        />
       ))}
     </box>
+  );
+}
+
+function GutterOverflowArrow({
+  glyph,
+  direction,
+}: {
+  glyph: string;
+  direction: "up" | "down";
+}) {
+  const dispatch = useStationMouse();
+  const theme = useStationTheme();
+  const interactive = glyph !== " ";
+  return (
+    <text
+      selectable={false}
+      {...(interactive
+        ? {
+            fg: toOpenTuiColor(theme.text.muted),
+            ...stationMouseProps(dispatch, { kind: "scrollIndicator", direction }),
+          }
+        : {})}
+    >
+      {glyph}
+    </text>
   );
 }
 

--- a/station/src/station/view/DashboardView.tsx
+++ b/station/src/station/view/DashboardView.tsx
@@ -11,7 +11,13 @@ import {
  } from "@station/dashboard-core/selectors";
 import { layoutWorktreeRowGrid, textSegment, truncateCells } from "@station/dashboard-core/selectors";
 import type { RowGridLayout, RowGridRowInput } from "@station/dashboard-core/selectors";
-import { selectDashboardViewport, selectFleetSummary } from "@station/dashboard-core/selectors";
+import {
+  dashboardScrollGutterChrome,
+  scrollbarOffsetForTrackIndex,
+  selectDashboardViewport,
+  selectFleetSummary,
+  verticalScrollbarCells,
+} from "@station/dashboard-core/selectors";
 import type {
   DashboardRowId,
   DashboardTreeRow,
@@ -68,34 +74,45 @@ export function DashboardView({ snapshot, viewState, screen, columns = 80 }: Das
       ? {}
       : { persistentFilter: viewport.persistentFilter }),
   });
+  const gutterChrome = dashboardScrollGutterChrome({ hasFleetBar: !firstRun });
+  const treeRowCount = viewport.hiddenAbove + viewport.rows.length + viewport.hiddenBelow;
   return (
-    <box
-      width="100%"
-      flexGrow={1}
-      flexDirection="column"
-      paddingRight={1}
-      onMouseScroll={stationMouseProps(dispatch, { kind: "body" }).onMouseScroll}
-    >
-      <text> </text>
-      {firstRun ? null : (
-        <FleetBar summary={fleet} counts={snapshot.counts} columns={contentColumns} />
-      )}
-      <Divider columns={contentColumns} />
-      <DashboardTableHeaderView model={tableHeader} />
-      {firstRun ? (
-        <box flexDirection="column" flexGrow={1}>
-          <FirstProjectButton columns={contentColumns} />
-        </box>
-      ) : (
-        <DashboardBody
-          columns={contentColumns}
-          rows={viewport.rows}
-          rowById={viewport.rowById}
-          layoutByItem={layoutByItem}
-        />
-      )}
-      <DashboardScrollIndicatorView direction="below" overflow={viewport.sessionOverflow} />
-      <Divider columns={contentColumns} />
+    <box width="100%" flexGrow={1} flexDirection="row">
+      <box
+        flexGrow={1}
+        flexDirection="column"
+        overflow="hidden"
+        onMouseScroll={stationMouseProps(dispatch, { kind: "body" }).onMouseScroll}
+      >
+        <text> </text>
+        {firstRun ? null : (
+          <FleetBar summary={fleet} counts={snapshot.counts} columns={contentColumns} />
+        )}
+        <Divider columns={contentColumns} />
+        <DashboardTableHeaderView model={tableHeader} />
+        {firstRun ? (
+          <box flexDirection="column" flexGrow={1}>
+            <FirstProjectButton columns={contentColumns} />
+          </box>
+        ) : (
+          <DashboardBody
+            columns={contentColumns}
+            rows={viewport.rows}
+            rowById={viewport.rowById}
+            layoutByItem={layoutByItem}
+          />
+        )}
+        <DashboardScrollIndicatorView direction="below" overflow={viewport.sessionOverflow} />
+        <Divider columns={contentColumns} />
+      </box>
+      <DashboardScrollGutter
+        chromeTop={gutterChrome.top}
+        chromeBottom={gutterChrome.bottom}
+        trackHeight={viewport.bodyRows}
+        contentLength={treeRowCount}
+        viewportLength={viewport.bodyRows}
+        offset={viewport.clampedScrollOffset}
+      />
     </box>
   );
 }
@@ -198,6 +215,66 @@ function dashboardRowLayouts(
       .map((layout) => [layout.id, layout]),
   );
   return { headerLayout, layoutByItem };
+}
+
+/** Sibling 1-col gutter outside Group frames; empty when the tree fits. */
+function DashboardScrollGutter({
+  chromeTop,
+  chromeBottom,
+  trackHeight,
+  contentLength,
+  viewportLength,
+  offset,
+}: {
+  chromeTop: number;
+  chromeBottom: number;
+  trackHeight: number;
+  contentLength: number;
+  viewportLength: number;
+  offset: number;
+}) {
+  const dispatch = useStationMouse();
+  const theme = useStationTheme();
+  const overflow = contentLength > viewportLength && trackHeight > 0;
+  const cells = verticalScrollbarCells({
+    trackHeight,
+    contentLength,
+    viewportLength,
+    offset,
+  });
+  return (
+    <box width={1} flexDirection="column" flexShrink={0}>
+      {Array.from({ length: chromeTop }, (_, index) => (
+        <text key={`top-${index}`}> </text>
+      ))}
+      <box flexGrow={1} flexDirection="column">
+        {cells.map((glyph, index) => (
+          <text
+            key={index}
+            fg={toOpenTuiColor(theme.text.muted)}
+            {...(overflow
+              ? stationMouseProps(dispatch, {
+                  kind: "scrollbar",
+                  surface: "dashboard",
+                  offset: scrollbarOffsetForTrackIndex({
+                    trackHeight,
+                    contentLength,
+                    viewportLength,
+                    offset,
+                    trackIndex: index,
+                  }),
+                })
+              : {})}
+          >
+            {glyph}
+          </text>
+        ))}
+      </box>
+      {Array.from({ length: chromeBottom }, (_, index) => (
+        <text key={`bottom-${index}`}> </text>
+      ))}
+    </box>
+  );
 }
 
 function DashboardBody({

--- a/station/src/station/view/HelpOverlayView.tsx
+++ b/station/src/station/view/HelpOverlayView.tsx
@@ -1,88 +1,33 @@
 // OpenTUI port of apps/tui's HelpOverlay: centered box-drawn panel above the
 // dashboard (absolute + zIndex; the dashboard must never reflow for it).
 // Lines come from the shared panel generator over Station's visible help copy.
-import { DASHBOARD_FILTER_CONDITION_KEYS, helpPanelLayout, helpPanelLines } from "@station/dashboard-core/selectors";
 import {
-  dashboardBindingHelp,
-  type TuiDashboardBindingId,
-} from "@station/dashboard-core/state";
+  helpOverlayContent,
+  helpPanelLayout,
+  helpPanelModel,
+} from "@station/dashboard-core/selectors";
+import type { DashboardScreenView } from "@station/dashboard-core/state";
 import { stationKeymapHelp } from "../../input/keymap/stationBindings.js";
 import { toOpenTuiColor, toOpenTuiOpaqueColor, useStationTheme } from "../../theme/index.js";
 import { useStationMouse, stationMouseProps } from "./stationMouseContext.js";
 
-const FILTER_CONDITION_KEY_HINT = DASHBOARD_FILTER_CONDITION_KEYS.join("/");
-
-function dashboardHelp(id: TuiDashboardBindingId): { key: string; description: string } {
-  const help = dashboardBindingHelp(id);
-  if (help === undefined) throw new Error(`Dashboard binding ${id} has no Help metadata.`);
-  return {
-    key: help.panelKeys ?? help.keys,
-    description: help.panelLabel ?? help.label,
-  };
-}
-
-function dashboardHelpGroup(
-  ids: readonly TuiDashboardBindingId[],
-): { key: string; description: string } {
-  const entries = ids.map(dashboardHelp);
-  return {
-    key: entries.map(({ key }) => key).join("/"),
-    description: [...new Set(entries.map(({ description }) => description))].join("/"),
-  };
-}
-
-function dashboardKeys(ids: readonly TuiDashboardBindingId[]): string {
-  return ids.map((id) => dashboardHelp(id).key).join(" ");
-}
-
-const navigation = dashboardHelpGroup(["tui.dashboard.focusUp", "tui.dashboard.focusDown"]);
-const helpAliases = dashboardHelpGroup(["tui.dashboard.help", "tui.dashboard.helpAlias"]);
-const refresh = dashboardHelp("tui.dashboard.refresh");
-
-const STATION_HELP_CONTENT = [
-  { text: "station help", align: "center" as const },
-  ...stationKeymapHelp(),
-  { text: "station project view", align: "center" as const },
-  { key: navigation.key, description: `${navigation.description} · wheel scroll` },
-  dashboardHelp("tui.dashboard.focusActivate"),
-  dashboardHelp("tui.dashboard.nextNeedsMe"),
-  dashboardHelpGroup(["tui.dashboard.quickGroup", "tui.dashboard.moveToGroup"]),
-  {
-    key: dashboardKeys([
-      "tui.dashboard.filter",
-      "tui.dashboard.focusActivate",
-      "tui.dashboard.dismissEsc",
-      "tui.dashboard.quit",
-    ]),
-    description: "edit/apply/cancel-clear/retain-close filter",
-  },
-  {
-    key: `Tab ${FILTER_CONDITION_KEY_HINT}`,
-    description: "build filter conditions · F applies builder",
-  },
-  dashboardHelp("tui.dashboard.slotActivate"),
-  dashboardHelpGroup([
-    "tui.dashboard.newSession",
-    "tui.dashboard.addProject",
-    "tui.dashboard.rename",
-    "tui.dashboard.collapse",
-    "tui.dashboard.fork",
-    "tui.dashboard.projectSettings",
-  ]),
-  dashboardHelp("tui.dashboard.widgetSettings"),
-  dashboardHelp("tui.dashboard.remove"),
-  {
-    key: helpAliases.key,
-    description: `${helpAliases.description} · ${refresh.key} ${refresh.description}`,
-  },
-] as const;
-
-export function HelpOverlayView({ columns, rows }: { columns: number; rows: number }) {
+export function HelpOverlayView({
+  screen,
+  columns,
+  rows,
+}: {
+  screen: Extract<DashboardScreenView, { name: "help" }>;
+  columns: number;
+  rows: number;
+}) {
   const theme = useStationTheme();
   const helpBackground = toOpenTuiOpaqueColor(theme.surfaces.help);
   const dispatch = useStationMouse();
-  const layout = helpPanelLayout(columns, rows, STATION_HELP_CONTENT);
-  const panelLines = helpPanelLines(layout.width, layout.height, STATION_HELP_CONTENT);
+  const content = helpOverlayContent(stationKeymapHelp());
+  const layout = helpPanelLayout(columns, rows, content);
+  const model = helpPanelModel(layout.width, layout.height, content, screen.scrollOffset);
+  const fg = toOpenTuiColor(theme.text.primary);
+  const barFg = toOpenTuiColor(theme.text.muted);
 
   return (
     <box
@@ -96,15 +41,37 @@ export function HelpOverlayView({ columns, rows }: { columns: number; rows: numb
       backgroundColor={helpBackground}
       {...stationMouseProps(dispatch, { kind: "sheetBackdrop" })}
     >
-      {panelLines.map((line, index) => (
-        <text
-          key={`${index}:${line}`}
-          fg={toOpenTuiColor(theme.text.primary)}
-          bg={helpBackground}
-        >
-          {line}
-        </text>
-      ))}
+      {model.lines.map((line, index) =>
+        line.kind === "border" ? (
+          <text key={`${index}:${line.text}`} fg={fg} bg={helpBackground}>
+            {line.text}
+          </text>
+        ) : (
+          <box key={`${index}:${line.prefix}`} flexDirection="row" height={1}>
+            <text fg={fg} bg={helpBackground}>
+              {line.prefix}
+            </text>
+            {line.bar === "" ? null : (
+              <text
+                fg={barFg}
+                bg={helpBackground}
+                {...(model.overflow
+                  ? stationMouseProps(dispatch, {
+                      kind: "scrollbar",
+                      surface: "help",
+                      offset: line.offset,
+                    })
+                  : {})}
+              >
+                {line.bar}
+              </text>
+            )}
+            <text fg={fg} bg={helpBackground}>
+              {line.suffix}
+            </text>
+          </box>
+        ),
+      )}
     </box>
   );
 }

--- a/station/src/station/view/HelpOverlayView.tsx
+++ b/station/src/station/view/HelpOverlayView.tsx
@@ -1,6 +1,8 @@
 // OpenTUI port of apps/tui's HelpOverlay: centered box-drawn panel above the
 // dashboard (absolute + zIndex; the dashboard must never reflow for it).
 // Lines come from the shared panel generator over Station's visible help copy.
+import { useRef } from "react";
+import type { BoxRenderable } from "@opentui/core";
 import {
   helpOverlayContent,
   helpPanelLayout,
@@ -9,7 +11,11 @@ import {
 import type { DashboardScreenView } from "@station/dashboard-core/state";
 import { stationKeymapHelp } from "../../input/keymap/stationBindings.js";
 import { toOpenTuiColor, toOpenTuiOpaqueColor, useStationTheme } from "../../theme/index.js";
-import { useStationMouse, stationMouseProps } from "./stationMouseContext.js";
+import {
+  useStationMouse,
+  stationMouseProps,
+  stationScrollbarPointerProps,
+} from "./stationMouseContext.js";
 
 export function HelpOverlayView({
   screen,
@@ -23,11 +29,25 @@ export function HelpOverlayView({
   const theme = useStationTheme();
   const helpBackground = toOpenTuiOpaqueColor(theme.surfaces.help);
   const dispatch = useStationMouse();
+  const trackRef = useRef<BoxRenderable | null>(null);
   const content = helpOverlayContent(stationKeymapHelp());
   const layout = helpPanelLayout(columns, rows, content);
   const model = helpPanelModel(layout.width, layout.height, content, screen.scrollOffset);
   const fg = toOpenTuiColor(theme.text.primary);
   const barFg = toOpenTuiColor(theme.text.muted);
+  const body = model.lines.flatMap((line) => (line.kind === "body" ? [line] : []));
+  const top = model.lines[0];
+  const bottom = model.lines.at(-1);
+  const barColumn = body[0]?.bar.length === 1;
+  const pointer = model.overflow
+    ? stationScrollbarPointerProps(dispatch, {
+        surface: "help",
+        contentLength: content.length,
+        viewportLength: model.bodyRows,
+        trackHeight: model.bodyRows,
+        trackTop: () => trackRef.current?.y ?? layout.top + 1,
+      })
+    : undefined;
 
   return (
     <box
@@ -39,39 +59,54 @@ export function HelpOverlayView({
       zIndex={10}
       flexDirection="column"
       backgroundColor={helpBackground}
+      selectable={false}
       {...stationMouseProps(dispatch, { kind: "sheetBackdrop" })}
     >
-      {model.lines.map((line, index) =>
-        line.kind === "border" ? (
-          <text key={`${index}:${line.text}`} fg={fg} bg={helpBackground}>
-            {line.text}
-          </text>
-        ) : (
-          <box key={`${index}:${line.prefix}`} flexDirection="row" height={1}>
-            <text fg={fg} bg={helpBackground}>
-              {line.prefix}
-            </text>
-            {line.bar === "" ? null : (
-              <text
-                fg={barFg}
-                bg={helpBackground}
-                {...(model.overflow
-                  ? stationMouseProps(dispatch, {
-                      kind: "scrollbar",
-                      surface: "help",
-                      offset: line.offset,
-                    })
-                  : {})}
-              >
-                {line.bar}
+      {top?.kind === "border" ? (
+        <text fg={fg} bg={helpBackground} selectable={false}>
+          {top.text}
+        </text>
+      ) : null}
+      {model.bodyRows > 0 ? (
+        <box flexDirection="row" height={model.bodyRows}>
+          <box flexDirection="column" flexShrink={0}>
+            {body.map((line, index) => (
+              <text key={`prefix:${index}`} fg={fg} bg={helpBackground} selectable={false}>
+                {line.prefix}
               </text>
-            )}
-            <text fg={fg} bg={helpBackground}>
-              {line.suffix}
-            </text>
+            ))}
           </box>
-        ),
-      )}
+          {barColumn ? (
+            <box
+              ref={trackRef}
+              width={1}
+              height={model.bodyRows}
+              flexShrink={0}
+              flexDirection="column"
+              selectable={false}
+              {...pointer}
+            >
+              {body.map((line, index) => (
+                <text key={`bar:${index}`} fg={barFg} bg={helpBackground} selectable={false}>
+                  {line.bar}
+                </text>
+              ))}
+            </box>
+          ) : null}
+          <box flexDirection="column" width={1} flexShrink={0}>
+            {body.map((line, index) => (
+              <text key={`suffix:${index}`} fg={fg} bg={helpBackground} selectable={false}>
+                {line.suffix}
+              </text>
+            ))}
+          </box>
+        </box>
+      ) : null}
+      {bottom?.kind === "border" && model.lines.length > 1 ? (
+        <text fg={fg} bg={helpBackground} selectable={false}>
+          {bottom.text}
+        </text>
+      ) : null}
     </box>
   );
 }

--- a/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
@@ -5,22 +5,22 @@ exports[`dashboard golden frames renders many-projects at 80x24 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-overlay                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
-                                                                                
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
- [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
- [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
-                                                                                
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-overlay                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
+                                                                               ▐
+▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾]▐
+ [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1▐
+ [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10▐
+                                                                               ▐
 ▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
@@ -77,11 +77,11 @@ exports[`dashboard golden frames renders many-projects at 60x16 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown   
 ─────────────────────────────────────────────────────────── 
        SESSION                 AGENT     STATUS          PR 
-▼ station  5 sessions · 4 agents              [sh] [qs] [▾] 
- [1] ○ cli-help-man            codex     idle         #70 ✓ 
- [2] - docs-cleanup            codex     no agent           
- [3] ○ pty-buffer              codex     idle         #73 ✓ 
- [4] + session-resume          codex     starting           
+▼ station  5 sessions · 4 agents              [sh] [qs] [▾]▐
+ [1] ○ cli-help-man            codex     idle         #70 ✓▐
+ [2] - docs-cleanup            codex     no agent          ▐
+ [3] ○ pty-buffer              codex     idle         #73 ✓▐
+ [4] + session-resume          codex     starting          ▐
  [5] ⠋ station-overlay         codex     working      #76 … 
                                                             
 ▼ observer  3 sessions · 3 agents             [sh] [qs] [▾] 
@@ -97,7 +97,7 @@ exports[`dashboard golden frames renders many-projects at 40x12 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0      
 ─────────────────────────────────────── 
        SESSION             STATUS       
-▼ station  5 sessions · … [sh] [qs] [▾] 
+▼ station  5 sessions · … [sh] [qs] [▾]▐
  [1] ○ cli-help-man        idle         
  [2] - docs-cleanup        no agent     
  [3] ○ pty-buffer          idle         
@@ -113,18 +113,18 @@ exports[`dashboard golden frames renders grouped-many-projects at 80x24 1`] = `
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                     AGENT     STATUS                 DIFF · PR   
-▼ station  12 sessions · 6 Groups · 11 agents                     [sh] [qs] [▾] 
-╭▼ Design refresh 2 sessions──────────────────────────────────────────[qs] [▾]╮ 
-│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│ 
-│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│ 
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Input parity and minimum-width interaction verification 1 session──[qs] [▾]╮ 
-│ [3] ○ input-routing               codex     idle                      +27 -6│ 
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Observer hardening 3 sessions──────────────────────────────────────[qs] [▾]╮ 
-│ [4] ○ diagnostic-index            codex     idle                      +38 -7│ 
-│ [5] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│ 
-│ [6] ⠋ trace-readiness             codex     working           +91 -22 #478 …│ 
+▼ station  12 sessions · 6 Groups · 11 agents                     [sh] [qs] [▾]▐
+╭▼ Design refresh 2 sessions──────────────────────────────────────────[qs] [▾]╮▐
+│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│▐
+│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
+╭▼ Input parity and minimum-width interaction verification 1 session──[qs] [▾]╮▐
+│ [3] ○ input-routing               codex     idle                      +27 -6│▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
+╭▼ Observer hardening 3 sessions──────────────────────────────────────[qs] [▾]╮▐
+│ [4] ○ diagnostic-index            codex     idle                      +38 -7│▐
+│ [5] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│▐
+│ [6] ⠋ trace-readiness             codex     working           +91 -22 #478 …│▐
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
 ╭▼ Post-launch 0 sessions─────────────────────────────────────────────[qs] [▾]╮ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
@@ -185,9 +185,9 @@ exports[`dashboard golden frames renders grouped-many-projects at 60x16 1`] = `
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited    
 ─────────────────────────────────────────────────────────── 
        SESSION                 AGENT     STATUS             
-▼ station  12 sessions · 6 Groups · 11 agents [sh] [qs] [▾] 
-╭▼ Design refresh 2 sessions──────────────────────[qs] [▾]╮ 
-│ [1] ⠋ group-contracts         codex     working         │ 
+▼ station  12 sessions · 6 Groups · 11 agents [sh] [qs] [▾]▐
+╭▼ Design refresh 2 sessions──────────────────────[qs] [▾]╮▐
+│ [1] ⠋ group-contracts         codex     working         │▐
 │ [2] ○ group-keyboard          codex     idle            │ 
 ╰─────────────────────────────────────────────────────────╯ 
 ╭▼ Input parity and minimum-width interaction ve…─[qs] [▾]╮ 
@@ -205,7 +205,7 @@ exports[`dashboard golden frames renders grouped-many-projects at 40x12 1`] = `
 FLEET  ● 0 ready  ⠋ 3 working  ! 1      
 ─────────────────────────────────────── 
        SESSION                          
-▼ station  12 sessions ·… [sh] [qs] [▾] 
+▼ station  12 sessions ·… [sh] [qs] [▾]▐
 ╭▼ Design refresh 2 sessions──[qs] [▾]╮ 
 │ [1] ⠋ group-contracts               │ 
 │ [2] ○ group-keyboard                │ 
@@ -313,9 +313,9 @@ exports[`dashboard golden frames renders attention-and-failures at 40x12 1`] = `
 FLEET  ● 0 ready  ⠋ 1 working  ! 3      
 ─────────────────────────────────────── 
        SESSION                          
-▼ station  4 sessions · … [sh] [qs] [▾] 
- [1] ! hook-scope                       
- [2] ? metadata-refresh                 
+▼ station  4 sessions · … [sh] [qs] [▾]▐
+ [1] ! hook-scope                      ▐
+ [2] ? metadata-refresh                ▐
  [3] ! popup-latency                    
  [4] ⠋ pr-info                          
 ▼ 2 below · showing 4 of 6              
@@ -572,9 +572,9 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 1
 ╭▼ Observer hardening 3 sessions──────────────────────────────────────[qs] [▾]╮ 
 │ [1] ○ diagnostic-index            codex     idle                      +38 -7│ 
 │ [2] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│ 
-│ [3] ⠋ trace-readiness             codex     working           +91 -22 #478 …│ 
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Post-launch 0 sessions─────────────────────────────────────────────[qs] [▾]╮ 
+│ [3] ⠋ trace-readiness             codex     working           +91 -22 #478 …│▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
+╭▼ Post-launch 0 sessions─────────────────────────────────────────────[qs] [▾]╮▐
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
 ╭▼ Release train 3 sessions───────────────────────────────────────────[qs] [▾]╮ 
 │ [4] x asset-proof                 codex     exited                    +19 -2│ 
@@ -633,22 +633,22 @@ exports[`dashboard golden frames renders a recoverable zero-match persistent pre
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
 ▏ FILTER /no-such-session▏                                         0/10 matches 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-overlay                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
-                                                                                
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
- [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
- [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
-                                                                                
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-overlay                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
+                                                                               ▐
+▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾]▐
+ [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1▐
+ [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10▐
+                                                                               ▐
 ▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
@@ -661,14 +661,14 @@ exports[`dashboard golden frames renders an applied persistent summary at compac
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown   
 ─────────────────────────────────────────────────────────── 
 FILTER working · Status=Working                2/10 matches 
-▼ station  5 sessions · 4 agents              [sh] [qs] [▾] 
- [1] ⠋ station-overlay         codex     working      #76 … 
-                                                            
-▼ observer  3 sessions · 3 agents             [sh] [qs] [▾] 
- [2] ⠋ provider-hooks          opencode  working      #16 … 
-                                                            
-▼ scripts  2 sessions · 2 agents              [sh] [qs] [▾] 
-                                                            
+▼ station  5 sessions · 4 agents              [sh] [qs] [▾]▐
+ [1] ⠋ station-overlay         codex     working      #76 …▐
+                                                           ▐
+▼ observer  3 sessions · 3 agents             [sh] [qs] [▾]▐
+ [2] ⠋ provider-hooks          opencode  working      #16 …▐
+                                                           ▐
+▼ scripts  2 sessions · 2 agents              [sh] [qs] [▾]▐
+                                                           ▐
 ▼ empty-project  0 sessions                   [sh] [qs] [▾] 
                                                             
 ─────────────────────────────────────────────────────────── 
@@ -681,7 +681,7 @@ exports[`dashboard golden frames clips a long persistent draft at minimum dashbo
 FLEET  ● 0 ready  ⠋ 2 working  ! 0      
 ─────────────────────────────────────── 
 ▏ FILTER /t-filter-draft▏  0/10 matches 
-▼ station  5 sessions · … [sh] [qs] [▾] 
+▼ station  5 sessions · … [sh] [qs] [▾]▐
  [1] ○ cli-help-man        idle         
  [2] - docs-cleanup        no agent     
  [3] ○ pty-buffer          idle         

--- a/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
@@ -21,8 +21,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1▐
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10▐
                                                                                ▐
-▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
-                                                                                
+▼ empty-project  0 sessions                                       [sh] [qs] [▾]▕
+▼ more below                                                                   ▼
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
 "
@@ -82,11 +82,11 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown
  [2] - docs-cleanup            codex     no agent          ▐
  [3] ○ pty-buffer              codex     idle         #73 ✓▐
  [4] + session-resume          codex     starting          ▐
- [5] ⠋ station-overlay         codex     working      #76 … 
-                                                            
-▼ observer  3 sessions · 3 agents             [sh] [qs] [▾] 
- [6] x batch-export            opencode  exited        #8 ✓ 
-▼ 4 below · showing 6 of 10                                 
+ [5] ⠋ station-overlay         codex     working      #76 …▕
+                                                           ▕
+▼ observer  3 sessions · 3 agents             [sh] [qs] [▾]▕
+ [6] x batch-export            opencode  exited        #8 ✓▕
+▼ 4 below · showing 6 of 10                                ▼
 ─────────────────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/e… 
 "
@@ -98,11 +98,11 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0
 ─────────────────────────────────────── 
        SESSION             STATUS       
 ▼ station  5 sessions · … [sh] [qs] [▾]▐
- [1] ○ cli-help-man        idle         
- [2] - docs-cleanup        no agent     
- [3] ○ pty-buffer          idle         
- [4] + session-resume      starting     
-▼ 6 below · showing 4 of 10             
+ [1] ○ cli-help-man        idle        ▕
+ [2] - docs-cleanup        no agent    ▕
+ [3] ○ pty-buffer          idle        ▕
+ [4] + session-resume      starting    ▕
+▼ 6 below · showing 4 of 10            ▼
 ─────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X… 
 "
@@ -125,12 +125,12 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 1
 │ [4] ○ diagnostic-index            codex     idle                      +38 -7│▐
 │ [5] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│▐
 │ [6] ⠋ trace-readiness             codex     working           +91 -22 #478 …│▐
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Post-launch 0 sessions─────────────────────────────────────────────[qs] [▾]╮ 
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Release train 3 sessions───────────────────────────────────────────[qs] [▾]╮ 
-│ [7] x asset-proof                 codex     exited                    +19 -2│ 
-▼ 5 below · showing 7 of 12                                                     
+╰─────────────────────────────────────────────────────────────────────────────╯▕
+╭▼ Post-launch 0 sessions─────────────────────────────────────────────[qs] [▾]╮▕
+╰─────────────────────────────────────────────────────────────────────────────╯▕
+╭▼ Release train 3 sessions───────────────────────────────────────────[qs] [▾]╮▕
+│ [7] x asset-proof                 codex     exited                    +19 -2│▕
+▼ 5 below · showing 7 of 12                                                    ▼
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
 "
@@ -188,13 +188,13 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited
 ▼ station  12 sessions · 6 Groups · 11 agents [sh] [qs] [▾]▐
 ╭▼ Design refresh 2 sessions──────────────────────[qs] [▾]╮▐
 │ [1] ⠋ group-contracts         codex     working         │▐
-│ [2] ○ group-keyboard          codex     idle            │ 
-╰─────────────────────────────────────────────────────────╯ 
-╭▼ Input parity and minimum-width interaction ve…─[qs] [▾]╮ 
-│ [3] ○ input-routing           codex     idle            │ 
-╰─────────────────────────────────────────────────────────╯ 
-╭▼ Observer hardening 3 sessions──────────────────[qs] [▾]╮ 
-▼ 9 below · showing 3 of 12                                 
+│ [2] ○ group-keyboard          codex     idle            │▕
+╰─────────────────────────────────────────────────────────╯▕
+╭▼ Input parity and minimum-width interaction ve…─[qs] [▾]╮▕
+│ [3] ○ input-routing           codex     idle            │▕
+╰─────────────────────────────────────────────────────────╯▕
+╭▼ Observer hardening 3 sessions──────────────────[qs] [▾]╮▕
+▼ 9 below · showing 3 of 12                                ▼
 ─────────────────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/e… 
 "
@@ -206,11 +206,11 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1
 ─────────────────────────────────────── 
        SESSION                          
 ▼ station  12 sessions ·… [sh] [qs] [▾]▐
-╭▼ Design refresh 2 sessions──[qs] [▾]╮ 
-│ [1] ⠋ group-contracts               │ 
-│ [2] ○ group-keyboard                │ 
-╰─────────────────────────────────────╯ 
-▼ 10 below · showing 2 of 12            
+╭▼ Design refresh 2 sessions──[qs] [▾]╮▕
+│ [1] ⠋ group-contracts               │▕
+│ [2] ○ group-keyboard                │▕
+╰─────────────────────────────────────╯▕
+▼ 10 below · showing 2 of 12           ▼
 ─────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X… 
 "
@@ -316,9 +316,9 @@ FLEET  ● 0 ready  ⠋ 1 working  ! 3
 ▼ station  4 sessions · … [sh] [qs] [▾]▐
  [1] ! hook-scope                      ▐
  [2] ? metadata-refresh                ▐
- [3] ! popup-latency                    
- [4] ⠋ pr-info                          
-▼ 2 below · showing 4 of 6              
+ [3] ! popup-latency                   ▕
+ [4] ⠋ pr-info                         ▕
+▼ 2 below · showing 4 of 6             ▼
 ─────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X… 
 "
@@ -568,17 +568,17 @@ exports[`dashboard golden frames renders filtered Group counts and clips framed 
 "                                                                                
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
-▲ 3 sessions above                                                              
-╭▼ Observer hardening 3 sessions──────────────────────────────────────[qs] [▾]╮ 
-│ [1] ○ diagnostic-index            codex     idle                      +38 -7│ 
-│ [2] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│ 
+▲ 3 sessions above                                                             ▲
+╭▼ Observer hardening 3 sessions──────────────────────────────────────[qs] [▾]╮▕
+│ [1] ○ diagnostic-index            codex     idle                      +38 -7│▕
+│ [2] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│▕
 │ [3] ⠋ trace-readiness             codex     working           +91 -22 #478 …│▐
 ╰─────────────────────────────────────────────────────────────────────────────╯▐
 ╭▼ Post-launch 0 sessions─────────────────────────────────────────────[qs] [▾]╮▐
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Release train 3 sessions───────────────────────────────────────────[qs] [▾]╮ 
-│ [4] x asset-proof                 codex     exited                    +19 -2│ 
-▼ 5 below · showing 4 of 12                                                     
+╰─────────────────────────────────────────────────────────────────────────────╯▕
+╭▼ Release train 3 sessions───────────────────────────────────────────[qs] [▾]╮▕
+│ [4] x asset-proof                 codex     exited                    +19 -2│▕
+▼ 5 below · showing 4 of 12                                                    ▼
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
 "
@@ -649,8 +649,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1▐
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10▐
                                                                                ▐
-▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
-                                                                                
+▼ empty-project  0 sessions                                       [sh] [qs] [▾]▕
+▼ more below                                                                   ▼
 ─────────────────────────────────────────────────────────────────────────────── 
  FILTER   ←→ cursor  Enter apply  Tab condition  Ctrl-U clear  Esc cancel       
 "
@@ -669,8 +669,8 @@ FILTER working · Status=Working                2/10 matches
                                                            ▐
 ▼ scripts  2 sessions · 2 agents              [sh] [qs] [▾]▐
                                                            ▐
-▼ empty-project  0 sessions                   [sh] [qs] [▾] 
-                                                            
+▼ empty-project  0 sessions                   [sh] [qs] [▾]▕
+▼ more below                                               ▼
 ─────────────────────────────────────────────────────────── 
 / edit  Esc clear  ↵ activate  N new  Q:close               
 "
@@ -682,11 +682,11 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0
 ─────────────────────────────────────── 
 ▏ FILTER /t-filter-draft▏  0/10 matches 
 ▼ station  5 sessions · … [sh] [qs] [▾]▐
- [1] ○ cli-help-man        idle         
- [2] - docs-cleanup        no agent     
- [3] ○ pty-buffer          idle         
- [4] + session-resume      starting     
-▼ 6 below · showing 4 of 10             
+ [1] ○ cli-help-man        idle        ▕
+ [2] - docs-cleanup        no agent    ▕
+ [3] ○ pty-buffer          idle        ▕
+ [4] + session-resume      starting    ▕
+▼ 6 below · showing 4 of 10            ▼
 ─────────────────────────────────────── 
  FILTER   ↵ apply  Esc cancel           
 "

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -4,24 +4,52 @@ exports[`modal flow golden frames renders the help overlay 1`] = `
 "                                                                                
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ────────╭──────────────────────────────────────────────────────────────╮─────── 
-       S│                         station help                         │FF · PR 
-▼ statio│  Ctrl-O     open/close project view                          │qs] [▾] 
- [1] ○ c│  Ctrl-Q     quit Station                                     │6 #70 ✓ 
- [2] - d│  Ctrl-\\     split pane right                                 │        
- [3] ○ p│  Ctrl-^     split pane below (Ctrl-6)                        │  #73 ✓ 
- [4] + s│  Ctrl-]     focus next pane                                  │        
- [5] ⠋ s│  Ctrl-/     close split pane (Ctrl-_)                        │6 #76 … 
-        │  Enter/Sp   open project view on welcome                     │        
-▼ observ│  Esc/↑↓     context menu close/move                          │qs] [▾] 
- [6] x b│  Enter/Sp   context menu select                              │   #8 ✓ 
- [7] ⠋ p│                     station project view                     │8 #16 … 
- [8] ○ t│  ↑/↓        move cursor · wheel scroll                       │-1 #4 ✓ 
-        │  ↵          open focused session                             │        
-▼ script│  tab        next session needing you                         │qs] [▾] 
- [9] ○ a│  G/M        quick group/move to group                        │6 #5 x1 
- [a] ? m│  / ↵ Esc Q  edit/apply/cancel-clear/retain-close filter      │ -1 #10 
-        │  Tab S/P/A  build filter conditions · F applies builder      │        
+       S│                         station help                        ▐│FF · PR 
+▼ statio│  Ctrl-O     open/close project view                         ▐│qs] [▾]▐
+ [1] ○ c│  Ctrl-Q     quit Station                                    ▐│6 #70 ✓▐
+ [2] - d│  Ctrl-\\     split pane right                                ▐│       ▐
+ [3] ○ p│  Ctrl-^     split pane below (Ctrl-6)                       ▐│  #73 ✓▐
+ [4] + s│  Ctrl-]     focus next pane                                 ▐│       ▐
+ [5] ⠋ s│  Ctrl-/     close split pane (Ctrl-_)                       ▐│6 #76 …▐
+        │  Enter/Sp   open project view on welcome                    ▐│       ▐
+▼ observ│  Esc/↑↓     context menu close/move                         ▐│qs] [▾]▐
+ [6] x b│  Enter/Sp   context menu select                             ▐│   #8 ✓▐
+ [7] ⠋ p│                     station project view                    ▐│8 #16 …▐
+ [8] ○ t│  ↑/↓        move cursor · wheel scroll                      ▐│-1 #4 ✓▐
+        │  ↵          open focused session                            ▐│       ▐
+▼ script│  tab        next session needing you                        ▐│qs] [▾]▐
+ [9] ○ a│  G/M        quick group/move to group                       ▐│6 #5 x1▐
+ [a] ? m│  / ↵ Esc Q  edit/apply/cancel-clear/retain-close filter      │ -1 #10▐
+        │  Tab S/P/A  build filter conditions · F applies builder      │       ▐
 ▼ empty-│  1-9/a-z    open visible session or toggle condition         │qs] [▾] 
+        ╰──────────────────────────────────────────────────────────────╯        
+─────────────────────────────────────────────────────────────────────────────── 
+↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
+"
+`;
+
+exports[`modal flow golden frames renders the help overlay scrolled 1`] = `
+"                                                                                
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+────────╭──────────────────────────────────────────────────────────────╮─────── 
+       S│  Ctrl-^     split pane below (Ctrl-6)                        │FF · PR 
+▼ statio│  Ctrl-]     focus next pane                                  │qs] [▾]▐
+ [1] ○ c│  Ctrl-/     close split pane (Ctrl-_)                        │6 #70 ✓▐
+ [2] - d│  Enter/Sp   open project view on welcome                    ▐│       ▐
+ [3] ○ p│  Esc/↑↓     context menu close/move                         ▐│  #73 ✓▐
+ [4] + s│  Enter/Sp   context menu select                             ▐│       ▐
+ [5] ⠋ s│                     station project view                    ▐│6 #76 …▐
+        │  ↑/↓        move cursor · wheel scroll                      ▐│       ▐
+▼ observ│  ↵          open focused session                            ▐│qs] [▾]▐
+ [6] x b│  tab        next session needing you                        ▐│   #8 ✓▐
+ [7] ⠋ p│  G/M        quick group/move to group                       ▐│8 #16 …▐
+ [8] ○ t│  / ↵ Esc Q  edit/apply/cancel-clear/retain-close filter     ▐│-1 #4 ✓▐
+        │  Tab S/P/A  build filter conditions · F applies builder     ▐│       ▐
+▼ script│  1-9/a-z    open visible session or toggle condition        ▐│qs] [▾]▐
+ [9] ○ a│  N/A/R/C/F/P  new/add/rename/fold/fork/settings             ▐│6 #5 x1▐
+ [a] ? m│  W          widgets                                         ▐│ -1 #10▐
+        │  X          delete session                                  ▐│       ▐
+▼ empty-│  H/?        help · Z refresh                                ▐│qs] [▾] 
         ╰──────────────────────────────────────────────────────────────╯        
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
@@ -33,22 +61,22 @@ exports[`modal flow golden frames renders the project menu 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
  [1] ○ cli-help-man                       codex     idle┌──────────────────────┐
  [2] - docs-cleanup                       codex     no a│ Quick Group          │
  [3] ○ pty-buffer                         codex     idle│ New Group…           │
  [4] + session-resume                     codex     star│ Set default agent    │
  [5] ⠋ station-XXXXXXy                    codex     work│ Project settings…    │
                                                         └──────────────────────┘
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
-                                                                                
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
- [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
- [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
-                                                                                
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
+                                                                               ▐
+▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾]▐
+ [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1▐
+ [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10▐
+                                                                               ▐
 ▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
@@ -73,19 +101,19 @@ exports[`modal flow golden frames renders the create group sheet 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
-                                                                                
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
+                                                                               ▐
+▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾]▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Create Group                                                                 │
 │  Name (N)    Release work                                                    │
@@ -101,11 +129,11 @@ exports[`modal flow golden frames renders the move to group destination sheet 1`
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                     AGENT     STATUS                 DIFF · PR   
-▼ station  12 sessions · 6 Groups · 11 agents                     [sh] [qs] [▾] 
-╭▼ Design refresh 2 sessions──────────────────────────────────────────[qs] [▾]╮ 
-│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│ 
-│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│ 
-╰─────────────────────────────────────────────────────────────────────────────╯ 
+▼ station  12 sessions · 6 Groups · 11 agents                     [sh] [qs] [▾]▐
+╭▼ Design refresh 2 sessions──────────────────────────────────────────[qs] [▾]╮▐
+│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│▐
+│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Move to Group                                                                │
 │ Session    group-contracts                                                   │
@@ -129,18 +157,18 @@ exports[`modal flow golden frames renders the move to group create sheet 1`] = `
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                     AGENT     STATUS                 DIFF · PR   
-▼ station  12 sessions · 6 Groups · 11 agents                     [sh] [qs] [▾] 
-╭▼ Design refresh 2 sessions──────────────────────────────────────────[qs] [▾]╮ 
-│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│ 
-│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│ 
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Input parity and minimum-width interaction verification 1 session──[qs] [▾]╮ 
-│ [3] ○ input-routing               codex     idle                      +27 -6│ 
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Observer hardening 3 sessions──────────────────────────────────────[qs] [▾]╮ 
-│ [4] ○ diagnostic-index            codex     idle                      +38 -7│ 
-│ [5] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│ 
-│ [6] ⠋ trace-readiness             codex     working           +91 -22 #478 …│ 
+▼ station  12 sessions · 6 Groups · 11 agents                     [sh] [qs] [▾]▐
+╭▼ Design refresh 2 sessions──────────────────────────────────────────[qs] [▾]╮▐
+│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│▐
+│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
+╭▼ Input parity and minimum-width interaction verification 1 session──[qs] [▾]╮▐
+│ [3] ○ input-routing               codex     idle                      +27 -6│▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
+╭▼ Observer hardening 3 sessions──────────────────────────────────────[qs] [▾]╮▐
+│ [4] ○ diagnostic-index            codex     idle                      +38 -7│▐
+│ [5] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│▐
+│ [6] ⠋ trace-readiness             codex     working           +91 -22 #478 …│▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Create Group                                                                 │
 │ Session    group-contracts                                                   │
@@ -157,22 +185,22 @@ exports[`modal flow golden frames renders the persistent filter header editor 1`
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
 ▏ FILTER /api▏                                                       1/10 match 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
-                                                                                
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
- [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
- [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
-                                                                                
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
+                                                                               ▐
+▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾]▐
+ [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1▐
+ [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10▐
+                                                                               ▐
 ▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
@@ -185,22 +213,22 @@ exports[`modal flow golden frames renders the persistent filter condition field 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
 ▏ FILTER /▏                                                       10/10 matches 
-┌────────────────────────────────┐                                [sh] [qs] [▾] 
-│ FILTER CONDITIONS           [×]│        codex     idle           +14 -6 #70 ✓ 
-│▸ S Status                 Any ›│        codex     no agent                    
-│  P Project                Any ›│        codex     idle                  #73 ✓ 
-│  A Agent                  Any ›│        codex     starting                    
-│                                │        codex     working      +412 -96 #76 … 
-│  Apply filter (F)              │                                              
-└────────────────────────────────┘                                [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
-                                                                                
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
- [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
- [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
-                                                                                
+┌────────────────────────────────┐                                [sh] [qs] [▾]▐
+│ FILTER CONDITIONS           [×]│        codex     idle           +14 -6 #70 ✓▐
+│▸ S Status                 Any ›│        codex     no agent                   ▐
+│  P Project                Any ›│        codex     idle                  #73 ✓▐
+│  A Agent                  Any ›│        codex     starting                   ▐
+│                                │        codex     working      +412 -96 #76 …▐
+│  Apply filter (F)              │                                             ▐
+└────────────────────────────────┘                                [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
+                                                                               ▐
+▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾]▐
+ [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1▐
+ [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10▐
+                                                                               ▐
 ▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
@@ -213,22 +241,22 @@ exports[`modal flow golden frames renders the persistent filter status condition
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
 ▏ FILTER /▏ Status=Working                                         2/10 matches 
-┌────────────────────────────────┐                                [sh] [qs] [▾] 
-│[←] STATUS CONDITION         [×]│        codex     idle           +14 -6 #70 ✓ 
-│  1 [ ] Needs attention         │        codex     no agent                    
-│  2 [ ] Stuck                   │        codex     idle                  #73 ✓ 
-│▸ 3 [✓] Working                 │        codex     starting                    
-│  4 [ ] Starting                │        codex     working      +412 -96 #76 … 
-│  5 [ ] Idle                    │                                              
-│  6 [ ] Exited                  │                                [sh] [qs] [▾] 
-│  7 [ ] No agent                │        opencode  exited                 #8 ✓ 
-│  8 [ ] Unknown                 │        opencode  working        +32 -8 #16 … 
-│  Done (Enter)                  │        opencode  idle             +1 -1 #4 ✓ 
-└────────────────────────────────┘                                              
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
- [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
- [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
-                                                                                
+┌────────────────────────────────┐                                [sh] [qs] [▾]▐
+│[←] STATUS CONDITION         [×]│        codex     idle           +14 -6 #70 ✓▐
+│  1 [ ] Needs attention         │        codex     no agent                   ▐
+│  2 [ ] Stuck                   │        codex     idle                  #73 ✓▐
+│▸ 3 [✓] Working                 │        codex     starting                   ▐
+│  4 [ ] Starting                │        codex     working      +412 -96 #76 …▐
+│  5 [ ] Idle                    │                                             ▐
+│  6 [ ] Exited                  │                                [sh] [qs] [▾]▐
+│  7 [ ] No agent                │        opencode  exited                 #8 ✓▐
+│  8 [ ] Unknown                 │        opencode  working        +32 -8 #16 …▐
+│  Done (Enter)                  │        opencode  idle             +1 -1 #4 ✓▐
+└────────────────────────────────┘                                             ▐
+▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾]▐
+ [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1▐
+ [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10▐
+                                                                               ▐
 ▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
@@ -241,7 +269,7 @@ exports[`modal flow golden frames renders the persistent filter condition values
 FLEET  ● 0 ready  ⠋ 2 working  ! 0      
 ─────────────────────────────────────── 
 ▏ FILTER /▏               10/10 matches 
-┌────────────────────────────────┐] [▾] 
+┌────────────────────────────────┐] [▾]▐
 │[←] STATUS CONDITION ↑5      [×]│      
 │  6 [ ] Exited                  │t     
 │▸ 7 [ ] No agent                │      
@@ -257,16 +285,16 @@ exports[`modal flow golden frames renders the collapse project sheet 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
 ───────────────────────────────────────────────────────────────────────────────
        SESSION                            AGENT     STATUS            DIFF · PR
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
- [2] - docs-cleanup                       codex     no agent
- [3] ○ pty-buffer                         codex     idle                  #73 ✓
- [4] + session-resume                     codex     starting
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …
-
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]
- [6] x batch-export                       opencode  exited                 #8 ✓
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Collapse Project                                                             │
 │                                                                              │
@@ -313,16 +341,16 @@ exports[`modal flow golden frames renders the project settings picker sheet 1`] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
 ───────────────────────────────────────────────────────────────────────────────
        SESSION                            AGENT     STATUS            DIFF · PR
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
- [2] - docs-cleanup                       codex     no agent
- [3] ○ pty-buffer                         codex     idle                  #73 ✓
- [4] + session-resume                     codex     starting
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …
-
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]
- [6] x batch-export                       opencode  exited                 #8 ✓
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Project Settings                                                             │
 │                                                                              │
@@ -341,22 +369,22 @@ exports[`modal flow golden frames renders the project settings panel 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ───┌────────────────────────────────────────────────────────────────────────┐── 
    │ Project settings                                                       │PR 
-▼ s│ station                  │ Default agent                               │▾] 
- [1│▸ Default agent           │✓1 codex ● update v0.3.0 → v0.4.0            │ ✓ 
- [2│  Remove project          │ 2 opencode unknown                          │   
- [3│                          │                                             │ ✓ 
- [4│                          │ ✓ current · ↑↓ ↵ · 1-9/a-z                  │   
- [5│                          │                                             │ … 
-   │                          │                                             │   
-▼ o│                          │                                             │▾] 
- [6│                          │                                             │ ✓ 
- [7│                          │                                             │ … 
- [8│                          │                                             │ ✓ 
-   │                          │                                             │   
-▼ s│                          │                                             │▾] 
- [9│                          │                                             │x1 
- [a│                          │                                             │10 
-   │                          │                                             │   
+▼ s│ station                  │ Default agent                               │▾]▐
+ [1│▸ Default agent           │✓1 codex ● update v0.3.0 → v0.4.0            │ ✓▐
+ [2│  Remove project          │ 2 opencode unknown                          │  ▐
+ [3│                          │                                             │ ✓▐
+ [4│                          │ ✓ current · ↑↓ ↵ · 1-9/a-z                  │  ▐
+ [5│                          │                                             │ …▐
+   │                          │                                             │  ▐
+▼ o│                          │                                             │▾]▐
+ [6│                          │                                             │ ✓▐
+ [7│                          │                                             │ …▐
+ [8│                          │                                             │ ✓▐
+   │                          │                                             │  ▐
+▼ s│                          │                                             │▾]▐
+ [9│                          │                                             │x1▐
+ [a│                          │                                             │10▐
+   │                          │                                             │  ▐
 ▼ e│ ↑↓ move   →/enter edit   esc close                                     │▾] 
    └────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
@@ -369,22 +397,22 @@ exports[`modal flow golden frames renders the project settings remove pane 1`] =
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ───┌────────────────────────────────────────────────────────────────────────┐── 
    │ Project settings                                                       │PR 
-▼ s│ station                  │ Remove project                              │▾] 
- [1│  Default agent           │ Removes it from Station.                    │ ✓ 
- [2│▸ Remove project          │ Worktrees & files stay on disk.             │   
- [3│                          │                                             │ ✓ 
- [4│                          │ Type "delete station" to confirm            │   
- [5│                          │ ▸ |delete station                           │ … 
-   │                          │                                             │   
-▼ o│                          │ [ Remove project (R) ]                      │▾] 
- [6│                          │                                             │ ✓ 
- [7│                          │                                             │ … 
- [8│                          │                                             │ ✓ 
-   │                          │                                             │   
-▼ s│                          │                                             │▾] 
- [9│                          │                                             │x1 
- [a│                          │                                             │10 
-   │                          │                                             │   
+▼ s│ station                  │ Remove project                              │▾]▐
+ [1│  Default agent           │ Removes it from Station.                    │ ✓▐
+ [2│▸ Remove project          │ Worktrees & files stay on disk.             │  ▐
+ [3│                          │                                             │ ✓▐
+ [4│                          │ Type "delete station" to confirm            │  ▐
+ [5│                          │ ▸ |delete station                           │ …▐
+   │                          │                                             │  ▐
+▼ o│                          │ [ Remove project (R) ]                      │▾]▐
+ [6│                          │                                             │ ✓▐
+ [7│                          │                                             │ …▐
+ [8│                          │                                             │ ✓▐
+   │                          │                                             │  ▐
+▼ s│                          │                                             │▾]▐
+ [9│                          │                                             │x1▐
+ [a│                          │                                             │10▐
+   │                          │                                             │  ▐
 ▼ e│ ←/esc back                                                             │▾] 
    └────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
@@ -397,22 +425,22 @@ exports[`modal flow golden frames renders the project settings optimistic defaul
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ───┌────────────────────────────────────────────────────────────────────────┐── 
    │ Project settings                                                       │PR 
-▼ s│ station                  │ Default agent                               │▾] 
- [1│▸ Default agent           │ 1 codex ● update v0.3.0 → v0.4.0            │ ✓ 
- [2│  Remove project          │✓2 opencode unknown                 updating…│   
- [3│                          │                                             │ ✓ 
- [4│                          │ ✓ current · ↑↓ ↵ · 1-9/a-z                  │   
- [5│                          │                                             │ … 
-   │                          │                                             │   
-▼ o│                          │                                             │▾] 
- [6│                          │                                             │ ✓ 
- [7│                          │                                             │ … 
- [8│                          │                                             │ ✓ 
-   │                          │                                             │   
-▼ s│                          │                                             │▾] 
- [9│                          │                                             │x1 
- [a│                          │                                             │10 
-   │                          │                                             │   
+▼ s│ station                  │ Default agent                               │▾]▐
+ [1│▸ Default agent           │ 1 codex ● update v0.3.0 → v0.4.0            │ ✓▐
+ [2│  Remove project          │✓2 opencode unknown                 updating…│  ▐
+ [3│                          │                                             │ ✓▐
+ [4│                          │ ✓ current · ↑↓ ↵ · 1-9/a-z                  │  ▐
+ [5│                          │                                             │ …▐
+   │                          │                                             │  ▐
+▼ o│                          │                                             │▾]▐
+ [6│                          │                                             │ ✓▐
+ [7│                          │                                             │ …▐
+ [8│                          │                                             │ ✓▐
+   │                          │                                             │  ▐
+▼ s│                          │                                             │▾]▐
+ [9│                          │                                             │x1▐
+ [a│                          │                                             │10▐
+   │                          │                                             │  ▐
 ▼ e│ ↑↓ move   →/enter edit   esc close                                     │▾] 
    └────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
@@ -425,22 +453,22 @@ exports[`modal flow golden frames renders the remove slot sheet 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
-                                                                                
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
-┌────────────────────────────────────────────┐code  idle           +14 -6 #5 x1 
-│ Select session to delete                   │code  unknown           +3 -1 #10 
-│                                            │                                  
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
+                                                                               ▐
+▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾]▐
+┌────────────────────────────────────────────┐code  idle           +14 -6 #5 x1▐
+│ Select session to delete                   │code  unknown           +3 -1 #10▐
+│                                            │                                 ▐
 │ ↑↓ move · ↵ choose · slot or click         │                    [sh] [qs] [▾] 
 │ Esc:cancel                                 │                                  
 │                                            │───────────────────────────────── 
@@ -453,22 +481,22 @@ exports[`modal flow golden frames renders the remove confirm sheet 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
-┌────────────────────────────────────────────┐                                  
-│ Delete session?                            │                    [sh] [qs] [▾] 
-│ Session  cli-help-man                      │code  idle           +14 -6 #5 x1 
-│ Removes agent, worktree, and panes.        │code  unknown           +3 -1 #10 
-│                                            │                                  
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
+┌────────────────────────────────────────────┐                                 ▐
+│ Delete session?                            │                    [sh] [qs] [▾]▐
+│ Session  cli-help-man                      │code  idle           +14 -6 #5 x1▐
+│ Removes agent, worktree, and panes.        │code  unknown           +3 -1 #10▐
+│                                            │                                 ▐
 │  Delete (Y)  ▸ Keep session (N)            │                    [sh] [qs] [▾] 
 │ ←→ choose · Enter activate · Esc cancel    │                                  
 │                                            │───────────────────────────────── 
@@ -481,22 +509,22 @@ exports[`modal flow golden frames renders the remove confirm delete focus 1`] = 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
-┌────────────────────────────────────────────┐                                  
-│ Delete session?                            │                    [sh] [qs] [▾] 
-│ Session  cli-help-man                      │code  idle           +14 -6 #5 x1 
-│ Removes agent, worktree, and panes.        │code  unknown           +3 -1 #10 
-│                                            │                                  
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
+┌────────────────────────────────────────────┐                                 ▐
+│ Delete session?                            │                    [sh] [qs] [▾]▐
+│ Session  cli-help-man                      │code  idle           +14 -6 #5 x1▐
+│ Removes agent, worktree, and panes.        │code  unknown           +3 -1 #10▐
+│                                            │                                 ▐
 │▸ Delete (Y)    Keep session (N)            │                    [sh] [qs] [▾] 
 │ ←→ choose · Enter activate · Esc cancel    │                                  
 │                                            │───────────────────────────────── 
@@ -509,9 +537,9 @@ exports[`modal flow golden frames renders the remove confirm narrow 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0      
 ─────────────────────────────────────── 
        SESSION             STATUS       
-▼ station  5 sessions · … [sh] [qs] [▾] 
- [1] ○ cli-help-man        idle         
- [2] - docs-cleanup        no agent     
+▼ station  5 sessions · … [sh] [qs] [▾]▐
+ [1] ○ cli-help-man        idle        ▐
+ [2] - docs-cleanup        no agent    ▐
 ┌──────────────────────────────────────┐
 │ Delete session?                      │
 │ Session  cli-help-man                │
@@ -529,22 +557,22 @@ exports[`modal flow golden frames renders the external agent removal information
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
 ───────────────────────────────────────────────────────────────────────────────
        SESSION                            AGENT     STATUS            DIFF · PR
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
- [2] - docs-cleanup                       codex     no agent
- [3] ○ pty-buffer                         codex     idle                  #73 ✓
- [4] + session-resume                     codex     starting
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …
-
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]
- [6] x batch-export                       opencode  exited                 #8 ✓
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓
-┌──────────────────────────────────────────────────────────────────┐
-│ Cannot delete worktree                                           │h] [qs] [▾]
-│ Station cannot stop the active agent.                            │14 -6 #5 x1
-│ Stop it in its terminal before deleting the worktree.            │  +3 -1 #10
-│                                                                  │
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
+┌──────────────────────────────────────────────────────────────────┐           ▐
+│ Cannot delete worktree                                           │h] [qs] [▾]▐
+│ Station cannot stop the active agent.                            │14 -6 #5 x1▐
+│ Stop it in its terminal before deleting the worktree.            │  +3 -1 #10▐
+│                                                                  │           ▐
 │                                                                  │h] [qs] [▾]
 │                                                                  │
 │ Esc/Enter:close                                                  │───────────
@@ -557,22 +585,22 @@ exports[`modal flow golden frames renders the rename slot prompt 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
-                                                                                
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
- [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
- [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
-                                                                                
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
+                                                                               ▐
+▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾]▐
+ [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1▐
+ [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10▐
+                                                                               ▐
 Rename: ↑↓ move · ↵ choose · 1-9/a-z or click                     [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
@@ -613,22 +641,22 @@ exports[`modal flow golden frames renders the fork slot sheet 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
-                                                                                
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
-┌────────────────────────────────────────────┐code  idle           +14 -6 #5 x1 
-│ Select session to fork                     │code  unknown           +3 -1 #10 
-│                                            │                                  
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
+                                                                               ▐
+▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾]▐
+┌────────────────────────────────────────────┐code  idle           +14 -6 #5 x1▐
+│ Select session to fork                     │code  unknown           +3 -1 #10▐
+│                                            │                                 ▐
 │ ↑↓ move · ↵ choose · slot or click         │                    [sh] [qs] [▾] 
 │ Esc:cancel                                 │                                  
 │                                            │───────────────────────────────── 
@@ -641,22 +669,22 @@ exports[`modal flow golden frames renders the fork details sheet 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
-┌────────────────────────────────────────────┐code  idle             +1 -1 #4 ✓ 
-│ Fork Session                               │                                  
-│ Source   station · cli-help-man            │                    [sh] [qs] [▾] 
-│▸ Name   Hexagonal PT 12|                   │code  idle           +14 -6 #5 x1 
-│  Copy   [x] uncommitted changes            │code  unknown           +3 -1 #10 
-│ Source keeps running — copy is read-only.  │                                  
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+┌────────────────────────────────────────────┐code  idle             +1 -1 #4 ✓▐
+│ Fork Session                               │                                 ▐
+│ Source   station · cli-help-man            │                    [sh] [qs] [▾]▐
+│▸ Name   Hexagonal PT 12|                   │code  idle           +14 -6 #5 x1▐
+│  Copy   [x] uncommitted changes            │code  unknown           +3 -1 #10▐
+│ Source keeps running — copy is read-only.  │                                 ▐
 │                                            │                    [sh] [qs] [▾] 
 │  Fork (enter)                              │                                  
 │ ↑↓ focus · Enter fork · Esc back           │───────────────────────────────── 
@@ -669,22 +697,22 @@ exports[`modal flow golden frames renders the fork details copy focus 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
-┌────────────────────────────────────────────┐code  idle             +1 -1 #4 ✓ 
-│ Fork Session                               │                                  
-│ Source   station · cli-help-man            │                    [sh] [qs] [▾] 
-│  Name   cli-help-man-fork                  │code  idle           +14 -6 #5 x1 
-│▸ Copy   [x] uncommitted changes            │code  unknown           +3 -1 #10 
-│ Source keeps running — copy is read-only.  │                                  
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+┌────────────────────────────────────────────┐code  idle             +1 -1 #4 ✓▐
+│ Fork Session                               │                                 ▐
+│ Source   station · cli-help-man            │                    [sh] [qs] [▾]▐
+│  Name   cli-help-man-fork                  │code  idle           +14 -6 #5 x1▐
+│▸ Copy   [x] uncommitted changes            │code  unknown           +3 -1 #10▐
+│ Source keeps running — copy is read-only.  │                                 ▐
 │                                            │                    [sh] [qs] [▾] 
 │  Fork (enter)                              │                                  
 │ Space/Enter toggle · ↑↓ focus · Esc back   │───────────────────────────────── 
@@ -697,22 +725,22 @@ exports[`modal flow golden frames renders the fork details submit focus 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
-┌────────────────────────────────────────────┐code  idle             +1 -1 #4 ✓ 
-│ Fork Session                               │                                  
-│ Source   station · cli-help-man            │                    [sh] [qs] [▾] 
-│  Name   cli-help-man-fork                  │code  idle           +14 -6 #5 x1 
-│  Copy   [x] uncommitted changes            │code  unknown           +3 -1 #10 
-│ Source keeps running — copy is read-only.  │                                  
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+┌────────────────────────────────────────────┐code  idle             +1 -1 #4 ✓▐
+│ Fork Session                               │                                 ▐
+│ Source   station · cli-help-man            │                    [sh] [qs] [▾]▐
+│  Name   cli-help-man-fork                  │code  idle           +14 -6 #5 x1▐
+│  Copy   [x] uncommitted changes            │code  unknown           +3 -1 #10▐
+│ Source keeps running — copy is read-only.  │                                 ▐
 │                                            │                    [sh] [qs] [▾] 
 │▸ Fork (enter)                              │                                  
 │ ↑↓ focus · Enter fork · Esc back           │───────────────────────────────── 
@@ -725,8 +753,8 @@ exports[`modal flow golden frames renders the fork details narrow copy focus 1`]
 FLEET  ● 0 ready  ⠋ 2 working  ! 0      
 ─────────────────────────────────────── 
        SESSION             STATUS       
-▼ station  5 sessions · … [sh] [qs] [▾] 
- [1] ○ cli-help-man        idle         
+▼ station  5 sessions · … [sh] [qs] [▾]▐
+ [1] ○ cli-help-man        idle        ▐
 ┌──────────────────────────────────────┐
 │ Fork Session                         │
 │ Source   station · cli-help-man      │
@@ -745,17 +773,17 @@ exports[`modal flow golden frames renders the new session review 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Create Session                                                               │
 │  Project (P) station                                                         │
@@ -773,17 +801,17 @@ exports[`modal flow golden frames renders the new session review project focus 1
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Create Session                                                               │
 │▸ Project (P) station                                                         │
@@ -801,17 +829,17 @@ exports[`modal flow golden frames renders the new session review name focus 1`] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Create Session                                                               │
 │  Project (P) station                                                         │
@@ -829,17 +857,17 @@ exports[`modal flow golden frames renders the new session review agent focus 1`]
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Create Session                                                               │
 │  Project (P) station                                                         │
@@ -857,17 +885,17 @@ exports[`modal flow golden frames renders the new session review Group focus 1`]
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Create Session                                                               │
 │  Project (P) station                                                         │
@@ -885,17 +913,17 @@ exports[`modal flow golden frames renders the new session healthy agent 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Create Session                                                               │
 │  Project (P) station                                                         │
@@ -913,17 +941,17 @@ exports[`modal flow golden frames renders the new session degraded agent 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Create Session                                                               │
 │  Project (P) station                                                         │
@@ -941,17 +969,17 @@ exports[`modal flow golden frames renders the new session unavailable agent 1`] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Create Session                                                               │
 │  Project (P) station                                                         │
@@ -969,18 +997,18 @@ exports[`modal flow golden frames renders the new session edit name 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
-                                                                                
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
+                                                                               ▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Set Session Name                                                             │
 │ Project      station                                                         │
@@ -997,18 +1025,18 @@ exports[`modal flow golden frames renders the new session edit name save focus 1
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
-                                                                                
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
+                                                                               ▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Set Session Name                                                             │
 │ Project      station                                                         │
@@ -1025,18 +1053,18 @@ exports[`modal flow golden frames renders the new session edit name back focus 1
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
-                                                                                
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
+                                                                               ▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Set Session Name                                                             │
 │ Project      station                                                         │
@@ -1053,9 +1081,9 @@ exports[`modal flow golden frames renders the new session narrow review 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0      
 ─────────────────────────────────────── 
        SESSION             STATUS       
-▼ station  5 sessions · … [sh] [qs] [▾] 
- [1] ○ cli-help-man        idle         
- [2] - docs-cleanup        no agent     
+▼ station  5 sessions · … [sh] [qs] [▾]▐
+ [1] ○ cli-help-man        idle        ▐
+ [2] - docs-cleanup        no agent    ▐
 ┌──────────────────────────────────────┐
 │ Create Session                       │
 │  Project (P) station                 │
@@ -1073,16 +1101,16 @@ exports[`modal flow golden frames renders the new session pick project 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Project                                                               │
 │                                                                              │
@@ -1101,18 +1129,18 @@ exports[`modal flow golden frames renders the new session pick agent 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
-                                                                                
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
+                                                                               ▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Agent                                                                 │
 │                                                                              │
@@ -1129,12 +1157,12 @@ exports[`modal flow golden frames renders the new session pick Group 1`] = `
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                     AGENT     STATUS                 DIFF · PR   
-▼ station  12 sessions · 6 Groups · 11 agents                     [sh] [qs] [▾] 
-╭▼ Design refresh 2 sessions──────────────────────────────────────────[qs] [▾]╮ 
-│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│ 
-│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│ 
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Input parity and minimum-width interaction verification 1 session──[qs] [▾]╮ 
+▼ station  12 sessions · 6 Groups · 11 agents                     [sh] [qs] [▾]▐
+╭▼ Design refresh 2 sessions──────────────────────────────────────────[qs] [▾]╮▐
+│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│▐
+│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
+╭▼ Input parity and minimum-width interaction verification 1 session──[qs] [▾]╮▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Group                                                                 │
 │                                                                              │
@@ -1157,18 +1185,18 @@ exports[`modal flow golden frames renders the new session edit inline Group 1`] 
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                     AGENT     STATUS                 DIFF · PR   
-▼ station  12 sessions · 6 Groups · 11 agents                     [sh] [qs] [▾] 
-╭▼ Design refresh 2 sessions──────────────────────────────────────────[qs] [▾]╮ 
-│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│ 
-│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│ 
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Input parity and minimum-width interaction verification 1 session──[qs] [▾]╮ 
-│ [3] ○ input-routing               codex     idle                      +27 -6│ 
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭▼ Observer hardening 3 sessions──────────────────────────────────────[qs] [▾]╮ 
-│ [4] ○ diagnostic-index            codex     idle                      +38 -7│ 
-│ [5] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│ 
-│ [6] ⠋ trace-readiness             codex     working           +91 -22 #478 …│ 
+▼ station  12 sessions · 6 Groups · 11 agents                     [sh] [qs] [▾]▐
+╭▼ Design refresh 2 sessions──────────────────────────────────────────[qs] [▾]╮▐
+│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│▐
+│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
+╭▼ Input parity and minimum-width interaction verification 1 session──[qs] [▾]╮▐
+│ [3] ○ input-routing               codex     idle                      +27 -6│▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
+╭▼ Observer hardening 3 sessions──────────────────────────────────────[qs] [▾]╮▐
+│ [4] ○ diagnostic-index            codex     idle                      +38 -7│▐
+│ [5] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│▐
+│ [6] ⠋ trace-readiness             codex     working           +91 -22 #478 …│▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Create Group                                                                 │
 │ Project      station                                                         │
@@ -1185,17 +1213,17 @@ exports[`modal flow golden frames renders the new session creating progress 1`] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       codex     no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Create Session                                                               │
 │  Project (P) station                                                         │
@@ -1213,18 +1241,18 @@ exports[`modal flow golden frames renders the project default agent picker 1`] =
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
 ───────────────────────────────────────────────────────────────────────────────
        SESSION                            AGENT     STATUS            DIFF · PR
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
- [2] - docs-cleanup                       codex     no agent
- [3] ○ pty-buffer                         codex     idle                  #73 ✓
- [4] + session-resume                     codex     starting
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …
-
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]
- [6] x batch-export                       opencode  exited                 #8 ✓
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓
-
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▐
+                                                                               ▐
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]▐
+ [6] x batch-export                       opencode  exited                 #8 ✓▐
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …▐
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓▐
+                                                                               ▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Select default agent for station                                             │
 │                                                                              │
@@ -1241,8 +1269,8 @@ exports[`modal flow golden frames renders the add project sheet 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Add Project                                                                  │
 │ Start location                                                               │
@@ -1297,8 +1325,8 @@ exports[`modal flow golden frames renders the add project folder actions 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Project Folder                                                        │
 │ Folder  /Users/example/Developer                                             │
@@ -1325,8 +1353,8 @@ exports[`modal flow golden frames renders the add project review actions 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Add Project: Review                                                          │
 │ Selected folder /Users/example/Developer/station                             │
@@ -1353,8 +1381,8 @@ exports[`modal flow golden frames renders the add project Git recovery 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Add Project: Review                                                          │
 │ Selected folder /Users/example/Developer/station                             │
@@ -1381,8 +1409,8 @@ exports[`modal flow golden frames renders the add project id editor actions 1`] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Add Project: Review                                                          │
 │ Selected folder /Users/example/Developer/station                             │
@@ -1409,8 +1437,8 @@ exports[`modal flow golden frames renders the add project success action 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Project Added                                                                │
 │ Project         Station                                                      │
@@ -1437,8 +1465,8 @@ exports[`modal flow golden frames renders the add project failure actions 1`] = 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Add Project Failed                                                           │
 │ Could not add this project.                                                  │
@@ -1485,22 +1513,22 @@ exports[`modal flow golden frames renders the widget settings panel 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
 ───────────────────────────────────────────────────────────────────────────────
        SESSION                            AGENT     STATUS            DIFF · PR
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
- [2] - docs-cleanup                       codex     no agent
- [3] ○ pty-buffe┌──────────────────────────────────────────────┐          #73 ✓
- [4] + session-r│ widgets                                      │
- [5] ⠋ station-o│ saved to config.toml                         │ +412 -96 #76 …
-                │ ▸ [on ] time                               × │
-▼ observer  3 se│   [off] weather NYC                        × │  [sh] [qs] [▾]
- [6] x batch-exp│   [on ] moon                               × │           #8 ✓
- [7] ⠋ provider-│   [ + add widget ]                           │   +32 -8 #16 …
- [8] ○ trace-bun│ ↵ toggle   [ ] reorder   x remove   a add   e│     +1 -1 #4 ✓
-                └──────────────────────────────────────────────┘
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾]
- [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1
- [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10
-
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffe┌──────────────────────────────────────────────┐          #73 ✓▐
+ [4] + session-r│ widgets                                      │               ▐
+ [5] ⠋ station-o│ saved to config.toml                         │ +412 -96 #76 …▐
+                │ ▸ [on ] time                               × │               ▐
+▼ observer  3 se│   [off] weather NYC                        × │  [sh] [qs] [▾]▐
+ [6] x batch-exp│   [on ] moon                               × │           #8 ✓▐
+ [7] ⠋ provider-│   [ + add widget ]                           │   +32 -8 #16 …▐
+ [8] ○ trace-bun│ ↵ toggle   [ ] reorder   x remove   a add   e│     +1 -1 #4 ✓▐
+                └──────────────────────────────────────────────┘               ▐
+▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾]▐
+ [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1▐
+ [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10▐
+                                                                               ▐
 ▼ empty-project  0 sessions                                       [sh] [qs] [▾]
 
 ───────────────────────────────────────────────────────────────────────────────
@@ -1513,22 +1541,22 @@ exports[`modal flow golden frames renders the widget settings picker 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
 ───────────────────────────────────────────────────────────────────────────────
        SESSION                            AGENT     STATUS            DIFF · PR
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
- [2] - docs-cleanup                       codex     no agent
- [3] ○ pty-buffe┌──────────────────────────────────────────────┐          #73 ✓
- [4] + session-r│ add widget                                   │
- [5] ⠋ station-o│ weather and tz require config.toml           │ +412 -96 #76 …
-                │ ▸ time                                       │
-▼ observer  3 se│   fleet                                      │  [sh] [qs] [▾]
- [6] x batch-exp│   open PRs                                   │           #8 ✓
- [7] ⠋ provider-│   moon                                       │   +32 -8 #16 …
- [8] ○ trace-bun│ ↵ add   esc back                             │     +1 -1 #4 ✓
-                └──────────────────────────────────────────────┘
-▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾]
- [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1
- [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10
-
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]▐
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffe┌──────────────────────────────────────────────┐          #73 ✓▐
+ [4] + session-r│ add widget                                   │               ▐
+ [5] ⠋ station-o│ weather and tz require config.toml           │ +412 -96 #76 …▐
+                │ ▸ time                                       │               ▐
+▼ observer  3 se│   fleet                                      │  [sh] [qs] [▾]▐
+ [6] x batch-exp│   open PRs                                   │           #8 ✓▐
+ [7] ⠋ provider-│   moon                                       │   +32 -8 #16 …▐
+ [8] ○ trace-bun│ ↵ add   esc back                             │     +1 -1 #4 ✓▐
+                └──────────────────────────────────────────────┘               ▐
+▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾]▐
+ [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1▐
+ [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10▐
+                                                                               ▐
 ▼ empty-project  0 sessions                                       [sh] [qs] [▾]
 
 ───────────────────────────────────────────────────────────────────────────────

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -19,10 +19,10 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
         │  ↵          open focused session                            ▐│       ▐
 ▼ script│  tab        next session needing you                        ▐│qs] [▾]▐
  [9] ○ a│  G/M        quick group/move to group                       ▐│6 #5 x1▐
- [a] ? m│  / ↵ Esc Q  edit/apply/cancel-clear/retain-close filter      │ -1 #10▐
-        │  Tab S/P/A  build filter conditions · F applies builder      │       ▐
-▼ empty-│  1-9/a-z    open visible session or toggle condition         │qs] [▾] 
-        ╰──────────────────────────────────────────────────────────────╯        
+ [a] ? m│  / ↵ Esc Q  edit/apply/cancel-clear/retain-close filter     ▕│ -1 #10▐
+        │  Tab S/P/A  build filter conditions · F applies builder     ▕│       ▐
+▼ empty-│  1-9/a-z    open visible session or toggle condition        ▕│qs] [▾]▕
+▼ more b╰──────────────────────────────────────────────────────────────╯       ▼
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
 "
@@ -32,9 +32,9 @@ exports[`modal flow golden frames renders the help overlay scrolled 1`] = `
 "                                                                                
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ────────╭──────────────────────────────────────────────────────────────╮─────── 
-       S│  Ctrl-^     split pane below (Ctrl-6)                        │FF · PR 
-▼ statio│  Ctrl-]     focus next pane                                  │qs] [▾]▐
- [1] ○ c│  Ctrl-/     close split pane (Ctrl-_)                        │6 #70 ✓▐
+       S│  Ctrl-^     split pane below (Ctrl-6)                       ▕│FF · PR 
+▼ statio│  Ctrl-]     focus next pane                                 ▕│qs] [▾]▐
+ [1] ○ c│  Ctrl-/     close split pane (Ctrl-_)                       ▕│6 #70 ✓▐
  [2] - d│  Enter/Sp   open project view on welcome                    ▐│       ▐
  [3] ○ p│  Esc/↑↓     context menu close/move                         ▐│  #73 ✓▐
  [4] + s│  Enter/Sp   context menu select                             ▐│       ▐
@@ -49,8 +49,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [9] ○ a│  N/A/R/C/F/P  new/add/rename/fold/fork/settings             ▐│6 #5 x1▐
  [a] ? m│  W          widgets                                         ▐│ -1 #10▐
         │  X          delete session                                  ▐│       ▐
-▼ empty-│  H/?        help · Z refresh                                ▐│qs] [▾] 
-        ╰──────────────────────────────────────────────────────────────╯        
+▼ empty-│  H/?        help · Z refresh                                ▐│qs] [▾]▕
+▼ more b╰──────────────────────────────────────────────────────────────╯       ▼
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
 "
@@ -77,8 +77,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1▐
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10▐
                                                                                ▐
-▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
-                                                                                
+▼ empty-project  0 sessions                                       [sh] [qs] [▾]▕
+▼ more below                                                                   ▼
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
 "
@@ -201,8 +201,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1▐
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10▐
                                                                                ▐
-▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
-                                                                                
+▼ empty-project  0 sessions                                       [sh] [qs] [▾]▕
+▼ more below                                                                   ▼
 ─────────────────────────────────────────────────────────────────────────────── 
  FILTER   ←→ cursor  Enter apply  Tab condition  Ctrl-U clear  Esc cancel       
 "
@@ -229,8 +229,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1▐
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10▐
                                                                                ▐
-▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
-                                                                                
+▼ empty-project  0 sessions                                       [sh] [qs] [▾]▕
+▼ more below                                                                   ▼
 ─────────────────────────────────────────────────────────────────────────────── 
  CONDITION   S/P/A edit  ↑↓ move  Enter select  F apply filter  Esc text        
 "
@@ -257,8 +257,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1▐
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10▐
                                                                                ▐
-▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
-                                                                                
+▼ empty-project  0 sessions                                       [sh] [qs] [▾]▕
+▼ more below                                                                   ▼
 ─────────────────────────────────────────────────────────────────────────────── 
  CONDITION   ← fields  ↑↓ move  Space/slot toggle  Enter done  Esc close        
 "
@@ -270,11 +270,11 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0
 ─────────────────────────────────────── 
 ▏ FILTER /▏               10/10 matches 
 ┌────────────────────────────────┐] [▾]▐
-│[←] STATUS CONDITION ↑5      [×]│      
-│  6 [ ] Exited                  │t     
-│▸ 7 [ ] No agent                │      
-│  8 [ ] Unknown                 │g     
-│  Done (Enter)                  │      
+│[←] STATUS CONDITION ↑5      [×]│     ▕
+│  6 [ ] Exited                  │t    ▕
+│▸ 7 [ ] No agent                │     ▕
+│  8 [ ] Unknown                 │g    ▕
+│  Done (Enter)                  │     ▼
 └────────────────────────────────┘───── 
  CONDITION  ← fields Sp toggle Esc clo… 
 "
@@ -385,8 +385,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [9│                          │                                             │x1▐
  [a│                          │                                             │10▐
    │                          │                                             │  ▐
-▼ e│ ↑↓ move   →/enter edit   esc close                                     │▾] 
-   └────────────────────────────────────────────────────────────────────────┘   
+▼ e│ ↑↓ move   →/enter edit   esc close                                     │▾]▕
+▼ m└────────────────────────────────────────────────────────────────────────┘  ▼
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
 "
@@ -413,8 +413,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [9│                          │                                             │x1▐
  [a│                          │                                             │10▐
    │                          │                                             │  ▐
-▼ e│ ←/esc back                                                             │▾] 
-   └────────────────────────────────────────────────────────────────────────┘   
+▼ e│ ←/esc back                                                             │▾]▕
+▼ m└────────────────────────────────────────────────────────────────────────┘  ▼
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
 "
@@ -441,8 +441,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [9│                          │                                             │x1▐
  [a│                          │                                             │10▐
    │                          │                                             │  ▐
-▼ e│ ↑↓ move   →/enter edit   esc close                                     │▾] 
-   └────────────────────────────────────────────────────────────────────────┘   
+▼ e│ ↑↓ move   →/enter edit   esc close                                     │▾]▕
+▼ m└────────────────────────────────────────────────────────────────────────┘  ▼
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
 "
@@ -469,8 +469,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 ┌────────────────────────────────────────────┐code  idle           +14 -6 #5 x1▐
 │ Select session to delete                   │code  unknown           +3 -1 #10▐
 │                                            │                                 ▐
-│ ↑↓ move · ↵ choose · slot or click         │                    [sh] [qs] [▾] 
-│ Esc:cancel                                 │                                  
+│ ↑↓ move · ↵ choose · slot or click         │                    [sh] [qs] [▾]▕
+│ Esc:cancel                                 │                                 ▼
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘ ? help  Q/esc:close              
 "
@@ -497,8 +497,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 │ Session  cli-help-man                      │code  idle           +14 -6 #5 x1▐
 │ Removes agent, worktree, and panes.        │code  unknown           +3 -1 #10▐
 │                                            │                                 ▐
-│  Delete (Y)  ▸ Keep session (N)            │                    [sh] [qs] [▾] 
-│ ←→ choose · Enter activate · Esc cancel    │                                  
+│  Delete (Y)  ▸ Keep session (N)            │                    [sh] [qs] [▾]▕
+│ ←→ choose · Enter activate · Esc cancel    │                                 ▼
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘ ? help  Q/esc:close              
 "
@@ -525,8 +525,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 │ Session  cli-help-man                      │code  idle           +14 -6 #5 x1▐
 │ Removes agent, worktree, and panes.        │code  unknown           +3 -1 #10▐
 │                                            │                                 ▐
-│▸ Delete (Y)    Keep session (N)            │                    [sh] [qs] [▾] 
-│ ←→ choose · Enter activate · Esc cancel    │                                  
+│▸ Delete (Y)    Keep session (N)            │                    [sh] [qs] [▾]▕
+│ ←→ choose · Enter activate · Esc cancel    │                                 ▼
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘ ? help  Q/esc:close              
 "
@@ -573,8 +573,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 │ Station cannot stop the active agent.                            │14 -6 #5 x1▐
 │ Stop it in its terminal before deleting the worktree.            │  +3 -1 #10▐
 │                                                                  │           ▐
-│                                                                  │h] [qs] [▾]
-│                                                                  │
+│                                                                  │h] [qs] [▾]▕
+│                                                                  │           ▼
 │ Esc/Enter:close                                                  │───────────
 └──────────────────────────────────────────────────────────────────┘
 "
@@ -601,8 +601,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1▐
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10▐
                                                                                ▐
-Rename: ↑↓ move · ↵ choose · 1-9/a-z or click                     [sh] [qs] [▾] 
-                                                                                
+Rename: ↑↓ move · ↵ choose · 1-9/a-z or click                     [sh] [qs] [▾]▕
+▼ more below                                                                   ▼
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
 "
@@ -657,8 +657,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 ┌────────────────────────────────────────────┐code  idle           +14 -6 #5 x1▐
 │ Select session to fork                     │code  unknown           +3 -1 #10▐
 │                                            │                                 ▐
-│ ↑↓ move · ↵ choose · slot or click         │                    [sh] [qs] [▾] 
-│ Esc:cancel                                 │                                  
+│ ↑↓ move · ↵ choose · slot or click         │                    [sh] [qs] [▾]▕
+│ Esc:cancel                                 │                                 ▼
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘ ? help  Q/esc:close              
 "
@@ -685,8 +685,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 │▸ Name   Hexagonal PT 12|                   │code  idle           +14 -6 #5 x1▐
 │  Copy   [x] uncommitted changes            │code  unknown           +3 -1 #10▐
 │ Source keeps running — copy is read-only.  │                                 ▐
-│                                            │                    [sh] [qs] [▾] 
-│  Fork (enter)                              │                                  
+│                                            │                    [sh] [qs] [▾]▕
+│  Fork (enter)                              │                                 ▼
 │ ↑↓ focus · Enter fork · Esc back           │───────────────────────────────── 
 └────────────────────────────────────────────┘ ? help  Q/esc:close              
 "
@@ -713,8 +713,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 │  Name   cli-help-man-fork                  │code  idle           +14 -6 #5 x1▐
 │▸ Copy   [x] uncommitted changes            │code  unknown           +3 -1 #10▐
 │ Source keeps running — copy is read-only.  │                                 ▐
-│                                            │                    [sh] [qs] [▾] 
-│  Fork (enter)                              │                                  
+│                                            │                    [sh] [qs] [▾]▕
+│  Fork (enter)                              │                                 ▼
 │ Space/Enter toggle · ↑↓ focus · Esc back   │───────────────────────────────── 
 └────────────────────────────────────────────┘ ? help  Q/esc:close              
 "
@@ -741,8 +741,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 │  Name   cli-help-man-fork                  │code  idle           +14 -6 #5 x1▐
 │  Copy   [x] uncommitted changes            │code  unknown           +3 -1 #10▐
 │ Source keeps running — copy is read-only.  │                                 ▐
-│                                            │                    [sh] [qs] [▾] 
-│▸ Fork (enter)                              │                                  
+│                                            │                    [sh] [qs] [▾]▕
+│▸ Fork (enter)                              │                                 ▼
 │ ↑↓ focus · Enter fork · Esc back           │───────────────────────────────── 
 └────────────────────────────────────────────┘ ? help  Q/esc:close              
 "
@@ -1529,8 +1529,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1▐
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10▐
                                                                                ▐
-▼ empty-project  0 sessions                                       [sh] [qs] [▾]
-
+▼ empty-project  0 sessions                                       [sh] [qs] [▾]▕
+▼ more below                                                                   ▼
 ───────────────────────────────────────────────────────────────────────────────
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close
 "
@@ -1557,8 +1557,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1▐
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10▐
                                                                                ▐
-▼ empty-project  0 sessions                                       [sh] [qs] [▾]
-
+▼ empty-project  0 sessions                                       [sh] [qs] [▾]▕
+▼ more below                                                                   ▼
 ───────────────────────────────────────────────────────────────────────────────
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close
 "

--- a/station/src/station/view/dashboard.golden.test.tsx
+++ b/station/src/station/view/dashboard.golden.test.tsx
@@ -44,6 +44,11 @@ function spanBgHex(span: ReturnType<typeof spanAtFrameCell>): string | undefined
   return span?.bg === undefined ? undefined : rgbToHex(span.bg);
 }
 
+/** Drop the reserved last-column gutter so Group chrome assertions stay on ╮/│. */
+function withoutScrollGutter(line: string): string {
+  return line.length === 0 ? line : line.slice(0, -1);
+}
+
 const lightObservation = parseStationTerminalPaletteObservation(lightTerminalColors);
 if (lightObservation === null) {
   throw new Error("Expected a complete light terminal palette fixture.");
@@ -251,7 +256,7 @@ describe("dashboard golden frames", () => {
       .find((line) => line.includes("station-quick-group"));
 
     expect(pendingLine?.startsWith("│")).toBe(true);
-    expect(pendingLine?.trimEnd().endsWith("│")).toBe(true);
+    expect(withoutScrollGutter(pendingLine ?? "").trimEnd().endsWith("│")).toBe(true);
   });
 
   it("renders filtered Group counts and clips framed blocks as ordinary rows", async () => {
@@ -401,7 +406,9 @@ describe("dashboard golden frames", () => {
         expect(line?.includes("[qs]")).toBe(testCase.quickSession);
         expect(line?.includes("[▾]")).toBe(testCase.menu);
         if (!collapsed) {
-          expect(line?.trimEnd().endsWith(testCase.expandedSuffix)).toBe(true);
+          expect(withoutScrollGutter(line ?? "").trimEnd().endsWith(testCase.expandedSuffix)).toBe(
+            true,
+          );
           expect(line?.lastIndexOf("╮")).toBe(78);
         }
       }

--- a/station/src/station/view/dashboard.scrollbar.stress.test.tsx
+++ b/station/src/station/view/dashboard.scrollbar.stress.test.tsx
@@ -1,6 +1,7 @@
 // Crowded dashboard + Help: last-cell identity (homebake maps last track cell
 // to maxOffset), one-row wheels with a stuck thumb, and Help click-away vs bar.
 import { afterEach, describe, expect, it } from "bun:test";
+import { TextRenderable, type BaseRenderable } from "@opentui/core";
 import { MouseButtons } from "@opentui/core/testing";
 import { testRender } from "@opentui/react/test-utils";
 import {
@@ -9,9 +10,11 @@ import {
   helpPanelLayout,
   helpPanelModel,
   selectDashboardViewport,
+  VERTICAL_SCROLLBAR_THUMB,
+  VERTICAL_SCROLLBAR_TRACK,
 } from "@station/dashboard-core/selectors";
 import { act } from "react";
-import { createCrowdedDashboardSnapshot } from "../../../../packages/dashboard-core/test/fixtures/snapshots.js";
+import { createCrowdedDashboardSnapshot, createCrowdedEmptyGroupsSnapshot } from "../../../../packages/dashboard-core/test/fixtures/snapshots.js";
 import { normalizeStationMouseEvent } from "../../input/mouse.js";
 import { stationKeymapHelp } from "../../input/keymap/stationBindings.js";
 import { nativeStationTheme, StationThemeProvider } from "../../theme/index.js";
@@ -23,7 +26,11 @@ import { StationHoverProvider, StationMouseProvider } from "./stationMouseContex
 const SIZE = { width: 80, height: 24 };
 const SESSION_COUNT = 300;
 const MOUSE = { delayMs: 0 } as const;
-const THUMB = "▐";
+const THUMB = VERTICAL_SCROLLBAR_THUMB;
+
+type RenderedDashboard = Awaited<ReturnType<typeof testRender>> & {
+  store: ReturnType<typeof makeStationTestRuntime>["runtime"];
+};
 
 describe("dashboard and help scrollbar stress", () => {
   const teardowns: Array<() => void> = [];
@@ -92,13 +99,100 @@ describe("dashboard and help scrollbar stress", () => {
     expect(gutterColumn(setup).slice(gutter.chromeTop, gutter.lastY + 1).join("")).toBe(startThumb);
   });
 
-  it("keeps fleet and header gutter cells blank while the thumb stays in the body", async () => {
+  it("keeps fleet gutter cells blank and paints ▼ beside the below count", async () => {
     const setup = await renderCrowded();
     const gutter = gutterGeometry(setup);
     const column = gutterColumn(setup);
+    const frame = setup.captureCharFrame();
     expect(column.slice(0, gutter.chromeTop).join("").trim()).toBe("");
-    expect(column.slice(gutter.lastY + 1).join("").trim()).toBe("");
     expect(column[gutter.chromeTop]).toBe(THUMB);
+    expect(column[gutter.lastY + 1]).toBe("▼");
+    const track = column.slice(gutter.chromeTop, gutter.lastY + 1);
+    expect(track.some((cell) => cell === VERTICAL_SCROLLBAR_TRACK)).toBe(true);
+    expect(track.every((cell) => cell === THUMB || cell === VERTICAL_SCROLLBAR_TRACK)).toBe(true);
+    expect(frame).toContain("below · showing");
+    expect(frame).not.toContain("sessions above");
+  });
+
+  it("paints ▲ beside the above count once sessions are hidden above", async () => {
+    const setup = await renderCrowded();
+    captureMaxWindow(setup);
+    await setup.flush();
+    const gutter = gutterGeometry(setup);
+    const column = gutterColumn(setup);
+    const frame = setup.captureCharFrame();
+    expect(column[gutter.chromeTop - 1]).toBe("▲");
+    expect(column[gutter.lastY + 1]?.trim() ?? "").toBe("");
+    expect(frame).toContain("sessions above");
+  });
+
+  it("paints overflow arrows when the tree can scroll even if every session is on screen", async () => {
+    const setup = await renderEmptyGroups();
+    const gutter = gutterGeometry(setup);
+    let column = gutterColumn(setup);
+    let frame = setup.captureCharFrame();
+    const atTop = selectDashboardViewport(
+      setup.store.state.getState().snapshot,
+      setup.store.state.getState(),
+    );
+    expect(atTop.hiddenBelow).toBeGreaterThan(0);
+    expect(atTop.sessionOverflow.below).toBe(0);
+    expect(column[gutter.lastY + 1]).toBe("▼");
+    expect(frame).toContain("▼ more below");
+    expect(frame).not.toContain("below · showing");
+    expect(column.slice(0, gutter.chromeTop).join("").trim()).toBe("");
+
+    await act(async () => {
+      setup.store.actions.dispatch({ type: "dashboard.scrollTo", offset: 1 });
+      await Promise.resolve();
+    });
+    await setup.flush();
+    column = gutterColumn(setup);
+    frame = setup.captureCharFrame();
+    const scrolled = selectDashboardViewport(
+      setup.store.state.getState().snapshot,
+      setup.store.state.getState(),
+    );
+    expect(scrolled.hiddenAbove).toBe(1);
+    expect(scrolled.sessionOverflow.above).toBe(0);
+    expect(column[gutter.chromeTop - 1]).toBe("▲");
+    expect(column[gutter.lastY + 1]).toBe("▼");
+    expect(frame).toContain("▲ more above");
+    expect(frame).toContain("▼ more below");
+    expect(frame).not.toContain("sessions above");
+
+    const offsetBeforePage = setup.store.state.getState().scrollOffset;
+    await act(async () => {
+      await setup.mockMouse.click(gutter.x, gutter.lastY + 1, MouseButtons.LEFT, MOUSE);
+    });
+    await setup.flush();
+    expect(setup.store.state.getState().scrollOffset).toBeGreaterThan(offsetBeforePage);
+  });
+
+  it("pages from the gutter ▼ without starting a selection", async () => {
+    const setup = await renderCrowded();
+    const atTop = currentWindow(setup);
+    const gutter = gutterGeometry(setup);
+    await act(async () => {
+      await setup.mockMouse.click(gutter.x, gutter.lastY + 1, MouseButtons.LEFT, MOUSE);
+    });
+    await setup.flush();
+    expect(setup.renderer.hasSelection).toBe(false);
+    expect(setup.store.state.getState().scrollOffset).toBeGreaterThan(atTop.offset);
+  });
+
+  it("pages from the gutter ▲ without starting a selection", async () => {
+    const setup = await renderCrowded();
+    captureMaxWindow(setup);
+    await setup.flush();
+    const atBottom = currentWindow(setup);
+    const gutter = gutterGeometry(setup);
+    await act(async () => {
+      await setup.mockMouse.click(gutter.x, gutter.chromeTop - 1, MouseButtons.LEFT, MOUSE);
+    });
+    await setup.flush();
+    expect(setup.renderer.hasSelection).toBe(false);
+    expect(setup.store.state.getState().scrollOffset).toBeLessThan(atBottom.offset);
   });
 
   it("clicking a fleet or header gutter cell does not move the dashboard window", async () => {
@@ -162,6 +256,202 @@ describe("dashboard and help scrollbar stress", () => {
     expect(setup.captureCharFrame()).not.toBe(startFrame);
   });
 
+  it("keeps every gutter cell out of OpenTUI selection", async () => {
+    const setup = await renderCrowded();
+    const gutterTexts = collectTextRenderables(setup.renderer.root).filter(
+      (text) => text.x === SIZE.width - 1,
+    );
+    expect(gutterTexts.length).toBeGreaterThan(0);
+    expect(gutterTexts.every((text) => text.selectable === false)).toBe(true);
+  });
+
+  it("keeps Help panel copy and the inset bar out of OpenTUI selection", async () => {
+    const setup = await renderCrowded();
+    await act(async () => {
+      setup.store.actions.handleKey({ input: "H" });
+      await Promise.resolve();
+    });
+    await setup.flush();
+    const overlay = findRenderableByZIndex(setup.renderer.root, 10);
+    expect(overlay).toBeDefined();
+    const panelTexts = collectTextRenderables(overlay!);
+    expect(panelTexts.length).toBeGreaterThan(0);
+    expect(panelTexts.every((text) => text.selectable === false)).toBe(true);
+  });
+
+  it("dragging the gutter from first to last reaches max without a selection", async () => {
+    const setup = await renderCrowded();
+    const expected = captureMaxWindow(setup);
+    await resetDashboard(setup);
+    const gutter = gutterGeometry(setup);
+    await drag(setup, gutter.x, gutter.firstY, gutter.x, gutter.lastY);
+    expect(setup.renderer.hasSelection).toBe(false);
+    expect(currentWindow(setup)).toEqual(expected);
+  });
+
+  it("dragging the gutter from last to first reaches the first window without a selection", async () => {
+    const setup = await renderCrowded();
+    const atTop = currentWindow(setup);
+    captureMaxWindow(setup);
+    await setup.flush();
+    const gutter = gutterGeometry(setup);
+    await drag(setup, gutter.x, gutter.lastY, gutter.x, gutter.firstY);
+    expect(setup.renderer.hasSelection).toBe(false);
+    expect(currentWindow(setup)).toEqual(atTop);
+  });
+
+  it("dragging past the last gutter cell still reaches max without a selection", async () => {
+    const setup = await renderCrowded();
+    const expected = captureMaxWindow(setup);
+    await resetDashboard(setup);
+    const gutter = gutterGeometry(setup);
+    await drag(setup, gutter.x, gutter.firstY, gutter.x, SIZE.height + 8);
+    expect(setup.renderer.hasSelection).toBe(false);
+    expect(currentWindow(setup)).toEqual(expected);
+  });
+
+  it("dragging past the first gutter cell still reaches the first window without a selection", async () => {
+    const setup = await renderCrowded();
+    const atTop = currentWindow(setup);
+    captureMaxWindow(setup);
+    await setup.flush();
+    const gutter = gutterGeometry(setup);
+    await drag(setup, gutter.x, gutter.lastY, gutter.x, -4);
+    expect(setup.renderer.hasSelection).toBe(false);
+    expect(currentWindow(setup)).toEqual(atTop);
+  });
+
+  it("dragging onto session copy from the gutter never starts a selection", async () => {
+    const setup = await renderCrowded();
+    const gutter = gutterGeometry(setup);
+    const midY = gutter.firstY + Math.floor((gutter.lastY - gutter.firstY) / 2);
+    await drag(setup, gutter.x, midY, 8, midY);
+    expect(setup.renderer.hasSelection).toBe(false);
+    expect(setup.store.state.getState().scrollOffset).toBeGreaterThan(0);
+  });
+
+  it("dragging every gutter cell from the top is monotone and never selects", async () => {
+    const setup = await renderCrowded();
+    const expected = captureMaxWindow(setup);
+    const gutter = gutterGeometry(setup);
+    let previous = 0;
+    for (let y = gutter.firstY; y <= gutter.lastY; y += 1) {
+      await resetDashboard(setup);
+      await drag(setup, gutter.x, gutter.firstY, gutter.x, y);
+      expect(setup.renderer.hasSelection).toBe(false);
+      const offset = setup.store.state.getState().scrollOffset;
+      expect(offset).toBeGreaterThanOrEqual(previous);
+      previous = offset;
+    }
+    expect(previous).toBe(expected.offset);
+  }, 15_000);
+
+  it("dragging every gutter cell from the bottom is monotone and never selects", async () => {
+    const setup = await renderCrowded();
+    const expected = captureMaxWindow(setup);
+    await setup.flush();
+    const gutter = gutterGeometry(setup);
+    let previous = expected.offset;
+    for (let y = gutter.lastY; y >= gutter.firstY; y -= 1) {
+      captureMaxWindow(setup);
+      await setup.flush();
+      await drag(setup, gutter.x, gutter.lastY, gutter.x, y);
+      expect(setup.renderer.hasSelection).toBe(false);
+      const offset = setup.store.state.getState().scrollOffset;
+      expect(offset).toBeLessThanOrEqual(previous);
+      previous = offset;
+    }
+    expect(previous).toBe(0);
+  }, 15_000);
+
+  it("a one-cell gutter drag still moves the window without a selection", async () => {
+    const setup = await renderCrowded();
+    const gutter = gutterGeometry(setup);
+    const start = currentWindow(setup);
+    await drag(setup, gutter.x, gutter.firstY, gutter.x, gutter.firstY + 1);
+    expect(setup.renderer.hasSelection).toBe(false);
+    expect(setup.store.state.getState().scrollOffset).toBeGreaterThan(start.offset);
+  });
+
+  it("dragging the Help bar from first to last reaches max without selecting or closing", async () => {
+    const setup = await renderCrowded();
+    await openHelp(setup);
+    const bar = helpBarGeometry(SIZE.width, SIZE.height);
+    await drag(setup, bar.x, bar.firstY, bar.x, bar.lastY);
+    expect(setup.renderer.hasSelection).toBe(false);
+    expect(setup.store.state.getState().screen).toMatchObject({
+      name: "help",
+      scrollOffset: bar.maxOffset,
+    });
+  });
+
+  it("dragging the Help bar from last to first reaches the first window without selecting", async () => {
+    const setup = await renderCrowded();
+    await openHelp(setup);
+    const bar = helpBarGeometry(SIZE.width, SIZE.height);
+    await act(async () => {
+      setup.store.actions.dispatch({ type: "help.scrollTo", offset: bar.maxOffset });
+      await Promise.resolve();
+    });
+    await setup.flush();
+    await drag(setup, bar.x, bar.lastY, bar.x, bar.firstY);
+    expect(setup.renderer.hasSelection).toBe(false);
+    expect(setup.store.state.getState().screen).toMatchObject({ name: "help", scrollOffset: 0 });
+  });
+
+  it("dragging past the Help bar last cell still reaches max without selecting or closing", async () => {
+    const setup = await renderCrowded();
+    await openHelp(setup);
+    const bar = helpBarGeometry(SIZE.width, SIZE.height);
+    await drag(setup, bar.x, bar.firstY, bar.x, bar.lastY + 6);
+    expect(setup.renderer.hasSelection).toBe(false);
+    expect(setup.store.state.getState().screen).toMatchObject({
+      name: "help",
+      scrollOffset: bar.maxOffset,
+    });
+  });
+
+  it("dragging off the Help bar onto overlay copy never starts a selection", async () => {
+    const setup = await renderCrowded();
+    await openHelp(setup);
+    const bar = helpBarGeometry(SIZE.width, SIZE.height);
+    await drag(setup, bar.x, bar.firstY + 2, bar.left + 4, bar.firstY + 2);
+    expect(setup.renderer.hasSelection).toBe(false);
+    expect(setup.store.state.getState().screen).toMatchObject({ name: "help" });
+  });
+
+  it("dragging every Help bar cell from the top is monotone and never selects", async () => {
+    const setup = await renderCrowded();
+    await openHelp(setup);
+    const bar = helpBarGeometry(SIZE.width, SIZE.height);
+    let previous = 0;
+    for (let y = bar.firstY; y <= bar.lastY; y += 1) {
+      await act(async () => {
+        setup.store.actions.dispatch({ type: "help.scrollTo", offset: 0 });
+        await Promise.resolve();
+      });
+      await setup.flush();
+      await drag(setup, bar.x, bar.firstY, bar.x, y);
+      expect(setup.renderer.hasSelection).toBe(false);
+      const screen = setup.store.state.getState().screen;
+      expect(screen).toMatchObject({ name: "help" });
+      if (screen.name !== "help") {
+        throw new Error("expected help");
+      }
+      expect(screen.scrollOffset).toBeGreaterThanOrEqual(previous);
+      previous = screen.scrollOffset;
+    }
+    expect(previous).toBe(bar.maxOffset);
+  }, 15_000);
+
+  it("still allows drag selection on session copy away from the gutter", async () => {
+    const setup = await renderCrowded();
+    const label = "crowd-0000";
+    const cell = cellFor(setup.captureCharFrame(), label);
+    await drag(setup, cell.col, cell.row, cell.col + label.length - 1, cell.row);
+    expect(setup.renderer.getSelection()?.getSelectedText()).toContain("crowd");
+  });
+
   async function renderCrowded() {
     const snapshot = createCrowdedDashboardSnapshot(SESSION_COUNT);
     const { runtime: store } = makeStationTestRuntime({
@@ -195,7 +485,104 @@ describe("dashboard and help scrollbar stress", () => {
     await setup.renderOnce();
     return Object.assign(setup, { store });
   }
+
+  async function renderEmptyGroups() {
+    const snapshot = createCrowdedEmptyGroupsSnapshot(20);
+    const { runtime: store } = makeStationTestRuntime({
+      snapshot,
+      terminalRows: SIZE.height,
+    });
+    store.start();
+    const setup = await testRender(
+      <StationThemeProvider theme={nativeStationTheme}>
+        <StationHoverProvider value={true}>
+          <StationMouseProvider
+            value={(target, event) => {
+              routeStationMouse(target, normalizeStationMouseEvent(event), store);
+            }}
+          >
+            <DashboardRoot
+              state={store.state}
+              actions={store.actions}
+              columns={SIZE.width}
+              rows={SIZE.height}
+              onCopyNotice={() => {}}
+            />
+          </StationMouseProvider>
+        </StationHoverProvider>
+      </StationThemeProvider>,
+      SIZE,
+    );
+    teardowns.push(() => {
+      setup.renderer.destroy();
+    });
+    await setup.renderOnce();
+    return Object.assign(setup, { store });
+  }
 });
+
+async function drag(
+  setup: RenderedDashboard,
+  startX: number,
+  startY: number,
+  endX: number,
+  endY: number,
+): Promise<void> {
+  await act(async () => {
+    await setup.mockMouse.drag(startX, startY, endX, endY, MouseButtons.LEFT, MOUSE);
+  });
+  await setup.flush();
+}
+
+async function resetDashboard(setup: RenderedDashboard): Promise<void> {
+  await act(async () => {
+    setup.store.actions.dispatch({ type: "dashboard.scrollTo", offset: 0 });
+    await Promise.resolve();
+  });
+  await setup.flush();
+}
+
+async function openHelp(setup: RenderedDashboard): Promise<void> {
+  await act(async () => {
+    setup.store.actions.handleKey({ input: "H" });
+    await Promise.resolve();
+  });
+  await setup.flush();
+}
+
+function collectTextRenderables(renderable: BaseRenderable): TextRenderable[] {
+  const collected = renderable instanceof TextRenderable ? [renderable] : [];
+  for (const child of renderable.getChildren()) {
+    collected.push(...collectTextRenderables(child));
+  }
+  return collected;
+}
+
+function findRenderableByZIndex(
+  renderable: BaseRenderable,
+  zIndex: number,
+): BaseRenderable | undefined {
+  if ("zIndex" in renderable && renderable.zIndex === zIndex) {
+    return renderable;
+  }
+  for (const child of renderable.getChildren()) {
+    const found = findRenderableByZIndex(child, zIndex);
+    if (found !== undefined) {
+      return found;
+    }
+  }
+  return undefined;
+}
+
+function cellFor(frame: string, snippet: string): { col: number; row: number } {
+  const lines = frame.split("\n");
+  const row = lines.findIndex((line) => line.includes(snippet));
+  const col = lines[row]?.indexOf(snippet) ?? -1;
+  if (row < 0 || col < 0) {
+    throw new Error(`expected frame to contain ${snippet}`);
+  }
+  return { col, row };
+}
 
 function currentWindow(setup: { store: ReturnType<typeof makeStationTestRuntime>["runtime"] }) {
   const state = setup.store.state.getState();
@@ -244,7 +631,12 @@ function helpBarGeometry(columns: number, rows: number) {
   const model = helpPanelModel(layout.width, layout.height, content, 0);
   return {
     content,
+    left: layout.left,
+    top: layout.top,
+    width: layout.width,
+    height: layout.height,
     x: layout.left + layout.width - 2,
+    firstY: layout.top + 1,
     lastY: layout.top + model.bodyRows,
     maxOffset: Math.max(0, content.length - model.bodyRows),
   };

--- a/station/src/station/view/dashboard.scrollbar.stress.test.tsx
+++ b/station/src/station/view/dashboard.scrollbar.stress.test.tsx
@@ -1,0 +1,251 @@
+// Crowded dashboard + Help: last-cell identity (homebake maps last track cell
+// to maxOffset), one-row wheels with a stuck thumb, and Help click-away vs bar.
+import { afterEach, describe, expect, it } from "bun:test";
+import { MouseButtons } from "@opentui/core/testing";
+import { testRender } from "@opentui/react/test-utils";
+import {
+  dashboardScrollGutterChrome,
+  helpOverlayContent,
+  helpPanelLayout,
+  helpPanelModel,
+  selectDashboardViewport,
+} from "@station/dashboard-core/selectors";
+import { act } from "react";
+import { createCrowdedDashboardSnapshot } from "../../../../packages/dashboard-core/test/fixtures/snapshots.js";
+import { normalizeStationMouseEvent } from "../../input/mouse.js";
+import { stationKeymapHelp } from "../../input/keymap/stationBindings.js";
+import { nativeStationTheme, StationThemeProvider } from "../../theme/index.js";
+import { makeStationTestRuntime } from "../test/support/makeStationTestRuntime.js";
+import { routeStationMouse } from "../input/stationMouse.js";
+import { DashboardRoot } from "./DashboardRoot.js";
+import { StationHoverProvider, StationMouseProvider } from "./stationMouseContext.js";
+
+const SIZE = { width: 80, height: 24 };
+const SESSION_COUNT = 300;
+const MOUSE = { delayMs: 0 } as const;
+const THUMB = "▐";
+
+describe("dashboard and help scrollbar stress", () => {
+  const teardowns: Array<() => void> = [];
+  afterEach(() => {
+    for (const teardown of teardowns.splice(0)) {
+      teardown();
+    }
+  });
+
+  it("clicking the last gutter cell shows the same last window as scrollTo(max)", async () => {
+    const setup = await renderCrowded();
+    const expected = captureMaxWindow(setup);
+    await act(async () => {
+      setup.store.actions.dispatch({ type: "dashboard.scrollTo", offset: 0 });
+      await Promise.resolve();
+    });
+    await setup.flush();
+    const gutter = gutterGeometry(setup);
+    await act(async () => {
+      await setup.mockMouse.click(gutter.x, gutter.lastY, MouseButtons.LEFT, MOUSE);
+    });
+    await setup.flush();
+    expect(setup.store.state.getState().scrollOffset).toBe(expected.offset);
+    expect(currentWindow(setup)).toEqual(expected);
+    expect(gutterColumn(setup).slice(gutter.chromeTop, gutter.lastY + 1).join("")).toContain(THUMB);
+  });
+
+  it("clicking the last gutter cell while already at max does not leave the last window", async () => {
+    const setup = await renderCrowded();
+    const expected = captureMaxWindow(setup);
+    await setup.flush();
+    const gutter = gutterGeometry(setup);
+    await act(async () => {
+      await setup.mockMouse.click(gutter.x, gutter.lastY, MouseButtons.LEFT, MOUSE);
+    });
+    await setup.flush();
+    expect(currentWindow(setup)).toEqual(expected);
+  });
+
+  it("clicking the first gutter cell from the bottom shows the first window", async () => {
+    const setup = await renderCrowded();
+    const atTop = currentWindow(setup);
+    expect(atTop.offset).toBe(0);
+    captureMaxWindow(setup);
+    await setup.flush();
+    expect(currentWindow(setup).offset).toBeGreaterThan(0);
+    const gutter = gutterGeometry(setup);
+    await act(async () => {
+      await setup.mockMouse.click(gutter.x, gutter.firstY, MouseButtons.LEFT, MOUSE);
+    });
+    await setup.flush();
+    expect(currentWindow(setup)).toEqual(atTop);
+  });
+
+  it("a one-row wheel still moves content when the gutter thumb glyph does not", async () => {
+    const setup = await renderCrowded();
+    const gutter = gutterGeometry(setup);
+    const startThumb = gutterColumn(setup).slice(gutter.chromeTop, gutter.lastY + 1).join("");
+    const startWindow = currentWindow(setup);
+    await act(async () => {
+      await setup.mockMouse.scroll(1, gutter.firstY, "down", MOUSE);
+    });
+    await setup.flush();
+    expect(setup.store.state.getState().scrollOffset).toBe(1);
+    expect(currentWindow(setup).firstId).not.toBe(startWindow.firstId);
+    expect(gutterColumn(setup).slice(gutter.chromeTop, gutter.lastY + 1).join("")).toBe(startThumb);
+  });
+
+  it("keeps fleet and header gutter cells blank while the thumb stays in the body", async () => {
+    const setup = await renderCrowded();
+    const gutter = gutterGeometry(setup);
+    const column = gutterColumn(setup);
+    expect(column.slice(0, gutter.chromeTop).join("").trim()).toBe("");
+    expect(column.slice(gutter.lastY + 1).join("").trim()).toBe("");
+    expect(column[gutter.chromeTop]).toBe(THUMB);
+  });
+
+  it("clicking a fleet or header gutter cell does not move the dashboard window", async () => {
+    const setup = await renderCrowded();
+    const atTop = currentWindow(setup);
+    const gutter = gutterGeometry(setup);
+    expect(gutter.chromeTop).toBeGreaterThan(0);
+    await act(async () => {
+      await setup.mockMouse.click(gutter.x, 0, MouseButtons.LEFT, MOUSE);
+    });
+    await setup.flush();
+    expect(currentWindow(setup)).toEqual(atTop);
+  });
+
+  it("clicking the Help bar last cell reaches the last window and does not close Help", async () => {
+    const setup = await renderCrowded();
+    await act(async () => {
+      setup.store.actions.handleKey({ input: "H" });
+      await Promise.resolve();
+    });
+    await setup.flush();
+    const bar = helpBarGeometry(SIZE.width, SIZE.height);
+    await act(async () => {
+      await setup.mockMouse.click(bar.x, bar.lastY, MouseButtons.LEFT, MOUSE);
+    });
+    await setup.flush();
+    const screen = setup.store.state.getState().screen;
+    expect(screen).toMatchObject({ name: "help" });
+    if (screen.name !== "help") {
+      throw new Error("expected help");
+    }
+    expect(screen.scrollOffset).toBe(bar.maxOffset);
+    const lastContent = bar.content.at(-1);
+    if (lastContent === undefined) {
+      throw new Error("expected help copy");
+    }
+    expect(setup.captureCharFrame()).toContain(
+      "description" in lastContent ? lastContent.description : lastContent.text,
+    );
+    await act(async () => {
+      await setup.mockMouse.click(0, 0, MouseButtons.LEFT, MOUSE);
+    });
+    await setup.flush();
+    expect(setup.store.state.getState().screen).toEqual({ name: "dashboard" });
+  });
+
+  it("a one-line Help wheel still moves copy and does not close Help", async () => {
+    const setup = await renderCrowded();
+    await act(async () => {
+      setup.store.actions.handleKey({ input: "H" });
+      await Promise.resolve();
+    });
+    await setup.flush();
+    const bar = helpBarGeometry(SIZE.width, SIZE.height);
+    const startFrame = setup.captureCharFrame();
+    await act(async () => {
+      await setup.mockMouse.scroll(bar.x, bar.lastY, "down", MOUSE);
+    });
+    await setup.flush();
+    expect(setup.store.state.getState().screen).toMatchObject({ name: "help", scrollOffset: 1 });
+    expect(setup.captureCharFrame()).not.toBe(startFrame);
+  });
+
+  async function renderCrowded() {
+    const snapshot = createCrowdedDashboardSnapshot(SESSION_COUNT);
+    const { runtime: store } = makeStationTestRuntime({
+      snapshot,
+      terminalRows: SIZE.height,
+    });
+    store.start();
+    const setup = await testRender(
+      <StationThemeProvider theme={nativeStationTheme}>
+        <StationHoverProvider value={true}>
+          <StationMouseProvider
+            value={(target, event) => {
+              routeStationMouse(target, normalizeStationMouseEvent(event), store);
+            }}
+          >
+            <DashboardRoot
+              state={store.state}
+              actions={store.actions}
+              columns={SIZE.width}
+              rows={SIZE.height}
+              onCopyNotice={() => {}}
+            />
+          </StationMouseProvider>
+        </StationHoverProvider>
+      </StationThemeProvider>,
+      SIZE,
+    );
+    teardowns.push(() => {
+      setup.renderer.destroy();
+    });
+    await setup.renderOnce();
+    return Object.assign(setup, { store });
+  }
+});
+
+function currentWindow(setup: { store: ReturnType<typeof makeStationTestRuntime>["runtime"] }) {
+  const state = setup.store.state.getState();
+  if (state.snapshot === undefined) {
+    throw new Error("expected snapshot");
+  }
+  const viewport = selectDashboardViewport(state.snapshot, state);
+  return {
+    offset: state.scrollOffset,
+    firstId: viewport.rows[0]?.id,
+    lastId: viewport.rows.at(-1)?.id,
+    hiddenBelow: viewport.hiddenBelow,
+  };
+}
+
+function captureMaxWindow(setup: { store: ReturnType<typeof makeStationTestRuntime>["runtime"] }) {
+  setup.store.actions.dispatch({ type: "dashboard.scrollTo", offset: Number.MAX_SAFE_INTEGER });
+  return currentWindow(setup);
+}
+
+function gutterGeometry(setup: {
+  store: ReturnType<typeof makeStationTestRuntime>["runtime"];
+  captureCharFrame: () => string;
+}) {
+  const state = setup.store.state.getState();
+  if (state.snapshot === undefined) {
+    throw new Error("expected snapshot");
+  }
+  const viewport = selectDashboardViewport(state.snapshot, state);
+  const chrome = dashboardScrollGutterChrome({ hasFleetBar: true });
+  return {
+    x: SIZE.width - 1,
+    chromeTop: chrome.top,
+    firstY: chrome.top,
+    lastY: chrome.top + viewport.bodyRows - 1,
+  };
+}
+
+function gutterColumn(setup: { captureCharFrame: () => string }): string[] {
+  return setup.captureCharFrame().split("\n").map((line) => line.at(-1) ?? "");
+}
+
+function helpBarGeometry(columns: number, rows: number) {
+  const content = helpOverlayContent(stationKeymapHelp());
+  const layout = helpPanelLayout(columns, rows, content);
+  const model = helpPanelModel(layout.width, layout.height, content, 0);
+  return {
+    content,
+    x: layout.left + layout.width - 2,
+    lastY: layout.top + model.bodyRows,
+    maxOffset: Math.max(0, content.length - model.bodyRows),
+  };
+}

--- a/station/src/station/view/modals.golden.test.tsx
+++ b/station/src/station/view/modals.golden.test.tsx
@@ -123,6 +123,17 @@ const CASES: ModalCase[] = [
     ],
   },
   {
+    name: "help overlay scrolled",
+    keys: [
+      { input: "H" },
+      { input: "", downArrow: true },
+      { input: "", downArrow: true },
+      { input: "", downArrow: true },
+      { input: "", downArrow: true },
+    ],
+    expect: ["widgets", "delete session", "refresh", "╭", "╰"],
+  },
+  {
     name: "project menu",
     keys: [],
     prepare: (state) => openProjectMenu(state, "station"),

--- a/station/src/station/view/stationMouseContext.tsx
+++ b/station/src/station/view/stationMouseContext.tsx
@@ -3,6 +3,7 @@
 // stopPropagation happen here. Default is no-op (golden tests don't need provider).
 import { createContext, useCallback, useContext, useState } from "react";
 import type { MouseEvent } from "@opentui/core";
+import { scrollbarOffsetForTrackIndex } from "@station/dashboard-core/selectors";
 import type { StationMouseTarget } from "../input/stationMouse.js";
 
 export type StationMouseDispatch = (target: StationMouseTarget, event: MouseEvent) => void;
@@ -55,5 +56,52 @@ export function stationMouseProps(
       event.stopPropagation();
       dispatch(target, event);
     },
+  };
+}
+
+/** Track pointer: map cell y through core's inclusive ends, and swallow the
+ * gesture so OpenTUI cannot start a drag selection on neighboring copy. */
+export function stationScrollbarPointerProps(
+  dispatch: StationMouseDispatch,
+  input: {
+    surface: "help" | "dashboard";
+    contentLength: number;
+    viewportLength: number;
+    trackHeight: number;
+    trackTop: () => number;
+  },
+): {
+  onMouseDown: (event: MouseEvent) => void;
+  onMouseDrag: (event: MouseEvent) => void;
+  onMouseScroll: (event: MouseEvent) => void;
+} {
+  const emitOffset = (event: MouseEvent) => {
+    event.stopPropagation();
+    event.preventDefault();
+    const trackHeight = Math.max(1, Math.floor(input.trackHeight));
+    const trackIndex = Math.min(Math.max(0, event.y - input.trackTop()), trackHeight - 1);
+    dispatch(
+      {
+        kind: "scrollbar",
+        surface: input.surface,
+        offset: scrollbarOffsetForTrackIndex({
+          trackHeight,
+          contentLength: input.contentLength,
+          viewportLength: input.viewportLength,
+          offset: 0,
+          trackIndex,
+        }),
+      },
+      event,
+    );
+  };
+  return {
+    onMouseDown: emitOffset,
+    onMouseDrag: emitOffset,
+    onMouseScroll: stationMouseProps(dispatch, {
+      kind: "scrollbar",
+      surface: input.surface,
+      offset: 0,
+    }).onMouseScroll,
   };
 }


### PR DESCRIPTION
## What this fixes

Station's Help overlay (`?`/`H`) silently clipped later bindings on typical 80×24 terminals, and arrows/wheel did nothing. The dashboard already clipped tree rows and showed `▲`/`▼` overflow copy, but it had no proportional thumb in the reserved last column.

This PR paints Station-owned vertical scrollbars so those two surfaces can actually be scrolled, without rewriting Help onto OpenTUI `ScrollBox` or putting a thumb on Group `╮│╯` chrome. Follow-up on the same branch: scrollbar drag was starting terminal text selection, leftover track cells were blank so unused range disappeared, and overflow arrows only appeared when *sessions* were clipped — empty groups and projects could still scroll with no cue.

## What changed

- Help is a real window: `{ name: "help"; scrollOffset; contentLength }`, with ↑/↓ and wheel moving the window. Esc/`H`/`?`/`Q` and click-away still close it.
- Help and dashboard thumbs are Station-owned `▐` cells. Thumb length follows Blink/WebKit `round(visible/content × track)` (one-cell minimum). Overflowing leftover cells keep a thin `▕` rail; when content fits, the column stays blank.
- The dashboard gutter is a 1-column sibling **outside** Group frames. Track down/drag maps through the inclusive last-cell formula and never activates dashboard cells.
- OpenTUI starts a selection on left-down before renderable handlers, so Help copy, overflow chrome, and both tracks are non-selectable. Station mouse `drag` is scrollbar-only.
- Overflow `▲`/`▼` (labels and gutter arrows) follow tree `hiddenAbove`/`hiddenBelow`, not session counts. Session wording stays when sessions are off-screen; otherwise the copy is `more above` / `more below`. Arrows page like the labels and stay off the thumb.

## Testing

- `pnpm exec vitest run --config config/vitest/vitest.unit.config.ts packages/dashboard-core/test/unit`
- `cd station && bun test src/station/view/modals.golden.test.tsx src/station/view/dashboard.golden.test.tsx src/station/view/dashboard.scrollbar.stress.test.tsx src/station/input/stationMouse.test.ts` (goldens updated)

## User-visible behavior

On 80×24, `?` then wheel or ↓ reaches Widget Settings / Delete / Refresh; Help corners stay rounded and the thumb sits inside `│`. A crowded list shows a small `▐` and a long `▕` rail; slight overflow shows a fat thumb. Dragging the rail does not highlight session copy. Empty groups below a fully visible session list still show `▼ more below` and a gutter triangle.

**Verify:** `?` on a short terminal, scroll the panel, Esc/click-away to close. Crowd the dashboard, drag the gutter without selecting text, then leave empty groups below every visible session and confirm `▼ more below` plus the gutter `▼`.