### PR TITLE
feat(tui): add semantic scrollbars to Help and dashboard

### DIFF
--- a/packages/dashboard-core/src/components/Dashboard/content.ts
+++ b/packages/dashboard-core/src/components/Dashboard/content.ts
@@ -116,9 +116,13 @@ export function scrollIndicatorLabel(
   overflow: DashboardSessionOverflow,
 ): string {
   if (direction === "above") {
-    return `▲ ${overflow.above} ${plural(overflow.above, "session")} above`;
+    return overflow.above > 0
+      ? `▲ ${overflow.above} ${plural(overflow.above, "session")} above`
+      : "▲ more above";
   }
-  return `▼ ${overflow.below} below · showing ${overflow.visible} of ${overflow.total}`;
+  return overflow.below > 0
+    ? `▼ ${overflow.below} below · showing ${overflow.visible} of ${overflow.total}`
+    : "▼ more below";
 }
 
 export type SnapshotLoadingContent =

--- a/packages/dashboard-core/src/components/Dashboard/tableHeader.ts
+++ b/packages/dashboard-core/src/components/Dashboard/tableHeader.ts
@@ -43,11 +43,13 @@ export type DashboardTableHeaderModel =
 export function dashboardTableHeaderModel({
   layout,
   overflow,
+  hasSemanticRowsAbove,
   columns,
   persistentFilter,
 }: {
   layout: RowGridLayout | undefined;
   overflow: DashboardSessionOverflow;
+  hasSemanticRowsAbove: boolean;
   columns: number;
   persistentFilter?: DashboardPersistentFilterProjection;
 }): DashboardTableHeaderModel | undefined {
@@ -61,8 +63,8 @@ export function dashboardTableHeaderModel({
       }),
     };
   }
-  // The position cue owns the shared row whenever sessions are hidden above.
-  if (overflow.above > 0) {
+  // The position cue owns the shared row whenever semantic content is hidden above.
+  if (hasSemanticRowsAbove) {
     return { kind: "aboveOverflow", overflow };
   }
   if (layout !== undefined) {

--- a/packages/dashboard-core/src/entrypoints/selectors.ts
+++ b/packages/dashboard-core/src/entrypoints/selectors.ts
@@ -99,10 +99,7 @@ export {
   selectDashboardSessionRows,
   sessionRowDisplayTitle,
 } from "../selectors/dashboardSessionRows.js";
-export type {
-  DashboardSessionOverflow,
-  DashboardSlots,
-} from "../selectors/dashboardSlots.js";
+export type { DashboardSessionOverflow, DashboardSlots } from "../selectors/dashboardSlots.js";
 export {
   selectDashboardSlots,
   selectDashboardSlotsForTree,

--- a/packages/dashboard-core/src/selectors/dashboardSlots.ts
+++ b/packages/dashboard-core/src/selectors/dashboardSlots.ts
@@ -35,6 +35,7 @@ export type DashboardSlots = {
   readonly rowChoices: readonly KeyedChoice<DashboardSessionRow>[];
   readonly displayRowChoices: readonly SelectionChoice<DashboardSessionRow>[];
   readonly sessionOverflow: DashboardSessionOverflow;
+  readonly semanticOverflow: { readonly above: boolean; readonly below: boolean };
   readonly persistentFilter?: DashboardPersistentFilterProjection;
 };
 
@@ -70,6 +71,7 @@ export function selectDashboardSlotsForTree(
     ),
     displayRowChoices,
     sessionOverflow: sessionOverflow(tree.visibleRows, rows),
+    semanticOverflow: semanticOverflow(tree.visibleRows, rows),
     ...(tree.persistentFilter === undefined ? {} : { persistentFilter: tree.persistentFilter }),
   };
 }
@@ -105,6 +107,17 @@ function sessionOverflow(
   const above = countSessionItems(allRows.slice(0, Math.max(0, first)));
   const below = countSessionItems(allRows.slice(last + 1));
   return { above, below, visible, total };
+}
+
+function semanticOverflow(
+  allRows: readonly DashboardTreeRow[],
+  visibleRows: readonly DashboardTreeRow[],
+): DashboardSlots["semanticOverflow"] {
+  if (visibleRows.length === 0) return { above: false, below: false };
+  return {
+    above: visibleRows[0]?.id !== allRows[0]?.id,
+    below: visibleRows.at(-1)?.id !== allRows.at(-1)?.id,
+  };
 }
 
 function countSessionItems(rows: readonly DashboardTreeRow[]): number {

--- a/packages/dashboard-core/test/unit/components/dashboardHeaderLine.test.ts
+++ b/packages/dashboard-core/test/unit/components/dashboardHeaderLine.test.ts
@@ -3,6 +3,7 @@ import {
   fleetCountsLabel,
   headerStrip,
   projectHeaderLabelParts,
+  scrollIndicatorLabel,
 } from "../../../src/components/Dashboard/content.js";
 import { createGroupedDashboardSnapshot } from "../../fixtures/snapshots.js";
 
@@ -56,6 +57,14 @@ describe("fleetCountsLabel", () => {
     expect(fleetCountsLabel({ projects: 1, sessions: 1, agents: 1 }, 60)).toBe(
       "1 project · 1 session · 1 agent",
     );
+  });
+});
+
+describe("scrollIndicatorLabel", () => {
+  it("falls back to structural continuation without inventing a session count", () => {
+    const overflow = { above: 0, below: 0, visible: 4, total: 4 };
+    expect(scrollIndicatorLabel("above", overflow)).toBe("▲ more above");
+    expect(scrollIndicatorLabel("below", overflow)).toBe("▼ more below");
   });
 });
 

