### PR TITLE
fix(tmux): preserve attached clients when creating workbench

### DIFF
--- a/config/vitest/vitest.integration.config.ts
+++ b/config/vitest/vitest.integration.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
       "packages/*/test/integration/**/*.test.ts",
       "integrations/*/*/test/integration/**/*.test.ts",
     ],
-    exclude: ["integrations/terminal/tmux/test/integration/popup-real.test.ts"],
+    exclude: [
+      "integrations/terminal/tmux/test/integration/placement-real.test.ts",
+      "integrations/terminal/tmux/test/integration/popup-real.test.ts",
+    ],
   },
 });

--- a/config/vitest/vitest.tmux-popup-real.config.ts
+++ b/config/vitest/vitest.tmux-popup-real.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
   test: {
     ...commonTestConfig,
     testTimeout: 30_000,
-    include: ["integrations/terminal/tmux/test/integration/popup-real.test.ts"],
+    include: [
+      "integrations/terminal/tmux/test/integration/placement-real.test.ts",
+      "integrations/terminal/tmux/test/integration/popup-real.test.ts",
+    ],
   },
 });

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -18062,7 +18062,7 @@
       "declaration": "TmuxPlacementService",
       "kind": "class",
       "role": "ADAPTER",
-      "purpose": "Proves caller-owned tmux topology on one configured endpoint and applies one-shot sibling or source-free detached placement with exact rollback authority.",
+      "purpose": "Proves caller-owned tmux topology on one configured endpoint and applies one-shot sibling or source-free detached placement with exact rollback authority, preserving attached client selection while creating a missing workbench session.",
       "dependencies": [
         {
           "path": "packages/contracts/src/providers.ts",

--- a/integrations/terminal/tmux/src/errors.ts
+++ b/integrations/terminal/tmux/src/errors.ts
@@ -139,7 +139,7 @@ export function isTmuxNoServerListError(error: unknown): boolean {
   if (
     diagnostic?.exitCode !== 1 ||
     diagnostic.stderrSnippet === undefined ||
-    !/(?:^|\s)list-panes\s+-a(?:\s|$)/.test(diagnostic.command)
+    !/(?:^|\s)(?:list-panes\s+-a|list-clients)(?:\s|$)/.test(diagnostic.command)
   ) {
     return false;
   }

--- a/integrations/terminal/tmux/src/parse.ts
+++ b/integrations/terminal/tmux/src/parse.ts
@@ -49,6 +49,32 @@ export const tmuxPrimaryPaneIdentityFormat = [
   "#{pane_id}",
 ].join("\t");
 
+const TmuxClientIdentitySchema = z
+  .object({
+    clientName: z.string().min(1),
+    clientPid: positiveIntegerTextSchema,
+  })
+  .strict();
+
+const TmuxClientSelectionSchema = TmuxClientIdentitySchema.extend({
+  sessionId: stableSessionIdSchema,
+  windowId: stableWindowIdSchema,
+  paneId: stablePaneIdSchema,
+}).strict();
+
+export type TmuxClientIdentity = z.infer<typeof TmuxClientIdentitySchema>;
+export type TmuxClientSelection = z.infer<typeof TmuxClientSelectionSchema>;
+
+export const tmuxClientIdentityFormat = ["#{client_name}", "#{client_pid}"].join("\t");
+
+export const tmuxClientSelectionFormat = [
+  "#{client_name}",
+  "#{client_pid}",
+  "#{session_id}",
+  "#{window_id}",
+  "#{pane_id}",
+].join("\t");
+
 export function parseTmuxPaneProof(stdout: string): TmuxPaneProof {
   const proofs = parseTmuxPaneProofLines(stdout);
   if (proofs.length !== 1) throw new Error("tmux returned ambiguous pane proof.");
@@ -76,6 +102,36 @@ export function parseTmuxPaneProofLines(stdout: string): TmuxPaneProof[] {
         openToken: fields[7],
         stationSessionId: fields[8],
       });
+    });
+}
+
+export function parseTmuxClientSelections(stdout: string): TmuxClientSelection[] {
+  if (stdout.trim().length === 0) return [];
+  return stdout
+    .split(/\r?\n/u)
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const fields = line.split("\t");
+      if (fields.length !== 5) throw new Error("tmux returned malformed client selection.");
+      return TmuxClientSelectionSchema.parse({
+        clientName: fields[0],
+        clientPid: fields[1],
+        sessionId: fields[2],
+        windowId: fields[3],
+        paneId: fields[4],
+      });
+    });
+}
+
+export function parseTmuxClientIdentities(stdout: string): TmuxClientIdentity[] {
+  if (stdout.trim().length === 0) return [];
+  return stdout
+    .split(/\r?\n/u)
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const fields = line.split("\t");
+      if (fields.length !== 2) throw new Error("tmux returned malformed client identity.");
+      return TmuxClientIdentitySchema.parse({ clientName: fields[0], clientPid: fields[1] });
     });
 }
 

