### PR TITLE
fix(tui): restore native filter-header click-away

### DIFF
--- a/station/src/station/StationOverlay.test.tsx
+++ b/station/src/station/StationOverlay.test.tsx
@@ -196,6 +196,65 @@ describe("StationOverlay", () => {
     expect(calls).toEqual([{ kind: "station", target: { kind: "screenBackdrop" } }]);
   });
 
+  it("clicks away from staged filter conditions through the rendered FILTER header", async () => {
+    const { runtime: store } = makeStationTestRuntime();
+    const calls: Array<{ target: MouseTargetRef; event: StationMouseEvent }> = [];
+    const setup = await renderOverlay((target, event) => {
+      calls.push({ target, event });
+      if (target.kind === "station") {
+        routeStationMouse(target.target, event, store);
+      }
+      return true;
+    }, store);
+    await act(async () => {
+      store.actions.handleKey({ input: "/" });
+      store.actions.handleKey({ input: "draft" });
+      store.actions.handleKey({ input: "i", ctrl: true });
+      store.actions.handleKey({ input: "S" });
+      store.actions.handleKey({ input: "3" });
+      store.actions.handleKey({ input: "\r", return: true });
+      store.actions.handleKey({ input: "S" });
+      store.actions.handleKey({ input: "5" });
+      await setup.flush();
+    });
+    const frame = setup.captureCharFrame();
+    const filter = cellFor(frame, "FILTER /draft");
+    const condition = cellFor(frame, "STATUS CONDITION");
+    const filterColumn = filter.col + Math.floor("FILTER /draft".length / 2);
+
+    expect(filter.row).toBeLessThan(condition.row);
+    expect(frame).toContain("[✓] Working");
+    expect(frame).toContain("[✓] Idle");
+    expect(store.state.getState().screen).toMatchObject({
+      conditionEditor: { stage: "values", selectedIds: ["working", "idle"] },
+    });
+
+    calls.splice(0);
+    await setup.mockMouse.click(filterColumn, filter.row, MouseButtons.LEFT);
+
+    expect(calls).toEqual([
+      {
+        target: { kind: "station", target: { kind: "screenBackdrop" } },
+        event: {
+          type: "down",
+          button: "left",
+          rawButton: 0,
+          x: filterColumn,
+          y: filter.row,
+          modifiers: { shift: false, alt: false, ctrl: false },
+        },
+      },
+    ]);
+    expect(store.state.getState().screen).toEqual({
+      name: "persistentFilter",
+      draft: { value: "draft", cursor: 5 },
+      draftConditions: [
+        { field: "status", values: [{ id: "working", label: "Working" }] },
+      ],
+    });
+    expect(setup.captureCharFrame()).not.toContain("STATUS CONDITION");
+  });
+
   it("routes obscured title-row clicks through the inner screen backdrop", async () => {
     const { runtime: store } = makeStationTestRuntime();
     const calls: Array<{ target: MouseTargetRef; event: StationMouseEvent }> = [];

--- a/station/src/station/view/DashboardView.tsx
+++ b/station/src/station/view/DashboardView.tsx
@@ -161,6 +161,10 @@ export function DashboardView({
           flexShrink={0}
           position="relative"
           {...(conditionPanelActive ? { zIndex: 10 } : {})}
+          // The elevated header must own click-away because it sits above the screen backdrop.
+          {...(conditionPanelActive
+            ? stationMouseProps(dispatch, { kind: "screenBackdrop" })
+            : {})}
         >
           {tableHeader === undefined ? null : <DashboardTableHeaderView model={tableHeader} />}
           {conditionPanelActive ? (

--- a/tests/e2e/real/real-native-tui-mouse.test.ts
+++ b/tests/e2e/real/real-native-tui-mouse.test.ts
@@ -327,7 +327,7 @@ describeReal("real native Station mouse input", () => {
       );
 
       await writeSgrClick(ptyClient, cellForText(collapsedFiltered, "/ edit"));
-      const reopenedFilter = await waitForNativeFrame(
+      await waitForNativeFrame(
         runtime,
         (frame) => frame.includes(`FILTER /${branch}`),
         "Clicking the native applied-filter edit control did not reopen the header editor.",
@@ -357,12 +357,12 @@ describeReal("real native Station mouse input", () => {
         "Clicking Status after Back did not reopen native condition values.",
       );
       await writeSgrClick(ptyClient, cellForText(reopenedStatusValues, "Working"));
-      await waitForNativeFrame(
+      const selectedWorking = await waitForNativeFrame(
         runtime,
         (frame) => frame.includes("[✓] Working"),
         "Clicking Working did not toggle the native condition value.",
       );
-      await writeSgrClick(ptyClient, cellForText(reopenedFilter, `FILTER /${branch}`));
+      await writeSgrClick(ptyClient, cellForText(selectedWorking, `FILTER /${branch}`));
       await waitForNativeFrame(
         runtime,
         (frame) => frame.includes(`FILTER /${branch}`) && !frame.includes("STATUS CONDITION"),


### PR DESCRIPTION
## What this fixes

Station’s persistent-filter condition editor renders beneath an elevated FILTER header. Because that header sat above the dashboard backdrop without owning its click-away handler, a native click on the visible header was swallowed and left the condition panel open.

## What changed

- Route clicks on the elevated FILTER header through the existing screen-backdrop behavior while the condition panel is active.
- Add a physical StationOverlay regression that retains Working, stages Idle without retaining it, clicks the rendered header, and verifies exactly one backdrop dispatch.
- Preserve the query and retained Working condition while discarding the unretained Idle selection on click-away.
- Calculate the real native FILTER click from the exact frame returned after Working becomes selected.

## Testing

- Captured the new StationOverlay regression failing without the handler and passing with it: 10 tests, 29 expectations.
- Passed bun run test:ci:station, including the Station renderer, bridge PTY, Bun PTY, and host-upgrade lanes.
- Passed bun run test:all, including build, typecheck, lint/architecture, deterministic suites, setup E2E, Observer E2E, and install smoke.
- Passed one temporary bounded real-native proof through the corrected click-away assertion; afterEach cleanup verified the exact renderer, attached-client, tmux-client, and Observer PIDs exited and all recorded fixture paths and sockets were absent. The temporary instrumentation was removed before commit.
- The permanent real-native lane passed the corrected click-away and subsequent filter/apply/clear UI path, then timed out at the later #712-owned wait for the retained Codex session to resume live. Retained TUI shutdown evidence places the run at that recovery-authority boundary; the run is not described as fully green, and all fixture/process/tmux residue was proven absent.

## User-visible behavior

Clicking the visible FILTER header now closes an open condition panel while preserving the filter query and retained conditions and discarding unretained edits.

Closes #735