### PR TITLE
fix(tui): settle native terminal loss before hangup

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -213,12 +213,15 @@ bun run dashboard                     # interactive dashboard renderer without n
 
 The native renderer is an independent semantic witness in `logs/tui.jsonl`. It
 records startup/ready, typed welcome, workspace, Station-overlay, and context-menu
-transitions, shutdown intent (`ctrl_q` or cooperative TTY takeover), fatal
-errors normalized to the fixed content-free `TUI_FATAL` shape, and normal
-shutdown completion. Normal shutdown flushes this evidence before process exit;
-abrupt loss and exact process signals remain covered by the launcher. Ctrl-O is
-a surface transition inside one `uiRunId`, not a renderer restart. Direct
-development mints a valid run ID and preserves it across Bun HMR.
+transitions, shutdown intent (`ctrl_q`, cooperative `tty_takeover`, or
+`terminal_loss`), fatal errors normalized to the fixed content-free `TUI_FATAL`
+shape, and successful shutdown completion. Station owns `SIGHUP`: terminal-loss
+composition cleanup is bounded to two seconds, after which Station flushes
+evidence, releases exact TTY ownership, and re-raises `SIGHUP` so the launcher
+observes the real signal outcome. Cleanup rejection or timeout records fatal
+evidence and never records completion or exits successfully. Ctrl-O is a surface
+transition inside one `uiRunId`, not a renderer restart. Direct development
+mints a valid run ID and preserves it across Bun HMR.
 
 Native Host clients carry the same typed run context with a fresh connection ID
 per socket and Host-issued attachment ID per attach attempt. `station-host.jsonl` uses typed
@@ -233,7 +236,9 @@ await admitted dashboard work before stopping the shared client and completing
 process shutdown. Native HMR releases renderer/stdin ownership synchronously,
 retains compatible workspace state and PTYs, publishes a settlement-only cleanup
 barrier in a process-global slot, and starts the replacement composition after
-that barrier even when prior cleanup reports a failure. Only the standalone
+that barrier even when prior cleanup reports a failure. Each native composition
+installs one `SIGHUP` listener only after it is ready and removes that listener
+during shutdown or HMR disposal. Only the standalone
 dashboard registers `process.on("exit")`; that path remains synchronous
 best-effort because the runtime cannot extend the event.
 
@@ -265,6 +270,8 @@ disposes subscriptions and PTYs, unmounts React, destroys OpenTUI to release raw
 stdin, closes its control endpoint, and releases the transaction last. The
 successor cannot enter raw mode until that acquisition succeeds. Station never
 signals another process during this flow and never escalates a failed takeover.
+Final shutdown releases the active transaction and adjacent control socket; the
+persistent SQLite claim file may remain and is not evidence of live ownership.
 
 Bun HMR retains the transaction and control endpoint in process-global state
 while replacing the takeover handler with the newest Station composition. An

--- a/packages/contracts/src/uiLifecycle.ts
+++ b/packages/contracts/src/uiLifecycle.ts
@@ -54,7 +54,7 @@ export const UiSurfaceChangeReasonSchema = z.enum([
 ]);
 export type UiSurfaceChangeReason = z.infer<typeof UiSurfaceChangeReasonSchema>;
 
