### PR TITLE
fix(worktrunk): unify Darwin temporary path identity

### DIFF
--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -17607,6 +17607,20 @@
       "purpose": "Translates Worktrunk lifecycle output and commands into Station worktree contracts. Hook diagnostics use an atomic requester runtime when supplied and retain the whole Observer composition expectation as a fallback. List results are returned without retaining inventory; only the Worktrunk project identifier needed to preserve managed-path precedence is memoized. Checkout roots are validated before Worktrunk runs, and removal freshly revalidates native Git identity, path, and branch before mutation.",
       "dependencies": [
         {
+          "path": "packages/contracts/src/observedPaths.ts",
+          "declaration": "observedPathIsSameOrInside",
+          "kind": "function",
+          "role": "POLICY",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "packages/contracts/src/observedPaths.ts",
+          "declaration": "sameObservedPath",
+          "kind": "function",
+          "role": "POLICY",
+          "edgeKind": "runtime"
+        },
+        {
           "path": "packages/contracts/src/providers.ts",
           "declaration": "WorktreeProvider",
           "kind": "interface",
@@ -17660,6 +17674,22 @@
       "kind": "const",
       "role": "POLICY",
       "purpose": "Owns canonical agent display semantics; readiness and view rollups remain consumer-derived.",
+      "dependencies": []
+    },
+    {
+      "path": "packages/contracts/src/observedPaths.ts",
+      "declaration": "observedPathIsSameOrInside",
+      "kind": "function",
+      "role": "POLICY",
+      "purpose": "Determines managed-path containment using the same authorized alias and lexical-safety identity as equality checks.",
+      "dependencies": []
+    },
+    {
+      "path": "packages/contracts/src/observedPaths.ts",
+      "declaration": "sameObservedPath",
+      "kind": "function",
+      "role": "POLICY",
+      "purpose": "Treats provider-observed paths as identical only when their authorized aliases and lexical safety rules agree.",
       "dependencies": []
     },
     {

--- a/integrations/worktree/worktrunk/src/parse.ts
+++ b/integrations/worktree/worktrunk/src/parse.ts
@@ -13,6 +13,8 @@ export type ParseWorktrunkListOptions = {
   project: ProviderProjectConfig;
   providerId?: ProviderId;
   observedAt: string;
+  /** Platform authority for deriving identity from OS-specific observed path aliases. */
+  platform?: NodeJS.Platform;
 };
 
 export type WorktrunkListItem = Record<string, unknown>;
@@ -67,7 +69,7 @@ export function parseWorktrunkListItem(
   const remote = repositoryRemoteFromItem(item);
   const headSha = headShaFromItem(item);
   const observationInput: WorktreeObservation = {
-    id: metadata?.worktreeId ?? worktreeId(options.project.id, path),
+    id: metadata?.worktreeId ?? worktreeId(options.project.id, path, options.platform),
     provider: options.providerId ?? "worktrunk",
     projectId: options.project.id,
     branch,
@@ -273,8 +275,8 @@ function hasWorktreePath(item: unknown): item is WorktrunkListItem {
   );
 }
 
-function worktreeId(projectId: string, path: string): string {
-  const identityPath = normalizeObservedPath(path);
+function worktreeId(projectId: string, path: string, platform?: NodeJS.Platform): string {
+  const identityPath = normalizeObservedPath(path, platform);
   const stableDisplayName = pathDisplaySlug(identityPath);
   return stableName({
     prefix: "wt",

--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { lstat, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { isAbsolute, join, normalize, relative, resolve } from "node:path";
+import { isAbsolute, join, normalize, resolve } from "node:path";
 import type {
   CreateWorktreeRequest,
   ProviderDoctorCheck,
@@ -17,6 +17,12 @@ import type {
   WorktreeProvider,
   WorktreeRemovalRefusalDiagnosticDetail,
   WorktreeRemovalRefusalReason,
+} from "@station/contracts";
+import {
+  normalizeObservedPath,
+  observedPathHasLexicalDotSegments,
+  observedPathIsSameOrInside,
+  sameObservedPath,
 } from "@station/contracts";
 import {
   type ExternalCommandRunner,
@@ -90,6 +96,7 @@ export class WorktrunkProvider implements WorktreeProvider {
   readonly #runner: ExternalCommandRunner | undefined;
   readonly #clock: RuntimeClock;
   readonly #resolveRegistrationIdentity: (worktreePath: string) => Promise<string | undefined>;
+  readonly #platform: NodeJS.Platform;
   readonly #managedPathProjectIdentifiers = new Map<string, string | null>();
 
   constructor(options: WorktrunkProviderOptions = {}) {
@@ -102,6 +109,7 @@ export class WorktrunkProvider implements WorktreeProvider {
     this.#clock = options.clock ?? systemClock;
     this.#resolveRegistrationIdentity =
       options.resolveRegistrationIdentity ?? nativeGitRegistrationIdentity;
+    this.#platform = options.platform ?? process.platform;
   }
 
   capabilities(): WorktreeCapabilities {
@@ -261,7 +269,7 @@ export class WorktrunkProvider implements WorktreeProvider {
 
     const observations = await this.#readWorktrees(project, policy);
     const managedObservations = observations.filter((observation) =>
-      isManagedWorktreeObservation(project, observation),
+      isManagedWorktreeObservation(project, observation, this.#platform),
     );
     return Promise.all(
       managedObservations.map((observation) =>
@@ -287,13 +295,17 @@ export class WorktrunkProvider implements WorktreeProvider {
       project,
       providerId: this.id,
       observedAt: toIsoTimestamp(this.#clock.now()),
+      platform: this.#platform,
     });
+    const safeObservations = observations.filter((observation) =>
+      isSafeWorktrunkObservationPath(observation.path),
+    );
     this.#managedPathProjectIdentifiers.set(
       project.id,
-      worktrunkProjectConfigIdentifier(observations),
+      worktrunkProjectConfigIdentifier(safeObservations),
     );
     return Promise.all(
-      observations.map((observation) => this.#withRegistrationIdentity(observation)),
+      safeObservations.map((observation) => this.#withRegistrationIdentity(observation)),
     );
   }
 
@@ -327,12 +339,18 @@ export class WorktrunkProvider implements WorktreeProvider {
       project: request.project,
       providerId: this.id,
       observedAt: toIsoTimestamp(this.#clock.now()),
+      platform: this.#platform,
     });
+    const safeCommandObservations = commandObservations.filter((observation) =>
+      isSafeWorktrunkObservationPath(observation.path),
+    );
     const observations = (
       await Promise.all(
-        commandObservations.map((observation) => this.#withRegistrationIdentity(observation)),
+        safeCommandObservations.map((observation) => this.#withRegistrationIdentity(observation)),
       )
-    ).filter((observation) => isManagedWorktreeObservation(request.project, observation));
+    ).filter((observation) =>
+      isManagedWorktreeObservation(request.project, observation, this.#platform),
+    );
     const found =
       observations.find((observation) => observation.branch === request.branch) ??
       observations.find((observation) => observation.path === request.path) ??
@@ -438,13 +456,25 @@ export class WorktrunkProvider implements WorktreeProvider {
   async removeWorktree(request: RemoveWorktreeRequest): Promise<RemoveWorktreeResult> {
     const project = request.project;
     await this.#assertProjectRootUsable(project);
+    if (!isSafeWorktrunkObservationPath(request.expectedPath)) {
+      throw worktreeRemovalRefusalError({
+        code: "WORKTRUNK_WORKTREE_CHANGED",
+        message: "The selected worktree path is not safe for Worktrunk removal.",
+        hint: "Refresh and reselect the worktree before retrying removal.",
+        request,
+        canonicalPath: request.expectedPath,
+        observedBranch: request.expectedBranch,
+        refusalReason: "path_changed",
+        platform: this.#platform,
+      });
+    }
 
     const currentWorktrees = await this.#readWorktrees(project, { retries: 1 });
     const identityMatches = currentWorktrees.filter(
       (worktree) => worktree.id === request.worktreeId,
     );
     const pathMatches = currentWorktrees.filter((worktree) =>
-      samePath(worktree.path, request.expectedPath),
+      samePath(worktree.path, request.expectedPath, this.#platform),
     );
     if (identityMatches.length === 0 && pathMatches.length === 0) {
       throw worktreeRemovalRefusalError({
@@ -455,6 +485,7 @@ export class WorktrunkProvider implements WorktreeProvider {
         canonicalPath: request.expectedPath,
         observedBranch: request.expectedBranch,
         refusalReason: "missing_target",
+        platform: this.#platform,
       });
     }
     const selected = identityMatches[0];
@@ -466,7 +497,7 @@ export class WorktrunkProvider implements WorktreeProvider {
           ? "identity_changed"
           : selected.state !== "exists"
             ? "missing_target"
-            : changedRemovalIdentityReason(selected, request);
+            : changedRemovalIdentityReason(selected, request, this.#platform);
     if (finalRefusalReason !== undefined || selected === undefined || pathMatch === undefined) {
       throw worktreeRemovalRefusalError({
         code: "WORKTRUNK_WORKTREE_CHANGED",
@@ -476,6 +507,7 @@ export class WorktrunkProvider implements WorktreeProvider {
         canonicalPath: selected?.path ?? pathMatch?.path ?? request.expectedPath,
         observedBranch: selected?.branch ?? pathMatch?.branch ?? request.expectedBranch,
         refusalReason: finalRefusalReason ?? "ambiguous_identity",
+        platform: this.#platform,
       });
     }
     const branchIsShared =
@@ -484,7 +516,7 @@ export class WorktrunkProvider implements WorktreeProvider {
         (worktree) =>
           worktree.state === "exists" &&
           worktree.branch === selected.branch &&
-          !samePath(worktree.path, selected.path),
+          !samePath(worktree.path, selected.path, this.#platform),
       );
     const removalFlags: string[] = [];
     if (request.force === true) {
@@ -887,6 +919,7 @@ function parseCommandObservation(
     project: ProviderProjectConfig;
     providerId: ProviderId;
     observedAt: string;
+    platform: NodeJS.Platform;
   },
 ): WorktreeObservation[] {
   const trimmed = stdout.trim();
@@ -911,8 +944,10 @@ function parseCommandObservation(
 function isManagedWorktreeObservation(
   project: ProviderProjectConfig,
   observation: WorktreeObservation,
+  platform: NodeJS.Platform,
 ): boolean {
-  if (isMainWorktree(project, observation)) {
+  if (!isSafeWorktrunkObservationPath(observation.path)) return false;
+  if (isMainWorktree(project, observation, platform)) {
     return project.worktrunk.includeMain !== false;
   }
 
@@ -921,11 +956,21 @@ function isManagedWorktreeObservation(
     return true;
   }
 
-  return isPathInside(observation.path, managedRoot);
+  return isPathInside(observation.path, managedRoot, platform);
 }
 
-function isMainWorktree(project: ProviderProjectConfig, observation: WorktreeObservation): boolean {
-  return samePath(observation.path, project.root) || observation.isPrimaryCheckout === true;
+function isSafeWorktrunkObservationPath(path: string): boolean {
+  return isAbsolute(path) && !observedPathHasLexicalDotSegments(path);
+}
+
+function isMainWorktree(
+  project: ProviderProjectConfig,
+  observation: WorktreeObservation,
+  platform: NodeJS.Platform,
+): boolean {
+  return (
+    samePath(observation.path, project.root, platform) || observation.isPrimaryCheckout === true
+  );
 }
 
 function worktrunkProjectConfigIdentifier(
@@ -985,20 +1030,20 @@ function resolveManagedRoot(project: ProviderProjectConfig): string | undefined 
   return normalize(isAbsolute(configured) ? configured : resolve(project.root, configured));
 }
 
-function isPathInside(path: string, root: string): boolean {
-  const fromRoot = relative(canonicalPathForComparison(root), canonicalPathForComparison(path));
-  return fromRoot === "" || (!fromRoot.startsWith("..") && !isAbsolute(fromRoot));
+function isPathInside(path: string, root: string, platform: NodeJS.Platform): boolean {
+  return isAbsolute(path) && isAbsolute(root) && observedPathIsSameOrInside(path, root, platform);
 }
 
-function samePath(left: string, right: string): boolean {
-  return canonicalPathForComparison(left) === canonicalPathForComparison(right);
+function samePath(left: string, right: string, platform: NodeJS.Platform): boolean {
+  return sameObservedPath(left, right, platform);
 }
 
 function changedRemovalIdentityReason(
   observation: WorktreeObservation,
   request: RemoveWorktreeRequest,
+  platform: NodeJS.Platform,
 ): WorktreeRemovalRefusalReason | undefined {
-  if (!samePath(observation.path, request.expectedPath)) {
+  if (!samePath(observation.path, request.expectedPath, platform)) {
     return "path_changed";
   }
   if (observation.branch !== request.expectedBranch) {
@@ -1021,11 +1066,12 @@ function worktreeRemovalRefusalError(input: {
   canonicalPath: string;
   observedBranch: string;
   refusalReason: WorktreeRemovalRefusalReason;
+  platform: NodeJS.Platform;
 }): WorktrunkProviderError {
   const detail: WorktreeRemovalRefusalDiagnosticDetail = {
     type: "worktree_removal_refusal",
     worktreeId: input.request.worktreeId,
-    canonicalPath: canonicalPathForComparison(input.canonicalPath),
+    canonicalPath: normalizeObservedPath(input.canonicalPath, input.platform),
     observedBranch: input.observedBranch,
     refusalReason: input.refusalReason,
     provider: "worktrunk",
@@ -1072,14 +1118,6 @@ async function nativeGitRegistrationIdentity(worktreePath: string): Promise<stri
   } catch {
     return undefined;
   }
-}
-
-function canonicalPathForComparison(path: string): string {
-  const normalized = normalize(path);
-  if (normalized.startsWith("/private/var/")) {
-    return normalized.slice("/private".length);
-  }
-  return normalized;
 }
 
 function shellQuote(value: string): string {

--- a/integrations/worktree/worktrunk/src/types.ts
+++ b/integrations/worktree/worktrunk/src/types.ts
@@ -69,4 +69,6 @@ export type WorktrunkProviderOptions = {
   runner?: ExternalCommandRunner;
   clock?: RuntimeClock;
   resolveRegistrationIdentity?: (worktreePath: string) => Promise<string | undefined>;
+  /** Platform authority for interpreting OS-specific observed path aliases. */
+  platform?: NodeJS.Platform;
 };

--- a/integrations/worktree/worktrunk/test/unit/parse.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/parse.test.ts
@@ -242,35 +242,41 @@ describe("Worktrunk list parser", () => {
     });
   });
 
-  it("keeps hashed worktree IDs stable across macOS /var aliases", () => {
+  it("derives fallback IDs from platform-authorized aliases while retaining raw paths", () => {
     const branch = "station/very-long-customer-account-permissions-rollout-for-enterprise-alpha";
-    const varObservation = parseWorktrunkListJson(
-      JSON.stringify([
-        {
-          path: "/var/folders/test/station/repo/.station-real-e2e/worktrees/feature",
-          branch,
-        },
-      ]),
-      {
-        project,
-        observedAt: now,
-      },
-    )[0];
-    const privateVarObservation = parseWorktrunkListJson(
-      JSON.stringify([
-        {
-          path: "/private/var/folders/test/station/repo/.station-real-e2e/worktrees/feature",
-          branch,
-        },
-      ]),
-      {
-        project,
-        observedAt: now,
-      },
-    )[0];
+    const observation = (path: string, platform: NodeJS.Platform, worktreeId?: string) =>
+      parseWorktrunkListJson(
+        JSON.stringify([
+          {
+            path,
+            branch,
+            ...(worktreeId === undefined ? {} : { vars: { station: { worktree_id: worktreeId } } }),
+          },
+        ]),
+        { project, observedAt: now, platform },
+      )[0];
+    const tmpPath = "/tmp/station/repo/worktrees/feature";
+    const privateTmpPath = "/private/tmp/station/repo/worktrees/feature";
+    const logicalTmp = observation(tmpPath, "darwin");
+    const physicalTmp = observation(privateTmpPath, "darwin");
+    const linuxPhysicalTmp = observation(privateTmpPath, "linux");
+    const varObservation = observation("/var/folders/test/station/repo/worktrees/feature", "linux");
+    const privateVarObservation = observation(
+      "/private/var/folders/test/station/repo/worktrees/feature",
+      "linux",
+    );
 
+    expect(logicalTmp?.id).toBe(physicalTmp?.id);
+    expect(logicalTmp?.id).not.toBe(linuxPhysicalTmp?.id);
+    expect([logicalTmp?.path, physicalTmp?.path]).toEqual([tmpPath, privateTmpPath]);
+    const whitespaceTmp = observation(`${tmpPath} `, "darwin");
+    expect(whitespaceTmp?.id).not.toBe(logicalTmp?.id);
+    expect(whitespaceTmp?.path).toBe(`${tmpPath} `);
     expect(varObservation?.id).toBe(privateVarObservation?.id);
     expect(varObservation?.id).toMatch(/^wt_web_feature_[a-f0-9]{10}$/);
+    expect(observation(privateTmpPath, "linux", "wt_provider_feature")?.id).toBe(
+      "wt_provider_feature",
+    );
   });
 
   it("rejects non-JSON output with a typed provider error", () => {

--- a/integrations/worktree/worktrunk/test/unit/provider.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/provider.test.ts
@@ -4,7 +4,11 @@ import { join } from "node:path";
 import type { ProviderProjectConfig } from "@station/contracts";
 import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
 import { gitLocalEnvironmentVariables, nodeExternalCommandRunner } from "@station/runtime";
-import { WorktrunkProvider, type WorktrunkProviderOptions } from "@station/worktrunk";
+import {
+  parseWorktrunkListJson,
+  WorktrunkProvider,
+  type WorktrunkProviderOptions,
+} from "@station/worktrunk";
 import { describe, expect, it } from "vitest";
 
 const now = "2026-05-21T12:00:00.000Z";
@@ -23,12 +27,31 @@ const project: ProviderProjectConfig = {
     base: "main",
   },
 };
+const tmpProject: ProviderProjectConfig = {
+  ...project,
+  worktrunk: {
+    ...project.worktrunk,
+    managedRoot: ".worktrees",
+    includeMain: false,
+    includeExternal: false,
+  },
+};
 
 function testProvider(options: WorktrunkProviderOptions): WorktrunkProvider {
   return new WorktrunkProvider({
     resolveRegistrationIdentity: async (path) => `git-registration:${path}`,
     ...options,
   });
+}
+
+function removalRequest(worktreeId: string, expectedPath: string, expectedBranch: string) {
+  return {
+    project: tmpProject,
+    worktreeId,
+    expectedPath,
+    expectedBranch,
+    expectedRegistrationIdentity: "git-registration:native-marker",
+  };
 }
 
 describe("WorktrunkProvider", () => {
@@ -169,6 +192,119 @@ describe("WorktrunkProvider", () => {
         branch: "feature",
       }),
     ]);
+  });
+
+  it("keeps Darwin create, physical list, and raw removal identity inside the managed root", async () => {
+    const calls: ExternalCommandInput[] = [];
+    const logical = "/tmp/station/web/.worktrees/feature";
+    const physical = "/private/tmp/station/web/.worktrees/feature";
+    let listCount = 0;
+    const provider = testProvider({
+      platform: "darwin",
+      resolveRegistrationIdentity: async () => "git-registration:native-marker",
+      runner: async (input) => {
+        calls.push(input);
+        if (input.args?.includes("remove")) return result(input, "{}");
+        const rows = input.args?.includes("switch")
+          ? [{ path: logical, branch: "feature" }]
+          : listCount++ === 0
+            ? [{ path: project.root, branch: "main", is_main: true }]
+            : [{ path: physical, branch: "feature" }];
+        return result(input, JSON.stringify(rows));
+      },
+    });
+    const created = await provider.createWorktree({ project: tmpProject, branch: "feature" });
+    const [listed] = await provider.listWorktrees(tmpProject);
+    expect(created.path).toBe(logical);
+    expect(listed).toMatchObject({
+      id: created.id,
+      path: physical,
+      registrationIdentity: created.registrationIdentity,
+    });
+    await provider.removeWorktree(removalRequest(created.id, created.path, created.branch));
+    expect(calls.find((call) => call.args?.includes("remove"))?.args).toEqual([
+      "-C",
+      physical,
+      "remove",
+      "--format=json",
+    ]);
+  });
+
+  it("rejects unsafe, non-Darwin, and physical-main rows at provider boundaries", async () => {
+    const calls: ExternalCommandInput[] = [];
+    const resolvedPaths: string[] = [];
+    const unsafeRows = [
+      { path: "/private/tmp/station/web/.worktrees ", branch: "whitespace" },
+      { path: "/private/tmp/station/web/.worktrees/link/../feature", branch: "dot" },
+    ];
+    const provider = testProvider({
+      platform: "darwin",
+      resolveRegistrationIdentity: async (path) => {
+        resolvedPaths.push(path);
+        return "git-registration:native-marker";
+      },
+      runner: async (input) => {
+        calls.push(input);
+        return result(input, JSON.stringify(unsafeRows));
+      },
+    });
+    const unsafe = parseWorktrunkListJson(JSON.stringify(unsafeRows), {
+      project,
+      observedAt: now,
+      platform: "darwin",
+    });
+    await expect(provider.listWorktrees(tmpProject)).resolves.toEqual([]);
+    expect(resolvedPaths).toEqual([unsafeRows[0]?.path]);
+    calls.length = 0;
+    await expect(
+      provider.removeWorktree(
+        removalRequest(unsafe[0]?.id ?? "wt_missing", "/tmp/station/web/.worktrees", "whitespace"),
+      ),
+    ).rejects.toMatchObject({ code: "WORKTRUNK_WORKTREE_CHANGED" });
+    expect(calls.some((call) => call.args?.includes("remove"))).toBe(false);
+    calls.length = 0;
+    await expect(
+      provider.removeWorktree(
+        removalRequest(unsafe[1]?.id ?? "wt_missing", unsafeRows[1]?.path ?? "missing", "dot"),
+      ),
+    ).rejects.toMatchObject({ code: "WORKTRUNK_WORKTREE_CHANGED" });
+    expect(calls).toEqual([]);
+
+    const rows = JSON.stringify([
+      { path: "/private/tmp/station/web", branch: "main" },
+      { path: "/private/tmp/station/web/.worktrees/feature", branch: "feature" },
+    ]);
+    const read = (platform: NodeJS.Platform, target = tmpProject) =>
+      testProvider({ platform, runner: async (input) => result(input, rows) }).listWorktrees(
+        target,
+      );
+    await expect(read("linux")).resolves.toEqual([]);
+    await expect(
+      read("darwin", {
+        ...project,
+        worktrunk: { ...project.worktrunk, includeMain: false, includeExternal: true },
+      }),
+    ).resolves.toEqual([expect.objectContaining({ branch: "feature" })]);
+  });
+
+  it("does not resolve registration identity for unsafe create output", async () => {
+    let resolutions = 0;
+    const provider = testProvider({
+      platform: "darwin",
+      resolveRegistrationIdentity: async () => {
+        resolutions += 1;
+        return "unexpected";
+      },
+      runner: async (input) =>
+        result(
+          input,
+          '[{"path":"relative/feature","branch":"feature"},{"path":"/private/tmp/root/link/../feature","branch":"feature"}]',
+        ),
+    });
+    await expect(provider.createWorktree({ project, branch: "feature" })).rejects.toMatchObject({
+      code: "WORKTRUNK_INVALID_OUTPUT",
+    });
+    expect(resolutions).toBe(0);
   });
 
   it("keeps managed roots authoritative over Worktrunk project path templates", async () => {

--- a/packages/contracts/src/harnessTerminalBinding.ts
+++ b/packages/contracts/src/harnessTerminalBinding.ts
@@ -1,4 +1,3 @@
-import { normalize } from "node:path";
 import { z } from "zod";
 import { ProviderIdSchema } from "./ids.js";
 import type {
@@ -6,6 +5,7 @@ import type {
   TerminalTargetObservation,
   WorktreeObservation,
 } from "./observations.js";
+import { observedPathIsSameOrInside, sameObservedPath } from "./observedPaths.js";
 import type { HarnessDiscoveryContext } from "./providers.js";
 
 const nonEmptyStringSchema = z.string().min(1);
@@ -171,28 +171,4 @@ export function discoverTerminalBoundHarnessRuns(
     );
   }
   return runs;
-}
-
-export function observedPathIsSameOrInside(candidate: string, root: string): boolean {
-  const normalizedCandidate = normalizeObservedPath(candidate);
-  const normalizedRoot = normalizeObservedPath(root);
-  if (normalizedCandidate === normalizedRoot) {
-    return true;
-  }
-  if (normalizedRoot === "/") {
-    return normalizedCandidate.startsWith("/");
-  }
-  return normalizedCandidate.startsWith(`${normalizedRoot}/`);
-}
-
-export function sameObservedPath(left: string, right: string): boolean {
-  return normalizeObservedPath(left) === normalizeObservedPath(right);
-}
-
-export function normalizeObservedPath(value: string): string {
-  const normalized = normalize(value.trim());
-  const withoutTrailingSlash = normalized.length > 1 ? normalized.replace(/\/+$/g, "") : normalized;
-  return withoutTrailingSlash.startsWith("/private/var/")
-    ? `/var/${withoutTrailingSlash.slice("/private/var/".length)}`
-    : withoutTrailingSlash;
 }

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -20,6 +20,7 @@ export * from "./ids.js";
 export * from "./liveness.js";
 export * from "./logging.js";
 export * from "./observations.js";
+export * from "./observedPaths.js";
 export * from "./observer.js";
 export * from "./providerHooks.js";
 export * from "./providers.js";

--- a/packages/contracts/src/observedPaths.ts
+++ b/packages/contracts/src/observedPaths.ts
@@ -1,0 +1,68 @@
+import { normalize } from "node:path";
+
+/** Applies only known OS path aliases and refuses ambiguous lexical dot segments. */
+export function applyObservedPathAliases(
+  value: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (observedPathHasLexicalDotSegments(value)) {
+    return value;
+  }
+  if (value.startsWith("/private/var/")) {
+    return `/var/${value.slice("/private/var/".length)}`;
+  }
+  if (platform === "darwin" && (value === "/private/tmp" || value.startsWith("/private/tmp/"))) {
+    return `/tmp${value.slice("/private/tmp".length)}`;
+  }
+  return value;
+}
+
+/** Detects lexical dot segments that make destructive and recovery comparisons fail closed. */
+export function observedPathHasLexicalDotSegments(value: string): boolean {
+  return value.split("/").some((segment) => segment === "." || segment === "..");
+}
+
+export function normalizeObservedPath(
+  value: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const normalized = normalize(value);
+  const withoutTrailingSlash = normalized.length > 1 ? normalized.replace(/\/+$/g, "") : normalized;
+  return applyObservedPathAliases(withoutTrailingSlash, platform);
+}
+
+/**
+ * POLICY
+ *
+ * Treats provider-observed paths as identical only when their authorized aliases and lexical safety rules agree.
+ */
+export function sameObservedPath(
+  left: string,
+  right: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if ([left, right].some(observedPathHasLexicalDotSegments)) return false;
+  return normalizeObservedPath(left, platform) === normalizeObservedPath(right, platform);
+}
+
+/**
+ * POLICY
+ *
+ * Determines managed-path containment using the same authorized alias and lexical-safety identity as equality checks.
+ */
+export function observedPathIsSameOrInside(
+  candidate: string,
+  root: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if ([candidate, root].some(observedPathHasLexicalDotSegments)) return false;
+  const normalizedCandidate = normalizeObservedPath(candidate, platform);
+  const normalizedRoot = normalizeObservedPath(root, platform);
+  if (normalizedCandidate === normalizedRoot) {
+    return true;
+  }
+  if (normalizedRoot === "/") {
+    return normalizedCandidate.startsWith("/");
+  }
+  return normalizedCandidate.startsWith(`${normalizedRoot}/`);
+}

--- a/packages/contracts/test/unit/observedPaths.test.ts
+++ b/packages/contracts/test/unit/observedPaths.test.ts
@@ -1,0 +1,60 @@
+import {
+  applyObservedPathAliases,
+  normalizeObservedPath,
+  observedPathIsSameOrInside,
+  sameObservedPath,
+} from "@station/contracts";
+import { describe, expect, it } from "vitest";
+
+describe("observed path identity", () => {
+  it("applies Darwin temporary aliases without weakening component boundaries", () => {
+    expect([
+      sameObservedPath("/tmp", "/private/tmp", "darwin"),
+      sameObservedPath("/tmp/root/task", "/private/tmp/root/task", "darwin"),
+      sameObservedPath("/tmp/root/task", "/private/tmp/root/task", "linux"),
+      normalizeObservedPath("/private/tmp-sibling/task", "darwin"),
+      observedPathIsSameOrInside("/private/tmp/root/task", "/tmp/root", "darwin"),
+      observedPathIsSameOrInside("/private/tmp/root-sibling/task", "/tmp/root", "darwin"),
+      observedPathIsSameOrInside("/private/tmp-sibling/root/task", "/tmp/root", "darwin"),
+      observedPathIsSameOrInside("private/tmp/root/task", "/tmp/root", "darwin"),
+    ]).toEqual([true, true, false, "/private/tmp-sibling/task", true, false, false, false]);
+  });
+
+  it("rejects same- and cross-spelling dot segments before comparison", () => {
+    expect(applyObservedPathAliases("/private/tmp/root/../escape", "darwin")).toBe(
+      "/private/tmp/root/../escape",
+    );
+    expect(normalizeObservedPath("/private/tmp/root/../escape", "darwin")).toBe("/tmp/escape");
+    for (const [candidate, root] of [
+      ["/tmp/root/../escape", "/tmp/escape"],
+      ["/tmp/root/../escape", "/private/tmp/root"],
+      ["/private/tmp/root", "/tmp/root/../escape"],
+      ["/tmp/root/./task", "/tmp/root/task"],
+      ["/tmp/root/./task", "/private/tmp/root/task"],
+      ["/private/tmp/root/task", "/tmp/root/./task"],
+    ]) {
+      expect(sameObservedPath(candidate, root, "darwin")).toBe(false);
+      expect(observedPathIsSameOrInside(candidate, root, "darwin")).toBe(false);
+    }
+  });
+
+  it("preserves POSIX whitespace as observed identity", () => {
+    for (const suffix of [" ", "\t", "\n"]) {
+      const path = `/private/tmp/root/feature${suffix}`;
+      expect(normalizeObservedPath(path, "darwin")).toBe(`/tmp/root/feature${suffix}`);
+      expect(sameObservedPath(path, "/tmp/root/feature", "darwin")).toBe(false);
+    }
+  });
+
+  it("preserves /private/var identity and ordinary paths on every platform", () => {
+    const platforms = ["darwin", "linux"] satisfies NodeJS.Platform[];
+    expect(platforms.map((p) => sameObservedPath("/var/task", "/private/var/task", p))).toEqual([
+      true,
+      true,
+    ]);
+    expect(platforms.map((p) => normalizeObservedPath("/home/task", p))).toEqual([
+      "/home/task",
+      "/home/task",
+    ]);
+  });
+});

--- a/packages/runtime/src/paths.ts
+++ b/packages/runtime/src/paths.ts
@@ -1,28 +1,34 @@
 import { homedir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
+import {
+  applyObservedPathAliases,
+  observedPathIsSameOrInside,
+  sameObservedPath,
+} from "@station/contracts";
 
-export function pathIsSame(candidate: string, root: string): boolean {
-  return normalizeLocalPath(candidate) === normalizeLocalPath(root);
+export function pathIsSame(
+  candidate: string,
+  root: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return sameObservedPath(candidate, root, platform);
 }
 
-export function pathIsSameOrInside(candidate: string, root: string): boolean {
-  const normalizedCandidate = normalizeLocalPath(candidate);
-  const normalizedRoot = normalizeLocalPath(root);
-  if (normalizedCandidate === normalizedRoot) {
-    return true;
-  }
-  if (normalizedRoot === "/") {
-    return normalizedCandidate.startsWith("/");
-  }
-  return normalizedCandidate.startsWith(`${normalizedRoot}/`);
+export function pathIsSameOrInside(
+  candidate: string,
+  root: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return observedPathIsSameOrInside(candidate, root, platform);
 }
 
-export function normalizeLocalPath(value: string): string {
+export function normalizeLocalPath(
+  value: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
   const trimmed = value.trim();
   const withoutTrailingSlash = trimmed.length > 1 ? trimmed.replace(/\/+$/g, "") : trimmed;
-  return withoutTrailingSlash.startsWith("/private/var/")
-    ? `/var/${withoutTrailingSlash.slice("/private/var/".length)}`
-    : withoutTrailingSlash;
+  return applyObservedPathAliases(withoutTrailingSlash, platform);
 }
 
 export function resolveLocalPath(

--- a/packages/runtime/test/unit/paths.test.ts
+++ b/packages/runtime/test/unit/paths.test.ts
@@ -1,0 +1,47 @@
+import { normalizeLocalPath, pathIsSame, pathIsSameOrInside } from "@station/runtime";
+import { describe, expect, it } from "vitest";
+
+describe("local path identity", () => {
+  it("applies only authorized aliases and preserves ordinary input shaping", () => {
+    expect([
+      pathIsSame("/tmp/root", "/private/tmp/root", "darwin"),
+      pathIsSame("/tmp/root", "/private/tmp/root", "linux"),
+      pathIsSame("/var/folders/task", "/private/var/folders/task", "linux"),
+      normalizeLocalPath("/private/tmp-sibling/root", "darwin"),
+      pathIsSameOrInside("/private/tmp/root/task", "/tmp/root", "darwin"),
+      normalizeLocalPath("/home/station/task/", "linux"),
+      normalizeLocalPath(" /home/station/task\t", "linux"),
+    ]).toEqual([
+      true,
+      false,
+      true,
+      "/private/tmp-sibling/root",
+      true,
+      "/home/station/task",
+      "/home/station/task",
+    ]);
+  });
+
+  it("rejects same- and cross-spelling dot segments before comparison", () => {
+    const physicalDotted = "/private/tmp/root/../escape";
+    expect(normalizeLocalPath(physicalDotted, "darwin")).toBe(physicalDotted);
+    for (const [candidate, root] of [
+      [physicalDotted, "/private/tmp/escape"],
+      ["/tmp/root/../escape", "/private/tmp/root"],
+      ["/private/tmp/root", "/tmp/root/../escape"],
+      ["/tmp/root/./task", "/tmp/root/task"],
+      ["/tmp/root/./task", "/private/tmp/root/task"],
+      ["/private/tmp/root/task", "/tmp/root/./task"],
+    ]) {
+      expect(pathIsSame(candidate, root, "darwin")).toBe(false);
+      expect(pathIsSameOrInside(candidate, root, "darwin")).toBe(false);
+    }
+  });
+
+  it("keeps observed POSIX whitespace siblings distinct", () => {
+    for (const suffix of [" ", "\t", "\n"]) {
+      expect(pathIsSame(`/tmp/root${suffix}`, "/tmp/root", "darwin")).toBe(false);
+      expect(pathIsSameOrInside(`/tmp/root${suffix}`, "/tmp/root", "darwin")).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## What this fixes

On Darwin, Worktrunk can report a `/tmp` worktree through the physical `/private/tmp` spelling. Station previously treated those observations as different, so managed-root filtering dropped valid worktrees and create/list fallback IDs diverged. This change gives create, list, correlation, recovery checks, and removal one provider-neutral observed-path identity while preserving raw Worktrunk paths for command authority.

## What changed

- Added the shared deterministic observed-path policy for Darwin `/tmp` ↔ `/private/tmp` aliases, existing `/private/var` behavior, whitespace identity, and fail-closed dot segments.
- Applied the policy to runtime path identity and Worktrunk parsing, managed-root filtering, create/list IDs, and guarded removal revalidation.
- Kept non-Darwin behavior, component boundaries, external-worktree filtering, and raw provider paths unchanged.
- Added causal contract, runtime, parser, and provider coverage; regenerated the required source-derived architecture manifest for the two `POLICY` exports.
- Temporary real-acceptance instrumentation is absent from the final diff; #735 click-away behavior and #712 recovery behavior are not claimed here.

## Testing

- 56 focused tests passed (172 expectations).
- `typecheck` passed (46 tasks); full lint and architecture check passed.
- Full deterministic suite passed with the expected Bun 1.4.0 and interactive TERM environment: 3,205 unit tests, 187 contract tests, 873 integration tests, 184 diagnostics tests, 5 scripted-agent tests, 30 setup-E2E tests, 27 observer-E2E tests, and install smoke.
- Isolated macOS native/tmux acceptance passed: command/result/reconciled native row IDs converged, physical Worktrunk `/private/tmp` was observed, registration and live Codex sentinel were verified, and exact cleanup completed with no failures.

## Safety and scope

The issue-approved 11 handwritten files remain the only production/test scope; the generated manifest is the sole required derived artifact added by the `POLICY` markers, as recorded on #736. The native acceptance evidence is retained locally at `/tmp/station-736-native.PF56yj/station-736-native-acceptance.json` with `phase=cleanup-proven` and `failures=[]`.

Closes #736.