--- a/integrations/terminal/tmux/src/placement/service.ts
+++ b/integrations/terminal/tmux/src/placement/service.ts
@@ -19,8 +19,17 @@ import {
   systemClock,
 } from "@station/runtime";
 import { createPlacementCommandRunner, isExpectedWorkbenchAbsence } from "../command.js";
-import { TmuxTerminalProviderError } from "../errors.js";
-import { parseTmuxPaneProofLines, tmuxPaneProofFormat } from "../parse.js";
+import { isTmuxNoServerListError, TmuxTerminalProviderError } from "../errors.js";
+import {
+  parseTmuxClientIdentities,
+  parseTmuxClientSelections,
+  parseTmuxPaneProofLines,
+  type TmuxClientIdentity,
+  type TmuxClientSelection,
+  tmuxClientIdentityFormat,
+  tmuxClientSelectionFormat,
+  tmuxPaneProofFormat,
+} from "../parse.js";
 import { parseTmuxTargetId } from "../targetId.js";
 import {
   buildWorkbenchWindowName,
@@ -54,7 +63,8 @@ export type TmuxPlacementServiceOptions = {
  * ADAPTER
  *
  * Proves caller-owned tmux topology on one configured endpoint and applies
- * one-shot sibling or source-free detached placement with exact rollback authority.
+ * one-shot sibling or source-free detached placement with exact rollback authority,
+ * preserving attached client selection while creating a missing workbench session.
  */
 export class TmuxPlacementService implements TerminalPlacementPort {
   readonly id: ProviderId = "tmux";
@@ -131,6 +141,7 @@ export class TmuxPlacementService implements TerminalPlacementPort {
     const bindingToken = this.#newBindingToken();
     let expectedGeneration: string | undefined;
     let siblingProof: TmuxPrivateProof | undefined;
+    let preservedClientSelections: TmuxClientSelection[] | undefined;
     let mutationMayExist = false;
     try {
       let destination:
@@ -153,6 +164,9 @@ export class TmuxPlacementService implements TerminalPlacementPort {
               sessionName: this.#config.workbenchSession,
             };
         configureWorkbench = true;
+        if (!sessionExists) {
+          preservedClientSelections = await this.#clientSelections();
+        }
       }
 
       const windowName = buildWorkbenchWindowName({
@@ -194,6 +208,9 @@ export class TmuxPlacementService implements TerminalPlacementPort {
         mutationMayExist = false;
         throw placementRejected("The tmux caller topology changed before sibling mutation.");
       }
+      if (preservedClientSelections !== undefined) {
+        await this.#restoreClientSelections(preservedClientSelections);
+      }
       const proofOutput = parseTmuxPaneProofLines(output.stdout).find(
         (candidate) => candidate.openToken === bindingToken,
       );
@@ -210,12 +227,23 @@ export class TmuxPlacementService implements TerminalPlacementPort {
       return placedWorkspaceResult(request, sessionId, proof, windowName, bindingToken);
     } catch (error) {
       if (!mutationMayExist) throw error;
+      const cleanupFailures: unknown[] = [];
       try {
         await this.#cleanup.rollback(bindingToken, expectedGeneration);
       } catch (rollbackError) {
+        cleanupFailures.push(rollbackError);
+      }
+      if (preservedClientSelections !== undefined) {
+        try {
+          await this.#restoreClientSelections(preservedClientSelections);
+        } catch (restoreError) {
+          cleanupFailures.push(restoreError);
+        }
+      }
+      if (cleanupFailures.length > 0) {
         throw cleanupUncertain(
-          "tmux could not prove that the partially placed target was rolled back.",
-          rollbackError,
+          "tmux could not prove partial-placement rollback and client selection restoration.",
+          new AggregateError([error, ...cleanupFailures]),
         );
       }
       throw error;
@@ -296,6 +324,81 @@ export class TmuxPlacementService implements TerminalPlacementPort {
     }
   }
 
+  async #clientSelections(): Promise<TmuxClientSelection[]> {
+    const identities = await this.#clientIdentities();
+    const selections: TmuxClientSelection[] = [];
+    for (const identity of identities) {
+      try {
+        const output = await this.#run(
+          ["display-message", "-p", "-c", identity.clientName, tmuxClientSelectionFormat],
+          "open",
+        );
+        const parsed = parseTmuxClientSelections(output.stdout);
+        const selection = parsed.length === 1 ? parsed[0] : undefined;
+        if (selection === undefined) throw new Error("tmux returned ambiguous client selection.");
+        if (sameClient(selection, identity)) selections.push(selection);
+      } catch (error) {
+        const current = await this.#clientIdentities();
+        if (!current.some((candidate) => sameClient(candidate, identity))) continue;
+        if (error instanceof TmuxTerminalProviderError) throw error;
+        throw new TmuxTerminalProviderError(
+          "TERMINAL_OPEN_FAILED",
+          "tmux returned invalid attached client selection.",
+          { cause: error },
+        );
+      }
+    }
+    return selections;
+  }
+
+  async #clientIdentities(): Promise<TmuxClientIdentity[]> {
+    try {
+      const output = await this.#run(["list-clients", "-F", tmuxClientIdentityFormat], "open");
+      return parseTmuxClientIdentities(output.stdout);
+    } catch (error) {
+      if (isTmuxNoServerListError(error)) return [];
+      if (error instanceof TmuxTerminalProviderError) throw error;
+      throw new TmuxTerminalProviderError(
+        "TERMINAL_OPEN_FAILED",
+        "tmux returned invalid attached client identity.",
+        { cause: error },
+      );
+    }
+  }
+
+  async #restoreClientSelections(expected: readonly TmuxClientSelection[]): Promise<void> {
+    if (expected.length === 0) return;
+    const current = await this.#clientSelections();
+    for (const selection of expected) {
+      const observed = current.find((candidate) => sameClient(candidate, selection));
+      if (observed === undefined || sameSelection(observed, selection)) continue;
+      const beforeSwitch = await this.#clientIdentities();
+      if (!beforeSwitch.some((candidate) => sameClient(candidate, selection))) continue;
+      try {
+        await this.#run(
+          ["switch-client", "-E", "-Z", "-c", selection.clientName, "-t", selection.paneId],
+          "open",
+        );
+      } catch (error) {
+        const afterFailure = await this.#clientIdentities();
+        if (!afterFailure.some((candidate) => sameClient(candidate, selection))) continue;
+        throw error;
+      }
+    }
+
+    const verified = await this.#clientSelections();
+    const changed = expected.some((selection) => {
+      const observed = verified.find((candidate) => sameClient(candidate, selection));
+      return observed !== undefined && !sameSelection(observed, selection);
+    });
+    if (changed) {
+      throw new TmuxTerminalProviderError(
+        "TERMINAL_OPEN_FAILED",
+        "tmux did not preserve attached client selection.",
+      );
+    }
+  }
+
   #assertSupported(request: TerminalPlacementRequest): void {
     if (!this.supportedIntents.includes(request.intent)) {
       throw new TmuxTerminalProviderError(
@@ -304,6 +407,18 @@ export class TmuxPlacementService implements TerminalPlacementPort {
       );
     }
   }
+}
+
+function sameClient(left: TmuxClientIdentity, right: TmuxClientIdentity): boolean {
+  return left.clientName === right.clientName && left.clientPid === right.clientPid;
+}
+
+function sameSelection(left: TmuxClientSelection, right: TmuxClientSelection): boolean {
+  return (
+    left.sessionId === right.sessionId &&
+    left.windowId === right.windowId &&
+    left.paneId === right.paneId
+  );
 }
 
 function placedWorkspaceResult(

--- a/integrations/terminal/tmux/test/integration/placement-real.test.ts
+++ b/integrations/terminal/tmux/test/integration/placement-real.test.ts
@@ -1,0 +1,156 @@
+import { execFile } from "node:child_process";
+import { chmod, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import type { OpenPlacedWorkspaceRequest, OpenPlacedWorkspaceResult } from "@station/contracts";
+import { resolveExecutablePath } from "@station/runtime";
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  closeRealTmuxEndpoint,
+  inspectTmuxClient,
+  type RealTmuxEndpoint,
+  startAttachedTmuxPtyClient,
+} from "../../../../../tests/support/real-station/tmux.js";
+import { TmuxPlacementService } from "../../src/placement/index.js";
+
+const execFileAsync = promisify(execFile);
+const describeRealTmux = process.env.STATION_REAL_TMUX === "1" ? describe : describe.skip;
+
+describeRealTmux("real tmux detached placement", () => {
+  let tmux: string;
+
+  beforeAll(async () => {
+    const requested = process.env.STATION_TMUX_BIN ?? "tmux";
+    const resolved = await resolveExecutablePath(requested);
+    if (resolved === undefined) throw new Error(`tmux executable not found: ${requested}`);
+    tmux = resolve(resolved);
+    await execFileAsync(tmux, ["-V"], { timeout: 10_000 });
+    await execFileAsync("python3", ["--version"], { timeout: 10_000 });
+  });
+
+  it("preserves an attached client's exact target while bootstrapping and reusing the workbench", async () => {
+    const endpoint = await createEndpoint(tmux);
+    let client: Awaited<ReturnType<typeof startAttachedTmuxPtyClient>> | undefined;
+    const failures: unknown[] = [];
+    try {
+      client = await startAttachedTmuxPtyClient({
+        endpoint,
+        sessionName: "_station-real-endpoint",
+      });
+      const expectedClient = await inspectTmuxClient(endpoint, client.clientName);
+      const service = new TmuxPlacementService({
+        command: endpoint.wrapperPath,
+        config: {
+          workbenchSession: "station-placement-real",
+          workbenchSocketPath: endpoint.socketPath,
+        },
+      });
+
+      const first = await service.openPlacedWorkspace(request(endpoint.rootPath, 1));
+      expect(first).toMatchObject({
+        placement: { intent: "detached", presentation: "detached" },
+        target: { providerData: { sessionName: "station-placement-real" } },
+      });
+      await expect(inspectTmuxClient(endpoint, client.clientName)).resolves.toBe(expectedClient);
+
+      const second = await service.openPlacedWorkspace(request(endpoint.rootPath, 2));
+      expect(second).toMatchObject({
+        placement: { intent: "detached", presentation: "detached" },
+        target: { providerData: { sessionName: "station-placement-real" } },
+      });
+      await expect(inspectTmuxClient(endpoint, client.clientName)).resolves.toBe(expectedClient);
+
+      await service.releasePlacedTarget(releaseRequest(second));
+      await expect(inspectTmuxClient(endpoint, client.clientName)).resolves.toBe(expectedClient);
+      await service.releasePlacedTarget(releaseRequest(first));
+      await expect(inspectTmuxClient(endpoint, client.clientName)).resolves.toBe(expectedClient);
+    } catch (error) {
+      failures.push(error);
+    } finally {
+      if (client !== undefined) {
+        await client.close().catch((error: unknown) => failures.push(error));
+      }
+      await closeRealTmuxEndpoint(endpoint).catch((error: unknown) => failures.push(error));
+    }
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures,
+        `real tmux placement proof or cleanup failed: ${failures.map(String).join("; ")}`,
+      );
+    }
+  });
+});
+
+function request(root: string, sequence: number): OpenPlacedWorkspaceRequest {
+  return {
+    project: {
+      id: "placement-real",
+      label: "placement-real",
+      root,
+      defaults: { harness: "codex", terminal: "tmux", layout: "agent-only" },
+      worktrunk: { enabled: true },
+    },
+    worktree: {
+      id: `wt_placement_${sequence}`,
+      provider: "worktrunk",
+      projectId: "placement-real",
+      branch: `placement-${sequence}`,
+      path: root,
+      state: "exists",
+      source: "worktrunk",
+      observedAt: new Date().toISOString(),
+    },
+    harness: "codex",
+    layout: "agent-only",
+    sessionId: `ses_placement_${sequence}`,
+    placement: { intent: "detached" },
+  };
+}
+
+function releaseRequest(opened: OpenPlacedWorkspaceResult) {
+  const sessionId = opened.target.sessionId;
+  if (sessionId === undefined) throw new Error("placed target omitted its Station session ID");
+  return {
+    targetId: opened.target.targetId,
+    sessionId,
+    generation: opened.placement.generation,
+    bindingToken: opened.bindingToken,
+  };
+}
+
+async function createEndpoint(tmux: string): Promise<RealTmuxEndpoint> {
+  const rootPath = await mkdtemp(join(tmpdir(), "stn-placement-real-"));
+  const endpoint = {
+    rootPath,
+    socketPath: join(rootPath, "server.sock"),
+    wrapperPath: join(rootPath, "tmux"),
+  };
+  await chmod(rootPath, 0o700);
+  await writeFile(endpoint.wrapperPath, `#!/bin/sh\nexec ${shellQuote(tmux)} -f /dev/null "$@"\n`);
+  await chmod(endpoint.wrapperPath, 0o700);
+  try {
+    await execFileAsync(
+      endpoint.wrapperPath,
+      [
+        "-S",
+        endpoint.socketPath,
+        "new-session",
+        "-d",
+        "-s",
+        "_station-real-endpoint",
+        "sleep",
+        "300",
+      ],
+      { timeout: 10_000 },
+    );
+    return endpoint;
+  } catch (error) {
+    await closeRealTmuxEndpoint(endpoint).catch(() => undefined);
+    throw error;
+  }
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}

