### PR TITLE
fix(tui): preserve Enter for focused attention session

### DIFF
--- a/station/src/input/keymap/stationBindings.ts
+++ b/station/src/input/keymap/stationBindings.ts
@@ -195,6 +195,11 @@ function createStationButtonLayer(
             pane?.role === "primary-agent" &&
             pane.agentIdentity?.sessionId === row.session.id
           ) {
+            // The island may intercept Enter only to change surfaces. Once the
+            // requesting pane owns focus, Enter is terminal input for Codex.
+            if (state.input.focus.kind === "pane" && state.input.focus.paneId === paneId) {
+              return { kind: "terminal-write", paneId, bytes: C0.CarriageReturn };
+            }
             return { kind: "focus", target: { kind: "pane", paneId } };
           }
           return { kind: "overlay-open", overlayId: STATION_OVERLAY_ID };

--- a/station/src/input/router.test.ts
+++ b/station/src/input/router.test.ts
@@ -390,6 +390,7 @@ describe("the station-button layer (island ↵ jump)", () => {
       sessionId: flagged.session.id,
       terminalTargetId: `native:${flagged.worktree.id}`,
     });
+    store.actions.focusPane(MAIN_PANE_ID);
     store.actions.setStationButtonHover(true);
     expect(routeKey("\r", store.getState(), keymapFor(snapshot))).toEqual({
       kind: "focus",
@@ -397,7 +398,26 @@ describe("the station-button layer (island ↵ jump)", () => {
     });
   });
 
-  it("opens the overlay instead of focusing another session in the same worktree", () => {
+  it("delivers ↵ to the flagged session when its agent pane is already focused", () => {
+    const snapshot = attentionAndFailuresSnapshot();
+    const flagged = flaggedSession(snapshot);
+    const paneId = agentWorktreePaneId(flagged.worktree.id);
+    const store = createStationStore();
+    store.actions.createPane(paneId, { role: "primary-agent" });
+    store.actions.setPrimaryAgent(paneId, {
+      sessionId: flagged.session.id,
+      terminalTargetId: `native:${flagged.worktree.id}`,
+    });
+    store.actions.setStationButtonHover(true);
+
+    expect(routeKey("\r", store.getState(), keymapFor(snapshot))).toEqual({
+      kind: "terminal-write",
+      paneId,
+      bytes: "\r",
+    });
+  });
+
+  it("opens the overlay when the focused pane belongs to another session in the same worktree", () => {
     const base = attentionAndFailuresSnapshot();
     const flagged = flaggedSession(base);
     const local = base.sessions.find((session) => session.status.value === "working");

--- a/station/src/stationButton/DynamicStationButton.test.tsx
+++ b/station/src/stationButton/DynamicStationButton.test.tsx
@@ -465,6 +465,33 @@ describe("DynamicStationButton", () => {
     }
   });
 
+  it("clears external hover when unmounted while hovered", async () => {
+    const hoverChanges: boolean[] = [];
+    const setup = await testRender(
+      <StationThemeProvider theme={nativeStationTheme}>
+        <DynamicStationButton
+          input={input({ attention: true, needsYouCount: 1, sessionName: "hook-scope" })}
+          onHoverChange={(hovered) => hoverChanges.push(hovered)}
+        />
+      </StationThemeProvider>,
+      SURFACE,
+    );
+    let destroyed = false;
+    try {
+      await setup.flush();
+      await setup.mockMouse.moveTo(SURFACE.width - 1, 0);
+      setup.renderer.destroy();
+      destroyed = true;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(hoverChanges).toEqual([true, false]);
+    } finally {
+      if (!destroyed) {
+        setup.renderer.destroy();
+      }
+    }
+  });
+
   it("attention wins over the celebration", async () => {
     const frame = await captureFrame(
       <DynamicStationButton

--- a/station/src/stationButton/DynamicStationButton.tsx
+++ b/station/src/stationButton/DynamicStationButton.tsx
@@ -1,6 +1,6 @@
 import type { MouseEvent } from "@opentui/core";
 import { textCellUnits } from "@station/dashboard-core/text";
-import { type ReactNode, useMemo, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import {
   isPrimaryMouseEvent,
   isRightMouseEvent,
@@ -66,11 +66,25 @@ export function DynamicStationButton(props: DynamicStationButtonProps): ReactNod
   const { input, onHoverChange } = props;
   const attention = input.status.attention;
   const [internalHover, setInternalHover] = useState(false);
+  const externalHoverActive = useRef(false);
+  const onHoverChangeRef = useRef(onHoverChange);
+  onHoverChangeRef.current = onHoverChange;
   const expanded = (props.hovered ?? false) || (props.focused ?? false) || internalHover;
   const handleHoverChange = (hovering: boolean): void => {
     setInternalHover(hovering);
-    onHoverChange?.(hovering);
+    externalHoverActive.current = hovering;
+    onHoverChangeRef.current?.(hovering);
   };
+  useEffect(
+    () => () => {
+      if (!externalHoverActive.current) {
+        return;
+      }
+      externalHoverActive.current = false;
+      onHoverChangeRef.current?.(false);
+    },
+    [],
+  );
   const pointerProps = useHoverPointer({
     acquireOnMouseOver: false,
     onHoverChange: handleHoverChange,


### PR DESCRIPTION
## What this fixes

The Station attention island reserves Enter while hovered so it can move focus to a session that needs the user. When that exact requesting Codex pane was already focused, the same binding intercepted Enter as another focus action instead of delivering it to the terminal, preventing the pending answer from submitting.

## What changed

- Deliver carriage return directly to the exact requesting primary-agent pane when it already owns keyboard focus.
- Preserve the attention jump when another pane is focused and the dashboard fallback when no matching local pane exists.
- Clear the island keyboard-routing hover flag when a hovered button unmounts without a mouse-out event.
- Cover exact-focus delivery, other-pane focus, same-worktree mismatch fallback, and hover cleanup.

## Testing

- bun run build:ensure
- bun test src/input/router.test.ts src/stationButton/DynamicStationButton.test.tsx (66 passed)
- bun run --cwd station typecheck
- bun run --cwd station test (1,769 passed)
- bun run test:ci:station
- bun run test:all (blocked in the unrelated setup-core-flow bootstrap fixture: could not determine executable to run for package bun; the isolated failure reproduces. All 893 integration tests passed on retry.)

## User-visible behavior

Hovering the attention island and pressing Enter now submits in an already focused requesting Codex pane. From another pane, Enter still jumps to that session.