--- a/packages/dashboard-core/test/unit/components/dashboardTableHeader.test.ts
+++ b/packages/dashboard-core/test/unit/components/dashboardTableHeader.test.ts
@@ -45,6 +45,7 @@ describe("dashboard table header model", () => {
     const model = dashboardTableHeaderModel({
       layout: HEADER_LAYOUT,
       overflow: { ...NO_OVERFLOW, above: 2 },
+      hasSemanticRowsAbove: true,
       columns: 80,
       persistentFilter: projection(),
     });
@@ -55,15 +56,24 @@ describe("dashboard table header model", () => {
   it("gives above overflow precedence over the available column layout", () => {
     const overflow = { ...NO_OVERFLOW, above: 2, total: 6 };
 
-    expect(dashboardTableHeaderModel({ layout: HEADER_LAYOUT, overflow, columns: 80 })).toEqual({
-      kind: "aboveOverflow",
-      overflow,
-    });
+    expect(
+      dashboardTableHeaderModel({
+        layout: HEADER_LAYOUT,
+        overflow,
+        hasSemanticRowsAbove: true,
+        columns: 80,
+      }),
+    ).toEqual({ kind: "aboveOverflow", overflow });
   });
 
   it("uses column headers when the viewport is at the top", () => {
     expect(
-      dashboardTableHeaderModel({ layout: HEADER_LAYOUT, overflow: NO_OVERFLOW, columns: 80 }),
+      dashboardTableHeaderModel({
+        layout: HEADER_LAYOUT,
+        overflow: NO_OVERFLOW,
+        hasSemanticRowsAbove: false,
+        columns: 80,
+      }),
     ).toEqual({
       kind: "columns",
       layout: HEADER_LAYOUT,
@@ -72,7 +82,12 @@ describe("dashboard table header model", () => {
 
   it("omits the header when no semantic header content exists", () => {
     expect(
-      dashboardTableHeaderModel({ layout: undefined, overflow: NO_OVERFLOW, columns: 80 }),
+      dashboardTableHeaderModel({
+        layout: undefined,
+        overflow: NO_OVERFLOW,
+        hasSemanticRowsAbove: false,
+        columns: 80,
+      }),
     ).toBeUndefined();
   });
 });

--- a/packages/dashboard-core/test/unit/selectors/dashboardSlots.test.ts
+++ b/packages/dashboard-core/test/unit/selectors/dashboardSlots.test.ts
@@ -6,6 +6,7 @@ import {
 import { dashboardRowIds, selectDashboardTree } from "../../../src/selectors/dashboardTree.js";
 import { createInitialTuiState } from "../../../src/state/screen.js";
 import {
+  createCommandSnapshot,
   createDashboardSnapshot,
   createGroupedDashboardSnapshot,
 } from "../../fixtures/snapshots.js";
@@ -128,6 +129,18 @@ describe("dashboard semantic slots", () => {
     expect(slots.sessionOverflow).toEqual({ above: 2, below: 3, visible: 2, total: 7 });
   });
 
+  it("retains structural overflow after the final visible session", () => {
+    const snapshot = createCommandSnapshot();
+    const state = createInitialTuiState({ initialSnapshot: snapshot });
+    const slots = selectDashboardSlots(snapshot, state, state.screen, [
+      dashboardRowIds.project("web"),
+      dashboardRowIds.session("ses_wt_web_idle"),
+    ]);
+
+    expect(slots.sessionOverflow.below).toBe(0);
+    expect(slots.semanticOverflow).toEqual({ above: false, below: true });
+  });
+
   it("uses the full semantic projection until a renderer reports visibility", () => {
     const snapshot = createDashboardSnapshot();
     const state = createInitialTuiState({ initialSnapshot: snapshot });
@@ -135,6 +148,7 @@ describe("dashboard semantic slots", () => {
 
     expect(slots.rowChoices).toHaveLength(7);
     expect(slots.sessionOverflow).toEqual({ above: 0, below: 0, visible: 7, total: 7 });
+    expect(slots.semanticOverflow).toEqual({ above: false, below: false });
   });
 
   it("keeps a measured empty viewport distinct from unmeasured visibility", () => {
@@ -145,6 +159,7 @@ describe("dashboard semantic slots", () => {
     expect(slots.rowChoices).toEqual([]);
     expect(slots.displayRowChoices).toEqual([]);
     expect(slots.sessionOverflow).toEqual({ above: 0, below: 7, visible: 0, total: 7 });
+    expect(slots.semanticOverflow).toEqual({ above: false, below: false });
   });
 
   it("passes through applied filter projection without fabricating layout nodes", () => {

--- a/station/src/app/StationApp.test.tsx
+++ b/station/src/app/StationApp.test.tsx
@@ -62,7 +62,7 @@ describe("Station app composition", () => {
     await waitFor(() => overlayVisible(station));
     const frame = await waitForFrame(
       station,
-      (candidate) => candidate.includes("FLEET") && candidate.includes("showing 5 of 10"),
+      (candidate) => candidate.includes("FLEET") && candidate.includes("showing 6 of 10"),
     );
 
     expect(frame).not.toContain(STATION_ICON);
@@ -85,7 +85,7 @@ describe("Station app composition", () => {
     await waitFor(() => overlayVisible(station));
     const frame = await waitForFrame(
       station,
-      (candidate) => candidate.includes("FLEET") && candidate.includes("showing 2 of 10"),
+      (candidate) => candidate.includes("FLEET") && candidate.includes("showing 3 of 10"),
     );
 
     expect(frame).not.toContain(STATION_ICON);

--- a/station/src/app/__snapshots__/StationApp.test.tsx.snap
+++ b/station/src/app/__snapshots__/StationApp.test.tsx.snap
@@ -11,16 +11,16 @@ exports[`Station app composition keeps the floating Station control out of the o
 │                   │FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1         │                   │
 │                   │───────────────────────────────────────────────────────── │                   │
 │                   │       SESSION               AGENT     STATUS          PR │                   │
-│                   │ ▼ station  5 sessions · 4 agents           [sh] [qs] [▾] │                   │
-│                   │ [1] ○ cli-help-man          codex     idle         #70 ✓ │                   │
-│                   │ [2] - docs-cleanup          codex     no agent           │                   │
-│                   │ [3] ○ pty-buffer            codex     idle         #73 ✓ │                   │
-│                   │ [4] + session-resume        codex     starting           │                   │
-│                   │ [5] ⠋ station-overlay       codex     working      #76 … │                   │
-│                   │                                                          │                   │
-│                   │ ▼ observer  3 sessions · 3 agents          [sh] [qs] [▾] │                   │
-│                   │▼ 5 below · showing 5 of 10                               │                   │
-│                   │───────────────────────────────────────────────────────── │                   │
+│                   │ ▼ station  5 sessions · 4 agents           [sh] [qs] [▾]▲│                   │
+│                   │ [1] ○ cli-help-man          codex     idle         #70 ✓▐│                   │
+│                   │ [2] - docs-cleanup          codex     no agent          ▐│                   │
+│                   │ [3] ○ pty-buffer            codex     idle         #73 ✓▐│                   │
+│                   │ [4] + session-resume        codex     starting          ▐│                   │
+│                   │ [5] ⠋ station-overlay       codex     working      #76 …▕│                   │
+│                   │                                                         ▕│                   │
+│                   │ ▼ observer  3 sessions · 3 agents          [sh] [qs] [▾]▕│                   │
+│                   │ [6] x batch-export          opencode  exited        #8 ✓▼│                   │
+│                   │── ▼ 4 below · showing 6 of 10 ────────────────────────── │                   │
 │                   │↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q… │                   │
 │                   └──────────────────────────────────────────────────────────┘                   │
 │                                                                                                  │
@@ -38,11 +38,11 @@ exports[`Station app composition keeps the native overlay unobscured in a 40x12 
 │FLEET  ● 0 ready  ⠋ 2 working  ! 0    │
 │───────────────────────────────────── │
 │       SESSION           STATUS       │
-│ ▼ station  5 sessions  [sh] [qs] [▾] │
-│ [1] ○ cli-help-man      idle         │
-│ [2] - docs-cleanup      no agent     │
-│▼ 8 below · showing 2 of 10           │
-│───────────────────────────────────── │
+│ ▼ station  5 sessions  [sh] [qs] [▾]▲│
+│ [1] ○ cli-help-man      idle        ▐│
+│ [2] - docs-cleanup      no agent    ▕│
+│ [3] ○ pty-buffer        idle        ▼│
+│── ▼ 7 below · showing 3 of 10 ────── │
 │↵ activate  N new  ⇥ next  / filter … │
 └──────────────────────────────────────┘
 "

--- a/station/src/app/types.ts
+++ b/station/src/app/types.ts
@@ -13,7 +13,7 @@ import type { StationStore } from "../state/store.js";
 import type { StationClient } from "../sources/types.js";
 import type { AuxShellPlacement } from "../terminal/pty/auxShellPlacement.js";
 import type { ManagedTerminalAttacher } from "../terminal/pty/managedTerminalAttacher.js";
-import type { DashboardScrollController } from "../station/view/layout/scrollViewport.js";
+import type { DashboardScrollController } from "../station/view/layout/dashboardScrollController.js";
 import type { PtyRegistry } from "../terminal/registry/ptyRegistry.js";
 import type {
   StationTerminalProcess,

--- a/station/src/dashboardRenderer/FullscreenDashboard.tsx
+++ b/station/src/dashboardRenderer/FullscreenDashboard.tsx
@@ -14,7 +14,7 @@ import {
   type StationMouseDispatch,
 } from "../station/view/stationMouseContext.js";
 import { routeDashboardMouse } from "./dashboardMouse.js";
-import type { DashboardScrollController } from "../station/view/layout/scrollViewport.js";
+import type { DashboardScrollController } from "../station/view/layout/dashboardScrollController.js";
 
 type FullscreenDashboardInput = {
   state: DashboardStateSource;

--- a/station/src/dashboardRenderer/main.tsx
+++ b/station/src/dashboardRenderer/main.tsx
@@ -23,7 +23,7 @@ import { openExternalUrl } from "../openUrl.js";
 import { createStationClient } from "../sources/createStationClient.js";
 import { sanitizePastedText } from "../station/input/sequenceToTuiKey.js";
 import { stationHelpEntryOrder } from "../station/helpEntries.js";
-import { createDashboardScrollController } from "../station/view/layout/scrollViewport.js";
+import { createDashboardScrollController } from "../station/view/layout/dashboardScrollController.js";
 import {
   createStationThemeController,
   type StationThemeController,

--- a/station/src/input/keymap/stationBindings.ts
+++ b/station/src/input/keymap/stationBindings.ts
@@ -21,7 +21,7 @@ import {
 } from "../mouse.js";
 import { C0 } from "../../terminal/protocol/syntax.js";
 import { ARROW_KEYS } from "../../terminal/protocol/cursorKeys.js";
-import type { DashboardScrollController } from "../../station/view/layout/scrollViewport.js";
+import type { DashboardScrollController } from "../../station/view/layout/dashboardScrollController.js";
 
 type StationDashboardInput = {
   state: DashboardStateSource;

--- a/station/src/input/stationInput.ts
+++ b/station/src/input/stationInput.ts
@@ -13,7 +13,7 @@ import { sanitizePastedText } from "../station/input/sequenceToTuiKey.js";
 import { dispatchStationKey } from "../station/input/stationActions.js";
 import type { StationClientStateSource } from "@station/client";
 import type { DashboardActions, DashboardStateSource } from "@station/dashboard-core/runtime";
-import type { DashboardScrollController } from "../station/view/layout/scrollViewport.js";
+import type { DashboardScrollController } from "../station/view/layout/dashboardScrollController.js";
 import {
   routeKey,
   routeMouse,

--- a/station/src/station/StationOverlay.tsx
+++ b/station/src/station/StationOverlay.tsx
@@ -10,7 +10,7 @@ import { DashboardFrameTitle } from "./view/DashboardFrameTitle.js";
 import { DashboardRoot } from "./view/DashboardRoot.js";
 import { toOpenTuiColor, toOpenTuiOpaqueColor, useStationTheme } from "../theme/index.js";
 import { StationMouseProvider, type StationMouseDispatch } from "./view/stationMouseContext.js";
-import type { DashboardScrollController } from "./view/layout/scrollViewport.js";
+import type { DashboardScrollController } from "./view/layout/dashboardScrollController.js";
 
 export type StationOverlayProps = {
   /** Read-only dashboard state owned by the renderer composition. */

--- a/station/src/station/input/stationActions.ts
+++ b/station/src/station/input/stationActions.ts
@@ -3,7 +3,7 @@ import { selectDashboardSlots } from "@station/dashboard-core/selectors";
 import type { DashboardRowId } from "@station/dashboard-core/selectors";
 import type { TuiKey, TuiSemanticAction } from "@station/dashboard-core/state";
 import { sequenceToTuiKey } from "./sequenceToTuiKey.js";
-import type { DashboardScrollController } from "../view/layout/scrollViewport.js";
+import type { DashboardScrollController } from "../view/layout/dashboardScrollController.js";
 
 type DashboardKeyInput = {
   actions: Pick<DashboardActions, "handleKey">;

--- a/station/src/station/input/stationMouse.ts
+++ b/station/src/station/input/stationMouse.ts
@@ -29,7 +29,7 @@ import {
   dispatchRowSlot,
   dispatchStationAction,
 } from "./stationActions.js";
-import type { DashboardScrollController } from "../view/layout/scrollViewport.js";
+import type { DashboardScrollController } from "../view/layout/dashboardScrollController.js";
 
 /** Read/action surface required by the pointer router shared by both Station renderers. */
 export type DashboardMouseRuntime = {

--- a/station/src/station/store/dashboardRuntime.ts
+++ b/station/src/station/store/dashboardRuntime.ts
@@ -12,7 +12,7 @@ import { stationHelpEntryOrder } from "../helpEntries.js";
 import {
   createDashboardScrollController,
   type DashboardScrollController,
-} from "../view/layout/scrollViewport.js";
+} from "../view/layout/dashboardScrollController.js";
 
 export type StationDashboardRuntime = DashboardRuntime & {
   /** Canonical snapshot/connection authority paired with this dashboard projection. */

--- a/station/src/station/test/support/makeStationTestRuntime.ts
+++ b/station/src/station/test/support/makeStationTestRuntime.ts
@@ -21,7 +21,7 @@ import { FakeTuiObserverService } from "./fakeObserverService.js";
 import {
   createDashboardScrollController,
   type DashboardScrollController,
-} from "../../view/layout/scrollViewport.js";
+} from "../../view/layout/dashboardScrollController.js";
 
 export type MakeStationTestRuntimeOptions = {
   /** Source snapshot; `null` exercises the no-snapshot states. Default: manyProjectsSnapshot(). */

--- a/station/src/station/view/DashboardControlsView.tsx
+++ b/station/src/station/view/DashboardControlsView.tsx
@@ -14,6 +14,9 @@ export function DashboardControlsView({
   dividerTitle?: string;
 }) {
   const dispatch = useStationMouse();
+  const dividerMouseProps = dividerTitle === undefined
+    ? {}
+    : stationMouseProps(dispatch, { kind: "scrollIndicator", direction: "down" });
   return (
     <box
       id="station-dashboard-controls"
@@ -24,12 +27,7 @@ export function DashboardControlsView({
       paddingRight={1}
       overflow="hidden"
     >
-      <box
-        flexShrink={0}
-        {...(dividerTitle === undefined
-          ? {}
-          : stationMouseProps(dispatch, { kind: "scrollIndicator", direction: "down" }))}
-      >
+      <box flexShrink={0} {...dividerMouseProps}>
         <DashboardDividerView
           {...(dividerTitle === undefined ? {} : { title: dividerTitle })}
         />

--- a/station/src/station/view/DashboardControlsView.tsx
+++ b/station/src/station/view/DashboardControlsView.tsx
@@ -1,15 +1,19 @@
 import type { DashboardStateSource } from "@station/dashboard-core/runtime";
 import { DashboardDividerView } from "./DashboardDividerView.js";
 import { DashboardFooterView } from "./DashboardFooterView.js";
+import { stationMouseProps, useStationMouse } from "./stationMouseContext.js";
 
 /** Composes the intrinsic divider and footer controls below dashboard content. */
 export function DashboardControlsView({
   state,
   columns,
+  dividerTitle,
 }: {
   state: DashboardStateSource;
   columns: number;
+  dividerTitle?: string;
 }) {
+  const dispatch = useStationMouse();
   return (
     <box
       id="station-dashboard-controls"
@@ -20,7 +24,16 @@ export function DashboardControlsView({
       paddingRight={1}
       overflow="hidden"
     >
-      <DashboardDividerView />
+      <box
+        flexShrink={0}
+        {...(dividerTitle === undefined
+          ? {}
+          : stationMouseProps(dispatch, { kind: "scrollIndicator", direction: "down" }))}
+      >
+        <DashboardDividerView
+          {...(dividerTitle === undefined ? {} : { title: dividerTitle })}
+        />
+      </box>
       <DashboardFooterView state={state} columns={columns} />
     </box>
   );

--- a/station/src/station/view/DashboardDividerView.tsx
+++ b/station/src/station/view/DashboardDividerView.tsx
@@ -1,7 +1,7 @@
 import { toOpenTuiColor, useStationTheme } from "../../theme/index.js";
 
 /** Structural hairline between dashboard-owned regions. */
-export function DashboardDividerView() {
+export function DashboardDividerView({ title }: { title?: string } = {}) {
   const theme = useStationTheme();
   return (
     <box
@@ -10,6 +10,12 @@ export function DashboardDividerView() {
       flexShrink={0}
       border={["top"]}
       borderColor={toOpenTuiColor(theme.text.muted)}
+      {...(title === undefined
+        ? {}
+        : {
+            title: ` ${title} `,
+            titleColor: toOpenTuiColor(theme.text.muted),
+          })}
     />
   );
 }

--- a/station/src/station/view/DashboardRoot.tsx
+++ b/station/src/station/view/DashboardRoot.tsx
@@ -2,10 +2,13 @@
 // between the loading/waiting/unavailable bodies and the live dashboard —
 // mirroring apps/tui's App.tsx branch for the popup posture, including the
 // toast overlay, kind-specific expiry timers, and explicit error dismissal.
-import { useEffect, useRef, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, type ReactNode } from "react";
 import { useStore } from "zustand/react";
 import type { DashboardActions, DashboardStateSource } from "@station/dashboard-core/runtime";
 import {
+  scrollIndicatorLabel,
+  selectDashboardSlotsForTree,
+  selectDashboardTree,
   snapshotLoadingContent,
   type SnapshotLoadingContent,
 } from "@station/dashboard-core/selectors";
@@ -25,6 +28,7 @@ import {
 import { ToastOverlayView } from "./ToastOverlayView.js";
 import { toOpenTuiColor, useStationTheme } from "../../theme/index.js";
 import type { DashboardScrollController } from "./layout/scrollViewport.js";
+import { useDashboardVisibleRows } from "./layout/DashboardScrollViewport.js";
 
 export type DashboardRootProps = {
   state: DashboardStateSource;
@@ -64,6 +68,35 @@ export function DashboardRoot({
   const activeToast = useStore(state, activeTuiToast);
   const nextExpiry = useStore(state, nextTuiToastExpiry);
   const hoverEnabled = useStationHoverEnabled();
+  const visibleRowIds = useDashboardVisibleRows(layout);
+  const dashboardProjection = useMemo(() => {
+    const viewState = {
+      collapsedProjectIds,
+      collapsedGroupIds,
+      groupOrderingMode,
+      groupHeaderActionVisibility,
+      localRows,
+      selection,
+      ...(persistentFilter === undefined ? {} : { persistentFilter }),
+      ...(dashboardFocus === undefined ? {} : { dashboardFocus }),
+    };
+    return {
+      viewState,
+      tree:
+        snapshot === undefined ? undefined : selectDashboardTree(snapshot, viewState, screen),
+    };
+  }, [
+    collapsedGroupIds,
+    collapsedProjectIds,
+    dashboardFocus,
+    groupHeaderActionVisibility,
+    groupOrderingMode,
+    localRows,
+    persistentFilter,
+    screen,
+    selection,
+    snapshot,
+  ]);
 
   const toastHiddenByScreen = isTuiToastHiddenByScreen(screen);
   const backgroundHoverEnabled =
@@ -98,7 +131,7 @@ export function DashboardRoot({
     />
   );
 
-  if (loading || snapshot === undefined) {
+  if (loading || snapshot === undefined || dashboardProjection.tree === undefined) {
     const content = snapshotLoadingContent(loading, observerConnectionStatus);
     // Keep both root branches padding-free because OpenTUI retains a removed inset during reconciliation.
     return (
@@ -113,16 +146,11 @@ export function DashboardRoot({
     );
   }
 
-  const viewState = {
-    collapsedProjectIds,
-    collapsedGroupIds,
-    groupOrderingMode,
-    groupHeaderActionVisibility,
-    localRows,
-    selection,
-    ...(persistentFilter === undefined ? {} : { persistentFilter }),
-    ...(dashboardFocus === undefined ? {} : { dashboardFocus }),
-  };
+  const { tree, viewState } = dashboardProjection;
+  const slots = selectDashboardSlotsForTree(tree, visibleRowIds);
+  const dividerTitle = slots.semanticOverflow.below
+    ? scrollIndicatorLabel("below", slots.sessionOverflow)
+    : undefined;
   return (
     <box width="100%" flexGrow={1} minHeight={0} flexDirection="column">
       <StationHoverProvider value={backgroundHoverEnabled}>
@@ -132,11 +160,17 @@ export function DashboardRoot({
             viewState={viewState}
             screen={screen}
             layout={layout}
+            tree={tree}
+            slots={slots}
             columns={columns}
             menuHoverEnabled={hoverEnabled}
           />
         </DashboardNoticeRegion>
-        <DashboardControlsView state={state} columns={contentColumns} />
+        <DashboardControlsView
+          state={state}
+          columns={contentColumns}
+          {...(dividerTitle === undefined ? {} : { dividerTitle })}
+        />
       </StationHoverProvider>
       <ActiveScreenOverlayView
         snapshot={snapshot}

--- a/station/src/station/view/DashboardRoot.tsx
+++ b/station/src/station/view/DashboardRoot.tsx
@@ -27,7 +27,7 @@ import {
 } from "./stationMouseContext.js";
 import { ToastOverlayView } from "./ToastOverlayView.js";
 import { toOpenTuiColor, useStationTheme } from "../../theme/index.js";
-import type { DashboardScrollController } from "./layout/scrollViewport.js";
+import type { DashboardScrollController } from "./layout/dashboardScrollController.js";
 import { useDashboardVisibleRows } from "./layout/DashboardScrollViewport.js";
 
 export type DashboardRootProps = {

--- a/station/src/station/view/DashboardTableHeaderView.test.tsx
+++ b/station/src/station/view/DashboardTableHeaderView.test.tsx
@@ -6,7 +6,6 @@ import { textSegment } from "@station/dashboard-core/selectors";
 import type { DashboardTableHeaderModel, RowGridLayout } from "@station/dashboard-core/selectors";
 import type { StationMouseTarget } from "../input/stationMouse.js";
 import {
-  DashboardScrollIndicatorView,
   DashboardTableHeaderView,
 } from "./DashboardTableHeaderView.js";
 import { StationMouseProvider } from "./stationMouseContext.js";
@@ -97,23 +96,4 @@ describe("DashboardTableHeaderView", () => {
     expect(targets).toEqual([{ kind: "scrollIndicator", direction: "up" }]);
   });
 
-  it("does not reserve a row for an absent below-overflow indicator", async () => {
-    const setup = await testRender(
-      <StationThemeProvider theme={nativeStationTheme}>
-        <box flexDirection="column">
-          <DashboardScrollIndicatorView
-            direction="below"
-            overflow={{ above: 0, below: 0, visible: 4, total: 4 }}
-          />
-          <text>NEXT</text>
-        </box>
-      </StationThemeProvider>,
-      { width: 60, height: 2 },
-    );
-    teardowns.push(() => setup.renderer.destroy());
-    await setup.renderOnce();
-
-    const lines = setup.captureCharFrame().split("\n");
-    expect(lines[0]?.trimEnd()).toBe("NEXT");
-  });
 });

--- a/station/src/station/view/DashboardTableHeaderView.tsx
+++ b/station/src/station/view/DashboardTableHeaderView.tsx
@@ -12,7 +12,7 @@ export function DashboardTableHeaderView({ model }: { model: DashboardTableHeade
     case "columns":
       return <ColumnHeaderRow layout={model.layout} />;
     case "aboveOverflow":
-      return <DashboardScrollIndicatorView direction="above" overflow={model.overflow} />;
+      return <DashboardScrollIndicatorView direction="above" overflow={model.overflow} visible />;
     default:
       return assertNeverDashboardTableHeaderModel(model);
   }
@@ -25,26 +25,28 @@ function assertNeverDashboardTableHeaderModel(_model: never): never {
 export function DashboardScrollIndicatorView({
   direction,
   overflow,
+  visible,
 }: {
   direction: "above" | "below";
   overflow: DashboardSessionOverflow;
+  visible: boolean;
 }) {
   const theme = useStationTheme();
   const dispatch = useStationMouse();
-  const hiddenSessions = direction === "above" ? overflow.above : overflow.below;
-  if (hiddenSessions === 0) return null;
   return (
-    <text
-      height={1}
-      flexShrink={0}
-      fg={toOpenTuiColor(theme.text.muted)}
-      {...stationMouseProps(dispatch, {
-        kind: "scrollIndicator",
-        direction: direction === "above" ? "up" : "down",
-      })}
-    >
-      {scrollIndicatorLabel(direction, overflow)}
-    </text>
+    <box height={1} flexShrink={0}>
+      {visible ? (
+        <text
+          fg={toOpenTuiColor(theme.text.muted)}
+          {...stationMouseProps(dispatch, {
+            kind: "scrollIndicator",
+            direction: direction === "above" ? "up" : "down",
+          })}
+        >
+          {scrollIndicatorLabel(direction, overflow)}
+        </text>
+      ) : null}
+    </box>
   );
 }
 

--- a/station/src/station/view/DashboardView.tsx
+++ b/station/src/station/view/DashboardView.tsx
@@ -5,12 +5,12 @@ import {
   emptyProjectLabel,
   fleetCountsLabel,
   FIRST_RUN_BODY_LABEL,
-  selectDashboardSlotsForTree,
-  selectDashboardTree,
   selectFleetSummary,
   withRowGridSelectionSlot,
   type DashboardRowId,
+  type DashboardSlots,
   type DashboardTreeBranch,
+  type DashboardTreeProjection,
   type DashboardTreeRow,
   type FleetSummary,
   type RowGridLayout,
@@ -21,10 +21,7 @@ import type {
   DashboardSnapshotView,
   DashboardViewState,
 } from "@station/dashboard-core/state";
-import {
-  DashboardScrollIndicatorView,
-  DashboardTableHeaderView,
-} from "./DashboardTableHeaderView.js";
+import { DashboardTableHeaderView } from "./DashboardTableHeaderView.js";
 import { GroupFrameView, groupFrameContentColumns } from "./GroupFrameView.js";
 import { GroupHeaderView } from "./GroupHeaderView.js";
 import { ProjectHeaderView } from "./ProjectHeaderView.js";
@@ -39,10 +36,7 @@ import {
   stationMouseProps,
 } from "./stationMouseContext.js";
 import { memo, useLayoutEffect, useMemo } from "react";
-import {
-  DashboardScrollViewport,
-  useDashboardVisibleRows,
-} from "./layout/DashboardScrollViewport.js";
+import { DashboardScrollViewport } from "./layout/DashboardScrollViewport.js";
 import {
   semanticItemRenderableId,
   type DashboardScrollController,
@@ -60,6 +54,8 @@ export type DashboardViewProps = {
   viewState: DashboardViewState;
   screen: DashboardScreenView;
   layout: DashboardScrollController;
+  tree: DashboardTreeProjection;
+  slots: DashboardSlots;
   columns: number;
   menuHoverEnabled: boolean;
 };
@@ -69,17 +65,13 @@ export function DashboardView({
   viewState,
   screen,
   layout,
+  tree,
+  slots,
   columns,
   menuHoverEnabled,
 }: DashboardViewProps) {
   const theme = useStationTheme();
-  const visibleRowIds = useDashboardVisibleRows(layout);
   const dispatch = useStationMouse();
-  const tree = useMemo(
-    () => selectDashboardTree(snapshot, viewState, screen),
-    [screen, snapshot, viewState],
-  );
-  const slots = selectDashboardSlotsForTree(tree, visibleRowIds);
   const rowGridProjector = useMemo(() => createDashboardRowGridProjector(), []);
   const itemIds = useMemo(() => tree.visibleRows.map((row) => row.id), [tree.visibleRows]);
   const contentColumns = Math.max(1, Math.floor(columns) - 1);
@@ -96,6 +88,7 @@ export function DashboardView({
   const tableHeader = dashboardTableHeaderModel({
     layout: headerLayout,
     overflow: slots.sessionOverflow,
+    hasSemanticRowsAbove: slots.semanticOverflow.above,
     columns: contentColumns,
     ...(slots.persistentFilter === undefined
       ? {}
@@ -192,7 +185,6 @@ export function DashboardView({
           />
         </DashboardScrollViewport>
       )}
-      <DashboardScrollIndicatorView direction="below" overflow={slots.sessionOverflow} />
       {screen.name === "projectMenu" && menuAnchorRenderableId !== undefined ? (
         <StationHoverProvider value={menuHoverEnabled}>
           <ProjectMenuView

--- a/station/src/station/view/DashboardView.tsx
+++ b/station/src/station/view/DashboardView.tsx
@@ -37,10 +37,8 @@ import {
 } from "./stationMouseContext.js";
 import { memo, useLayoutEffect, useMemo } from "react";
 import { DashboardScrollViewport } from "./layout/DashboardScrollViewport.js";
-import {
-  semanticItemRenderableId,
-  type DashboardScrollController,
-} from "./layout/scrollViewport.js";
+import { semanticItemRenderableId } from "./layout/scrollViewport.js";
+import type { DashboardScrollController } from "./layout/dashboardScrollController.js";
 import { DashboardFilterConditionView } from "./DashboardFilterConditionView.js";
 import { DashboardDividerView } from "./DashboardDividerView.js";
 import { GroupMenuView } from "./GroupMenuView.js";

--- a/station/src/station/view/HelpOverlayView.test.tsx
+++ b/station/src/station/view/HelpOverlayView.test.tsx
@@ -50,8 +50,13 @@ describe("HelpOverlayView", () => {
     expect(viewport).toBeDefined();
     expect(wrapped?.height).toBeGreaterThan(1);
     expect(finalEntry).toBeDefined();
-    expect(setup.captureCharFrame()).toContain("refresh");
-    expect(setup.captureCharFrame()).toContain("↑ more");
+    const initialFrame = setup.captureCharFrame();
+    expect(initialFrame).toContain("refresh");
+    expect(initialFrame).toMatch(/↑\d+/);
+    expect(initialFrame).toContain("▲");
+    expect(initialFrame).toContain("▼");
+    expect(initialFrame).toContain("▐");
+    expect(initialFrame).toContain("▕");
 
     await act(async () => {
       for (let index = 0; index < 60; index += 1) {
@@ -74,5 +79,20 @@ describe("HelpOverlayView", () => {
     expect(wrapped?.height).toBeGreaterThan(2);
     expect(finalEntry).toBeDefined();
     expect(setup.captureCharFrame()).toContain("▸");
+
+    const scrollStepsToTop = Math.ceil(viewport?.scrollTop ?? 0) + 1;
+    await act(async () => {
+      for (let index = 0; index < scrollStepsToTop; index += 1) {
+        await setup.mockMouse.scroll(
+          viewport?.x ?? 0,
+          (viewport?.y ?? 0) + 1,
+          "up",
+        );
+      }
+    });
+    await setup.flush();
+
+    expect(viewport?.scrollTop).toBe(0);
+    expect(setup.captureCharFrame()).toMatch(/↓\d+/);
   });
 });

--- a/station/src/station/view/HelpOverlayView.tsx
+++ b/station/src/station/view/HelpOverlayView.tsx
@@ -34,7 +34,7 @@ export function HelpOverlayView({
     controller.snapshot,
     controller.snapshot,
   );
-  const continuation = helpContinuation(visibleEntryIds);
+  const continuation = helpContinuation(visibleEntryIds, columns);
 
   return (
     <box
@@ -67,6 +67,7 @@ export function HelpOverlayView({
           followedItemId={focusedEntryId}
           viewportId="station-help-content"
           controller={controller}
+          scrollbar="inside"
         >
           <box width="100%" flexDirection="column" paddingLeft={2} paddingRight={2}>
             {STATION_HELP_ENTRIES.map((entry) => (
@@ -135,14 +136,24 @@ function HelpEntryView({ entry, focused }: { entry: StationHelpEntry; focused: b
   );
 }
 
-function helpContinuation(visibleEntryIds: readonly string[] | undefined): string {
+function helpContinuation(
+  visibleEntryIds: readonly string[] | undefined,
+  panelWidth: number,
+): string {
   const first = visibleEntryIds?.[0];
   const last = visibleEntryIds?.at(-1);
-  const hasAbove = first !== undefined && STATION_HELP_ENTRY_IDS.indexOf(first) > 0;
-  const hasBelow =
-    last !== undefined && STATION_HELP_ENTRY_IDS.indexOf(last) < STATION_HELP_ENTRY_IDS.length - 1;
-  if (hasAbove && hasBelow) return "↕ more";
-  if (hasAbove) return "↑ more";
-  if (hasBelow) return "↓ more";
+  const above = first === undefined ? 0 : Math.max(0, STATION_HELP_ENTRY_IDS.indexOf(first));
+  const below = last === undefined
+    ? 0
+    : Math.max(0, STATION_HELP_ENTRY_IDS.length - STATION_HELP_ENTRY_IDS.indexOf(last) - 1);
+  if (panelWidth < 48) {
+    if (above > 0 && below > 0) return `↑${above}/↓${below}`;
+    if (above > 0) return `↑${above}`;
+    if (below > 0) return `↓${below}`;
+    return "all";
+  }
+  if (above > 0 && below > 0) return `↑ ${above} above · ↓ ${below} below`;
+  if (above > 0) return `↑ ${above} above`;
+  if (below > 0) return `↓ ${below} below`;
   return "all visible";
 }

--- a/station/src/station/view/HelpOverlayView.tsx
+++ b/station/src/station/view/HelpOverlayView.tsx
@@ -7,12 +7,16 @@ import {
   STATION_HELP_ENTRY_IDS,
   type StationHelpEntry,
 } from "../helpEntries.js";
+import { helpScrollChrome } from "./helpScrollChrome.js";
 import { SemanticScrollRegion } from "./layout/SemanticScrollViewport.js";
 import {
   createScrollViewportController,
   semanticItemRenderableId,
 } from "./layout/scrollViewport.js";
-import { helpPanelFrame } from "./layout/helpPanelFrame.js";
+import {
+  HELP_PANEL_MAX_WIDTH,
+  helpPanelFrame,
+} from "./layout/helpPanelFrame.js";
 import { useStationMouse, stationMouseProps } from "./stationMouseContext.js";
 
 export function HelpOverlayView({
@@ -34,15 +38,19 @@ export function HelpOverlayView({
     controller.snapshot,
     controller.snapshot,
   );
-  const continuation = helpContinuation(visibleEntryIds, columns);
+  const continuation = helpScrollChrome({
+    allIds: STATION_HELP_ENTRY_IDS,
+    visibleIds: visibleEntryIds,
+    panelWidth: frame.effectiveWidth,
+  });
 
   return (
     <box
       position="absolute"
       top={0}
       left={0}
-      width={Math.max(1, columns)}
-      height={Math.max(1, rows)}
+      width={frame.overlayWidth}
+      height={frame.overlayHeight}
       zIndex={10}
       alignItems="center"
       justifyContent="center"
@@ -52,7 +60,7 @@ export function HelpOverlayView({
         id="station-help-surface"
         width={frame.width}
         height={frame.height}
-        maxWidth={64}
+        maxWidth={HELP_PANEL_MAX_WIDTH}
         flexDirection="column"
         flexShrink={1}
         border
@@ -134,26 +142,4 @@ function HelpEntryView({ entry, focused }: { entry: StationHelpEntry; focused: b
       </text>
     </box>
   );
-}
-
-function helpContinuation(
-  visibleEntryIds: readonly string[] | undefined,
-  panelWidth: number,
-): string {
-  const first = visibleEntryIds?.[0];
-  const last = visibleEntryIds?.at(-1);
-  const above = first === undefined ? 0 : Math.max(0, STATION_HELP_ENTRY_IDS.indexOf(first));
-  const below = last === undefined
-    ? 0
-    : Math.max(0, STATION_HELP_ENTRY_IDS.length - STATION_HELP_ENTRY_IDS.indexOf(last) - 1);
-  if (panelWidth < 48) {
-    if (above > 0 && below > 0) return `↑${above}/↓${below}`;
-    if (above > 0) return `↑${above}`;
-    if (below > 0) return `↓${below}`;
-    return "all";
-  }
-  if (above > 0 && below > 0) return `↑ ${above} above · ↓ ${below} below`;
-  if (above > 0) return `↑ ${above} above`;
-  if (below > 0) return `↓ ${below} below`;
-  return "all visible";
 }

--- a/station/src/station/view/__snapshots__/ToastOverlayView.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/ToastOverlayView.test.tsx.snap
@@ -13,13 +13,13 @@ exports[`ToastOverlayView actions keeps a notice in its structural region throug
 FL│ needs attention        [copy][x] │
 ──│ Worktrunk failed to remove the   │─
   │ selected checkout because the    │
- ▼│ main worktree cannot be removed  │]
- [│ while Station is running there.  │
- [│ Open a different linked          │
- [│ checkout, select the session     │
- [│ again, and retry after           │
-▼ └──────────────────────────────────┘
-───────────────────────────────────────
+ ▼│ main worktree cannot be removed  │]▲
+ [│ while Station is running there.  │ ▐
+ [│ Open a different linked          │ ▕
+ [│ checkout, select the session     │ ▕
+ [│ again, and retry after           │ ▕
+ [└──────────────────────────────────┘ ▼
+── ▼ 5 below · showing 5 of 10 ────────
 Esc:dismiss  Q:close
 "
 `;
@@ -29,8 +29,8 @@ exports[`ToastOverlayView actions keeps a notice in its structural region throug
 FL│ need…[copy][x] │
 ──│ Worktrunk      │─
   │ failed to      │…
- ▼│ remove the     │]
-▼ └────────────────┘
+ ▼│ remove the     │]▲
+ [└────────────────┘e▼
 ─────────────────────
 Esc:dismiss  Q:close
 "

--- a/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
@@ -77,17 +77,17 @@ exports[`dashboard golden frames renders many-projects at 60x16 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown   
 ─────────────────────────────────────────────────────────── 
        SESSION                 AGENT     STATUS          PR 
- ▼ station  5 sessions · 4 agents             [sh] [qs] [▾] 
- [1] ○ cli-help-man            codex     idle         #70 ✓ 
- [2] - docs-cleanup            codex     no agent           
- [3] ○ pty-buffer              codex     idle         #73 ✓ 
- [4] + session-resume          codex     starting           
- [5] ⠋ station-overlay         codex     working      #76 … 
-                                                            
- ▼ observer  3 sessions · 3 agents            [sh] [qs] [▾] 
- [6] x batch-export            opencode  exited        #8 ✓ 
-▼ 4 below · showing 6 of 10                                 
-─────────────────────────────────────────────────────────── 
+ ▼ station  5 sessions · 4 agents             [sh] [qs] [▾]▲
+ [1] ○ cli-help-man            codex     idle         #70 ✓▐
+ [2] - docs-cleanup            codex     no agent          ▐
+ [3] ○ pty-buffer              codex     idle         #73 ✓▐
+ [4] + session-resume          codex     starting          ▐
+ [5] ⠋ station-overlay         codex     working      #76 …▕
+                                                           ▕
+ ▼ observer  3 sessions · 3 agents            [sh] [qs] [▾]▕
+ [6] x batch-export            opencode  exited        #8 ✓▕
+ [7] ⠋ provider-hooks          opencode  working      #16 …▼
+── ▼ 3 below · showing 7 of 10 ──────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/e… 
 "
 `;
@@ -97,13 +97,13 @@ exports[`dashboard golden frames renders many-projects at 40x12 1`] = `
 FLEET  ● 0 ready  ⠋ 2 working  ! 0      
 ─────────────────────────────────────── 
        SESSION             STATUS       
- ▼ station  5 sessions ·  [sh] [qs] [▾] 
- [1] ○ cli-help-man        idle         
- [2] - docs-cleanup        no agent     
- [3] ○ pty-buffer          idle         
- [4] + session-resume      starting     
-▼ 6 below · showing 4 of 10             
-─────────────────────────────────────── 
+ ▼ station  5 sessions ·  [sh] [qs] [▾]▲
+ [1] ○ cli-help-man        idle        ▐
+ [2] - docs-cleanup        no agent    ▕
+ [3] ○ pty-buffer          idle        ▕
+ [4] + session-resume      starting    ▕
+ [5] ⠋ station-overlay     working     ▼
+── ▼ 5 below · showing 5 of 10 ──────── 
 ↵ activate  N new  ⇥ next  / filter  X… 
 "
 `;
@@ -113,25 +113,25 @@ exports[`dashboard golden frames renders grouped-many-projects at 80x24 1`] = `
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                       AGENT     STATUS                 DIFF · PR 
- ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾] 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Design refresh 2 sessions                                         [qs] [▾]│ 
-│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│ 
-│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│ 
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│ 
-│ [3] ○ input-routing               codex     idle                      +27 -6│ 
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Observer hardening 3 sessions                                     [qs] [▾]│ 
-│ [4] ○ diagnostic-index            codex     idle                      +38 -7│ 
-│ [5] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│ 
-│ [6] ⠋ trace-readiness             codex     working           +91 -22 #478 …│ 
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-▼ 6 below · showing 6 of 12                                                     
-─────────────────────────────────────────────────────────────────────────────── 
+ ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾]▲
+╭─────────────────────────────────────────────────────────────────────────────╮▐
+│ ▼ Design refresh 2 sessions                                         [qs] [▾]│▐
+│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│▐
+│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
+╭─────────────────────────────────────────────────────────────────────────────╮▐
+│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│▐
+│ [3] ○ input-routing               codex     idle                      +27 -6│▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
+╭─────────────────────────────────────────────────────────────────────────────╮▕
+│ ▼ Observer hardening 3 sessions                                     [qs] [▾]│▕
+│ [4] ○ diagnostic-index            codex     idle                      +38 -7│▕
+│ [5] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│▕
+│ [6] ⠋ trace-readiness             codex     working           +91 -22 #478 …│▕
+╰─────────────────────────────────────────────────────────────────────────────╯▕
+╭─────────────────────────────────────────────────────────────────────────────╮▕
+│ ▼ Post-launch 0 sessions                                            [qs] [▾]│▼
+── ▼ 6 below · showing 6 of 12 ──────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
 "
 `;
@@ -185,17 +185,17 @@ exports[`dashboard golden frames renders grouped-many-projects at 60x16 1`] = `
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited    
 ─────────────────────────────────────────────────────────── 
        SESSION           AGENT     STATUS                PR 
- ▼ station  12 sessions · 6 Groups · 11 agent [sh] [qs] [▾] 
-╭─────────────────────────────────────────────────────────╮ 
-│ ▼ Design refresh 2 sessions                     [qs] [▾]│ 
-│ [1] ⠋ group-contracts         codex     working         │ 
-│ [2] ○ group-keyboard          codex     idle            │ 
-╰─────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────╮ 
-│ ▼ Input parity and minimum-width interaction ve [qs] [▾]│ 
-│ [3] ○ input-routing           codex     idle            │ 
-▼ 9 below · showing 3 of 12                                 
-─────────────────────────────────────────────────────────── 
+ ▼ station  12 sessions · 6 Groups · 11 agent [sh] [qs] [▾]▲
+╭─────────────────────────────────────────────────────────╮▐
+│ ▼ Design refresh 2 sessions                     [qs] [▾]│▐
+│ [1] ⠋ group-contracts         codex     working         │▐
+│ [2] ○ group-keyboard          codex     idle            │▕
+╰─────────────────────────────────────────────────────────╯▕
+╭─────────────────────────────────────────────────────────╮▕
+│ ▼ Input parity and minimum-width interaction ve [qs] [▾]│▕
+│ [3] ○ input-routing           codex     idle            │▕
+╰─────────────────────────────────────────────────────────╯▼
+── ▼ 9 below · showing 3 of 12 ──────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/e… 
 "
 `;
@@ -205,13 +205,13 @@ exports[`dashboard golden frames renders grouped-many-projects at 40x12 1`] = `
 FLEET  ● 0 ready  ⠋ 3 working  ! 1      
 ─────────────────────────────────────── 
        SESSION                          
- ▼ station  12 sessions · [sh] [qs] [▾] 
-╭─────────────────────────────────────╮ 
-│ ▼ Design refresh 2 sessions [qs] [▾]│ 
-│ [1] ⠋ group-contracts               │ 
-│ [2] ○ group-keyboard                │ 
-▼ 10 below · showing 2 of 12            
-─────────────────────────────────────── 
+ ▼ station  12 sessions · [sh] [qs] [▾]▲
+╭─────────────────────────────────────╮▐
+│ ▼ Design refresh 2 sessions [qs] [▾]│▕
+│ [1] ⠋ group-contracts               │▕
+│ [2] ○ group-keyboard                │▕
+╰─────────────────────────────────────╯▼
+── ▼ 10 below · showing 2 of 12 ─────── 
 ↵ activate  N new  ⇥ next  / filter  X… 
 "
 `;
@@ -313,13 +313,13 @@ exports[`dashboard golden frames renders attention-and-failures at 40x12 1`] = `
 FLEET  ● 0 ready  ⠋ 1 working  ! 3      
 ─────────────────────────────────────── 
        SESSION                          
- ▼ station  4 sessions ·  [sh] [qs] [▾] 
- [1] ! hook-scope                       
- [2] ? metadata-refresh                 
- [3] ! popup-latency                    
- [4] ⠋ pr-info                          
-▼ 2 below · showing 4 of 6              
-─────────────────────────────────────── 
+ ▼ station  4 sessions ·  [sh] [qs] [▾]▲
+ [1] ! hook-scope                      ▐
+ [2] ? metadata-refresh                ▐
+ [3] ! popup-latency                   ▐
+ [4] ⠋ pr-info                         ▕
+                                       ▼
+── ▼ 2 below · showing 4 of 6 ───────── 
 ↵ activate  N new  ⇥ next  / filter  X… 
 "
 `;
@@ -569,17 +569,17 @@ exports[`dashboard golden frames renders filtered Group counts and clips structu
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
 ▲ 2 sessions above                                                              
-│ [1] ○ input-routing               codex     idle                      +27 -6│ 
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Observer hardening 3 sessions                                     [qs] [▾]│ 
-│ [2] ○ diagnostic-index            codex     idle                      +38 -7│ 
-│ [3] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│ 
-│ [4] ⠋ trace-readiness             codex     working           +91 -22 #478 …│ 
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-▼ 6 below · showing 4 of 12                                                     
-─────────────────────────────────────────────────────────────────────────────── 
+│ [1] ○ input-routing               codex     idle                      +27 -6│▲
+╰─────────────────────────────────────────────────────────────────────────────╯▕
+╭─────────────────────────────────────────────────────────────────────────────╮▕
+│ ▼ Observer hardening 3 sessions                                     [qs] [▾]│▐
+│ [2] ○ diagnostic-index            codex     idle                      +38 -7│▐
+│ [3] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│▐
+│ [4] ⠋ trace-readiness             codex     working           +91 -22 #478 …│▕
+╰─────────────────────────────────────────────────────────────────────────────╯▕
+╭─────────────────────────────────────────────────────────────────────────────╮▕
+│ ▼ Post-launch 0 sessions                                            [qs] [▾]│▼
+── ▼ 6 below · showing 4 of 12 ──────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
 "
 `;
@@ -681,13 +681,13 @@ exports[`dashboard golden frames clips a long persistent draft at minimum dashbo
 FLEET  ● 0 ready  ⠋ 2 working  ! 0      
 ─────────────────────────────────────── 
 ▏ FILTER /t-filter-draft▏  0/10 matches 
- ▼ station  5 sessions ·  [sh] [qs] [▾] 
- [1] ○ cli-help-man        idle         
- [2] - docs-cleanup        no agent     
- [3] ○ pty-buffer          idle         
- [4] + session-resume      starting     
-▼ 6 below · showing 4 of 10             
-─────────────────────────────────────── 
+ ▼ station  5 sessions ·  [sh] [qs] [▾]▲
+ [1] ○ cli-help-man        idle        ▐
+ [2] - docs-cleanup        no agent    ▕
+ [3] ○ pty-buffer          idle        ▕
+ [4] + session-resume      starting    ▕
+ [5] ⠋ station-overlay     working     ▼
+── ▼ 5 below · showing 5 of 10 ──────── 
  FILTER   ↵ apply  Esc cancel           
 "
 `;

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -4,24 +4,24 @@ exports[`modal flow golden frames renders the help overlay 1`] = `
 "                                                                                
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ────────╭──────────────────────────────────────────────────────────────╮─────── 
-       S│    station help                                              │FF · PR 
- ▼ stati│      Ctrl-O       open/close project view                    │qs] [▾] 
- [1] ○ c│      Ctrl-Q       quit Station                               │6 #70 ✓ 
- [2] - d│      Ctrl-\\       split pane right                           │        
- [3] ○ p│      Ctrl-^       split pane below (Ctrl-6)                  │  #73 ✓ 
- [4] + s│      Ctrl-]       focus next pane                            │        
- [5] ⠋ s│      Ctrl-/       close split pane (Ctrl-_)                  │6 #76 … 
-        │      Enter/Sp     open project view on welcome               │        
- ▼ obser│      Esc/↑↓       context menu close/move                    │qs] [▾] 
- [6] x b│      Enter/Sp     context menu select                        │   #8 ✓ 
- [7] ⠋ p│    station project view                                      │8 #16 … 
- [8] ○ t│      ↑/↓          move cursor · wheel scroll                 │-1 #4 ✓ 
-        │      ↵            open focused session                       │        
- ▼ scrip│      tab          next session needing you                   │qs] [▾] 
- [9] ○ a│      G/M          quick group/move to group                  │6 #5 x1 
- [a] ? m│      / ↵ Esc Q   edit/apply/cancel-clear/retain-close        │ -1 #10 
-        │                  filter                                      │        
- ▼ empty│ ↓ more · ↑↓ · PgUp/PgDn · Esc                                │qs] [▾] 
+       S│    station help                                             ▲│FF · PR 
+ ▼ stati│      Ctrl-O       open/close project view                   ▐│qs] [▾] 
+ [1] ○ c│      Ctrl-Q       quit Station                              ▐│6 #70 ✓ 
+ [2] - d│      Ctrl-\\       split pane right                          ▐│        
+ [3] ○ p│      Ctrl-^       split pane below (Ctrl-6)                 ▐│  #73 ✓ 
+ [4] + s│      Ctrl-]       focus next pane                           ▐│        
+ [5] ⠋ s│      Ctrl-/       close split pane (Ctrl-_)                 ▐│6 #76 … 
+        │      Enter/Sp     open project view on welcome              ▐│        
+ ▼ obser│      Esc/↑↓       context menu close/move                   ▐│qs] [▾] 
+ [6] x b│      Enter/Sp     context menu select                       ▐│   #8 ✓ 
+ [7] ⠋ p│    station project view                                     ▐│8 #16 … 
+ [8] ○ t│      ↑/↓          move cursor · wheel scroll                ▐│-1 #4 ✓ 
+        │      ↵            open focused session                      ▕│        
+ ▼ scrip│      tab          next session needing you                  ▕│qs] [▾] 
+ [9] ○ a│      G/M          quick group/move to group                 ▕│6 #5 x1 
+ [a] ? m│      / ↵ Esc Q   edit/apply/cancel-clear/retain-close       ▕│ -1 #10 
+        │                  filter                                     ▼│        
+ ▼ empty│ ↓ 6 below · ↑↓ · PgUp/PgDn · Esc                             │qs] [▾] 
  no sess╰──────────────────────────────────────────────────────────────╯        
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
@@ -32,24 +32,24 @@ exports[`modal flow golden frames renders the help overlay middle at standard si
 "                                                                                
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ────────╭──────────────────────────────────────────────────────────────╮─────── 
-       S│    station help                                              │FF · PR 
- ▼ stati│      Ctrl-O       open/close project view                    │qs] [▾] 
- [1] ○ c│      Ctrl-Q       quit Station                               │6 #70 ✓ 
- [2] - d│      Ctrl-\\       split pane right                           │        
- [3] ○ p│      Ctrl-^       split pane below (Ctrl-6)                  │  #73 ✓ 
- [4] + s│      Ctrl-]       focus next pane                            │        
- [5] ⠋ s│      Ctrl-/       close split pane (Ctrl-_)                  │6 #76 … 
-        │      Enter/Sp     open project view on welcome               │        
- ▼ obser│      Esc/↑↓       context menu close/move                    │qs] [▾] 
- [6] x b│  ▸   Enter/Sp     context menu select                        │   #8 ✓ 
- [7] ⠋ p│    station project view                                      │8 #16 … 
- [8] ○ t│      ↑/↓          move cursor · wheel scroll                 │-1 #4 ✓ 
-        │      ↵            open focused session                       │        
- ▼ scrip│      tab          next session needing you                   │qs] [▾] 
- [9] ○ a│      G/M          quick group/move to group                  │6 #5 x1 
- [a] ? m│      / ↵ Esc Q   edit/apply/cancel-clear/retain-close        │ -1 #10 
-        │                  filter                                      │        
- ▼ empty│ ↓ more · ↑↓ · PgUp/PgDn · Esc                                │qs] [▾] 
+       S│    station help                                             ▲│FF · PR 
+ ▼ stati│      Ctrl-O       open/close project view                   ▐│qs] [▾] 
+ [1] ○ c│      Ctrl-Q       quit Station                              ▐│6 #70 ✓ 
+ [2] - d│      Ctrl-\\       split pane right                          ▐│        
+ [3] ○ p│      Ctrl-^       split pane below (Ctrl-6)                 ▐│  #73 ✓ 
+ [4] + s│      Ctrl-]       focus next pane                           ▐│        
+ [5] ⠋ s│      Ctrl-/       close split pane (Ctrl-_)                 ▐│6 #76 … 
+        │      Enter/Sp     open project view on welcome              ▐│        
+ ▼ obser│      Esc/↑↓       context menu close/move                   ▐│qs] [▾] 
+ [6] x b│  ▸   Enter/Sp     context menu select                       ▐│   #8 ✓ 
+ [7] ⠋ p│    station project view                                     ▐│8 #16 … 
+ [8] ○ t│      ↑/↓          move cursor · wheel scroll                ▐│-1 #4 ✓ 
+        │      ↵            open focused session                      ▕│        
+ ▼ scrip│      tab          next session needing you                  ▕│qs] [▾] 
+ [9] ○ a│      G/M          quick group/move to group                 ▕│6 #5 x1 
+ [a] ? m│      / ↵ Esc Q   edit/apply/cancel-clear/retain-close       ▕│ -1 #10 
+        │                  filter                                     ▼│        
+ ▼ empty│ ↓ 6 below · ↑↓ · PgUp/PgDn · Esc                             │qs] [▾] 
  no sess╰──────────────────────────────────────────────────────────────╯        
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
@@ -60,24 +60,24 @@ exports[`modal flow golden frames renders the help overlay final entry at standa
 "                                                                                
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ────────╭──────────────────────────────────────────────────────────────╮─────── 
-       S│      Enter/Sp     open project view on welcome               │FF · PR 
- ▼ stati│      Esc/↑↓       context menu close/move                    │qs] [▾] 
- [1] ○ c│      Enter/Sp     context menu select                        │6 #70 ✓ 
- [2] - d│    station project view                                      │        
- [3] ○ p│      ↑/↓          move cursor · wheel scroll                 │  #73 ✓ 
- [4] + s│      ↵            open focused session                       │        
- [5] ⠋ s│      tab          next session needing you                   │6 #76 … 
-        │      G/M          quick group/move to group                  │        
- ▼ obser│      / ↵ Esc Q   edit/apply/cancel-clear/retain-close        │qs] [▾] 
- [6] x b│                  filter                                      │   #8 ✓ 
- [7] ⠋ p│      Tab S/P/A   build filter conditions · F applies         │8 #16 … 
- [8] ○ t│                  builder                                     │-1 #4 ✓ 
-        │      1-9/a-z      open visible session or toggle condition   │        
- ▼ scrip│      N/A/R/C/F/P  new/add/rename/fold/fork/settings          │qs] [▾] 
- [9] ○ a│      W            widgets                                    │6 #5 x1 
- [a] ? m│      X            delete session                             │ -1 #10 
-        │  ▸   H/?          help · Z refresh                           │        
- ▼ empty│ ↑ more · ↑↓ · PgUp/PgDn · Esc                                │qs] [▾] 
+       S│      Enter/Sp     open project view on welcome              ▲│FF · PR 
+ ▼ stati│      Esc/↑↓       context menu close/move                   ▕│qs] [▾] 
+ [1] ○ c│      Enter/Sp     context menu select                       ▕│6 #70 ✓ 
+ [2] - d│    station project view                                     ▕│        
+ [3] ○ p│      ↑/↓          move cursor · wheel scroll                ▕│  #73 ✓ 
+ [4] + s│      ↵            open focused session                      ▐│        
+ [5] ⠋ s│      tab          next session needing you                  ▐│6 #76 … 
+        │      G/M          quick group/move to group                 ▐│        
+ ▼ obser│      / ↵ Esc Q   edit/apply/cancel-clear/retain-close       ▐│qs] [▾] 
+ [6] x b│                  filter                                     ▐│   #8 ✓ 
+ [7] ⠋ p│      Tab S/P/A   build filter conditions · F applies        ▐│8 #16 … 
+ [8] ○ t│                  builder                                    ▐│-1 #4 ✓ 
+        │      1-9/a-z      open visible session or toggle condition  ▐│        
+ ▼ scrip│      N/A/R/C/F/P  new/add/rename/fold/fork/settings         ▐│qs] [▾] 
+ [9] ○ a│      W            widgets                                   ▐│6 #5 x1 
+ [a] ? m│      X            delete session                            ▐│ -1 #10 
+        │  ▸   H/?          help · Z refresh                          ▼│        
+ ▼ empty│ ↑ 7 above · ↑↓ · PgUp/PgDn · Esc                             │qs] [▾] 
  no sess╰──────────────────────────────────────────────────────────────╯        
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
@@ -86,48 +86,48 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 
 exports[`modal flow golden frames renders the help overlay top at minimum size 1`] = `
 "  ╭──────────────────────────────────╮  
-FL│    station help                  │  
-──│      Ctrl-O   open/close         │─ 
-  │               project view       │  
- ▼│      Ctrl-Q       quit Station   │] 
- [│      Ctrl-\\     split pane       │  
- [│                 right            │  
- [│      Ctrl-^   split pane below   │  
- [│               (Ctrl-6)           │  
-▼ │      Ctrl-]      focus next      │  
-──│ ↓ more · ↑↓ · PgUp/PgDn · Esc    │─ 
+FL│    station help                 ▲│  
+──│      Ctrl-O   open/close        ▐│─ 
+  │               project view      ▕│  
+ ▼│      Ctrl-Q       quit Station  ▕│]▲
+ [│      Ctrl-\\     split pane      ▕│ ▐
+ [│                 right           ▕│ ▕
+ [│      Ctrl-^   split pane below  ▕│ ▕
+ [│               (Ctrl-6)          ▕│ ▕
+ [│      Ctrl-]      focus next     ▼│ ▼
+──│ ↓16 · ↑↓ · PgUp/PgDn · Esc       │─ 
 ↵ ╰──────────────────────────────────╯… 
 "
 `;
 
 exports[`modal flow golden frames renders the help overlay middle at minimum size 1`] = `
 "  ╭──────────────────────────────────╮  
-FL│                  pane            │  
-──│      Ctrl-/   close split pane   │─ 
-  │               (Ctrl-_)           │  
- ▼│      Enter/  open project view   │] 
- [│      Sp      on welcome          │  
- [│      Esc/↑↓   context menu       │  
- [│               close/move         │  
- [│  ▸   Enter/Sp  context menu      │  
-▼ │                select            │  
-──│ ↕ more · ↑↓ · PgUp/PgDn · Esc    │─ 
+FL│                  pane           ▲│  
+──│      Ctrl-/   close split pane  ▕│─ 
+  │               (Ctrl-_)          ▕│  
+ ▼│      Enter/  open project view  ▐│]▲
+ [│      Sp      on welcome         ▕│ ▐
+ [│      Esc/↑↓   context menu      ▕│ ▕
+ [│               close/move        ▕│ ▕
+ [│  ▸   Enter/Sp  context menu     ▕│ ▕
+ [│                select           ▼│ ▼
+──│ ↑5/↓12 · ↑↓ · PgUp/PgDn · Esc    │─ 
 ↵ ╰──────────────────────────────────╯… 
 "
 `;
 
 exports[`modal flow golden frames renders the help overlay final entry at minimum size 1`] = `
 "  ╭──────────────────────────────────╮  
-FL│               toggle condition   │  
-──│      N/A/R/C/ new/add/rename/    │─ 
-  │      F/P      fold/fork/         │  
- ▼│               settings           │] 
- [│      W            widgets        │  
- [│      X           delete session  │  
- [│                                  │  
- [│  ▸   H/?        help · Z         │  
-▼ │                 refresh          │  
-──│ ↑ more · ↑↓ · PgUp/PgDn · Esc    │─ 
+FL│               toggle condition  ▲│  
+──│      N/A/R/C/ new/add/rename/   ▕│─ 
+  │      F/P      fold/fork/        ▕│  
+ ▼│               settings          ▕│]▲
+ [│      W            widgets       ▕│ ▐
+ [│      X           delete session ▕│ ▕
+ [│                                 ▕│ ▕
+ [│  ▸   H/?        help · Z        ▐│ ▕
+ [│                 refresh         ▼│ ▼
+──│ ↑17 · ↑↓ · PgUp/PgDn · Esc       │─ 
 ↵ ╰──────────────────────────────────╯… 
 "
 `;
@@ -166,7 +166,7 @@ FLEET │▸Quick Group         G│
 ──────│ New Group…           │
       │ Set default agent    │
  ▼ sta│ Project settings…    │
-▼ 10 b└──────────────────────┘
+ [1] ○└──────────────────────┘
 ───────────────────────────── 
 ↵ activate  N new  ⇥ next  /… 
 "
@@ -177,9 +177,9 @@ exports[`modal flow golden frames renders the Group menu 1`] = `
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                       AGENT     STATUS                 DIFF · PR 
- ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾] 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Design refresh 2 sessions                                         [qs]▸[▾]│ 
+ ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾]▲
+╭─────────────────────────────────────────────────────────────────────────────╮▐
+│ ▼ Design refresh 2 sessions                                         [qs]▸[▾]│▐
 │ [1] ⠋ group-contracts             codex     workin┌─Design refresh───────────┐
 │ [2] ○ group-keyboard              codex     idle  │▸Quick session           Q│
 ╰───────────────────────────────────────────────────│ New session…            N│
@@ -188,26 +188,25 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 1
 │ [3] ○ input-routing               codex     idle  │──────────────────────────│
 ╰───────────────────────────────────────────────────│ Remove Group…           R│
 ╭───────────────────────────────────────────────────└──────────────────────────┘
-│ ▼ Observer hardening 3 sessions                                     [qs] [▾]│ 
-│ [4] ○ diagnostic-index            codex     idle                      +38 -7│ 
-│ [5] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│ 
-│ [6] ⠋ trace-readiness             codex     working           +91 -22 #478 …│ 
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-▼ 6 below · showing 6 of 12                                                     
-─────────────────────────────────────────────────────────────────────────────── 
+│ ▼ Observer hardening 3 sessions                                     [qs] [▾]│▕
+│ [4] ○ diagnostic-index            codex     idle                      +38 -7│▕
+│ [5] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│▕
+│ [6] ⠋ trace-readiness             codex     working           +91 -22 #478 …│▕
+╰─────────────────────────────────────────────────────────────────────────────╯▕
+╭─────────────────────────────────────────────────────────────────────────────╮▕
+│ ▼ Post-launch 0 sessions                                            [qs] [▾]│▼
+── ▼ 6 below · showing 6 of 12 ──────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
 "
 `;
 
 exports[`modal flow golden frames renders the Group menu above a short viewport 1`] = `
 "  ┌─Design refresh───────────┐
-FL│ New session…            N│
-──│──────────────────────────│
-  │ Group settings…         S│
-╭─│──────────────────────────│
-│ │▸Remove Group…           R│
-▼ └──────────────────────────┘
+FL│──────────────────────────│
+──│ Group settings…         S│
+▲ │──────────────────────────│
+╭─│▸Remove Group…           R│
+│ └──────────────────────────┘
 ───────────────────────────── 
 ↵ activate  N new  ⇥ next  /… 
 "
@@ -302,14 +301,14 @@ exports[`modal flow golden frames renders the move to group destination sheet 1`
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                       AGENT     STATUS                 DIFF · PR 
- ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾] 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Design refresh 2 sessions                                         [qs] [▾]│ 
-│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│ 
-│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│ 
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│ 
+ ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾]▲
+╭─────────────────────────────────────────────────────────────────────────────╮▐
+│ ▼ Design refresh 2 sessions                                         [qs] [▾]│▐
+│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│▐
+│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
+╭─────────────────────────────────────────────────────────────────────────────╮▐
+│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Move to Group                                                                │
 │ Session    group-contracts                                                   │
@@ -330,14 +329,14 @@ exports[`modal flow golden frames renders the move to group follows the final se
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                       AGENT     STATUS                 DIFF · PR 
- ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾] 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Design refresh 2 sessions                                         [qs] [▾]│ 
-│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│ 
-│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│ 
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│ 
+ ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾]▲
+╭─────────────────────────────────────────────────────────────────────────────╮▐
+│ ▼ Design refresh 2 sessions                                         [qs] [▾]│▐
+│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│▐
+│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
+╭─────────────────────────────────────────────────────────────────────────────╮▐
+│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Move to Group                                                                │
 │  U Ungrouped                                                                 │
@@ -358,14 +357,14 @@ exports[`modal flow golden frames renders the move to group create sheet 1`] = `
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                       AGENT     STATUS                 DIFF · PR 
- ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾] 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Design refresh 2 sessions                                         [qs] [▾]│ 
-│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│ 
-│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│ 
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│ 
+ ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾]▲
+╭─────────────────────────────────────────────────────────────────────────────╮▐
+│ ▼ Design refresh 2 sessions                                         [qs] [▾]│▐
+│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│▐
+│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
+╭─────────────────────────────────────────────────────────────────────────────╮▐
+│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Create Group                                                                 │
 │ Session    group-contracts                                                   │
@@ -442,13 +441,13 @@ exports[`modal flow golden frames renders the persistent filter condition fields
 FLEET  ● 0 ready  ⠋ 2 working  ! 0      
 ─────────────────────────────────────── 
 ▏ FILTER /▏               10/10 matches 
-┌────────────────────────────────┐] [▾] 
-│ FILTER CONDITIONS           [×]│      
-│▸ S Status                 Any ›│t     
-│                                │      
-│  Apply filter (F)              │g     
-└────────────────────────────────┘      
-─────────────────────────────────────── 
+┌────────────────────────────────┐] [▾]▲
+│ FILTER CONDITIONS           [×]│     ▐
+│▸ S Status                 Any ›│t    ▕
+│                                │     ▕
+│  Apply filter (F)              │g    ▕
+└────────────────────────────────┘     ▼
+── ▼ 5 below · showing 5 of 10 ──────── 
  CONDITION  S/P/A edit F apply Esc text 
 "
 `;
@@ -458,13 +457,13 @@ exports[`modal flow golden frames renders the persistent filter follows the fina
 FLEET  ● 0 ready  ⠋ 2 working  ! 0      
 ─────────────────────────────────────── 
 ▏ FILTER /▏               10/10 matches 
-┌────────────────────────────────┐] [▾] 
-│ FILTER CONDITIONS           [×]│      
-│▸ A Agent                  Any ›│t     
-│                                │      
-│  Apply filter (F)              │g     
-└────────────────────────────────┘      
-─────────────────────────────────────── 
+┌────────────────────────────────┐] [▾]▲
+│ FILTER CONDITIONS           [×]│     ▐
+│▸ A Agent                  Any ›│t    ▕
+│                                │     ▕
+│  Apply filter (F)              │g    ▕
+└────────────────────────────────┘     ▼
+── ▼ 5 below · showing 5 of 10 ──────── 
  CONDITION  S/P/A edit F apply Esc text 
 "
 `;
@@ -502,13 +501,13 @@ exports[`modal flow golden frames renders the persistent filter condition values
 FLEET  ● 0 ready  ⠋ 2 working  ! 0      
 ─────────────────────────────────────── 
 ▏ FILTER /▏               10/10 matches 
-┌────────────────────────────────┐] [▾] 
-│[←] STATUS CONDITION         [×]│      
-│  6 [ ] Exited                  │t     
-│▸ 7 [ ] No agent                │      
-│  Done (Enter)                  │g     
-└────────────────────────────────┘      
-─────────────────────────────────────── 
+┌────────────────────────────────┐] [▾]▲
+│[←] STATUS CONDITION         [×]│     ▐
+│  6 [ ] Exited                  │t    ▕
+│▸ 7 [ ] No agent                │     ▕
+│  Done (Enter)                  │g    ▕
+└────────────────────────────────┘     ▼
+── ▼ 5 below · showing 5 of 10 ──────── 
  CONDITION  ← fields Sp toggle Esc clo… 
 "
 `;
@@ -546,14 +545,14 @@ exports[`modal flow golden frames renders the collapse project sheet scrolls a l
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
 ───────────────────────────────────────────────────────────────────────────────
        SESSION                            AGENT     STATUS            DIFF · PR
- ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾]
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
- [2] - docs-cleanup                       codex     no agent
- [3] ○ pty-buffer                         codex     idle                  #73 ✓
- [4] + session-resume                     codex     starting
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …
-
- ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾]
+ ▼ station  5 sessions · 4 agents                                 [sh] [qs] [▾]▲
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓▐
+ [2] - docs-cleanup                       codex     no agent                   ▐
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓▐
+ [4] + session-resume                     codex     starting                   ▐
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …▕
+                                                                               ▕
+ ▼ observer  3 sessions · 3 agents                                [sh] [qs] [▾]▕
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Collapse Project                                                             │
 │  i overflow-project-13 healthy                                               │
@@ -602,30 +601,30 @@ exports[`modal flow golden frames renders the new session project picker reaches
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
 ───────────────────────────────────────────────────────────────────────────────
        SESSION                                 AGENT     STATUS       DIFF · PR
- ▼ sheet-project-00  5 sessions · 4 agents                        [sh] [qs] [▾]
- no sessions yet · [ + add session ]
-
- ▼ sheet-project-01  5 sessions · 4 agents                        [sh] [qs] [▾]
- no sessions yet · [ + add session ]
-
- ▼ sheet-project-02  5 sessions · 4 agents                        [sh] [qs] [▾]
- no sessions yet · [ + add session ]
-
- ▼ sheet-project-03  5 sessions · 4 agents                        [sh] [qs] [▾]
- no sessions yet · [ + add session ]
-
- ▼ sheet-project-04  5 sessions · 4 agents                        [sh] [qs] [▾]
- no sessions yet · [ + add session ]
-
- ▼ sheet-project-05  5 sessions · 4 agents                        [sh] [qs] [▾]
- no sessions yet · [ + add session ]
-
- ▼ sheet-project-06  5 sessions · 4 agents                        [sh] [qs] [▾]
- no sessions yet · [ + add session ]
-
- ▼ sheet-project-07  5 sessions · 4 agents                        [sh] [qs] [▾]
- no sessions yet · [ + add session ]
-
+ ▼ sheet-project-00  5 sessions · 4 agents                        [sh] [qs] [▾]▲
+ no sessions yet · [ + add session ]                                           ▐
+                                                                               ▐
+ ▼ sheet-project-01  5 sessions · 4 agents                        [sh] [qs] [▾]▐
+ no sessions yet · [ + add session ]                                           ▐
+                                                                               ▐
+ ▼ sheet-project-02  5 sessions · 4 agents                        [sh] [qs] [▾]▐
+ no sessions yet · [ + add session ]                                           ▐
+                                                                               ▐
+ ▼ sheet-project-03  5 sessions · 4 agents                        [sh] [qs] [▾]▐
+ no sessions yet · [ + add session ]                                           ▕
+                                                                               ▕
+ ▼ sheet-project-04  5 sessions · 4 agents                        [sh] [qs] [▾]▕
+ no sessions yet · [ + add session ]                                           ▕
+                                                                               ▕
+ ▼ sheet-project-05  5 sessions · 4 agents                        [sh] [qs] [▾]▕
+ no sessions yet · [ + add session ]                                           ▕
+                                                                               ▕
+ ▼ sheet-project-06  5 sessions · 4 agents                        [sh] [qs] [▾]▕
+ no sessions yet · [ + add session ]                                           ▕
+                                                                               ▕
+ ▼ sheet-project-07  5 sessions · 4 agents                        [sh] [qs] [▾]▕
+ no sessions yet · [ + add session ]                                           ▕
+                                                                               ▕
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Project                                                               │
 │  x sheet-project-32 healthy                                                  │
@@ -646,25 +645,25 @@ exports[`modal flow golden frames renders the group settings general 1`] = `
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ───┌────────────────────────────────────────────────────────────────────────┐── 
    │ Group settings · Design refresh                                        │PR 
- ▼ │ Design refresh           │ General                                     │▾] 
-╭──│▸ General                 │  Name Design refresh                        │─╮ 
-│ ▼│  Sessions                │ Save renames; sessions stay attached.       │]│ 
-│ [│  Remove Group            │                                             │…│ 
-│ [│                          │ Project station (read-only)                 │✓│ 
-╰──│                          │ /Users/example/Developer/station            │─╯ 
-╭──│                          │                                             │─╮ 
-│ ▼│                          │                                             │]│ 
-│ [│                          │                                             │6│ 
-╰──│                          │                                             │─╯ 
-╭──│                          │                                             │─╮ 
-│ ▼│                          │                                             │]│ 
-│ [│                          │                                             │7│ 
-│ [│                          │                                             │1│ 
-│ [│                          │                                             │…│ 
-╰──│                          │  Save (Enter)    Cancel (Esc)               │─╯ 
-╭──│ ↑↓ or G/S/R select · →/enter edit · esc back                           │─╮ 
-▼ 6└────────────────────────────────────────────────────────────────────────┘   
-─────────────────────────────────────────────────────────────────────────────── 
+ ▼ │ Design refresh           │ General                                     │▾]▲
+╭──│▸ General                 │  Name Design refresh                        │─╮▐
+│ ▼│  Sessions                │ Save renames; sessions stay attached.       │]│▐
+│ [│  Remove Group            │                                             │…│▐
+│ [│                          │ Project station (read-only)                 │✓│▐
+╰──│                          │ /Users/example/Developer/station            │─╯▐
+╭──│                          │                                             │─╮▐
+│ ▼│                          │                                             │]│▐
+│ [│                          │                                             │6│▐
+╰──│                          │                                             │─╯▐
+╭──│                          │                                             │─╮▕
+│ ▼│                          │                                             │]│▕
+│ [│                          │                                             │7│▕
+│ [│                          │                                             │1│▕
+│ [│                          │                                             │…│▕
+╰──│                          │  Save (Enter)    Cancel (Esc)               │─╯▕
+╭──│ ↑↓ or G/S/R select · →/enter edit · esc back                           │─╮▕
+│ ▼└────────────────────────────────────────────────────────────────────────┘]│▼
+── ▼ 6 below · showing 6 of 12 ──────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
 "
 `;
@@ -1206,24 +1205,24 @@ exports[`modal flow golden frames renders the fork details grouped source 1`] = 
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                       AGENT     STATUS                 DIFF · PR 
- ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾] 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Design refresh 2 sessions                                         [qs] [▾]│ 
-│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│ 
-│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│ 
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│ 
-┌────────────────────────────────────────────┐idle                      +27 -6│ 
-│ Fork Session                               │────────────────────────────────╯ 
-│ Source   station · group-contracts         │────────────────────────────────╮ 
-│  Name   group-contracts-fork               │                        [qs] [▾]│ 
-│▸ Group  [x] create in Design refresh       │idle                      +38 -7│ 
-│  Copy   [x] uncommitted changes            │Agent needs app… +53 -11 #476 x1│ 
-│ Source keeps running — copy is read-only.  │working           +91 -22 #478 …│ 
-│                                            │────────────────────────────────╯ 
-│                                            │────────────────────────────────╮ 
-│  Fork (enter)                              │                                  
+ ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾]▲
+╭─────────────────────────────────────────────────────────────────────────────╮▐
+│ ▼ Design refresh 2 sessions                                         [qs] [▾]│▐
+│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│▐
+│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
+╭─────────────────────────────────────────────────────────────────────────────╮▐
+│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│▐
+┌────────────────────────────────────────────┐idle                      +27 -6│▐
+│ Fork Session                               │────────────────────────────────╯▐
+│ Source   station · group-contracts         │────────────────────────────────╮▕
+│  Name   group-contracts-fork               │                        [qs] [▾]│▕
+│▸ Group  [x] create in Design refresh       │idle                      +38 -7│▕
+│  Copy   [x] uncommitted changes            │Agent needs app… +53 -11 #476 x1│▕
+│ Source keeps running — copy is read-only.  │working           +91 -22 #478 …│▕
+│                                            │────────────────────────────────╯▕
+│                                            │────────────────────────────────╮▕
+│  Fork (enter)                              │                        [qs] [▾]│▼
 │ Space/Enter toggle · ↑↓ focus · Esc back   │───────────────────────────────── 
 └────────────────────────────────────────────┘ ? help  Q/esc:close              
 "
@@ -1694,14 +1693,14 @@ exports[`modal flow golden frames renders the new session pick Group 1`] = `
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                       AGENT     STATUS                 DIFF · PR 
- ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾] 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Design refresh 2 sessions                                         [qs] [▾]│ 
-│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│ 
-│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│ 
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│ 
+ ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾]▲
+╭─────────────────────────────────────────────────────────────────────────────╮▐
+│ ▼ Design refresh 2 sessions                                         [qs] [▾]│▐
+│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│▐
+│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
+╭─────────────────────────────────────────────────────────────────────────────╮▐
+│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Group                                                                 │
 │                                                                              │
@@ -1722,14 +1721,14 @@ exports[`modal flow golden frames renders the new session follows the final Grou
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                       AGENT     STATUS                 DIFF · PR 
- ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾] 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Design refresh 2 sessions                                         [qs] [▾]│ 
-│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│ 
-│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│ 
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│ 
+ ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾]▲
+╭─────────────────────────────────────────────────────────────────────────────╮▐
+│ ▼ Design refresh 2 sessions                                         [qs] [▾]│▐
+│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│▐
+│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
+╭─────────────────────────────────────────────────────────────────────────────╮▐
+│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Group                                                                 │
 │ ✓U Ungrouped                                                                 │
@@ -1750,14 +1749,14 @@ exports[`modal flow golden frames renders the new session edit inline Group 1`] 
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                       AGENT     STATUS                 DIFF · PR 
- ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾] 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Design refresh 2 sessions                                         [qs] [▾]│ 
-│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│ 
-│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│ 
-╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│ 
+ ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾]▲
+╭─────────────────────────────────────────────────────────────────────────────╮▐
+│ ▼ Design refresh 2 sessions                                         [qs] [▾]│▐
+│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│▐
+│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
+╭─────────────────────────────────────────────────────────────────────────────╮▐
+│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Create Group                                                                 │
 │ Project      station                                                         │

--- a/station/src/station/view/dashboard.golden.test.tsx
+++ b/station/src/station/view/dashboard.golden.test.tsx
@@ -367,17 +367,32 @@ describe("dashboard golden frames", () => {
     expect(filteredFrame).not.toContain("group-contracts");
     expect(stableGoldenFrame(filteredFrame)).toMatchSnapshot();
 
+    const pointerTargets: StationMouseTarget[] = [];
     const scrolled = await renderDashboard({
       width: 80,
       height: 16,
       snapshot,
+      dispatchMouse: (target) => pointerTargets.push(target),
     });
     scrolled.store.layout.scrollBy(8);
     await scrolled.flush();
     const scrolledFrame = scrolled.captureCharFrame();
     expect(scrolledFrame).toContain("▲");
     expect(scrolledFrame).toContain("│");
+    expect(scrolledFrame).toMatch(/▼ \d+ below · showing/u);
     expect(stableGoldenFrame(scrolledFrame)).toMatchSnapshot();
+
+    const belowRow = scrolledFrame.split("\n").findIndex((line) => line.includes("below"));
+    await scrolled.mockMouse.click(2, belowRow, MouseButtons.LEFT);
+    expect(pointerTargets).toEqual([{ kind: "scrollIndicator", direction: "down" }]);
+
+    const downArrowRow = scrolledFrame.split("\n").findIndex((line) => line.endsWith("▼"));
+    expect(belowRow).toBe(downArrowRow + 1);
+    scrolled.store.layout.scrollBy(1_000);
+    await scrolled.flush();
+    const bottomFrame = scrolled.captureCharFrame();
+    expect(bottomFrame).not.toContain("below");
+    expect(bottomFrame.split("\n").findIndex((line) => line.endsWith("▼"))).toBe(downArrowRow);
   });
 
   it("uses the same responsive Quick Session label for Group and Project headers", async () => {
@@ -424,8 +439,8 @@ describe("dashboard golden frames", () => {
     expect(group).toBeDefined();
     expect(project).not.toContain("�");
     expect(group).not.toContain("�");
-    expect(project?.trimEnd().endsWith("[sh] [qs] [▾]")).toBe(true);
-    expect(group?.trimEnd().endsWith("[qs] [▾]│")).toBe(true);
+    expect(project?.replace(/[▐▕▲▼]$/u, "").trimEnd().endsWith("[sh] [qs] [▾]")).toBe(true);
+    expect(group?.replace(/[▐▕▲▼]$/u, "").trimEnd().endsWith("[qs] [▾]│")).toBe(true);
     expect(cellWidth(project ?? "")).toBe(40);
     expect(cellWidth(group ?? "")).toBe(40);
   });
@@ -561,7 +576,9 @@ describe("dashboard golden frames", () => {
         expect(line?.includes("[qs]")).toBe(testCase.quickSession);
         expect(line?.includes("[▾]")).toBe(testCase.menu);
         if (!collapsed) {
-          expect(line?.trimEnd().endsWith(testCase.expandedSuffix)).toBe(true);
+          expect(line?.replace(/[▐▕]$/u, "").trimEnd().endsWith(testCase.expandedSuffix)).toBe(
+            true,
+          );
           expect(line?.lastIndexOf("│")).toBe(78);
         }
       }

--- a/station/src/station/view/helpScrollChrome.test.ts
+++ b/station/src/station/view/helpScrollChrome.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { helpScrollChrome } from "./helpScrollChrome.js";
+
+const allIds = ["one", "two", "three", "four", "five"] as const;
+
+describe("help scroll chrome", () => {
+  it("formats the expanded label for a middle visible window", () => {
+    expect(
+      helpScrollChrome({
+        allIds,
+        visibleIds: ["two", "three"],
+        panelWidth: 64,
+      }),
+    ).toBe("↑ 1 above · ↓ 2 below");
+  });
+
+  it("formats top and bottom expanded labels", () => {
+    expect(helpScrollChrome({ allIds, visibleIds: ["one"], panelWidth: 48 })).toBe(
+      "↓ 4 below",
+    );
+    expect(helpScrollChrome({ allIds, visibleIds: ["five"], panelWidth: 48 })).toBe(
+      "↑ 4 above",
+    );
+  });
+
+  it("formats compact labels using the effective panel width", () => {
+    expect(
+      helpScrollChrome({
+        allIds,
+        visibleIds: ["two", "three"],
+        panelWidth: 46,
+      }),
+    ).toBe("↑1/↓2");
+    expect(helpScrollChrome({ allIds, visibleIds: undefined, panelWidth: 46 })).toBe("all");
+  });
+});

--- a/station/src/station/view/helpScrollChrome.ts
+++ b/station/src/station/view/helpScrollChrome.ts
@@ -1,0 +1,45 @@
+type HelpScrollChromeInput = {
+  readonly allIds: readonly string[];
+  readonly visibleIds: readonly string[] | undefined;
+  readonly panelWidth: number;
+};
+
+type HelpContinuationCounts = {
+  readonly above: number;
+  readonly below: number;
+};
+
+/** Formats the Help continuation cue from the semantic visible window and rendered panel width. */
+export function helpScrollChrome({
+  allIds,
+  visibleIds,
+  panelWidth,
+}: HelpScrollChromeInput): string {
+  const counts = helpContinuationCounts(allIds, visibleIds);
+  if (panelWidth < 48) {
+    if (counts.above > 0 && counts.below > 0) return `↑${counts.above}/↓${counts.below}`;
+    if (counts.above > 0) return `↑${counts.above}`;
+    if (counts.below > 0) return `↓${counts.below}`;
+    return "all";
+  }
+  if (counts.above > 0 && counts.below > 0) {
+    return `↑ ${counts.above} above · ↓ ${counts.below} below`;
+  }
+  if (counts.above > 0) return `↑ ${counts.above} above`;
+  if (counts.below > 0) return `↓ ${counts.below} below`;
+  return "all visible";
+}
+
+function helpContinuationCounts(
+  allIds: readonly string[],
+  visibleIds: readonly string[] | undefined,
+): HelpContinuationCounts {
+  const firstId = visibleIds?.[0];
+  const lastId = visibleIds?.at(-1);
+  const firstIndex = firstId === undefined ? -1 : allIds.indexOf(firstId);
+  const lastIndex = lastId === undefined ? -1 : allIds.indexOf(lastId);
+  return {
+    above: firstIndex < 0 ? 0 : firstIndex,
+    below: lastIndex < 0 ? 0 : Math.max(0, allIds.length - lastIndex - 1),
+  };
+}

--- a/station/src/station/view/layout/DashboardScrollViewport.tsx
+++ b/station/src/station/view/layout/DashboardScrollViewport.tsx
@@ -1,7 +1,7 @@
 import type { DashboardRowId } from "@station/dashboard-core/selectors";
 import { useSyncExternalStore, type ReactNode } from "react";
 import { SemanticScrollViewport } from "./SemanticScrollViewport.js";
-import type { DashboardScrollController } from "./scrollViewport.js";
+import type { DashboardScrollController } from "./dashboardScrollController.js";
 
 export function useDashboardVisibleRows(
   controller: DashboardScrollController,

--- a/station/src/station/view/layout/DashboardScrollViewport.tsx
+++ b/station/src/station/view/layout/DashboardScrollViewport.tsx
@@ -20,7 +20,7 @@ export function DashboardScrollViewport({
   children: ReactNode;
 }) {
   return (
-    <SemanticScrollViewport controller={controller} itemIds={itemIds}>
+    <SemanticScrollViewport controller={controller} itemIds={itemIds} scrollbar="gutter">
       {children}
     </SemanticScrollViewport>
   );

--- a/station/src/station/view/layout/SemanticScrollViewport.test.tsx
+++ b/station/src/station/view/layout/SemanticScrollViewport.test.tsx
@@ -1,7 +1,15 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { ScrollBoxRenderable } from "@opentui/core";
+import { rgbToHex, ScrollBoxRenderable } from "@opentui/core";
+import { MouseButtons } from "@opentui/core/testing";
 import { testRender } from "@opentui/react/test-utils";
 import { act, useState } from "react";
+import {
+  nativeStationTheme,
+  stationColorSnapshotValue,
+  StationThemeProvider,
+} from "../../../theme/index.js";
+import { spanAtFrameCell } from "../../../terminal/testing/frameProbe.js";
+import { StationHoverProvider } from "../stationMouseContext.js";
 import { SemanticScrollViewport } from "./SemanticScrollViewport.js";
 import {
   createScrollViewportController,
@@ -43,7 +51,12 @@ describe("SemanticScrollViewport", () => {
       );
     }
 
-    const setup = await testRender(<IndexedViewport />, { width: 24, height: 6 });
+    const setup = await testRender(
+      <StationThemeProvider theme={nativeStationTheme}>
+        <IndexedViewport />
+      </StationThemeProvider>,
+      { width: 24, height: 6 },
+    );
     teardowns.push(() => setup.renderer.destroy());
     await setup.flush();
     const viewport = setup.renderer.root.findDescendantById("indexed-semantic-viewport");
@@ -77,22 +90,24 @@ describe("SemanticScrollViewport", () => {
     const itemIds = ["one", "two", "three"] as const;
     const controller = createScrollViewportController<string>();
     const setup = await testRender(
-      <box width={20} height={3} flexDirection="column">
-        <SemanticScrollViewport
-          controller={controller}
-          itemIds={itemIds}
-          viewportId="zero-height-semantic-viewport"
-        >
-          {itemIds.map((itemId) => (
-            <box
-              key={itemId}
-              id={semanticItemRenderableId(itemId)}
-              height={1}
-              flexShrink={0}
-            />
-          ))}
-        </SemanticScrollViewport>
-      </box>,
+      <StationThemeProvider theme={nativeStationTheme}>
+        <box width={20} height={3} flexDirection="column">
+          <SemanticScrollViewport
+            controller={controller}
+            itemIds={itemIds}
+            viewportId="zero-height-semantic-viewport"
+          >
+            {itemIds.map((itemId) => (
+              <box
+                key={itemId}
+                id={semanticItemRenderableId(itemId)}
+                height={1}
+                flexShrink={0}
+              />
+            ))}
+          </SemanticScrollViewport>
+        </box>
+      </StationThemeProvider>,
       { width: 20, height: 5 },
     );
     teardowns.push(() => setup.renderer.destroy());
@@ -117,5 +132,147 @@ describe("SemanticScrollViewport", () => {
     measuredHeight = 0;
     controller.synchronize();
     expect(controller.snapshot()).toEqual([]);
+  });
+
+  it("uses native scrollbar mechanics with stable Station chrome", async () => {
+    const itemIds = Array.from({ length: 20 }, (_, index) => `item-${index}`);
+    const controller = createScrollViewportController<string>();
+    const setup = await testRender(
+      <StationThemeProvider theme={nativeStationTheme}>
+        <StationHoverProvider value>
+          <box width={10} height={5} flexDirection="column" paddingRight={1}>
+            <SemanticScrollViewport
+              controller={controller}
+              itemIds={itemIds}
+              viewportId="scrollbar-semantic-viewport"
+              scrollbar="gutter"
+            >
+              {itemIds.map((itemId) => (
+                <box
+                  key={itemId}
+                  id={semanticItemRenderableId(itemId)}
+                  height={1}
+                  flexShrink={0}
+                />
+              ))}
+            </SemanticScrollViewport>
+          </box>
+        </StationHoverProvider>
+      </StationThemeProvider>,
+      { width: 10, height: 5 },
+    );
+    teardowns.push(() => setup.renderer.destroy());
+    await setup.flush();
+
+    const viewport = setup.renderer.root.findDescendantById("scrollbar-semantic-viewport");
+    if (!(viewport instanceof ScrollBoxRenderable)) {
+      throw new Error("scrollbar semantic viewport did not render");
+    }
+    const slider = viewport.verticalScrollBar.slider;
+    const startArrow = viewport.verticalScrollBar.startArrow;
+    const endArrow = viewport.verticalScrollBar.endArrow;
+    expect(viewport.viewport.width).toBe(9);
+    expect(slider.x).toBe(9);
+    expect(startArrow.y).toBeLessThan(slider.y);
+    expect(endArrow.y).toBeGreaterThan(slider.y);
+    expect(setup.captureCharFrame()).toContain("▲");
+    expect(setup.captureCharFrame()).toContain("▼");
+    expect(setup.captureCharFrame()).toContain("▐");
+    expect(setup.captureCharFrame()).toContain("▕");
+    const topThumbHeight = setup.captureCharFrame().match(/▐/gu)?.length ?? 0;
+    controller.scrollBy(7);
+    await setup.flush();
+    expect(setup.captureCharFrame().match(/▐/gu)?.length).toBe(topThumbHeight);
+    controller.scrollBy(-100);
+    await setup.flush();
+    const ordinary = spanAtFrameCell(setup.captureSpans(), slider.y, slider.x)?.fg;
+    expect(ordinary === undefined ? undefined : rgbToHex(ordinary)).toBe(
+      stationColorSnapshotValue(nativeStationTheme.text.muted),
+    );
+
+    await act(async () => setup.mockMouse.moveTo(startArrow.x, startArrow.y));
+    await setup.flush();
+    const hoveredArrow = spanAtFrameCell(
+      setup.captureSpans(),
+      startArrow.y,
+      startArrow.x,
+    )?.fg;
+    expect(hoveredArrow === undefined ? undefined : rgbToHex(hoveredArrow)).toBe(
+      stationColorSnapshotValue(nativeStationTheme.text.primary),
+    );
+
+    await act(async () =>
+      setup.mockMouse.click(endArrow.x, endArrow.y, MouseButtons.LEFT),
+    );
+    await setup.flush();
+    const afterDownArrow = viewport.scrollTop;
+    expect(afterDownArrow).toBeGreaterThan(0);
+    expect(controller.snapshot()).not.toContain("item-0");
+    await act(async () =>
+      setup.mockMouse.click(startArrow.x, startArrow.y, MouseButtons.LEFT),
+    );
+    await setup.flush();
+    expect(viewport.scrollTop).toBeLessThan(afterDownArrow);
+
+    controller.follow("item-19");
+    await setup.flush();
+    expect(viewport.scrollTop).toBeGreaterThan(0);
+    await act(async () => {
+      for (let index = 0; index < 20; index += 1) {
+        await setup.mockMouse.click(startArrow.x, startArrow.y, MouseButtons.LEFT);
+      }
+    });
+    await setup.flush();
+    expect(viewport.scrollTop).toBe(0);
+    controller.reflow();
+    expect(viewport.scrollTop).toBe(0);
+
+    controller.follow("item-19");
+    await setup.flush();
+    await act(async () => {
+      await setup.mockMouse.click(startArrow.x, startArrow.y, MouseButtons.LEFT);
+      for (let index = 0; index < 20; index += 1) {
+        await setup.mockMouse.scroll(2, 2, "up");
+      }
+    });
+    await setup.flush();
+    expect(viewport.scrollTop).toBe(0);
+    controller.reflow();
+    expect(viewport.scrollTop).toBe(0);
+
+    controller.scrollBy(-100);
+
+    await act(async () => setup.mockMouse.moveTo(slider.x, slider.y));
+    await setup.flush();
+    const hovered = spanAtFrameCell(setup.captureSpans(), slider.y, slider.x)?.fg;
+    expect(hovered === undefined ? undefined : rgbToHex(hovered)).toBe(
+      stationColorSnapshotValue(nativeStationTheme.text.primary),
+    );
+
+    await act(async () =>
+      setup.mockMouse.pressDown(
+        slider.x,
+        slider.y + slider.height - 1,
+        MouseButtons.LEFT,
+      ),
+    );
+    await setup.flush();
+    expect(viewport.scrollTop).toBe(
+      viewport.scrollHeight - viewport.viewport.height,
+    );
+    const pressed = spanAtFrameCell(
+      setup.captureSpans(),
+      slider.y + slider.height - 1,
+      slider.x,
+    )?.bg;
+    expect(pressed === undefined ? undefined : rgbToHex(pressed)).toBe(
+      stationColorSnapshotValue(nativeStationTheme.interaction.hover),
+    );
+    await act(async () =>
+      setup.mockMouse.release(slider.x, slider.y + slider.height - 1, MouseButtons.LEFT),
+    );
+    expect(viewport.scrollTop).toBe(
+      viewport.scrollHeight - viewport.viewport.height,
+    );
   });
 });

--- a/station/src/station/view/layout/SemanticScrollViewport.tsx
+++ b/station/src/station/view/layout/SemanticScrollViewport.tsx
@@ -1,5 +1,14 @@
-import type { ScrollBoxRenderable } from "@opentui/core";
+import type {
+  MouseEvent,
+  OptimizedBuffer,
+  ScrollBarOptions,
+  ScrollBarRenderable,
+  ScrollBoxRenderable,
+  SliderRenderable,
+} from "@opentui/core";
 import { useEffect, useLayoutEffect, useMemo, useRef, type ReactNode } from "react";
+import { toOpenTuiColor, type StationTheme, useStationTheme } from "../../../theme/index.js";
+import { useStationHoverEnabled } from "../stationMouseContext.js";
 import {
   createScrollViewportController,
   type ScrollViewportController,
@@ -11,6 +20,7 @@ export function SemanticScrollRegion<ItemId extends string>({
   followedItemId,
   children,
   fill = true,
+  scrollbar,
   viewportId,
   controller: suppliedController,
 }: {
@@ -18,6 +28,7 @@ export function SemanticScrollRegion<ItemId extends string>({
   followedItemId?: ItemId;
   children: ReactNode;
   fill?: boolean;
+  scrollbar?: "inside" | "gutter";
   viewportId?: string;
   controller?: ScrollViewportController<ItemId>;
 }) {
@@ -32,6 +43,7 @@ export function SemanticScrollRegion<ItemId extends string>({
       controller={controller}
       itemIds={itemIds}
       fill={fill}
+      {...(scrollbar === undefined ? {} : { scrollbar })}
       viewportId={viewportId}
     >
       {children}
@@ -45,6 +57,7 @@ export function SemanticScrollViewport<ItemId extends string>({
   itemIds,
   children,
   fill = true,
+  scrollbar,
   viewportId,
 }: {
   controller: ScrollViewportController<ItemId>;
@@ -52,17 +65,25 @@ export function SemanticScrollViewport<ItemId extends string>({
   children: ReactNode;
   /** Fill a definite parent height; intrinsic overlays leave this false and only shrink at max-height. */
   fill?: boolean;
+  scrollbar?: "inside" | "gutter";
   viewportId?: string;
 }) {
+  const theme = useStationTheme();
+  const hoverEnabled = useStationHoverEnabled();
   const ref = useRef<ScrollBoxRenderable>(null);
-  const itemIdsRef = useRef(itemIds);
-  itemIdsRef.current = itemIds;
+  const verticalScrollbarOptions = useMemo(
+    () =>
+      scrollbar === undefined
+        ? { visible: false }
+        : stationScrollbarOptions(theme, hoverEnabled, scrollbar, controller.synchronize),
+    [controller, hoverEnabled, scrollbar, theme],
+  );
   const itemIdentity = itemIds.join("\u0000");
   // biome-ignore lint/correctness/useExhaustiveDependencies: reattach only when semantic identity changes, not when a selector returns a new array.
   useLayoutEffect(() => {
     const viewport = ref.current;
     if (viewport === null) return;
-    controller.attach(viewport, itemIdsRef.current);
+    controller.attach(viewport, itemIds);
     queueMicrotask(controller.reflow);
     return () => controller.detach(viewport);
   }, [controller, itemIdentity]);
@@ -79,7 +100,7 @@ export function SemanticScrollViewport<ItemId extends string>({
       scrollX={false}
       scrollY
       viewportCulling
-      verticalScrollbarOptions={{ visible: false }}
+      verticalScrollbarOptions={verticalScrollbarOptions}
       horizontalScrollbarOptions={{ visible: false }}
       contentOptions={{
         flexDirection: "column",
@@ -91,4 +112,137 @@ export function SemanticScrollViewport<ItemId extends string>({
       {children}
     </scrollbox>
   );
+}
+
+function stationScrollbarOptions(
+  theme: StationTheme,
+  hoverEnabled: boolean,
+  placement: "inside" | "gutter",
+  synchronize: () => void,
+): Omit<ScrollBarOptions, "orientation"> {
+  const restingColor = toOpenTuiColor(theme.text.muted);
+  const hoverColor = toOpenTuiColor(theme.text.primary);
+  return {
+    width: 1,
+    height: "100%",
+    position: "absolute",
+    top: 0,
+    right: placement === "gutter" ? -1 : 0,
+    showArrows: true,
+    arrowOptions: {
+      foregroundColor: restingColor,
+      backgroundColor: "transparent",
+      onMouse(event) {
+        if (event.type === "over") {
+          this.foregroundColor = hoverEnabled ? hoverColor : restingColor;
+        } else if (event.type === "out") {
+          this.foregroundColor = restingColor;
+        }
+        synchronizeAfterScrollbarMouse(event, synchronize);
+      },
+    },
+    trackOptions: {
+      width: 1,
+      backgroundColor: "transparent",
+      foregroundColor: restingColor,
+      renderAfter(buffer) {
+        paintStationScrollbar(this, buffer);
+      },
+      onMouse(event) {
+        switch (event.type) {
+          case "over":
+            this.foregroundColor = hoverEnabled ? hoverColor : restingColor;
+            break;
+          case "out":
+            this.foregroundColor = restingColor;
+            this.backgroundColor = "transparent";
+            break;
+          case "down":
+          case "drag":
+            this.backgroundColor = toOpenTuiColor(theme.interaction.hover);
+            break;
+          case "up":
+          case "drag-end":
+            this.backgroundColor = "transparent";
+            break;
+        }
+        snapScrollbarTrackEnd(this, event);
+        synchronizeAfterScrollbarMouse(event, synchronize);
+      },
+    },
+  };
+}
+
+function synchronizeAfterScrollbarMouse(event: MouseEvent, synchronize: () => void): void {
+  if (
+    event.type === "down" ||
+    event.type === "drag" ||
+    event.type === "up" ||
+    event.type === "drag-end"
+  ) {
+    queueMicrotask(synchronize);
+  }
+}
+
+function paintStationScrollbar(slider: SliderRenderable, buffer: OptimizedBuffer): void {
+  const scrollbar = slider.parent as ScrollBarRenderable;
+  const trackHeight = Math.max(0, Math.floor(slider.height));
+  const contentHeight = Math.max(0, Math.floor(scrollbar.scrollSize));
+  const viewportHeight = Math.max(1, Math.floor(scrollbar.viewportSize));
+  const overflow = contentHeight > viewportHeight && trackHeight > 0;
+  // A whole-cell thumb keeps the same painted height at every scroll position.
+  const thumbHeight = overflow
+    ? Math.min(
+        trackHeight,
+        Math.max(1, Math.round((viewportHeight * trackHeight) / contentHeight)),
+      )
+    : 0;
+  const maxThumbTop = Math.max(0, trackHeight - thumbHeight);
+  const maxOffset = Math.max(1, contentHeight - viewportHeight);
+  const offset = Math.min(Math.max(0, Math.floor(scrollbar.scrollPosition)), maxOffset);
+  const thumbTop = Math.round((offset * maxThumbTop) / maxOffset);
+
+  for (let row = 0; row < trackHeight; row += 1) {
+    const glyph = overflow && row >= thumbTop && row < thumbTop + thumbHeight ? "▐" : "▕";
+    buffer.setCellWithAlphaBlending(
+      slider.x,
+      slider.y + row,
+      glyph,
+      slider.foregroundColor,
+      slider.backgroundColor,
+    );
+  }
+}
+
+function snapScrollbarTrackEnd(slider: SliderRenderable, event: MouseEvent): void {
+  if (
+    event.type !== "down" &&
+    event.type !== "drag" &&
+    event.type !== "up" &&
+    event.type !== "drag-end"
+  ) {
+    return;
+  }
+  if (slider.height <= 1) {
+    return;
+  }
+  const localY = event.y - slider.y;
+  const scrollbar = slider.parent as ScrollBarRenderable;
+  let position: number;
+  if (localY <= 0) {
+    position = 0;
+  } else if (localY >= slider.height - 1) {
+    position = Math.max(0, scrollbar.scrollSize - scrollbar.viewportSize);
+  } else {
+    return;
+  }
+  const snap = () => {
+    scrollbar.scrollPosition = position;
+  };
+  if (event.type === "up" || event.type === "drag-end") {
+    // OpenTUI writes its exclusive-end mouse ratio after the generic release handler.
+    queueMicrotask(snap);
+  } else {
+    snap();
+  }
 }

--- a/station/src/station/view/layout/SemanticScrollViewport.tsx
+++ b/station/src/station/view/layout/SemanticScrollViewport.tsx
@@ -1,18 +1,12 @@
-import type {
-  MouseEvent,
-  OptimizedBuffer,
-  ScrollBarOptions,
-  ScrollBarRenderable,
-  ScrollBoxRenderable,
-  SliderRenderable,
-} from "@opentui/core";
+import type { ScrollBoxRenderable } from "@opentui/core";
 import { useEffect, useLayoutEffect, useMemo, useRef, type ReactNode } from "react";
-import { toOpenTuiColor, type StationTheme, useStationTheme } from "../../../theme/index.js";
+import { useStationTheme } from "../../../theme/index.js";
 import { useStationHoverEnabled } from "../stationMouseContext.js";
 import {
   createScrollViewportController,
   type ScrollViewportController,
 } from "./scrollViewport.js";
+import { stationScrollbarOptions } from "./stationScrollbar.js";
 
 /** Scroll region for overlays whose geometry is wholly renderer-owned. */
 export function SemanticScrollRegion<ItemId extends string>({
@@ -112,137 +106,4 @@ export function SemanticScrollViewport<ItemId extends string>({
       {children}
     </scrollbox>
   );
-}
-
-function stationScrollbarOptions(
-  theme: StationTheme,
-  hoverEnabled: boolean,
-  placement: "inside" | "gutter",
-  synchronize: () => void,
-): Omit<ScrollBarOptions, "orientation"> {
-  const restingColor = toOpenTuiColor(theme.text.muted);
-  const hoverColor = toOpenTuiColor(theme.text.primary);
-  return {
-    width: 1,
-    height: "100%",
-    position: "absolute",
-    top: 0,
-    right: placement === "gutter" ? -1 : 0,
-    showArrows: true,
-    arrowOptions: {
-      foregroundColor: restingColor,
-      backgroundColor: "transparent",
-      onMouse(event) {
-        if (event.type === "over") {
-          this.foregroundColor = hoverEnabled ? hoverColor : restingColor;
-        } else if (event.type === "out") {
-          this.foregroundColor = restingColor;
-        }
-        synchronizeAfterScrollbarMouse(event, synchronize);
-      },
-    },
-    trackOptions: {
-      width: 1,
-      backgroundColor: "transparent",
-      foregroundColor: restingColor,
-      renderAfter(buffer) {
-        paintStationScrollbar(this, buffer);
-      },
-      onMouse(event) {
-        switch (event.type) {
-          case "over":
-            this.foregroundColor = hoverEnabled ? hoverColor : restingColor;
-            break;
-          case "out":
-            this.foregroundColor = restingColor;
-            this.backgroundColor = "transparent";
-            break;
-          case "down":
-          case "drag":
-            this.backgroundColor = toOpenTuiColor(theme.interaction.hover);
-            break;
-          case "up":
-          case "drag-end":
-            this.backgroundColor = "transparent";
-            break;
-        }
-        snapScrollbarTrackEnd(this, event);
-        synchronizeAfterScrollbarMouse(event, synchronize);
-      },
-    },
-  };
-}
-
-function synchronizeAfterScrollbarMouse(event: MouseEvent, synchronize: () => void): void {
-  if (
-    event.type === "down" ||
-    event.type === "drag" ||
-    event.type === "up" ||
-    event.type === "drag-end"
-  ) {
-    queueMicrotask(synchronize);
-  }
-}
-
-function paintStationScrollbar(slider: SliderRenderable, buffer: OptimizedBuffer): void {
-  const scrollbar = slider.parent as ScrollBarRenderable;
-  const trackHeight = Math.max(0, Math.floor(slider.height));
-  const contentHeight = Math.max(0, Math.floor(scrollbar.scrollSize));
-  const viewportHeight = Math.max(1, Math.floor(scrollbar.viewportSize));
-  const overflow = contentHeight > viewportHeight && trackHeight > 0;
-  // A whole-cell thumb keeps the same painted height at every scroll position.
-  const thumbHeight = overflow
-    ? Math.min(
-        trackHeight,
-        Math.max(1, Math.round((viewportHeight * trackHeight) / contentHeight)),
-      )
-    : 0;
-  const maxThumbTop = Math.max(0, trackHeight - thumbHeight);
-  const maxOffset = Math.max(1, contentHeight - viewportHeight);
-  const offset = Math.min(Math.max(0, Math.floor(scrollbar.scrollPosition)), maxOffset);
-  const thumbTop = Math.round((offset * maxThumbTop) / maxOffset);
-
-  for (let row = 0; row < trackHeight; row += 1) {
-    const glyph = overflow && row >= thumbTop && row < thumbTop + thumbHeight ? "▐" : "▕";
-    buffer.setCellWithAlphaBlending(
-      slider.x,
-      slider.y + row,
-      glyph,
-      slider.foregroundColor,
-      slider.backgroundColor,
-    );
-  }
-}
-
-function snapScrollbarTrackEnd(slider: SliderRenderable, event: MouseEvent): void {
-  if (
-    event.type !== "down" &&
-    event.type !== "drag" &&
-    event.type !== "up" &&
-    event.type !== "drag-end"
-  ) {
-    return;
-  }
-  if (slider.height <= 1) {
-    return;
-  }
-  const localY = event.y - slider.y;
-  const scrollbar = slider.parent as ScrollBarRenderable;
-  let position: number;
-  if (localY <= 0) {
-    position = 0;
-  } else if (localY >= slider.height - 1) {
-    position = Math.max(0, scrollbar.scrollSize - scrollbar.viewportSize);
-  } else {
-    return;
-  }
-  const snap = () => {
-    scrollbar.scrollPosition = position;
-  };
-  if (event.type === "up" || event.type === "drag-end") {
-    // OpenTUI writes its exclusive-end mouse ratio after the generic release handler.
-    queueMicrotask(snap);
-  } else {
-    snap();
-  }
 }

--- a/station/src/station/view/layout/dashboardScrollController.ts
+++ b/station/src/station/view/layout/dashboardScrollController.ts
@@ -1,0 +1,18 @@
+import type { DashboardVisibleRowsSource } from "@station/dashboard-core/runtime";
+import type { DashboardRowId } from "@station/dashboard-core/selectors";
+import {
+  createScrollViewportController,
+  type ScrollViewportController,
+} from "./scrollViewport.js";
+
+export type DashboardScrollController = ScrollViewportController<DashboardRowId> & {
+  readonly visibleRows: DashboardVisibleRowsSource;
+};
+
+export function createDashboardScrollController(): DashboardScrollController {
+  const controller = createScrollViewportController<DashboardRowId>();
+  return {
+    ...controller,
+    visibleRows: { visibleRowIds: controller.visibility.visibleItemIds },
+  };
+}

--- a/station/src/station/view/layout/helpPanelFrame.test.ts
+++ b/station/src/station/view/layout/helpPanelFrame.test.ts
@@ -3,11 +3,33 @@ import { helpPanelFrame } from "./helpPanelFrame.js";
 
 describe("helpPanelFrame", () => {
   it("bounds a tall terminal to a stable preferred height", () => {
-    expect(helpPanelFrame(120, 50)).toEqual({ width: "90%", height: 20 });
+    expect(helpPanelFrame(120, 50)).toEqual({
+      width: "90%",
+      height: 20,
+      overlayWidth: 120,
+      overlayHeight: 50,
+      effectiveWidth: 64,
+    });
   });
 
   it("shrinks with short and degenerate terminals", () => {
-    expect(helpPanelFrame(40, 12)).toEqual({ width: "90%", height: 12 });
-    expect(helpPanelFrame(0, 0)).toEqual({ width: 1, height: 1 });
+    expect(helpPanelFrame(40, 12)).toEqual({
+      width: "90%",
+      height: 12,
+      overlayWidth: 40,
+      overlayHeight: 12,
+      effectiveWidth: 36,
+    });
+    expect(helpPanelFrame(0, 0)).toEqual({
+      width: 1,
+      height: 1,
+      overlayWidth: 1,
+      overlayHeight: 1,
+      effectiveWidth: 1,
+    });
+  });
+
+  it("uses the capped rendered width for continuation policy", () => {
+    expect(helpPanelFrame(52, 12).effectiveWidth).toBe(46);
   });
 });

--- a/station/src/station/view/layout/helpPanelFrame.ts
+++ b/station/src/station/view/layout/helpPanelFrame.ts
@@ -1,16 +1,34 @@
 export type HelpPanelFrame = {
   readonly width: number | `${number}%`;
   readonly height: number;
+  readonly overlayWidth: number;
+  readonly overlayHeight: number;
+  readonly effectiveWidth: number;
 };
 
+export const HELP_PANEL_MAX_WIDTH = 64;
+
 const PREFERRED_HELP_HEIGHT = 20;
+const HELP_PANEL_WIDTH_RATIO = 0.9;
 
 /** OpenTUI boundary for the bounded Help panel; semantic entries never observe cell geometry. */
 export function helpPanelFrame(columns: number, rows: number): HelpPanelFrame {
   const availableColumns = Math.max(1, Math.floor(columns));
   const availableRows = Math.max(1, Math.floor(rows));
+  const effectiveWidth = availableColumns <= 1
+    ? 1
+    : Math.max(
+        1,
+        Math.min(
+          HELP_PANEL_MAX_WIDTH,
+          Math.floor(availableColumns * HELP_PANEL_WIDTH_RATIO),
+        ),
+      );
   return {
     width: availableColumns <= 1 ? 1 : "90%",
     height: Math.min(availableRows, PREFERRED_HELP_HEIGHT),
+    overlayWidth: availableColumns,
+    overlayHeight: availableRows,
+    effectiveWidth,
   };
 }

--- a/station/src/station/view/layout/scrollViewport.ts
+++ b/station/src/station/view/layout/scrollViewport.ts
@@ -111,6 +111,7 @@ export function createScrollViewportController<
   let visibleIds: readonly ItemId[] | undefined;
   let followedId: ItemId | undefined;
   let followAlignment: "start" | "end" | undefined;
+  let synchronizedScrollTop: number | undefined;
   let reflowQueued = false;
   let itemIndexDirty = true;
   const itemById = new Map<ItemId, Renderable>();
@@ -191,7 +192,12 @@ export function createScrollViewportController<
   };
   const synchronize = (): void => {
     ensureItemIndex();
+    synchronizedScrollTop = viewport?.scrollTop;
     synchronizeIndexed();
+  };
+  const stopFollowing = (): void => {
+    followedId = undefined;
+    followAlignment = undefined;
   };
   const revealFollowedItemIndexed = (): void => {
     if (
@@ -229,6 +235,7 @@ export function createScrollViewportController<
   const reflow = (): void => {
     ensureItemIndex();
     revealFollowedItemIndexed();
+    synchronizedScrollTop = viewport?.scrollTop;
     synchronizeIndexed();
   };
 
@@ -251,6 +258,7 @@ export function createScrollViewportController<
       viewport = undefined;
       orderedIds = [];
       followAlignment = undefined;
+      synchronizedScrollTop = undefined;
       clearItemIndex();
       itemIndexDirty = true;
       if (visibleIds === undefined) return;
@@ -259,7 +267,13 @@ export function createScrollViewportController<
     },
     reflow,
     synchronize: (): void => {
-      followAlignment = undefined;
+      if (
+        viewport !== undefined &&
+        synchronizedScrollTop !== undefined &&
+        viewport.scrollTop !== synchronizedScrollTop
+      ) {
+        stopFollowing();
+      }
       synchronize();
     },
     subscribe: (listener): (() => void) => {
@@ -268,14 +282,16 @@ export function createScrollViewportController<
     },
     snapshot: () => visibleIds,
     scrollBy: (cells): void => {
-      followAlignment = undefined;
+      const previousScrollTop = viewport?.scrollTop;
       viewport?.scrollBy(cells);
+      if (viewport?.scrollTop !== previousScrollTop) stopFollowing();
       synchronize();
     },
     scrollPage: (direction): void => {
-      followAlignment = undefined;
+      const previousScrollTop = viewport?.scrollTop;
       const page = Math.max(1, (viewport?.viewport.height ?? 1) - 1);
       viewport?.scrollBy(direction * page);
+      if (viewport?.scrollTop !== previousScrollTop) stopFollowing();
       synchronize();
     },
     follow: (itemId): void => {
@@ -284,6 +300,7 @@ export function createScrollViewportController<
       if (itemId === undefined) return;
       ensureItemIndex();
       revealFollowedItemIndexed();
+      synchronizedScrollTop = viewport?.scrollTop;
       synchronizeIndexed();
     },
   };

--- a/station/src/station/view/layout/scrollViewport.ts
+++ b/station/src/station/view/layout/scrollViewport.ts
@@ -1,83 +1,9 @@
 import { Renderable, type BaseRenderable, type ScrollBoxRenderable } from "@opentui/core";
-import type { DashboardVisibleRowsSource } from "@station/dashboard-core/runtime";
-import type { DashboardRowId } from "@station/dashboard-core/selectors";
-
-export type SemanticItemGeometry<ItemId extends string> = {
-  readonly id: ItemId;
-  readonly top: number;
-  readonly bottom: number;
-};
-
-/** Inclusive intersection at the top and exclusive intersection at the bottom. */
-export function intersectingSemanticItems<ItemId extends string>(
-  viewport: { readonly top: number; readonly bottom: number },
-  items: readonly SemanticItemGeometry<ItemId>[],
-): ItemId[] {
-  return items
-    .filter((item) => item.bottom > viewport.top && item.top < viewport.bottom)
-    .map((item) => item.id);
-}
-
-/**
- * Resolves a viewport against top-to-bottom, non-overlapping semantic boxes.
- * With constant-time geometry lookup, steady-state work is logarithmic in all items plus the
- * intersecting boxes. The controller below maintains that lookup at the renderer boundary.
- */
-export function intersectingOrderedSemanticItems<ItemId extends string>(
-  viewport: { readonly top: number; readonly bottom: number },
-  itemIds: readonly ItemId[],
-  geometryFor: (id: ItemId) => SemanticItemGeometry<ItemId> | undefined,
-): ItemId[] {
-  let low = 0;
-  let high = itemIds.length;
-  while (low < high) {
-    const middle = Math.floor((low + high) / 2);
-    const id = itemIds[middle];
-    const item = id === undefined ? undefined : geometryFor(id);
-    if (item === undefined) {
-      return intersectingSemanticItems(
-        viewport,
-        itemIds.flatMap((candidateId) => {
-          const candidate = geometryFor(candidateId);
-          return candidate === undefined ? [] : [candidate];
-        }),
-      );
-    }
-    if (item.bottom <= viewport.top) low = middle + 1;
-    else high = middle;
-  }
-
-  const visible: ItemId[] = [];
-  for (let index = low; index < itemIds.length; index += 1) {
-    const id = itemIds[index];
-    if (id === undefined) break;
-    const item = geometryFor(id);
-    if (item === undefined) continue;
-    if (item.top >= viewport.bottom) break;
-    if (item.bottom > viewport.top) visible.push(id);
-  }
-  return visible;
-}
-
-/** Cell delta that reveals a semantic box; oversized boxes align their leading edge. */
-export function semanticRevealDelta(
-  viewport: { readonly top: number; readonly bottom: number },
-  item: { readonly top: number; readonly bottom: number },
-  alignment: "nearest" | "start" | "end" = "nearest",
-): number {
-  const itemHeight = item.bottom - item.top;
-  const viewportHeight = viewport.bottom - viewport.top;
-  if (itemHeight >= viewportHeight) {
-    return item.bottom > viewport.top && item.top < viewport.bottom
-      ? 0
-      : item.top - viewport.top;
-  }
-  if (alignment === "start") return item.top - viewport.top;
-  if (alignment === "end") return item.bottom - viewport.bottom;
-  if (item.top < viewport.top) return item.top - viewport.top;
-  if (item.bottom > viewport.bottom) return item.bottom - viewport.bottom;
-  return 0;
-}
+import {
+  intersectingOrderedSemanticItems,
+  semanticRevealDelta,
+  type SemanticItemGeometry,
+} from "./semanticScrollGeometry.js";
 
 export function semanticItemRenderableId(id: string): string {
   return `station-semantic-item:${id}`;
@@ -303,18 +229,6 @@ export function createScrollViewportController<
       synchronizedScrollTop = viewport?.scrollTop;
       synchronizeIndexed();
     },
-  };
-}
-
-export type DashboardScrollController = ScrollViewportController<DashboardRowId> & {
-  readonly visibleRows: DashboardVisibleRowsSource;
-};
-
-export function createDashboardScrollController(): DashboardScrollController {
-  const controller = createScrollViewportController<DashboardRowId>();
-  return {
-    ...controller,
-    visibleRows: { visibleRowIds: controller.visibility.visibleItemIds },
   };
 }
 

--- a/station/src/station/view/layout/scrollbarGeometry.test.ts
+++ b/station/src/station/view/layout/scrollbarGeometry.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import { scrollbarThumbGeometry, scrollbarTrackEndpoint } from "./scrollbarGeometry.js";
+
+describe("scrollbar geometry", () => {
+  it("hides the thumb when content does not overflow", () => {
+    expect(
+      scrollbarThumbGeometry({
+        trackHeight: 8,
+        contentHeight: 8,
+        viewportHeight: 8,
+        scrollPosition: 0,
+      }),
+    ).toEqual({ trackHeight: 8, thumbTop: 0, thumbHeight: 0, overflow: false });
+  });
+
+  it("keeps a whole-cell thumb stable while clamping scroll offsets", () => {
+    const atTop = scrollbarThumbGeometry({
+      trackHeight: 8,
+      contentHeight: 20,
+      viewportHeight: 5,
+      scrollPosition: -100,
+    });
+    const atBottom = scrollbarThumbGeometry({
+      trackHeight: 8,
+      contentHeight: 20,
+      viewportHeight: 5,
+      scrollPosition: 100,
+    });
+
+    expect(atTop.thumbHeight).toBe(2);
+    expect(atTop.thumbTop).toBe(0);
+    expect(atBottom.thumbHeight).toBe(atTop.thumbHeight);
+    expect(atBottom.thumbTop).toBe(6);
+  });
+
+  it("normalizes a zero track without producing a thumb", () => {
+    expect(
+      scrollbarThumbGeometry({
+        trackHeight: 0,
+        contentHeight: 20,
+        viewportHeight: 5,
+        scrollPosition: 4,
+      }),
+    ).toEqual({ trackHeight: 0, thumbTop: 0, thumbHeight: 0, overflow: false });
+  });
+
+  it("snaps only the first and last track cells to scroll endpoints", () => {
+    const input = { trackHeight: 8, contentHeight: 20, viewportHeight: 5 } as const;
+
+    expect(scrollbarTrackEndpoint({ ...input, localY: -1 })).toBe(0);
+    expect(scrollbarTrackEndpoint({ ...input, localY: 3 })).toBeUndefined();
+    expect(scrollbarTrackEndpoint({ ...input, localY: 7 })).toBe(15);
+    expect(scrollbarTrackEndpoint({ ...input, localY: 8 })).toBe(15);
+    expect(scrollbarTrackEndpoint({ ...input, localY: 0, trackHeight: 1 })).toBeUndefined();
+  });
+});

--- a/station/src/station/view/layout/scrollbarGeometry.ts
+++ b/station/src/station/view/layout/scrollbarGeometry.ts
@@ -1,0 +1,59 @@
+export type ScrollbarThumbGeometryInput = {
+  readonly trackHeight: number;
+  readonly contentHeight: number;
+  readonly viewportHeight: number;
+  readonly scrollPosition: number;
+};
+
+export type ScrollbarThumbGeometry = {
+  readonly trackHeight: number;
+  readonly thumbTop: number;
+  readonly thumbHeight: number;
+  readonly overflow: boolean;
+};
+
+/** Maps scroll content coordinates to a stable whole-cell scrollbar thumb. */
+export function scrollbarThumbGeometry({
+  trackHeight: rawTrackHeight,
+  contentHeight: rawContentHeight,
+  viewportHeight: rawViewportHeight,
+  scrollPosition,
+}: ScrollbarThumbGeometryInput): ScrollbarThumbGeometry {
+  const trackHeight = Math.max(0, Math.floor(rawTrackHeight));
+  const contentHeight = Math.max(0, Math.floor(rawContentHeight));
+  const viewportHeight = Math.max(1, Math.floor(rawViewportHeight));
+  const overflow = contentHeight > viewportHeight && trackHeight > 0;
+  // A whole-cell thumb keeps the same painted height at every scroll position.
+  const thumbHeight = overflow
+    ? Math.min(
+        trackHeight,
+        Math.max(1, Math.round((viewportHeight * trackHeight) / contentHeight)),
+      )
+    : 0;
+  const maxThumbTop = Math.max(0, trackHeight - thumbHeight);
+  const maxOffset = Math.max(1, contentHeight - viewportHeight);
+  const offset = Math.min(Math.max(0, Math.floor(scrollPosition)), maxOffset);
+  const thumbTop = Math.round((offset * maxThumbTop) / maxOffset);
+
+  return { trackHeight, thumbTop, thumbHeight, overflow };
+}
+
+/** Returns a scroll offset only when a pointer lands on the first or last track cell. */
+export function scrollbarTrackEndpoint({
+  localY,
+  trackHeight,
+  contentHeight,
+  viewportHeight,
+}: {
+  readonly localY: number;
+  readonly trackHeight: number;
+  readonly contentHeight: number;
+  readonly viewportHeight: number;
+}): number | undefined {
+  if (trackHeight <= 1) return undefined;
+  if (localY <= 0) return 0;
+  if (localY >= trackHeight - 1) {
+    return Math.max(0, contentHeight - viewportHeight);
+  }
+  return undefined;
+}

--- a/station/src/station/view/layout/semanticScrollGeometry.test.ts
+++ b/station/src/station/view/layout/semanticScrollGeometry.test.ts
@@ -3,9 +3,9 @@ import {
   intersectingOrderedSemanticItems,
   intersectingSemanticItems,
   semanticRevealDelta,
-} from "./scrollViewport.js";
+} from "./semanticScrollGeometry.js";
 
-describe("semantic scroll viewport", () => {
+describe("semantic scroll geometry", () => {
   it("resolves visibility from mixed-height coordinates instead of item count", () => {
     const items = [
       { id: "one", top: 0, bottom: 1 },
@@ -54,11 +54,11 @@ describe("semantic scroll viewport", () => {
     const itemIds = Array.from({ length: 10_000 }, (_, index) => `item-${index}`);
     let top = 0;
     const geometry = itemIds.map((id, index) => {
-        const height = index % 2 === 0 ? 1 : 4;
-        const item = { id, top, bottom: top + height };
-        top += height;
-        return item;
-      });
+      const height = index % 2 === 0 ? 1 : 4;
+      const item = { id, top, bottom: top + height };
+      top += height;
+      return item;
+    });
     const geometryById = new Map(geometry.map((item) => [item.id, item] as const));
     let geometryReads = 0;
     for (let experiment = 0; experiment < 200; experiment += 1) {

--- a/station/src/station/view/layout/semanticScrollGeometry.ts
+++ b/station/src/station/view/layout/semanticScrollGeometry.ts
@@ -1,0 +1,76 @@
+export type SemanticItemGeometry<ItemId extends string> = {
+  readonly id: ItemId;
+  readonly top: number;
+  readonly bottom: number;
+};
+
+/** Inclusive intersection at the top and exclusive intersection at the bottom. */
+export function intersectingSemanticItems<ItemId extends string>(
+  viewport: { readonly top: number; readonly bottom: number },
+  items: readonly SemanticItemGeometry<ItemId>[],
+): ItemId[] {
+  return items
+    .filter((item) => item.bottom > viewport.top && item.top < viewport.bottom)
+    .map((item) => item.id);
+}
+
+/**
+ * Resolves a viewport against top-to-bottom, non-overlapping semantic boxes.
+ * With constant-time geometry lookup, steady-state work is logarithmic in all items plus the
+ * intersecting boxes. The controller maintains that lookup at the renderer boundary.
+ */
+export function intersectingOrderedSemanticItems<ItemId extends string>(
+  viewport: { readonly top: number; readonly bottom: number },
+  itemIds: readonly ItemId[],
+  geometryFor: (id: ItemId) => SemanticItemGeometry<ItemId> | undefined,
+): ItemId[] {
+  let low = 0;
+  let high = itemIds.length;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    const id = itemIds[middle];
+    const item = id === undefined ? undefined : geometryFor(id);
+    if (item === undefined) {
+      return intersectingSemanticItems(
+        viewport,
+        itemIds.flatMap((candidateId) => {
+          const candidate = geometryFor(candidateId);
+          return candidate === undefined ? [] : [candidate];
+        }),
+      );
+    }
+    if (item.bottom <= viewport.top) low = middle + 1;
+    else high = middle;
+  }
+
+  const visible: ItemId[] = [];
+  for (let index = low; index < itemIds.length; index += 1) {
+    const id = itemIds[index];
+    if (id === undefined) break;
+    const item = geometryFor(id);
+    if (item === undefined) continue;
+    if (item.top >= viewport.bottom) break;
+    if (item.bottom > viewport.top) visible.push(id);
+  }
+  return visible;
+}
+
+/** Cell delta that reveals a semantic box; oversized boxes align their leading edge. */
+export function semanticRevealDelta(
+  viewport: { readonly top: number; readonly bottom: number },
+  item: { readonly top: number; readonly bottom: number },
+  alignment: "nearest" | "start" | "end" = "nearest",
+): number {
+  const itemHeight = item.bottom - item.top;
+  const viewportHeight = viewport.bottom - viewport.top;
+  if (itemHeight >= viewportHeight) {
+    return item.bottom > viewport.top && item.top < viewport.bottom
+      ? 0
+      : item.top - viewport.top;
+  }
+  if (alignment === "start") return item.top - viewport.top;
+  if (alignment === "end") return item.bottom - viewport.bottom;
+  if (item.top < viewport.top) return item.top - viewport.top;
+  if (item.bottom > viewport.bottom) return item.bottom - viewport.bottom;
+  return 0;
+}

--- a/station/src/station/view/layout/stationScrollbar.ts
+++ b/station/src/station/view/layout/stationScrollbar.ts
@@ -1,0 +1,135 @@
+import type {
+  MouseEvent,
+  OptimizedBuffer,
+  ScrollBarOptions,
+  ScrollBarRenderable,
+  SliderRenderable,
+} from "@opentui/core";
+import { toOpenTuiColor, type StationTheme } from "../../../theme/index.js";
+import {
+  scrollbarThumbGeometry,
+  scrollbarTrackEndpoint,
+} from "./scrollbarGeometry.js";
+
+export function stationScrollbarOptions(
+  theme: StationTheme,
+  hoverEnabled: boolean,
+  placement: "inside" | "gutter",
+  synchronize: () => void,
+): Omit<ScrollBarOptions, "orientation"> {
+  const restingColor = toOpenTuiColor(theme.text.muted);
+  const hoverColor = toOpenTuiColor(theme.text.primary);
+  return {
+    width: 1,
+    height: "100%",
+    position: "absolute",
+    top: 0,
+    right: placement === "gutter" ? -1 : 0,
+    showArrows: true,
+    arrowOptions: {
+      foregroundColor: restingColor,
+      backgroundColor: "transparent",
+      onMouse(event) {
+        if (event.type === "over") {
+          this.foregroundColor = hoverEnabled ? hoverColor : restingColor;
+        } else if (event.type === "out") {
+          this.foregroundColor = restingColor;
+        }
+        synchronizeAfterScrollbarMouse(event, synchronize);
+      },
+    },
+    trackOptions: {
+      width: 1,
+      backgroundColor: "transparent",
+      foregroundColor: restingColor,
+      renderAfter(buffer) {
+        paintStationScrollbar(this, buffer);
+      },
+      onMouse(event) {
+        switch (event.type) {
+          case "over":
+            this.foregroundColor = hoverEnabled ? hoverColor : restingColor;
+            break;
+          case "out":
+            this.foregroundColor = restingColor;
+            this.backgroundColor = "transparent";
+            break;
+          case "down":
+          case "drag":
+            this.backgroundColor = toOpenTuiColor(theme.interaction.hover);
+            break;
+          case "up":
+          case "drag-end":
+            this.backgroundColor = "transparent";
+            break;
+        }
+        snapScrollbarTrackEnd(this, event);
+        synchronizeAfterScrollbarMouse(event, synchronize);
+      },
+    },
+  };
+}
+
+function synchronizeAfterScrollbarMouse(event: MouseEvent, synchronize: () => void): void {
+  if (
+    event.type === "down" ||
+    event.type === "drag" ||
+    event.type === "up" ||
+    event.type === "drag-end"
+  ) {
+    queueMicrotask(synchronize);
+  }
+}
+
+function paintStationScrollbar(slider: SliderRenderable, buffer: OptimizedBuffer): void {
+  const scrollbar = slider.parent as ScrollBarRenderable;
+  const geometry = scrollbarThumbGeometry({
+    trackHeight: slider.height,
+    contentHeight: scrollbar.scrollSize,
+    viewportHeight: scrollbar.viewportSize,
+    scrollPosition: scrollbar.scrollPosition,
+  });
+
+  for (let row = 0; row < geometry.trackHeight; row += 1) {
+    const glyph = geometry.overflow &&
+        row >= geometry.thumbTop &&
+        row < geometry.thumbTop + geometry.thumbHeight
+      ? "▐"
+      : "▕";
+    buffer.setCellWithAlphaBlending(
+      slider.x,
+      slider.y + row,
+      glyph,
+      slider.foregroundColor,
+      slider.backgroundColor,
+    );
+  }
+}
+
+function snapScrollbarTrackEnd(slider: SliderRenderable, event: MouseEvent): void {
+  if (
+    event.type !== "down" &&
+    event.type !== "drag" &&
+    event.type !== "up" &&
+    event.type !== "drag-end"
+  ) {
+    return;
+  }
+  const scrollbar = slider.parent as ScrollBarRenderable;
+  const position = scrollbarTrackEndpoint({
+    localY: event.y - slider.y,
+    trackHeight: slider.height,
+    contentHeight: scrollbar.scrollSize,
+    viewportHeight: scrollbar.viewportSize,
+  });
+  if (position === undefined) return;
+  const snap = () => {
+    scrollbar.scrollPosition = position;
+  };
+  if (event.type === "up" || event.type === "drag-end") {
+    // OpenTUI writes its exclusive-end mouse ratio after the generic release handler.
+    queueMicrotask(snap);
+  } else {
+    snap();
+  }
+}

--- a/station/src/station/view/modals.golden.test.tsx
+++ b/station/src/station/view/modals.golden.test.tsx
@@ -175,7 +175,7 @@ const CASES: ModalCase[] = [
       "station help",
       "Ctrl-\\",
       "split pane right",
-      "↓ more",
+      "↓ 6 below",
       "PgUp/PgDn",
       "╭",
       "╰",
@@ -187,18 +187,18 @@ const CASES: ModalCase[] = [
       { input: "H" },
       ...Array.from({ length: 10 }, () => ({ input: "", downArrow: true })),
     ],
-    expect: ["station help", "▸", "↓ more", "PgUp/PgDn"],
+    expect: ["station help", "▸", "↓ 6 below", "PgUp/PgDn"],
   },
   {
     name: "help overlay final entry at standard size",
     keys: [{ input: "H" }, { input: "", pageDown: true }],
-    expect: ["widgets", "delete", "▸   H/?", "refresh", "↑ more", "PgUp/PgDn"],
+    expect: ["widgets", "delete", "▸   H/?", "refresh", "↑ 7 above", "PgUp/PgDn"],
   },
   {
     name: "help overlay top at minimum size",
     keys: [{ input: "H" }],
     size: { width: 40, height: 12 },
-    expect: ["station help", "Ctrl-O", "↓ more", "PgUp/PgDn"],
+    expect: ["station help", "Ctrl-O", "↓16", "PgUp/PgDn"],
   },
   {
     name: "help overlay middle at minimum size",
@@ -207,13 +207,13 @@ const CASES: ModalCase[] = [
       ...Array.from({ length: 10 }, () => ({ input: "", downArrow: true })),
     ],
     size: { width: 40, height: 12 },
-    expect: ["▸", "↕ more", "PgUp/PgDn"],
+    expect: ["▸", "↑5/↓12", "PgUp/PgDn"],
   },
   {
     name: "help overlay final entry at minimum size",
     keys: [{ input: "H" }, { input: "", pageDown: true }],
     size: { width: 40, height: 12 },
-    expect: ["widgets", "delete", "▸", "refresh", "↑ more", "PgUp/PgDn"],
+    expect: ["widgets", "delete", "▸", "refresh", "↑17", "PgUp/PgDn"],
   },
   {
     name: "project menu",
@@ -244,7 +244,7 @@ const CASES: ModalCase[] = [
   {
     name: "Group menu above a short viewport",
     keys: [],
-    size: { width: 30, height: 9 },
+    size: { width: 30, height: 8 },
     snapshot: groupedManyProjectsSnapshot,
     prepare: (state) => {
       let opened = openGroupMenu(state, "group_design_refresh");
@@ -253,8 +253,8 @@ const CASES: ModalCase[] = [
       }
       return opened;
     },
-    expect: ["New session…", "Group settings…", "Remove Group…"],
-    reject: ["Quick session"],
+    expect: ["Group settings…", "Remove Group…"],
+    reject: ["Quick session", "New session…"],
   },
   {
     name: "create group sheet",


### PR DESCRIPTION
## What this fixes

Help and the dashboard use semantic viewports for identity-based scrolling, but overflowing content lacked dependable position chrome. OpenTUI native half-cell thumb painting can occupy a different number of terminal rows as it moves, while a separate dashboard continuation row makes viewport height depend on whether that row is mounted.

## What changed

- Keep OpenTUI native arrow, track, drag, and wheel mechanics.
- Apply Station colors and hover feedback through native scrollbar options.
- Paint only the rail and thumb with fixed whole-cell geometry, so thumb height is independent of scroll position.
- Snap the first and final track cells to exact scroll boundaries.
- Stop semantic focus-follow only after manual input actually moves the viewport.
- Preserve exact session counts while detecting project, Group, and empty-state continuation that has no hidden session count.
- Put the clickable below cue on the existing dashboard controls divider instead of allocating another row.
- Keep Help numeric above and below continuation cues.

## Testing

- bun run test:ci:station
- bun run lint
- bun run typecheck - 46/46 tasks
- Station renderer and golden suite - 171 pass, 121 existing snapshots
- Focused dashboard-core and scrollbar behavior - 35 pass
- PTY suites - 105 native bridge and 69 Bun PTY tests
- Host upgrade suite - 10 pass
- No snapshot cases or snapshot files added

## User-visible behavior

Help and overflowing dashboards show arrows, a stable thin thumb, and above/below continuation cues. Arrow, track, and wheel scrolling can reach and remain at the true endpoints. The dashboard below cue remains clickable without shrinking the content viewport or moving the bottom arrow, and exact-fit dashboards keep their full height.

Manual check: scroll the dashboard and Help from top to bottom and back using both arrows and the wheel. Confirm the thumb keeps one apparent height, arrows highlight on hover, the below cue appears on the divider when content remains, and the bottom arrow stays fixed when that cue clears.