--- a/integrations/terminal/tmux/test/unit/errors.test.ts
+++ b/integrations/terminal/tmux/test/unit/errors.test.ts
@@ -1,6 +1,7 @@
 import { externalCommandErrorFromUnknown, publicSafeErrorFromUnknown } from "@station/runtime";
 import { describe, expect, it } from "vitest";
 import {
+  isTmuxNoServerListError,
   TmuxTerminalProviderError,
   tmuxProviderErrorFromUnknown,
   tmuxSafeError,
@@ -12,6 +13,30 @@ const fallback = {
 };
 
 describe("tmux provider error mapping", () => {
+  it("recognizes exact no-server failures only for topology listings", () => {
+    const noServer = (args: string[]) =>
+      externalCommandErrorFromUnknown(
+        { code: 1, stderr: "no server running on /tmp/private.sock" },
+        { command: "tmux", args },
+      );
+
+    expect(
+      isTmuxNoServerListError(
+        noServer(["-S", "/tmp/private.sock", "list-panes", "-a", "-F", "#{pane_id}"]),
+      ),
+    ).toBe(true);
+    expect(
+      isTmuxNoServerListError(
+        noServer(["-S", "/tmp/private.sock", "list-clients", "-F", "#{client_name}"]),
+      ),
+    ).toBe(true);
+    expect(
+      isTmuxNoServerListError(
+        noServer(["-S", "/tmp/private.sock", "has-session", "-t", "station"]),
+      ),
+    ).toBe(false);
+  });
+
   it("classifies missing targets from typed command evidence", () => {
     const commandError = externalCommandErrorFromUnknown(
       { code: 1, stderr: "can't find pane: %12" },

--- a/integrations/terminal/tmux/test/unit/parse.test.ts
+++ b/integrations/terminal/tmux/test/unit/parse.test.ts
@@ -1,9 +1,56 @@
 import { TerminalTargetObservationSchema } from "@station/contracts";
 import { describe, expect, it } from "vitest";
-import { parseTmuxTargetLines } from "../../src/parse";
+import {
+  parseTmuxClientIdentities,
+  parseTmuxClientSelections,
+  parseTmuxTargetLines,
+  tmuxClientIdentityFormat,
+  tmuxClientSelectionFormat,
+} from "../../src/parse";
 
 const now = "2026-05-21T12:00:00.000Z";
 const generation = "a".repeat(64);
+
+describe("tmux client selection parser", () => {
+  it("parses stable attached-client identity and selection", () => {
+    expect(tmuxClientIdentityFormat).toBe("#{client_name}\t#{client_pid}");
+    expect(parseTmuxClientIdentities("/dev/ttys001\t123\n/dev/ttys002\t456")).toEqual([
+      { clientName: "/dev/ttys001", clientPid: 123 },
+      { clientName: "/dev/ttys002", clientPid: 456 },
+    ]);
+    expect(tmuxClientSelectionFormat).toBe(
+      "#{client_name}\t#{client_pid}\t#{session_id}\t#{window_id}\t#{pane_id}",
+    );
+    expect(
+      parseTmuxClientSelections(
+        ["/dev/ttys001\t123\t$1\t@2\t%3", "/dev/ttys002\t456\t$4\t@5\t%6"].join("\n"),
+      ),
+    ).toEqual([
+      {
+        clientName: "/dev/ttys001",
+        clientPid: 123,
+        sessionId: "$1",
+        windowId: "@2",
+        paneId: "%3",
+      },
+      {
+        clientName: "/dev/ttys002",
+        clientPid: 456,
+        sessionId: "$4",
+        windowId: "@5",
+        paneId: "%6",
+      },
+    ]);
+  });
+
+  it("rejects malformed or unstable client selection evidence", () => {
+    expect(() => parseTmuxClientIdentities("client\tnot-a-pid")).toThrow();
+    expect(() => parseTmuxClientSelections("client\t123\tstation\t@2\t%3")).toThrow();
+    expect(() => parseTmuxClientSelections("client\t123\t$1\t@2")).toThrow(
+      "tmux returned malformed client selection.",
+    );
+  });
+});
 
 describe("tmux target parser", () => {
   it("normalizes workbench pane output into TerminalTargetObservation values", () => {

--- a/integrations/terminal/tmux/test/unit/placement.test.ts
+++ b/integrations/terminal/tmux/test/unit/placement.test.ts
@@ -1,7 +1,7 @@
 import type { OpenPlacedWorkspaceRequest, TerminalPlacementRequest } from "@station/contracts";
 import type { ExternalCommandInput } from "@station/runtime";
 import { describe, expect, it } from "vitest";
-import { tmuxPaneProofFormat } from "../../src/parse.js";
+import { tmuxClientSelectionFormat, tmuxPaneProofFormat } from "../../src/parse.js";
 import { TmuxPlacementService } from "../../src/placement/index.js";
 import { tmuxCommandResult } from "../support/commands.js";
 
@@ -26,6 +26,22 @@ const worktree = {
   state: "exists" as const,
   source: "worktrunk" as const,
   observedAt: now,
+};
+
+type FixtureClientSelection = {
+  clientName: string;
+  clientPid: number;
+  sessionId: string;
+  windowId: string;
+  paneId: string;
+};
+
+const sourceClient: FixtureClientSelection = {
+  clientName: "/dev/ttys001",
+  clientPid: 300,
+  sessionId: "$1",
+  windowId: "@1",
+  paneId: "%1",
 };
 
 describe("TmuxPlacementService", () => {
@@ -111,6 +127,132 @@ describe("TmuxPlacementService", () => {
     await expect(fixture.service.releasePlacedTarget(releaseRequest(opened))).resolves.toEqual({
       status: "already-absent",
     });
+    expect(fixture.calls.some((call) => tmuxArgs(call)[0] === "list-clients")).toBe(false);
+  });
+
+  it("restores exact attached clients after creating a missing workbench session", async () => {
+    const fixture = placementFixture({
+      workbenchAbsent: true,
+      clients: [sourceClient],
+      clientsAfterSessionCreate: [
+        { ...sourceClient, sessionId: "$2", windowId: "@2", paneId: "%2" },
+      ],
+    });
+
+    await expect(
+      openWorkspace(fixture, "ses_bootstrap", { intent: "detached" }),
+    ).resolves.toMatchObject({
+      placement: { intent: "detached", presentation: "detached" },
+    });
+
+    expect(
+      fixture.calls
+        .map((call) => tmuxArgs(call)[0])
+        .filter((command) => command === "list-clients"),
+    ).toHaveLength(4);
+    expect(
+      fixture.calls.filter((call) => tmuxArgs(call)[0] === "switch-client").map(tmuxArgs),
+    ).toEqual([
+      ["switch-client", "-E", "-Z", "-c", sourceClient.clientName, "-t", sourceClient.paneId],
+    ]);
+    expect(fixture.clients).toEqual([sourceClient]);
+  });
+
+  it("never restores exited, replaced, or newly attached client identities", async () => {
+    const replaced = { ...sourceClient, clientName: "/dev/ttys002", clientPid: 301 };
+    const exited = { ...sourceClient, clientName: "/dev/ttys003", clientPid: 302 };
+    const moved = { ...sourceClient, sessionId: "$2", windowId: "@2", paneId: "%2" };
+    const replacement = {
+      ...replaced,
+      clientPid: 999,
+      sessionId: "$2",
+      windowId: "@2",
+      paneId: "%2",
+    };
+    const newlyAttached = {
+      ...sourceClient,
+      clientName: "/dev/ttys004",
+      clientPid: 303,
+      sessionId: "$2",
+      windowId: "@2",
+      paneId: "%2",
+    };
+    const fixture = placementFixture({
+      workbenchAbsent: true,
+      clients: [sourceClient, replaced, exited],
+      clientsAfterSessionCreate: [moved, replacement, newlyAttached],
+    });
+
+    await openWorkspace(fixture, "ses_identity", { intent: "detached" });
+
+    expect(
+      fixture.calls.filter((call) => tmuxArgs(call)[0] === "switch-client").map(tmuxArgs),
+    ).toEqual([
+      ["switch-client", "-E", "-Z", "-c", sourceClient.clientName, "-t", sourceClient.paneId],
+    ]);
+    expect(fixture.clients).toEqual([sourceClient, replacement, newlyAttached]);
+  });
+
+  it("ignores an exact client that exits immediately before restoration", async () => {
+    const fixture = placementFixture({
+      workbenchAbsent: true,
+      clients: [sourceClient],
+      clientsAfterSessionCreate: [
+        { ...sourceClient, sessionId: "$2", windowId: "@2", paneId: "%2" },
+      ],
+      exitClientsBeforeRestore: true,
+    });
+
+    await expect(
+      openWorkspace(fixture, "ses_client_exit", { intent: "detached" }),
+    ).resolves.toMatchObject({ placement: { intent: "detached" } });
+    expect(fixture.calls.some((call) => tmuxArgs(call)[0] === "switch-client")).toBe(false);
+    expect(fixture.clients).toEqual([]);
+  });
+
+  it("treats exact server absence as an empty client baseline", async () => {
+    const fixture = placementFixture({ serverAbsent: true });
+
+    await expect(
+      openWorkspace(fixture, "ses_new_server", { intent: "detached" }),
+    ).resolves.toMatchObject({
+      placement: { intent: "detached", presentation: "detached" },
+    });
+    expect(fixture.calls.some((call) => tmuxArgs(call)[0] === "new-session")).toBe(true);
+    expect(fixture.calls.some((call) => tmuxArgs(call)[0] === "switch-client")).toBe(false);
+  });
+
+  it("fails before mutation when attached client selection cannot be inspected", async () => {
+    const fixture = placementFixture({ workbenchAbsent: true, failClientList: true });
+
+    await expectCode(
+      openWorkspace(fixture, "ses_client_list_failure", { intent: "detached" }),
+      "TERMINAL_OPEN_FAILED",
+    );
+    expect(fixture.calls.some((call) => tmuxArgs(call)[0] === "new-session")).toBe(false);
+  });
+
+  it("reports uncertain cleanup when client restoration cannot converge", async () => {
+    const fixture = placementFixture({
+      workbenchAbsent: true,
+      clients: [sourceClient],
+      clientsAfterSessionCreate: [
+        { ...sourceClient, sessionId: "$2", windowId: "@2", paneId: "%2" },
+      ],
+      restoreClients: false,
+      restoreClientsAfterRollback: false,
+    });
+
+    await expectCode(
+      openWorkspace(fixture, "ses_restore_failure", { intent: "detached" }),
+      "TERMINAL_CLEANUP_UNCERTAIN",
+    );
+    expect(
+      fixture.calls.some(
+        (call) =>
+          tmuxArgs(call)[0] === "if-shell" && tmuxArgs(call).join(" ").includes("kill-window"),
+      ),
+    ).toBe(true);
   });
 
   it("rejects endpoint mismatch, public-field tampering, and unqualified cleanup authority", async () => {
@@ -224,6 +366,14 @@ function placementFixture(
     failOpenAfterMutation?: boolean;
     omitStationSessionId?: boolean;
     mutateReleaseBinding?: boolean;
+    workbenchAbsent?: boolean;
+    serverAbsent?: boolean;
+    failClientList?: boolean;
+    clients?: FixtureClientSelection[];
+    clientsAfterSessionCreate?: FixtureClientSelection[];
+    exitClientsBeforeRestore?: boolean;
+    restoreClients?: boolean;
+    restoreClientsAfterRollback?: boolean;
   } = {},
 ) {
   const calls: ExternalCommandInput[] = [];
@@ -238,6 +388,15 @@ function placementFixture(
   let binding = 0;
   let placed: string | undefined;
   let mutateReleaseBinding = options.mutateReleaseBinding === true;
+  let serverExists = options.serverAbsent !== true;
+  let workbenchExists = serverExists && options.workbenchAbsent !== true;
+  let createdWorkbenchSession = false;
+  let clientListCount = 0;
+  const initialClients = options.clients?.map((client) => ({ ...client })) ?? [];
+  const clients = initialClients.map((client) => ({ ...client }));
+  const replaceClients = (next: readonly FixtureClientSelection[]) => {
+    clients.splice(0, clients.length, ...next.map((client) => ({ ...client })));
+  };
   const service = new TmuxPlacementService({
     config: { workbenchSession: "station", workbenchSocketPath: socketPath },
     clock: { now: () => currentNow },
@@ -257,8 +416,60 @@ function placementFixture(
       if (args[0] === "display-message" && args.at(-1) === tmuxPaneProofFormat) {
         return tmuxCommandResult(input, sourceProof);
       }
-      if (args[0] === "has-session") return tmuxCommandResult(input, "");
       if (
+        args[0] === "display-message" &&
+        args.includes("-c") &&
+        args.at(-1) === tmuxClientSelectionFormat
+      ) {
+        const clientName = args[args.indexOf("-c") + 1];
+        const selection = clients.find((client) => client.clientName === clientName);
+        if (selection === undefined) {
+          throw Object.assign(new Error("tmux failed"), {
+            code: 1,
+            stderr: `can't find client: ${clientName}`,
+          });
+        }
+        return tmuxCommandResult(input, serializeClientSelection(selection));
+      }
+      if (args[0] === "has-session") {
+        if (!serverExists) {
+          throw Object.assign(new Error("tmux failed"), {
+            code: 1,
+            stderr: `no server running on ${socketPath}`,
+          });
+        }
+        if (!workbenchExists) {
+          throw Object.assign(new Error("tmux failed"), {
+            code: 1,
+            stderr: "can't find session: station",
+          });
+        }
+        return tmuxCommandResult(input, "");
+      }
+      if (args[0] === "list-clients") {
+        clientListCount += 1;
+        if (!serverExists) {
+          throw Object.assign(new Error("tmux failed"), {
+            code: 1,
+            stderr: `no server running on ${socketPath}`,
+          });
+        }
+        if (options.failClientList === true) {
+          throw Object.assign(new Error("tmux failed"), {
+            code: 1,
+            stderr: "client inspection failed",
+          });
+        }
+        if (options.exitClientsBeforeRestore === true && clientListCount === 3) {
+          replaceClients([]);
+        }
+        return tmuxCommandResult(
+          input,
+          clients.map((client) => `${client.clientName}\t${client.clientPid}`).join("\n"),
+        );
+      }
+      if (
+        args[0] === "new-session" ||
         args[0] === "new-window" ||
         (args[0] === "if-shell" && args.join(" ").includes("new-window"))
       ) {
@@ -269,17 +480,25 @@ function placementFixture(
         const serialized = args.join(" ");
         const sibling = serialized.includes("$1:");
         const token =
-          args[0] === "new-window"
+          args[0] !== "if-shell"
             ? (args[args.indexOf("@station.open_token") + 1] ?? "")
             : (/@station\.open_token" "([^"]+)"/u.exec(serialized)?.[1] ?? "");
         const stationSessionId =
-          args[0] === "new-window"
+          args[0] !== "if-shell"
             ? (args[args.indexOf("@station.session_id") + 1] ?? "")
             : (/@station\.session_id" "([^"]+)"/u.exec(serialized)?.[1] ?? "");
         const sessionId = sibling ? "$1" : "$2";
         const sessionName = sibling ? "caller" : "station";
         const sessionBinding = options.omitStationSessionId === true ? "" : stationSessionId;
         placed = `${socketPath}\t10\t${sessionId}\t${sessionName}\t@2\t%2\t200\t${token}\t${sessionBinding}`;
+        if (args[0] === "new-session") {
+          serverExists = true;
+          workbenchExists = true;
+          createdWorkbenchSession = true;
+          if (options.clientsAfterSessionCreate !== undefined) {
+            replaceClients(options.clientsAfterSessionCreate);
+          }
+        }
         if (options.failOpenAfterMutation === true) {
           throw {
             tag: "TimeoutError",
@@ -288,6 +507,24 @@ function placementFixture(
           };
         }
         return tmuxCommandResult(input, placed);
+      }
+      if (args[0] === "switch-client") {
+        if (
+          options.restoreClients !== false ||
+          (placed === undefined && options.restoreClientsAfterRollback !== false)
+        ) {
+          const clientName = args[args.indexOf("-c") + 1];
+          const paneId = args[args.indexOf("-t") + 1];
+          const expected = initialClients.find(
+            (client) => client.clientName === clientName && client.paneId === paneId,
+          );
+          const index = clients.findIndex(
+            (client) =>
+              client.clientName === clientName && client.clientPid === expected?.clientPid,
+          );
+          if (expected !== undefined && index >= 0) clients[index] = { ...expected };
+        }
+        return tmuxCommandResult(input, "");
       }
       if (args[0] === "list-panes") {
         return tmuxCommandResult(
@@ -305,6 +542,8 @@ function placementFixture(
             return tmuxCommandResult(input, "__station_release_guard_rejected__");
           }
           placed = undefined;
+          if (createdWorkbenchSession) workbenchExists = false;
+          if (options.restoreClientsAfterRollback !== false) replaceClients(initialClients);
           return tmuxCommandResult(input, "");
         }
         placed = undefined;
@@ -317,6 +556,7 @@ function placementFixture(
   return {
     service,
     calls,
+    clients,
     processStartTokens,
     advance: (milliseconds: number) => {
       currentNow = new Date(currentNow.getTime() + milliseconds);
@@ -325,6 +565,16 @@ function placementFixture(
       rejectOpenGuard = true;
     },
   };
+}
+
+function serializeClientSelection(selection: FixtureClientSelection): string {
+  return [
+    selection.clientName,
+    String(selection.clientPid),
+    selection.sessionId,
+    selection.windowId,
+    selection.paneId,
+  ].join("\t");
 }
 
 async function placementSource(fixture: ReturnType<typeof placementFixture>) {

--- a/tests/README.md
+++ b/tests/README.md
@@ -102,7 +102,8 @@ Real lanes use installed tools, credentials, or terminal state and are excluded
 from `test:all`:
 
 - `bun run test:e2e:worktrunk:real` uses a real Worktrunk installation.
-- `STATION_REAL_TMUX=1 bun run test:tmux-popup:real` uses an isolated tmux server.
+- `STATION_REAL_TMUX=1 bun run test:tmux-popup:real` uses an isolated tmux server for
+  placement and popup behavior.
 - `bun run test:e2e:claude:real`, `test:e2e:codex:real`, and
   `test:e2e:cursor:real` use authenticated agent CLIs.
 - `bun run test:e2e:pi:real` and `test:e2e:opencode:real` exercise those real

--- a/tests/diagnostics/vitest-machine-isolation-policy.test.ts
+++ b/tests/diagnostics/vitest-machine-isolation-policy.test.ts
@@ -59,7 +59,8 @@ const realMachineConfigs = [
   },
   {
     file: "vitest.tmux-popup-real.config.ts",
-    rationale: "The lane drives a real tmux server and production popup process boundaries.",
+    rationale:
+      "The lane drives a real tmux server and production placement and popup process boundaries.",
   },
   {
     file: "vitest.worktrunk-real.config.ts",


### PR DESCRIPTION
## What this fixes

Creating the first detached tmux session initializes Station’s configured workbench. On tmux 3.7, that `new-session -d` mutation can retarget an already attached client into the new workbench, violating detached placement’s no-focus contract. This was discovered by the real-agent acceptance work in #770.

## What changed

- Capture each attached client’s exact name, PID, session, window, and pane before creating a missing workbench.
- Restore and verify only still-live exact client identities after placement; ignore clients that exited or were replaced during the mutation.
- Fold unproven restoration into the existing exact rollback and cleanup-uncertain path.
- Add strict client-output parsing and no-server classification.
- Add an opt-in real tmux/PTTY regression covering first workbench creation, reuse, release, and exact client selection.

## Testing

- `bun run build`
- `bun run --cwd integrations/terminal/tmux typecheck`
- 30 focused tmux unit tests
- `STATION_REAL_TMUX=1` focused real placement test
- Three-agent Luna xhigh acceptance cell: application PASS, agent PASS, exact cleanup PASS

## Safety and scope

The new behavior runs only when detached placement must create the missing workbench session. Sibling placement and detached placement into an existing workbench retain their existing mutation paths.