### PR TITLE
fix(station): preserve native rename sheet handoff

### DIFF
--- a/station/src/input/runtime/executeOutcome.ts
+++ b/station/src/input/runtime/executeOutcome.ts
@@ -166,13 +166,14 @@ function selectContextMenuItem(
       return;
     case "renameSession":
       if (dashboardRuntime !== undefined) {
+        dismissCurrentAttention(effects);
+        // Overlay-open synchronization restores row focus through the dashboard screen.
+        effects.store.actions.openOverlay(STATION_OVERLAY_ID);
         dashboardRuntime.actions.dispatch({
           type: "renameSession.openEdit",
           rowId: action.sessionId,
           returnTo: "dashboard",
         });
-        dismissCurrentAttention(effects);
-        effects.store.actions.openOverlay(STATION_OVERLAY_ID);
       }
       return;
     case "moveToGroup":

--- a/station/src/input/stationInput.test.ts
+++ b/station/src/input/stationInput.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { dashboardRowIds } from "@station/dashboard-core/selectors";
+import { createOverlayRowFocusReconciler } from "../state/reconcilers/overlayRowFocus.js";
 import { selectActivePaneId, selectStationOverlayVisible } from "../state/selectors.js";
 import { createStationStore } from "../state/store.js";
 import {
@@ -356,7 +357,7 @@ describe("createStationInputRuntime", () => {
     expect(store.getState().input.focus).toEqual({ kind: "pane", paneId: MAIN_PANE_ID });
   });
 
-  it("context-menu Rename from a primary-agent pane opens directly and Esc closes to the dashboard", () => {
+  it("right-click Rename from a primary-agent pane opens directly and Esc closes to the dashboard", () => {
     const snapshot = manyProjectsSnapshot();
     const dashboardRuntime = createStationTestDashboardRuntime({
       source: new FakeStationSource(snapshot),
@@ -372,12 +373,22 @@ describe("createStationInputRuntime", () => {
       sessionId: "ses_wt_station_idle",
       terminalTargetId: "native:wt_station_idle",
     });
+    const dispose = createOverlayRowFocusReconciler(store, dashboardRuntime);
 
     expect(runtime.dispatchMouse({ kind: "pane", paneId }, RIGHT_DOWN)).toBe(true);
-    expect(runtime.handleSequence("\r")).toBe(true);
+    expect(
+      runtime.dispatchMouse(
+        { kind: "contextMenuItem", itemId: "station.renameSession" },
+        LEFT_DOWN,
+      ),
+    ).toBe(true);
 
     expect(store.getState().input.contextMenu).toBeNull();
     expect(selectStationOverlayVisible(store.getState())).toBe(true);
+    expect(dashboardRuntime.state.getState().dashboardFocus).toEqual({
+      rowId: dashboardRowIds.session("ses_wt_station_idle"),
+      cellId: "identity",
+    });
     expect(dashboardRuntime.state.getState().screen).toMatchObject({
       name: "renameSession",
       step: "editName",
@@ -387,6 +398,11 @@ describe("createStationInputRuntime", () => {
 
     expect(runtime.handleSequence("\x1b")).toBe(true);
     expect(dashboardRuntime.state.getState().screen).toEqual({ name: "dashboard" });
+    expect(dashboardRuntime.state.getState().dashboardFocus).toEqual({
+      rowId: dashboardRowIds.session("ses_wt_station_idle"),
+      cellId: "identity",
+    });
+    dispose();
   });
 
   it("runs an automation: splits a shell pane and executes its command with a trailing Enter", async () => {


### PR DESCRIPTION
## What this fixes

Native Station pane context-menu Rename could open the dashboard without the Rename Session editor. The overlay focus reconciler ran after the rename transition and reset the requested screen to dashboard.

## What changed

- Let native overlay activation and row-focus synchronization finish before dispatching renameSession.openEdit.
- Extend the native input regression to use right-click plus left-click selection with the production overlay-focus reconciler, and verify Escape returns to the same focused row.

## Testing

- bun run --cwd station test src/input/stationInput.test.ts (75 passed)
- bun run --cwd station typecheck
- bun run test:ci:station (all Station renderer, PTY, and Host lanes passed)
- bun run test:all (build, typecheck, lint, unit, contracts, integration, diagnostics, and scripted lanes passed; setup E2E has two unrelated baseline failures: Bun package resolution in bootstrap and OSC-8 hyperlink expectation)
- bun run test:e2e:observer (27 passed)
- bun run smoke:install

## User-visible behavior

Native primary-agent pane → right-click → Rename now opens the prefilled Rename Session sheet; Escape returns to the focused dashboard row. Manual live-runtime verification was not run to avoid disturbing the installed Station runtime.