-export const UiShutdownReasonSchema = z.enum(["ctrl_q", "tty_takeover", "fatal"]);
+export const UiShutdownReasonSchema = z.enum(["ctrl_q", "tty_takeover", "terminal_loss", "fatal"]);
 export type UiShutdownReason = z.infer<typeof UiShutdownReasonSchema>;
 
 export const UiLifecycleDetachReasonSchema = z.enum([

--- a/packages/contracts/test/schema/diagnostics-schema.test.ts
+++ b/packages/contracts/test/schema/diagnostics-schema.test.ts
@@ -91,7 +91,9 @@ describe("diagnostics schemas", () => {
     expect(
       UiLifecycleEventSchema.safeParse({ ...rendererExit, causalEventId: "event_unused" }).success,
     ).toBe(false);
+    expect(UiShutdownReasonSchema.parse("terminal_loss")).toBe("terminal_loss");
     expect(UiShutdownReasonSchema.safeParse("signal").success).toBe(false);
+    expect(UiShutdownReasonSchema.safeParse("SIGTERM").success).toBe(false);
     expect(UiSurfaceChangeReasonSchema.safeParse("startup").success).toBe(false);
     expect(UiLifecycleSurfaceSchema.parse("welcome")).toBe("welcome");
     const hostDetach = {

--- a/station/src/app/createStation.ts
+++ b/station/src/app/createStation.ts
@@ -102,9 +102,9 @@ export function createStation(options: CreateStationOptions): Station {
     layoutWriter,
     tuiConfigPath: options.tuiConfigPath,
   });
-  let shutdownStarted = false;
+  let shutdownRequested = false;
 
-  // Input runtime; its shutdown tears down this composition, then exits the app.
+  // The process owner admits shutdown before starting coordinated composition disposal.
   const stationInput = createInputRuntime(options, {
     store,
     dashboardRuntime,
@@ -112,12 +112,11 @@ export function createStation(options: CreateStationOptions): Station {
     paneEffects,
     automations,
     onShutdown: () => {
-      if (shutdownStarted) {
+      if (shutdownRequested) {
         return;
       }
-      shutdownStarted = true;
-      const finishShutdown = (): void => options.shutdown();
-      void lifecycle.disposeForShutdown().then(finishShutdown, finishShutdown);
+      shutdownRequested = true;
+      options.shutdown();
     },
   });
 

--- a/station/src/app/createStationLifecycle.test.ts
+++ b/station/src/app/createStationLifecycle.test.ts
@@ -50,7 +50,7 @@ describe("native Station lifecycle", () => {
     ]);
   });
 
-  it("attempts later cleanup after failure and handles Ctrl-Q fire-and-forget rejection", async () => {
+  it("attempts later cleanup after failure and admits Ctrl-Q once", async () => {
     const snapshot = manyProjectsSnapshot();
     const source = new FakeStationSource(snapshot);
     const scripted = createScriptedTerminal();
@@ -94,18 +94,38 @@ describe("native Station lifecycle", () => {
     expect(stopAttempts).toBe(1);
     expect(scripted.helpers.isDisposed()).toBe(true);
 
-    const unhandled: unknown[] = [];
-    const observeUnhandled = (reason: unknown): void => {
-      unhandled.push(reason);
-    };
-    process.on("unhandledRejection", observeUnhandled);
-    try {
-      expect(composition.stationInput.handleSequence("\x11")).toBe(true);
-      await waitFor(() => shutdowns === 1);
-      await new Promise<void>((resolve) => setTimeout(resolve, 0));
-    } finally {
-      process.off("unhandledRejection", observeUnhandled);
-    }
-    expect(unhandled).toEqual([]);
+    expect(composition.stationInput.handleSequence("\x11")).toBe(true);
+    expect(composition.stationInput.handleSequence("\x11")).toBe(true);
+    expect(shutdowns).toBe(1);
+  });
+
+  it("admits Ctrl-Q before process-owned composition disposal settles", async () => {
+    const snapshot = manyProjectsSnapshot();
+    const source = new FakeStationSource(snapshot);
+    let settleStop!: () => void;
+    const stopped = new Promise<void>((resolve) => {
+      settleStop = resolve;
+    });
+    let cleanup: Promise<void> | undefined;
+    let composition!: ReturnType<typeof createStation>;
+    composition = createStation({
+      store: createStationStore(),
+      clipboardEffects: NO_OP_CLIPBOARD_EFFECTS,
+      stationClient: {
+        state: source,
+        service: new FakeTuiObserverService(snapshot),
+        start: () => source.start(),
+        stop: () => stopped,
+      },
+      shutdown: () => {
+        cleanup = composition.disposeForShutdown();
+      },
+    });
+    composition.start();
+
+    expect(composition.stationInput.handleSequence("\x11")).toBe(true);
+    if (cleanup === undefined) throw new Error("Ctrl-Q was not admitted synchronously.");
+    settleStop();
+    await cleanup;
   });
 });

--- a/station/src/app/types.ts
+++ b/station/src/app/types.ts
@@ -42,6 +42,7 @@ export type StationAppProps = {
 export type CreateStationOptions = {
   store: StationStore;
   stationClient: StationClient;
+  /** Admit an input-requested shutdown; the process owner coordinates `disposeForShutdown()`. */
   shutdown(): void;
   /** Real copy sinks (OSC 52 + a clipboard CLI); tests pass NO_OP_CLIPBOARD_EFFECTS. */
   clipboardEffects: ClipboardEffects;

--- a/station/src/config/tuiConfig.test.ts
+++ b/station/src/config/tuiConfig.test.ts
@@ -189,16 +189,14 @@ root = "${projectRoot}"
     ]);
   });
 
-  it("flushes the native Station input flow before its shutdown callback", async () => {
+  it("lets the process owner flush native Station after an immediate shutdown request", async () => {
     const dir = await mkdtemp(join(tmpdir(), "station-tui-config-"));
     dirs.push(dir);
     const configPath = await writeWidgetTestConfig(dir);
     const source = new FakeStationSource(manyProjectsSnapshot());
-    let resolveShutdown: (() => void) | undefined;
-    const shutdown = new Promise<void>((resolve) => {
-      resolveShutdown = resolve;
-    });
-    const composition = createStation({
+    let shutdown: Promise<void> | undefined;
+    let composition!: ReturnType<typeof createStation>;
+    composition = createStation({
       store: createStationStore(),
       clipboardEffects: NO_OP_CLIPBOARD_EFFECTS,
       stationClient: {
@@ -209,7 +207,9 @@ root = "${projectRoot}"
       },
       tuiConfig: { widgets: [{ type: "time" }] },
       tuiConfigPath: configPath,
-      shutdown: () => resolveShutdown?.(),
+      shutdown: () => {
+        shutdown = composition.disposeForShutdown();
+      },
     });
     composition.start();
 
@@ -217,6 +217,7 @@ root = "${projectRoot}"
     composition.dashboard.actions.handleKey({ input: " " });
     composition.stationInput.handleSequence("\x11");
 
+    if (shutdown === undefined) throw new Error("Ctrl-Q was not admitted synchronously.");
     await shutdown;
     expect((await loadStationTuiConfig({ path: configPath })).config?.widgets).toEqual([
       { type: "time", enabled: false },

--- a/station/src/diagnostics/uiLifecycle.test.ts
+++ b/station/src/diagnostics/uiLifecycle.test.ts
@@ -75,6 +75,30 @@ describe("UI lifecycle witness", () => {
     expect(JSON.stringify(records)).not.toContain("renderer failed");
   });
 
+  it("records content-free terminal-loss failure evidence without completion", async () => {
+    const stateDir = await mkdtemp(join(tmpdir(), "station-ui-terminal-loss-"));
+    const logger = createJsonlLogger({
+      component: "tui",
+      path: componentLogPath(stateDir, "tui"),
+    });
+    const witness = createUiLifecycleWitness({ logger, context });
+
+    await witness.shutdownRequested("terminal_loss");
+    await witness.fatal(new Error("private terminal output"));
+    await witness.flush();
+
+    const records = await readJsonlLog(join(stateDir, "logs", "tui.jsonl"));
+    expect(records.map((record) => record.lifecycle?.kind)).toEqual([
+      "ui.shutdown.requested",
+      "ui.fatal",
+    ]);
+    expect(records[0]?.lifecycle).toMatchObject({ reason: "terminal_loss" });
+    expect(records[1]?.lifecycle).toMatchObject({
+      error: { code: "TUI_FATAL", message: "The native Station UI failed." },
+    });
+    expect(JSON.stringify(records)).not.toContain("private terminal output");
+  });
+
   for (const { label, error, privateValue } of [
     {
       label: "SafeError",

--- a/station/src/entrypoints.test.ts
+++ b/station/src/entrypoints.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-const shutdownSignals = ["exit", "SIGINT", "SIGTERM"] as const;
+const shutdownSignals = ["exit", "SIGHUP", "SIGINT", "SIGTERM"] as const;
 
 describe("Station process entrypoints", () => {
   it("imports without starting renderers, clients, sockets, or shutdown handlers", async () => {

--- a/station/src/lifecycle/nativeProcessLifecycle.test.ts
+++ b/station/src/lifecycle/nativeProcessLifecycle.test.ts
@@ -11,6 +11,8 @@ type Input = Parameters<typeof createNativeProcessLifecycle>[0];
 function harness(options: {
   cleanupSteps?: Input["cleanupSteps"];
   killResult?: boolean;
+  onRelease?: (listenerInstalled: boolean) => void;
+  releaseError?: unknown;
   terminalLossTimeoutMs?: number;
 } = {}) {
   const events: string[] = [];
@@ -32,7 +34,11 @@ function harness(options: {
         events.push("flush");
       },
     },
-    releaseTty: () => events.push("tty:release"),
+    releaseTty: () => {
+      events.push("tty:release");
+      options.onRelease?.(signalHandler !== undefined);
+      if (options.releaseError !== undefined) throw options.releaseError;
+    },
     processControl: {
       pid: 4242,
       on: (_signal, listener) => {
@@ -181,6 +187,34 @@ describe("native process lifecycle", () => {
       "signal:4242:SIGHUP",
       "exit:129",
     ]);
+  });
+
+  it("keeps coalescing SIGHUP through TTY release and self-signals when release throws", async () => {
+    let listenerInstalledDuringRelease = false;
+    const station = harness({
+      onRelease: (installed) => {
+        listenerInstalledDuringRelease = installed;
+        station.signal();
+      },
+      releaseError: new Error("release failed"),
+    });
+    station.lifecycle.install();
+    station.signal();
+
+    await station.lifecycle.request("ctrl_q");
+
+    expect(listenerInstalledDuringRelease).toBe(true);
+    expect(station.events.slice(-2)).toEqual(["tty:release", "signal:4242:SIGHUP"]);
+    station.signal();
+    expect(station.events.slice(-2)).toEqual(["tty:release", "signal:4242:SIGHUP"]);
+  });
+
+  it("exits unsuccessfully when TTY release fails during a non-signal shutdown", async () => {
+    const station = harness({ releaseError: new Error("release failed") });
+
+    await station.lifecycle.request("tty_takeover");
+
+    expect(station.events.slice(-2)).toEqual(["tty:release", "exit:1"]);
   });
 
   it("re-raises a real SIGHUP only after spawned-process cleanup settles", async () => {

--- a/station/src/lifecycle/nativeProcessLifecycle.test.ts
+++ b/station/src/lifecycle/nativeProcessLifecycle.test.ts
@@ -1,0 +1,230 @@
+import { once } from "node:events";
+import { readFile, mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+import { describe, expect, it } from "bun:test";
+import { createNativeProcessLifecycle } from "./nativeProcessLifecycle.js";
+
+type Input = Parameters<typeof createNativeProcessLifecycle>[0];
+
+function harness(options: {
+  cleanupSteps?: Input["cleanupSteps"];
+  killResult?: boolean;
+  terminalLossTimeoutMs?: number;
+} = {}) {
+  const events: string[] = [];
+  let signalHandler: (() => void) | undefined;
+  const lifecycle = createNativeProcessLifecycle({
+    stopSurfaceObservation: () => events.push("surface:stop"),
+    cleanupSteps: options.cleanupSteps ?? [() => void events.push("cleanup")],
+    lifecycle: {
+      shutdownRequested: async (reason) => {
+        events.push(`requested:${reason}`);
+      },
+      shutdownCompleted: async (reason) => {
+        events.push(`completed:${reason}`);
+      },
+      fatal: async () => {
+        events.push("fatal:TUI_FATAL");
+      },
+      flush: async () => {
+        events.push("flush");
+      },
+    },
+    releaseTty: () => events.push("tty:release"),
+    processControl: {
+      pid: 4242,
+      on: (_signal, listener) => {
+        signalHandler = listener;
+      },
+      off: (_signal, listener) => {
+        if (signalHandler === listener) signalHandler = undefined;
+      },
+      kill: (pid, signal) => {
+        events.push(`signal:${pid}:${signal}`);
+        return options.killResult ?? true;
+      },
+      exit: (code) => events.push(`exit:${code}`),
+    },
+    ...(options.terminalLossTimeoutMs === undefined
+      ? {}
+      : { terminalLossTimeoutMs: options.terminalLossTimeoutMs }),
+  });
+  return { events, lifecycle, signal: () => signalHandler?.() };
+}
+
+describe("native process lifecycle", () => {
+  it("is pure on construction and installs, disposes, and reinstalls one SIGHUP listener", () => {
+    const before = process.listenerCount("SIGHUP");
+    const lifecycle = createNativeProcessLifecycle({
+      stopSurfaceObservation: () => undefined,
+      cleanupSteps: [],
+      lifecycle: {
+        shutdownRequested: async () => undefined,
+        shutdownCompleted: async () => undefined,
+        fatal: async () => undefined,
+        flush: async () => undefined,
+      },
+      releaseTty: () => undefined,
+    });
+    expect(process.listenerCount("SIGHUP")).toBe(before);
+    try {
+      lifecycle.install();
+      lifecycle.install();
+      expect(process.listenerCount("SIGHUP")).toBe(before + 1);
+      lifecycle.dispose();
+      expect(process.listenerCount("SIGHUP")).toBe(before);
+      lifecycle.install();
+      expect(process.listenerCount("SIGHUP")).toBe(before + 1);
+    } finally {
+      lifecycle.dispose();
+    }
+    expect(process.listenerCount("SIGHUP")).toBe(before);
+  });
+
+  it("admits the first racing request and attempts every cleanup step once", async () => {
+    const calls: string[] = [];
+    let settlePty!: () => void;
+    const ptySettlement = new Promise<void>((resolve) => {
+      settlePty = resolve;
+    });
+    const station = harness({
+      cleanupSteps: [
+        () => void calls.push("station"),
+        () => void calls.push("root"),
+        () => void calls.push("renderer"),
+        () => {
+          calls.push("pty");
+          return ptySettlement;
+        },
+      ],
+    });
+    station.lifecycle.install();
+
+    const first = station.lifecycle.request("ctrl_q");
+    const repeated = station.lifecycle.request("ctrl_q");
+    const takeover = station.lifecycle.request("tty_takeover");
+    station.signal();
+    expect(repeated).toBe(first);
+    expect(takeover).toBe(first);
+    await Promise.resolve();
+    expect(calls).toEqual(["station", "root", "renderer", "pty"]);
+    expect(station.events).toEqual(["surface:stop", "requested:ctrl_q"]);
+    settlePty();
+    await first;
+
+    expect(station.events).toEqual([
+      "surface:stop",
+      "requested:ctrl_q",
+      "completed:ctrl_q",
+      "flush",
+      "tty:release",
+      "exit:0",
+    ]);
+  });
+
+  it("records fatal evidence after rejected cleanup and cannot exit successfully", async () => {
+    const calls: string[] = [];
+    const station = harness({
+      cleanupSteps: [
+        () => void calls.push("station"),
+        () => {
+          calls.push("root");
+          throw new Error("private terminal content");
+        },
+        () => void calls.push("renderer"),
+        () => void calls.push("pty"),
+      ],
+    });
+
+    await station.lifecycle.request("tty_takeover");
+
+    expect(calls).toEqual(["station", "root", "renderer", "pty"]);
+    expect(station.events).toEqual([
+      "surface:stop",
+      "requested:tty_takeover",
+      "fatal:TUI_FATAL",
+      "flush",
+      "tty:release",
+      "exit:1",
+    ]);
+  });
+
+  it("bounds terminal-loss cleanup and releases TTY ownership before signaling", async () => {
+    const station = harness({
+      cleanupSteps: [() => new Promise<void>(() => undefined)],
+      terminalLossTimeoutMs: 5,
+    });
+    station.lifecycle.install();
+
+    station.signal();
+    await station.lifecycle.request("ctrl_q");
+
+    expect(station.events).toEqual([
+      "surface:stop",
+      "requested:terminal_loss",
+      "fatal:TUI_FATAL",
+      "flush",
+      "tty:release",
+      "signal:4242:SIGHUP",
+    ]);
+  });
+
+  it("falls back to derived status 129 when SIGHUP self-signaling fails", async () => {
+    const station = harness({ killResult: false });
+    station.lifecycle.install();
+    station.signal();
+    await station.lifecycle.request("tty_takeover");
+    expect(station.events.slice(-3)).toEqual([
+      "tty:release",
+      "signal:4242:SIGHUP",
+      "exit:129",
+    ]);
+  });
+
+  it("re-raises a real SIGHUP only after spawned-process cleanup settles", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-native-sighup-"));
+    const marker = join(root, "cleanup.txt");
+    const moduleUrl = new URL("./nativeProcessLifecycle.ts", import.meta.url).href;
+    const fixture = `
+      import { writeFile } from "node:fs/promises";
+      const { createNativeProcessLifecycle } = await import(${JSON.stringify(moduleUrl)});
+      const lifecycle = createNativeProcessLifecycle({
+        stopSurfaceObservation() {},
+        cleanupSteps: [() => writeFile(${JSON.stringify(marker)}, "settled")],
+        lifecycle: {
+          shutdownRequested: async () => {},
+          shutdownCompleted: async () => {},
+          fatal: async () => {},
+          flush: async () => {},
+        },
+        releaseTty() {},
+      });
+      lifecycle.install();
+      process.stdout.write("ready\\n");
+      setInterval(() => {}, 1000);
+    `;
+    const child = spawn(process.execPath, ["--eval", fixture], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stderr = "";
+    child.stderr?.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    try {
+      await Promise.race([
+        once(child.stdout!, "data"),
+        once(child, "exit").then(() => Promise.reject(new Error(stderr || "fixture exited"))),
+      ]);
+      const exited = once(child, "exit");
+      process.kill(child.pid!, "SIGHUP");
+      const [code, signal] = (await exited) as [number | null, NodeJS.Signals | null];
+
+      expect({ code, signal }).toEqual({ code: null, signal: "SIGHUP" });
+      expect(await readFile(marker, "utf8")).toBe("settled");
+    } finally {
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+    }
+  });
+});

--- a/station/src/lifecycle/nativeProcessLifecycle.ts
+++ b/station/src/lifecycle/nativeProcessLifecycle.ts
@@ -1,0 +1,119 @@
+import type { UiShutdownReason } from "@station/contracts";
+import { settleCleanupSteps, type CleanupStep } from "./cleanup.js";
+
+const TERMINAL_LOSS_TIMEOUT_MS = 2_000;
+type NativeShutdownReason = Exclude<UiShutdownReason, "fatal">;
+
+type ProcessControl = {
+  readonly pid: number;
+  on(signal: "SIGHUP", listener: () => void): void;
+  off(signal: "SIGHUP", listener: () => void): void;
+  kill(pid: number, signal: "SIGHUP"): boolean;
+  exit(code: number): void;
+};
+
+export type NativeProcessLifecycle = {
+  install(): void;
+  request(reason: NativeShutdownReason): Promise<void>;
+  dispose(): void;
+};
+
+/**
+ * Coordinates first-wins native shutdown and preserves a real SIGHUP outcome
+ * by releasing Station resources and exact TTY ownership before self-signaling.
+ */
+export function createNativeProcessLifecycle(input: {
+  stopSurfaceObservation(): void;
+  cleanupSteps: readonly CleanupStep[];
+  lifecycle: {
+    shutdownRequested(reason: UiShutdownReason): Promise<void>;
+    shutdownCompleted(reason: UiShutdownReason): Promise<void>;
+    fatal(error: unknown): Promise<void>;
+    flush(): Promise<void>;
+  };
+  releaseTty(): void;
+  processControl?: ProcessControl;
+  terminalLossTimeoutMs?: number;
+}): NativeProcessLifecycle {
+  const processControl = input.processControl ?? process;
+  const timeoutMs = input.terminalLossTimeoutMs ?? TERMINAL_LOSS_TIMEOUT_MS;
+  let installed = false;
+  let shutdown: Promise<void> | undefined;
+
+  const onTerminalLoss = (): void => {
+    void request("terminal_loss");
+  };
+  const dispose = (): void => {
+    if (!installed) return;
+    processControl.off("SIGHUP", onTerminalLoss);
+    installed = false;
+  };
+  const terminate = (reason: NativeShutdownReason, failed: boolean): void => {
+    dispose();
+    input.releaseTty();
+    if (reason !== "terminal_loss") {
+      processControl.exit(failed ? 1 : 0);
+      return;
+    }
+    try {
+      if (!processControl.kill(processControl.pid, "SIGHUP")) processControl.exit(129);
+    } catch {
+      processControl.exit(129);
+    }
+  };
+  const request = (reason: NativeShutdownReason): Promise<void> => {
+    if (shutdown !== undefined) return shutdown;
+    shutdown = (async () => {
+      let failure: unknown;
+      try {
+        input.stopSurfaceObservation();
+      } catch (error) {
+        failure = error;
+      }
+      await input.lifecycle.shutdownRequested(reason);
+      const cleanup = settleCleanupSteps(
+        input.cleanupSteps,
+        "Native renderer shutdown cleanup failed.",
+      );
+      try {
+        if (reason === "terminal_loss") {
+          await settleBeforeTimeout(cleanup, timeoutMs);
+        } else {
+          await cleanup;
+        }
+      } catch (error) {
+        failure ??= error;
+      }
+      if (failure === undefined) {
+        await input.lifecycle.shutdownCompleted(reason);
+      } else {
+        await input.lifecycle.fatal(failure);
+      }
+      await input.lifecycle.flush();
+      terminate(reason, failure !== undefined);
+    })();
+    return shutdown;
+  };
+
+  return {
+    install: () => {
+      if (installed) return;
+      processControl.on("SIGHUP", onTerminalLoss);
+      installed = true;
+    },
+    request,
+    dispose,
+  };
+}
+
+async function settleBeforeTimeout(settlement: Promise<void>, timeoutMs: number): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<void>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error("Native terminal-loss cleanup timed out.")), timeoutMs);
+  });
+  try {
+    await Promise.race([settlement, timeout]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}

--- a/station/src/lifecycle/nativeProcessLifecycle.ts
+++ b/station/src/lifecycle/nativeProcessLifecycle.ts
@@ -49,10 +49,20 @@ export function createNativeProcessLifecycle(input: {
     installed = false;
   };
   const terminate = (reason: NativeShutdownReason, failed: boolean): void => {
-    dispose();
-    input.releaseTty();
+    let finalizationFailed = failed;
+    // Keep later hangups coalesced until ownership release is attempted, and always terminate.
+    try {
+      input.releaseTty();
+    } catch {
+      finalizationFailed = true;
+    }
+    try {
+      dispose();
+    } catch {
+      finalizationFailed = true;
+    }
     if (reason !== "terminal_loss") {
-      processControl.exit(failed ? 1 : 0);
+      processControl.exit(finalizationFailed ? 1 : 0);
       return;
     }
     try {

--- a/station/src/main.tsx
+++ b/station/src/main.tsx
@@ -2,7 +2,6 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createCliRenderer, type CliRenderer } from "@opentui/core";
 import { createRoot } from "@opentui/react";
-import type { UiShutdownReason } from "@station/contracts";
 import { createStationHostClient } from "@station/host";
 import { componentLogPath, createJsonlLogger, toSafeError } from "@station/observability";
 import { stationBuildInfo } from "@station/runtime";
@@ -22,6 +21,10 @@ import {
   type StationHotSlots,
 } from "./hmr/stationHotRuntime.js";
 import { invokeCleanup, settleCleanupSteps } from "./lifecycle/cleanup.js";
+import {
+  createNativeProcessLifecycle,
+  type NativeProcessLifecycle,
+} from "./lifecycle/nativeProcessLifecycle.js";
 import { createRenderProfiler, readRenderProfileEnabled } from "./profiling/renderProfiler.js";
 import {
   acquireStationTtyOwnership,
@@ -98,8 +101,8 @@ function stationHostSuccessorCommand(
 /**
  * Callable native OpenTUI process entry and semantic lifecycle witness boundary.
  * It acquires TTY ownership before other startup work, binds one validated run
- * context into Host terminal factories, flushes shutdown evidence, and releases
- * ownership only after renderer shutdown.
+ * context into Host terminal factories, owns native signal/lifecycle evidence,
+ * and releases final TTY ownership only after renderer shutdown.
  */
 export async function runStationMain(options: RunStationMainOptions = {}): Promise<void> {
   const ownershipResult = await acquireStationTtyOwnership();
@@ -342,35 +345,7 @@ async function startStationMain(
   let rendererForInput: CliRenderer | undefined;
   let rootForShutdown: { unmount(): void } | undefined;
   let stopSurfaceObservation: (() => void) | undefined;
-  let shutdownStarted = false;
-  const finishProcessShutdown = (reason: UiShutdownReason): void => {
-    if (shutdownStarted) return;
-    shutdownStarted = true;
-    stopSurfaceObservation?.();
-    void (async () => {
-      let exitCode = 0;
-      await uiLifecycle.shutdownRequested(reason);
-      try {
-        await settleCleanupSteps(
-          [
-            () => rootForShutdown?.unmount(),
-            () => rendererForInput?.destroy(),
-            () => ptyRuntime?.dispose(),
-            () => stationClient.stop(),
-          ],
-          "Native renderer shutdown cleanup failed.",
-        );
-        await uiLifecycle.shutdownCompleted(reason);
-      } catch (error) {
-        exitCode = 1;
-        await uiLifecycle.fatal(error);
-      } finally {
-        await uiLifecycle.flush();
-        ttyOwnership?.release();
-        process.exit(exitCode);
-      }
-    })();
-  };
+  let processLifecycle: NativeProcessLifecycle | undefined;
   const station = createStation({
     store,
     stationClient,
@@ -389,7 +364,7 @@ async function startStationMain(
     ...(managedTerminalAttacher === undefined ? {} : { managedTerminalAttacher }),
     ...(layoutPath === undefined ? {} : { layout: { path: layoutPath } }),
     ...(ptyRuntime === undefined ? {} : { createTerminal: ptyRuntime.createTerminal }),
-    shutdown: () => finishProcessShutdown("ctrl_q"),
+    shutdown: () => void processLifecycle?.request("ctrl_q"),
   });
 
   if (ttyOwnership !== undefined && !currentStdinMatchesStationTty(ttyOwnership.identity)) {
@@ -403,16 +378,18 @@ async function startStationMain(
     process.exitCode = 1;
     return false;
   }
-  ttyOwnership?.setTakeoverHandler(() => {
-    void (async () => {
-      try {
-        await station.disposeForShutdown();
-      } catch {
-        // The shutdown witness still owns the final fatal path after best-effort disposal.
-      }
-      finishProcessShutdown("tty_takeover");
-    })();
+  processLifecycle = createNativeProcessLifecycle({
+    stopSurfaceObservation: () => stopSurfaceObservation?.(),
+    cleanupSteps: [
+      () => station.disposeForShutdown(),
+      () => rootForShutdown?.unmount(),
+      () => rendererForInput?.destroy(),
+      () => ptyRuntime?.dispose(),
+    ],
+    lifecycle: uiLifecycle,
+    releaseTty: () => ttyOwnership?.release(),
   });
+  ttyOwnership?.setTakeoverHandler(() => void processLifecycle?.request("tty_takeover"));
 
   const copySelectedText = createOpenTuiSelectionCopyHandler(
     () => rendererForInput,
@@ -420,6 +397,15 @@ async function startStationMain(
   );
   const renderer = await createCliRenderer({
     exitOnCtrlC: false,
+    exitSignals: [
+      "SIGINT",
+      "SIGTERM",
+      "SIGQUIT",
+      "SIGABRT",
+      "SIGBREAK",
+      "SIGPIPE",
+      "SIGBUS",
+    ],
     prependInputHandlers: [copySelectedText, station.stationInput.handleSequence],
     useKittyKeyboard: STATION_KEYBOARD_PROTOCOL,
   });
@@ -456,6 +442,7 @@ async function startStationMain(
 
   await uiLifecycle.ready(selectUiLifecycleSurface(store.getState()));
   stopSurfaceObservation = observeUiSurfaceLifecycle({ store, witness: uiLifecycle });
+  processLifecycle.install();
 
   if (import.meta.hot) {
     import.meta.hot.accept();
@@ -465,6 +452,7 @@ async function startStationMain(
         () =>
           settleCleanupSteps(
             [
+              () => processLifecycle?.dispose(),
               // Renderer and stdin release cannot wait for asynchronous dashboard settlement.
               () => stopSurfaceObservation?.(),
               () => root.unmount(),


### PR DESCRIPTION
## What this fixes

Native Station is the terminal renderer that owns TTY state and Host attachments. When its controlling terminal disappeared, OpenTUI consumed `SIGHUP` and destroyed only renderer state, bypassing Station's lifecycle evidence, exact TTY claim release, and coordinated client detachment. That could leave renderer ownership resources behind while hiding the launcher's real signal outcome. Fixes #737.

## What changed

- Give native Station sole ownership of `SIGHUP` while preserving OpenTUI's other default exit signals.
- Coordinate terminal loss, Ctrl-Q, and cooperative TTY takeover through one first-wins shutdown sequence; Ctrl-Q is admitted before composition disposal begins.
- Settle Station, React, renderer, and PTY runtime cleanup before flushing evidence and releasing exact TTY ownership.
- Bound terminal-loss cleanup to two seconds; failures emit fixed `TUI_FATAL` evidence without a completion record.
- Keep later hangups coalesced through TTY release and guarantee a real signal or non-success exit even if final ownership release fails.
- Re-raise `SIGHUP` to the exact renderer PID so the launcher observes the real signaled exit while Host-owned PTYs remain available for reattachment.
- Remove the native listener during finalization and HMR disposal, and document active claims versus persistent SQLite files.

## Testing

- `bun run --cwd station typecheck`
- `bun run --cwd station test` — 1,750 passed
- `bun run test:ci:station`
- `bun run test:contracts` — 187 passed
- `bun run lint`
- `bun run test:all`

## User-visible behavior

Destroying the terminal now closes native Station cleanly and preserves a real `SIGHUP` outcome; Host-backed agents remain alive for reattachment.
