### PR TITLE
perf(observer): bound creates after true quiescence

### DIFF
--- a/apps/observer/src/commands/queue.ts
+++ b/apps/observer/src/commands/queue.ts
@@ -440,6 +440,10 @@ function commandScope(command: StationCommand): string {
     case "worktree.fork":
     case "session.create":
     case "session.fork":
+      return `worktree-create:${JSON.stringify([
+        command.payload.projectId,
+        command.payload.branch,
+      ])}`;
     case "sessionGroup.create":
     case "sessionGroup.rename":
     case "sessionGroup.updateMembership":

--- a/apps/observer/src/commands/router.ts
+++ b/apps/observer/src/commands/router.ts
@@ -7,6 +7,10 @@ import type { ObserverCore } from "../reconcile/core.js";
 import type { ObserverEventBus } from "../runtime/eventBus.js";
 import type { StationLogger } from "../stationLogger.js";
 import {
+  createWorktreeCreateCoordinator,
+  type WorktreeCreateCoordinator,
+} from "../worktreeCreateCoordinator.js";
+import {
   createWorktreeMutationCoordinator,
   type WorktreeMutationCoordinator,
 } from "../worktreeMutationCoordinator.js";
@@ -55,6 +59,7 @@ export type RegisterObserverCommandHandlersOptions = {
   launchPreflight?: HarnessLaunchPreflight | undefined;
   projectConfigWriter: ProjectConfigWriter;
   worktreeMutations?: WorktreeMutationCoordinator | undefined;
+  worktreeCreates?: WorktreeCreateCoordinator | undefined;
 };
 
 /**
@@ -63,15 +68,17 @@ export type RegisterObserverCommandHandlersOptions = {
  * Constructs process-lifetime Observer command use cases and registers their
  * handlers with the command queue.
  *
- * Runtime-prebound config-aware launch preflight and ProjectConfigWriter are composed here;
- * one shared worktree mutation coordinator serializes lifecycle use cases across command and native
- * activation boundaries. Handlers remain provider-neutral and receive no configuration or home paths.
+ * Runtime-prebound config-aware launch preflight and ProjectConfigWriter are composed here. One
+ * shared create policy bounds per-project provider pressure and retains cross-command branch
+ * ownership through rollback; the existing mutation coordinator serializes lifecycle use cases
+ * across command and native activation boundaries. Handlers receive no configuration or home paths.
  */
 export function registerObserverCommandHandlers(
   options: RegisterObserverCommandHandlersOptions,
 ): void {
   const getProjects = options.getProjects ?? (() => options.projects);
   const worktreeMutations = options.worktreeMutations ?? createWorktreeMutationCoordinator();
+  const worktreeCreates = options.worktreeCreates ?? createWorktreeCreateCoordinator();
   const featureFlags = options.featureFlags ?? createFeatureFlagEvaluator();
   const launchPreflight: HarnessLaunchPreflight =
     options.launchPreflight ??
@@ -98,6 +105,7 @@ export function registerObserverCommandHandlers(
       eventBus: options.eventBus,
       clock: options.clock,
       logger: options.logger,
+      worktreeCreates,
     }),
     "worktree.fork": createWorktreeForkHandler({
       getProjects,
@@ -107,6 +115,7 @@ export function registerObserverCommandHandlers(
       eventBus: options.eventBus,
       clock: options.clock,
       logger: options.logger,
+      worktreeCreates,
     }),
     "worktree.remove": createWorktreeRemoveHandler({
       getProjects,
@@ -128,6 +137,7 @@ export function registerObserverCommandHandlers(
       clock: options.clock,
       idFactory: options.idFactory,
       logger: options.logger,
+      worktreeCreates,
     }),
     "session.startAgent": createSessionStartAgentHandler({
       getProjects,
@@ -173,6 +183,7 @@ export function registerObserverCommandHandlers(
       clock: options.clock,
       idFactory: options.idFactory,
       logger: options.logger,
+      worktreeCreates,
     }),
     "terminal.focus": createTerminalFocusHandler({
       core: options.core,

--- a/apps/observer/src/commands/session/create.ts
+++ b/apps/observer/src/commands/session/create.ts
@@ -13,6 +13,10 @@ import type { ProviderRegistry } from "../../providers/registry.js";
 import type { ObserverCore } from "../../reconcile/core.js";
 import type { ObserverEventBus } from "../../runtime/eventBus.js";
 import type { StationLogger } from "../../stationLogger.js";
+import {
+  createWorktreeCreateCoordinator,
+  type WorktreeCreateCoordinator,
+} from "../../worktreeCreateCoordinator.js";
 import { assertCommandType } from "../assertCommand.js";
 import type { HarnessLaunchPreflight } from "../harnessLaunchPreflight.js";
 import {
@@ -47,6 +51,7 @@ export type CreateSessionCreateHandlerOptions = {
   clock?: RuntimeClock | undefined;
   idFactory?: Partial<SessionCommandIdFactory> | undefined;
   logger?: StationLogger | undefined;
+  worktreeCreates?: WorktreeCreateCoordinator | undefined;
 };
 
 /**
@@ -55,13 +60,15 @@ export type CreateSessionCreateHandlerOptions = {
  * Preflights the selected harness, creates a session worktree on its generated branch, durably
  * seeds its independent title with optional atomic root Group placement or inline Group creation,
  * and launches its primary agent only after explicit placement authorization before
- * worktree mutation and revalidation before terminal mutation; rollback removes
- * only state owned by this command. Success returns the exact created identities,
- * resolved Group identity when grouped, and provider-resolved placement projection.
+ * worktree mutation and revalidation before terminal mutation. Shared branch ownership spans the
+ * complete seed, launch, publication, and rollback transaction while per-project capacity spans
+ * only provider creation. Rollback removes only state owned by this command. Success returns the
+ * exact created identities, resolved Group identity when grouped, and placement projection.
  */
 export function createSessionCreateHandler(
   options: CreateSessionCreateHandlerOptions,
 ): CommandResultHandler<"session.create"> {
+  const worktreeCreates = options.worktreeCreates ?? createWorktreeCreateCoordinator();
   const idFactory = {
     ...defaultSessionCommandIdFactory,
     ...options.idFactory,
@@ -96,148 +103,152 @@ export function createSessionCreateHandler(
     let groupProvenance: SessionSeedGroupProvenance | undefined;
     let placementResult: ReturnType<typeof commandPlacementResult>;
 
-    try {
-      // Authorization must be fresh at the first irreversible worktree mutation.
-      await runProviderMutation(
-        {
-          ...runtime,
-          operation: `provider.${placementPort.id}.validatePlacement`,
-          fallback: {
-            tag: "TerminalProviderError",
-            code: "TERMINAL_PLACEMENT_REJECTED",
-            message: "The requested terminal placement is no longer valid.",
-            provider: placementPort.id,
+    return worktreeCreates.run(project.id, payload.branch, context.signal, async (create) => {
+      try {
+        // Authorization must be fresh at the first irreversible worktree mutation.
+        await runProviderMutation(
+          {
+            ...runtime,
+            operation: `provider.${placementPort.id}.validatePlacement`,
+            fallback: {
+              tag: "TerminalProviderError",
+              code: "TERMINAL_PLACEMENT_REJECTED",
+              message: "The requested terminal placement is no longer valid.",
+              provider: placementPort.id,
+            },
           },
-        },
-        () => placementPort.validatePlacement(payload.placement),
-      );
-      const worktree = await runProviderMutation(
-        {
-          ...runtime,
-          operation: `provider.${options.providers.worktree.id}.createWorktree`,
-          fallback: {
-            tag: "WorktreeProviderError",
-            code: "WORKTREE_CREATE_FAILED",
-            message: "The worktree provider failed to create the session worktree.",
-            provider: options.providers.worktree.id,
-          },
-        },
-        () =>
-          options.providers.worktree.createWorktree({
+          () => placementPort.validatePlacement(payload.placement),
+        );
+        const worktree = await create(() =>
+          runProviderMutation(
+            {
+              ...runtime,
+              operation: `provider.${options.providers.worktree.id}.createWorktree`,
+              fallback: {
+                tag: "WorktreeProviderError",
+                code: "WORKTREE_CREATE_FAILED",
+                message: "The worktree provider failed to create the session worktree.",
+                provider: options.providers.worktree.id,
+              },
+            },
+            () =>
+              options.providers.worktree.createWorktree({
+                project,
+                branch: payload.branch,
+                ...(payload.base === undefined ? {} : { base: payload.base }),
+              }),
+          ),
+        );
+        createdWorktree = worktree;
+        throwIfAborted(context.signal);
+
+        const seed = await seedSession({
+          persistence: options.persistence,
+          sessionId,
+          projectId: project.id,
+          worktreeId: worktree.id,
+          initialTitle: payload.title ?? payload.branch,
+          harness: payload.harness.provider,
+          terminalProvider: payload.terminal.provider,
+          ...(group === undefined ? {} : { group }),
+          clock: options.clock,
+        });
+        sessionSeeded = true;
+        groupProvenance = seed.groupProvenance;
+        throwIfAborted(context.signal);
+
+        const resolvedPlacement = await ensureAgentWorkspace({
+          terminal,
+          harness,
+          launchPreflight: options.launchPreflight,
+          project,
+          worktree,
+          sessionId,
+          harnessOptions: payload.harness,
+          layout: payload.terminal.layout ?? project.defaults.layout,
+          placementPort,
+          placement: payload.placement,
+          initialPrompt: payload.initialPrompt,
+          context,
+          clock: options.clock,
+          logger: options.logger,
+        });
+        placementResult = commandPlacementResult(payload.placement, resolvedPlacement);
+        throwIfAborted(context.signal);
+      } catch (error) {
+        if (isTerminalCleanupUncertain(error)) {
+          try {
+            await reconcileAndPublish({
+              core: options.core,
+              eventBus: options.eventBus,
+              clock: options.clock,
+              reason: "command:session.create:cleanup-uncertain",
+              trace: context.trace,
+            });
+          } catch (reconcileError) {
+            await options.logger?.warn("Observer could not publish retained cleanup state.", {
+              commandId: context.commandId,
+              traceId: context.trace.traceId,
+              operation: "session.create.cleanup-uncertain.reconcile",
+              error: reconcileError,
+            });
+          }
+          throw error;
+        }
+        let worktreeRemoved = false;
+        if (createdWorktree !== undefined) {
+          worktreeRemoved = await removeWorktreeBestEffort({
+            providers: options.providers,
             project,
-            branch: payload.branch,
-            ...(payload.base === undefined ? {} : { base: payload.base }),
-          }),
-      );
-      createdWorktree = worktree;
-      throwIfAborted(context.signal);
-
-      const seed = await seedSession({
-        persistence: options.persistence,
-        sessionId,
-        projectId: project.id,
-        worktreeId: worktree.id,
-        initialTitle: payload.title ?? payload.branch,
-        harness: payload.harness.provider,
-        terminalProvider: payload.terminal.provider,
-        ...(group === undefined ? {} : { group }),
-        clock: options.clock,
-      });
-      sessionSeeded = true;
-      groupProvenance = seed.groupProvenance;
-      throwIfAborted(context.signal);
-
-      const resolvedPlacement = await ensureAgentWorkspace({
-        terminal,
-        harness,
-        launchPreflight: options.launchPreflight,
-        project,
-        worktree,
-        sessionId,
-        harnessOptions: payload.harness,
-        layout: payload.terminal.layout ?? project.defaults.layout,
-        placementPort,
-        placement: payload.placement,
-        initialPrompt: payload.initialPrompt,
-        context,
-        clock: options.clock,
-        logger: options.logger,
-      });
-      placementResult = commandPlacementResult(payload.placement, resolvedPlacement);
-      throwIfAborted(context.signal);
-    } catch (error) {
-      if (isTerminalCleanupUncertain(error)) {
-        try {
-          await reconcileAndPublish({
-            core: options.core,
-            eventBus: options.eventBus,
+            worktreeId: createdWorktree.id,
+            expectedPath: createdWorktree.path,
+            expectedBranch: createdWorktree.branch,
+            expectedRegistrationIdentity: createdWorktree.registrationIdentity,
+            context,
+            logger: options.logger,
             clock: options.clock,
-            reason: "command:session.create:cleanup-uncertain",
-            trace: context.trace,
           });
-        } catch (reconcileError) {
-          await options.logger?.warn("Observer could not publish retained cleanup state.", {
-            commandId: context.commandId,
-            traceId: context.trace.traceId,
-            operation: "session.create.cleanup-uncertain.reconcile",
-            error: reconcileError,
+        }
+        if (sessionSeeded && worktreeRemoved) {
+          await discardSessionSeedBestEffort({
+            persistence: options.persistence,
+            sessionId,
+            ...(groupProvenance === undefined ? {} : { groupProvenance }),
+            ...(worktreeRemoved && createdWorktree !== undefined
+              ? { removedWorktree: { projectId: project.id, worktreeId: createdWorktree.id } }
+              : {}),
+            context,
+            logger: options.logger,
+            clock: options.clock,
           });
         }
         throw error;
       }
-      let worktreeRemoved = false;
-      if (createdWorktree !== undefined) {
-        worktreeRemoved = await removeWorktreeBestEffort({
-          providers: options.providers,
-          project,
-          worktreeId: createdWorktree.id,
-          expectedPath: createdWorktree.path,
-          expectedBranch: createdWorktree.branch,
-          expectedRegistrationIdentity: createdWorktree.registrationIdentity,
-          context,
-          logger: options.logger,
-          clock: options.clock,
-        });
-      }
-      if (sessionSeeded && worktreeRemoved) {
-        await discardSessionSeedBestEffort({
-          persistence: options.persistence,
-          sessionId,
-          ...(groupProvenance === undefined ? {} : { groupProvenance }),
-          ...(worktreeRemoved && createdWorktree !== undefined
-            ? { removedWorktree: { projectId: project.id, worktreeId: createdWorktree.id } }
-            : {}),
-          context,
-          logger: options.logger,
-          clock: options.clock,
-        });
-      }
-      throw error;
-    }
 
-    const snapshot = await reconcileAndPublish({
-      core: options.core,
-      eventBus: options.eventBus,
-      clock: options.clock,
-      reason: "command:session.create",
-      trace: context.trace,
+      const snapshot = await reconcileAndPublish({
+        core: options.core,
+        eventBus: options.eventBus,
+        clock: options.clock,
+        reason: "command:session.create",
+        trace: context.trace,
+      });
+      await publishSessionCreated({
+        snapshot,
+        sessionId,
+        persistence: options.persistence,
+        eventBus: options.eventBus,
+        context,
+        clock: options.clock,
+      });
+      const result: SessionCreateCommandResult = {
+        type: "session.create",
+        projectId: project.id,
+        worktreeId: createdWorktree.id,
+        sessionId,
+        ...placementResult,
+      };
+      if (groupProvenance !== undefined) result.resolvedGroupId = groupProvenance.groupId;
+      return result;
     });
-    await publishSessionCreated({
-      snapshot,
-      sessionId,
-      persistence: options.persistence,
-      eventBus: options.eventBus,
-      context,
-      clock: options.clock,
-    });
-    const result: SessionCreateCommandResult = {
-      type: "session.create",
-      projectId: project.id,
-      worktreeId: createdWorktree.id,
-      sessionId,
-      ...placementResult,
-    };
-    if (groupProvenance !== undefined) result.resolvedGroupId = groupProvenance.groupId;
-    return result;
   };
 }

--- a/apps/observer/src/commands/session/fork.ts
+++ b/apps/observer/src/commands/session/fork.ts
@@ -13,6 +13,10 @@ import type { ProviderRegistry } from "../../providers/registry.js";
 import type { ObserverCore } from "../../reconcile/core.js";
 import type { ObserverEventBus } from "../../runtime/eventBus.js";
 import type { StationLogger } from "../../stationLogger.js";
+import {
+  createWorktreeCreateCoordinator,
+  type WorktreeCreateCoordinator,
+} from "../../worktreeCreateCoordinator.js";
 import { assertCommandType } from "../assertCommand.js";
 import type { HarnessLaunchPreflight } from "../harnessLaunchPreflight.js";
 import {
@@ -51,6 +55,7 @@ export type CreateSessionForkHandlerOptions = {
   clock?: RuntimeClock | undefined;
   idFactory?: Partial<SessionCommandIdFactory> | undefined;
   logger?: StationLogger | undefined;
+  worktreeCreates?: WorktreeCreateCoordinator | undefined;
 };
 
 /**
@@ -59,14 +64,15 @@ export type CreateSessionForkHandlerOptions = {
  * Resolves and preflights the selected harness, forks an existing worktree onto an internal
  * branch, and atomically seeds its title with the source session's current Group when requested
  * before launching a fresh agent with pre-mutation placement authorization and
- * provider-side revalidation immediately before terminal mutation; cleanup
- * retires only fork-owned state after verified rollback. Success returns the exact
- * created identities, transaction-resolved Group identity when grouped, and the
- * provider-resolved placement projection.
+ * provider-side revalidation immediately before terminal mutation. Shared branch ownership spans
+ * seed, launch, publication, and verified rollback while per-project capacity spans only provider
+ * creation. Cleanup retires only fork-owned state. Success returns the exact created identities,
+ * transaction-resolved Group identity when grouped, and the placement projection.
  */
 export function createSessionForkHandler(
   options: CreateSessionForkHandlerOptions,
 ): CommandResultHandler<"session.fork"> {
+  const worktreeCreates = options.worktreeCreates ?? createWorktreeCreateCoordinator();
   const idFactory = {
     ...defaultSessionCommandIdFactory,
     ...options.idFactory,
@@ -137,147 +143,153 @@ export function createSessionForkHandler(
     let groupProvenance: SessionSeedGroupProvenance | undefined;
     let placementResult: ReturnType<typeof commandPlacementResult>;
 
-    try {
-      await runProviderMutation(
-        {
-          ...runtime,
-          operation: `provider.${placementPort.id}.validatePlacement`,
-          fallback: {
-            tag: "TerminalProviderError",
-            code: "TERMINAL_PLACEMENT_REJECTED",
-            message: "The requested terminal placement is no longer valid.",
-            provider: placementPort.id,
+    return worktreeCreates.run(project.id, payload.branch, context.signal, async (create) => {
+      try {
+        await runProviderMutation(
+          {
+            ...runtime,
+            operation: `provider.${placementPort.id}.validatePlacement`,
+            fallback: {
+              tag: "TerminalProviderError",
+              code: "TERMINAL_PLACEMENT_REJECTED",
+              message: "The requested terminal placement is no longer valid.",
+              provider: placementPort.id,
+            },
           },
-        },
-        () => placementPort.validatePlacement(payload.placement),
-      );
-      const worktree = await runProviderMutation(
-        {
-          ...runtime,
-          operation: `provider.${options.providers.worktree.id}.createWorktree`,
-          fallback: {
-            tag: "WorktreeProviderError",
-            code: "WORKTREE_CREATE_FAILED",
-            message: "The worktree provider failed to create the forked worktree.",
-            provider: options.providers.worktree.id,
-          },
-        },
-        () =>
-          options.providers.worktree.createWorktree({
+          () => placementPort.validatePlacement(payload.placement),
+        );
+        const worktree = await create(() =>
+          runProviderMutation(
+            {
+              ...runtime,
+              operation: `provider.${options.providers.worktree.id}.createWorktree`,
+              fallback: {
+                tag: "WorktreeProviderError",
+                code: "WORKTREE_CREATE_FAILED",
+                message: "The worktree provider failed to create the forked worktree.",
+                provider: options.providers.worktree.id,
+              },
+            },
+            () =>
+              options.providers.worktree.createWorktree({
+                project,
+                branch: payload.branch,
+                base,
+                ...(copyDirty
+                  ? { seedFrom: { path: sourceRow.path, worktreeId: sourceRow.id } }
+                  : {}),
+              }),
+          ),
+        );
+        createdWorktree = worktree;
+        throwIfAborted(context.signal);
+
+        const seed = await seedSession({
+          persistence: options.persistence,
+          sessionId,
+          projectId: project.id,
+          worktreeId: worktree.id,
+          initialTitle: payload.title ?? payload.branch,
+          harness: harnessProviderId,
+          terminalProvider: terminalProviderId,
+          ...(group === undefined ? {} : { group }),
+          clock: options.clock,
+        });
+        sessionSeeded = true;
+        groupProvenance = seed.groupProvenance;
+        throwIfAborted(context.signal);
+
+        const resolvedPlacement = await ensureAgentWorkspace({
+          terminal,
+          harness,
+          launchPreflight: options.launchPreflight,
+          project,
+          worktree,
+          sessionId,
+          harnessOptions: payload.harness,
+          layout: payload.terminal.layout ?? project.defaults.layout,
+          placementPort,
+          placement: payload.placement,
+          initialPrompt: payload.initialPrompt,
+          context,
+          clock: options.clock,
+          logger: options.logger,
+        });
+        placementResult = commandPlacementResult(payload.placement, resolvedPlacement);
+        throwIfAborted(context.signal);
+      } catch (error) {
+        if (isTerminalCleanupUncertain(error)) {
+          try {
+            await reconcileAndPublish({
+              core: options.core,
+              eventBus: options.eventBus,
+              clock: options.clock,
+              reason: "command:session.fork:cleanup-uncertain",
+              trace: context.trace,
+            });
+          } catch (reconcileError) {
+            await options.logger?.warn("Observer could not publish retained cleanup state.", {
+              commandId: context.commandId,
+              traceId: context.trace.traceId,
+              operation: "session.fork.cleanup-uncertain.reconcile",
+              error: reconcileError,
+            });
+          }
+          throw error;
+        }
+        let worktreeRemoved = false;
+        if (createdWorktree !== undefined) {
+          worktreeRemoved = await removeWorktreeBestEffort({
+            providers: options.providers,
             project,
-            branch: payload.branch,
-            base,
-            ...(copyDirty ? { seedFrom: { path: sourceRow.path, worktreeId: sourceRow.id } } : {}),
-          }),
-      );
-      createdWorktree = worktree;
-      throwIfAborted(context.signal);
-
-      const seed = await seedSession({
-        persistence: options.persistence,
-        sessionId,
-        projectId: project.id,
-        worktreeId: worktree.id,
-        initialTitle: payload.title ?? payload.branch,
-        harness: harnessProviderId,
-        terminalProvider: terminalProviderId,
-        ...(group === undefined ? {} : { group }),
-        clock: options.clock,
-      });
-      sessionSeeded = true;
-      groupProvenance = seed.groupProvenance;
-      throwIfAborted(context.signal);
-
-      const resolvedPlacement = await ensureAgentWorkspace({
-        terminal,
-        harness,
-        launchPreflight: options.launchPreflight,
-        project,
-        worktree,
-        sessionId,
-        harnessOptions: payload.harness,
-        layout: payload.terminal.layout ?? project.defaults.layout,
-        placementPort,
-        placement: payload.placement,
-        initialPrompt: payload.initialPrompt,
-        context,
-        clock: options.clock,
-        logger: options.logger,
-      });
-      placementResult = commandPlacementResult(payload.placement, resolvedPlacement);
-      throwIfAborted(context.signal);
-    } catch (error) {
-      if (isTerminalCleanupUncertain(error)) {
-        try {
-          await reconcileAndPublish({
-            core: options.core,
-            eventBus: options.eventBus,
+            worktreeId: createdWorktree.id,
+            expectedPath: createdWorktree.path,
+            expectedBranch: createdWorktree.branch,
+            expectedRegistrationIdentity: createdWorktree.registrationIdentity,
+            context,
+            logger: options.logger,
             clock: options.clock,
-            reason: "command:session.fork:cleanup-uncertain",
-            trace: context.trace,
           });
-        } catch (reconcileError) {
-          await options.logger?.warn("Observer could not publish retained cleanup state.", {
-            commandId: context.commandId,
-            traceId: context.trace.traceId,
-            operation: "session.fork.cleanup-uncertain.reconcile",
-            error: reconcileError,
+        }
+        if (sessionSeeded && worktreeRemoved) {
+          await discardSessionSeedBestEffort({
+            persistence: options.persistence,
+            sessionId,
+            ...(groupProvenance === undefined ? {} : { groupProvenance }),
+            ...(worktreeRemoved && createdWorktree !== undefined
+              ? { removedWorktree: { projectId: project.id, worktreeId: createdWorktree.id } }
+              : {}),
+            context,
+            logger: options.logger,
           });
         }
         throw error;
       }
-      let worktreeRemoved = false;
-      if (createdWorktree !== undefined) {
-        worktreeRemoved = await removeWorktreeBestEffort({
-          providers: options.providers,
-          project,
-          worktreeId: createdWorktree.id,
-          expectedPath: createdWorktree.path,
-          expectedBranch: createdWorktree.branch,
-          expectedRegistrationIdentity: createdWorktree.registrationIdentity,
-          context,
-          logger: options.logger,
-          clock: options.clock,
-        });
-      }
-      if (sessionSeeded && worktreeRemoved) {
-        await discardSessionSeedBestEffort({
-          persistence: options.persistence,
-          sessionId,
-          ...(groupProvenance === undefined ? {} : { groupProvenance }),
-          ...(worktreeRemoved && createdWorktree !== undefined
-            ? { removedWorktree: { projectId: project.id, worktreeId: createdWorktree.id } }
-            : {}),
-          context,
-          logger: options.logger,
-        });
-      }
-      throw error;
-    }
 
-    const nextSnapshot = await reconcileAndPublish({
-      core: options.core,
-      eventBus: options.eventBus,
-      clock: options.clock,
-      reason: "command:session.fork",
-      trace: context.trace,
+      const nextSnapshot = await reconcileAndPublish({
+        core: options.core,
+        eventBus: options.eventBus,
+        clock: options.clock,
+        reason: "command:session.fork",
+        trace: context.trace,
+      });
+      await publishSessionCreated({
+        snapshot: nextSnapshot,
+        sessionId,
+        persistence: options.persistence,
+        eventBus: options.eventBus,
+        context,
+        clock: options.clock,
+      });
+      const result: SessionForkCommandResult = {
+        type: "session.fork",
+        projectId: project.id,
+        worktreeId: createdWorktree.id,
+        sessionId,
+        ...placementResult,
+      };
+      if (groupProvenance !== undefined) result.resolvedGroupId = groupProvenance.groupId;
+      return result;
     });
-    await publishSessionCreated({
-      snapshot: nextSnapshot,
-      sessionId,
-      persistence: options.persistence,
-      eventBus: options.eventBus,
-      context,
-      clock: options.clock,
-    });
-    const result: SessionForkCommandResult = {
-      type: "session.fork",
-      projectId: project.id,
-      worktreeId: createdWorktree.id,
-      sessionId,
-      ...placementResult,
-    };
-    if (groupProvenance !== undefined) result.resolvedGroupId = groupProvenance.groupId;
-    return result;
   };
 }

--- a/apps/observer/src/commands/worktree/create.ts
+++ b/apps/observer/src/commands/worktree/create.ts
@@ -4,6 +4,10 @@ import type { ProviderRegistry } from "../../providers/registry.js";
 import type { ObserverCore } from "../../reconcile/core.js";
 import type { ObserverEventBus } from "../../runtime/eventBus.js";
 import type { StationLogger } from "../../stationLogger.js";
+import {
+  createWorktreeCreateCoordinator,
+  type WorktreeCreateCoordinator,
+} from "../../worktreeCreateCoordinator.js";
 import { assertCommandType } from "../assertCommand.js";
 import type { HarnessLaunchPreflight } from "../harnessLaunchPreflight.js";
 import type { CommandResultHandler } from "../queue.js";
@@ -18,6 +22,7 @@ export type CreateWorktreeCreateHandlerOptions = {
   eventBus?: ObserverEventBus | undefined;
   clock?: RuntimeClock | undefined;
   logger?: StationLogger | undefined;
+  worktreeCreates?: WorktreeCreateCoordinator | undefined;
 };
 
 /**
@@ -27,11 +32,14 @@ export type CreateWorktreeCreateHandlerOptions = {
  * worktree, preflighting the selected launch harness before mutation when Station
  * will immediately host an agent through prepareExternalLaunch. Exact provider-returned
  * launch evidence commits through the serialized snapshot writer before publication;
- * ambiguous evidence and worktree-only creation retain synchronous reconciliation.
+ * ambiguous evidence and worktree-only creation retain synchronous reconciliation. Shared branch
+ * ownership spans projection, reconciliation, and late cancellation; provider-call capacity spans
+ * only the bounded create operation.
  */
 export function createWorktreeCreateHandler(
   options: CreateWorktreeCreateHandlerOptions,
 ): CommandResultHandler<"worktree.create"> {
+  const worktreeCreates = options.worktreeCreates ?? createWorktreeCreateCoordinator();
   return async (context) => {
     assertCommandType(context, "worktree.create");
     throwIfAborted(context.signal);
@@ -53,77 +61,81 @@ export function createWorktreeCreateHandler(
       request.path = payload.path;
     }
 
-    const worktree = await runProviderMutation(
-      {
-        clock: options.clock,
-        signal: context.signal,
-        trace: context.trace,
-        operation: `provider.${options.providers.worktree.id}.createWorktree`,
-        fallback: {
-          tag: "WorktreeProviderError",
-          code: "WORKTREE_CREATE_FAILED",
-          message: "The worktree provider failed to create the worktree.",
-          provider: options.providers.worktree.id,
-        },
-      },
-      () => options.providers.worktree.createWorktree(request),
-    );
+    return worktreeCreates.run(project.id, payload.branch, context.signal, async (create) => {
+      const worktree = await create(() =>
+        runProviderMutation(
+          {
+            clock: options.clock,
+            signal: context.signal,
+            trace: context.trace,
+            operation: `provider.${options.providers.worktree.id}.createWorktree`,
+            fallback: {
+              tag: "WorktreeProviderError",
+              code: "WORKTREE_CREATE_FAILED",
+              message: "The worktree provider failed to create the worktree.",
+              provider: options.providers.worktree.id,
+            },
+          },
+          () => options.providers.worktree.createWorktree(request),
+        ),
+      );
 
-    const result = {
-      type: "worktree.create",
-      projectId: project.id,
-      worktreeId: worktree.id,
-    } as const;
-    let requiresReconcile = payload.launchHarness === undefined;
-    if (payload.launchHarness !== undefined) {
-      try {
-        const projection = await options.core.commitCreatedWorktreeObservation({
-          projectId: project.id,
-          worktree,
-        });
-        if (projection.status === "rejected") {
+      const result = {
+        type: "worktree.create",
+        projectId: project.id,
+        worktreeId: worktree.id,
+      } as const;
+      let requiresReconcile = payload.launchHarness === undefined;
+      if (payload.launchHarness !== undefined) {
+        try {
+          const projection = await options.core.commitCreatedWorktreeObservation({
+            projectId: project.id,
+            worktree,
+          });
+          if (projection.status === "rejected") {
+            requiresReconcile = true;
+            await options.logger
+              ?.warn("Created worktree evidence required reconciliation fallback.", {
+                projectId: project.id,
+                worktreeId: worktree.id,
+                reason: projection.reason,
+              })
+              .catch(() => undefined);
+          } else {
+            for (const event of projection.events) {
+              options.eventBus?.publish(event);
+            }
+          }
+        } catch (cause) {
           requiresReconcile = true;
+          const error = safeErrorFromUnknown(cause, {
+            tag: "ObserverProjectionError",
+            code: "WORKTREE_CREATE_PROJECTION_FAILED",
+            message: "Created worktree evidence could not be projected.",
+          });
           await options.logger
             ?.warn("Created worktree evidence required reconciliation fallback.", {
               projectId: project.id,
               worktreeId: worktree.id,
-              reason: projection.reason,
+              error,
             })
             .catch(() => undefined);
-        } else {
-          for (const event of projection.events) {
-            options.eventBus?.publish(event);
-          }
         }
-      } catch (cause) {
-        requiresReconcile = true;
-        const error = safeErrorFromUnknown(cause, {
-          tag: "ObserverProjectionError",
-          code: "WORKTREE_CREATE_PROJECTION_FAILED",
-          message: "Created worktree evidence could not be projected.",
-        });
-        await options.logger
-          ?.warn("Created worktree evidence required reconciliation fallback.", {
-            projectId: project.id,
-            worktreeId: worktree.id,
-            error,
-          })
-          .catch(() => undefined);
       }
-    }
 
-    if (requiresReconcile) {
-      await reconcileAndPublish({
-        core: options.core,
-        eventBus: options.eventBus,
-        clock: options.clock,
-        reason: "command:worktree.create",
-        trace: context.trace,
-      });
-    }
-    // The external mutation is already complete; make its canonical visibility settle before
-    // recording a late cancellation so clients never observe a cancelled-but-missing worktree.
-    throwIfAborted(context.signal);
-    return result;
+      if (requiresReconcile) {
+        await reconcileAndPublish({
+          core: options.core,
+          eventBus: options.eventBus,
+          clock: options.clock,
+          reason: "command:worktree.create",
+          trace: context.trace,
+        });
+      }
+      // The external mutation is already complete; make its canonical visibility settle before
+      // recording a late cancellation so clients never observe a cancelled-but-missing worktree.
+      throwIfAborted(context.signal);
+      return result;
+    });
   };
 }

--- a/apps/observer/src/commands/worktree/fork.ts
+++ b/apps/observer/src/commands/worktree/fork.ts
@@ -4,6 +4,10 @@ import type { ProviderRegistry } from "../../providers/registry.js";
 import type { ObserverCore } from "../../reconcile/core.js";
 import type { ObserverEventBus } from "../../runtime/eventBus.js";
 import type { StationLogger } from "../../stationLogger.js";
+import {
+  createWorktreeCreateCoordinator,
+  type WorktreeCreateCoordinator,
+} from "../../worktreeCreateCoordinator.js";
 import { assertCommandType } from "../assertCommand.js";
 import type { HarnessLaunchPreflight } from "../harnessLaunchPreflight.js";
 import type { CommandResultHandler } from "../queue.js";
@@ -25,6 +29,7 @@ export type WorktreeForkHandlerOptions = {
   eventBus?: ObserverEventBus | undefined;
   clock?: RuntimeClock | undefined;
   logger?: StationLogger | undefined;
+  worktreeCreates?: WorktreeCreateCoordinator | undefined;
 };
 
 /**
@@ -34,11 +39,13 @@ export type WorktreeForkHandlerOptions = {
  * working tree (when copyDirty), validating any source-Group inheritance intent while minting no
  * session and launching no terminal so Station can host the inherited harness itself. A selected
  * launch harness is preflighted before mutation. No live-agent guard on the source — the seed is a
- * read-only snapshot. Success returns the exact project and forked-worktree identities.
+ * read-only snapshot. Shared branch ownership spans the completion reconcile while provider-call
+ * capacity spans only creation. Success returns the exact project and forked-worktree identities.
  */
 export function createWorktreeForkHandler(
   options: WorktreeForkHandlerOptions,
 ): CommandResultHandler<"worktree.fork"> {
+  const worktreeCreates = options.worktreeCreates ?? createWorktreeCreateCoordinator();
   return async (context) => {
     assertCommandType(context, "worktree.fork");
     throwIfAborted(context.signal);
@@ -82,34 +89,38 @@ export function createWorktreeForkHandler(
       request.seedFrom = { path: sourceRow.path, worktreeId: sourceRow.id };
     }
 
-    const worktree = await runProviderMutation(
-      {
-        clock: options.clock,
-        signal: context.signal,
-        trace: context.trace,
-        operation: `provider.${options.providers.worktree.id}.createWorktree`,
-        fallback: {
-          tag: "WorktreeProviderError",
-          code: "WORKTREE_CREATE_FAILED",
-          message: "The worktree provider failed to create the forked worktree.",
-          provider: options.providers.worktree.id,
-        },
-      },
-      () => options.providers.worktree.createWorktree(request),
-    );
-    throwIfAborted(context.signal);
+    return worktreeCreates.run(project.id, payload.branch, context.signal, async (create) => {
+      const worktree = await create(() =>
+        runProviderMutation(
+          {
+            clock: options.clock,
+            signal: context.signal,
+            trace: context.trace,
+            operation: `provider.${options.providers.worktree.id}.createWorktree`,
+            fallback: {
+              tag: "WorktreeProviderError",
+              code: "WORKTREE_CREATE_FAILED",
+              message: "The worktree provider failed to create the forked worktree.",
+              provider: options.providers.worktree.id,
+            },
+          },
+          () => options.providers.worktree.createWorktree(request),
+        ),
+      );
+      throwIfAborted(context.signal);
 
-    await reconcileAndPublish({
-      core: options.core,
-      eventBus: options.eventBus,
-      clock: options.clock,
-      reason: "command:worktree.fork",
-      trace: context.trace,
+      await reconcileAndPublish({
+        core: options.core,
+        eventBus: options.eventBus,
+        clock: options.clock,
+        reason: "command:worktree.fork",
+        trace: context.trace,
+      });
+      return {
+        type: "worktree.fork",
+        projectId: project.id,
+        worktreeId: worktree.id,
+      };
     });
-    return {
-      type: "worktree.fork",
-      projectId: project.id,
-      worktreeId: worktree.id,
-    };
   };
 }

--- a/apps/observer/src/runtime/api.ts
+++ b/apps/observer/src/runtime/api.ts
@@ -71,6 +71,7 @@ import { type ObserverCore, providerProjectsFromConfig } from "../reconcile/core
 import { inspectObserverRecoveryAssessment } from "../sessionRecovery/assessment.js";
 import { inspectObserverRecoveryInventory } from "../sessionRecovery/inventory.js";
 import type { StationLogger } from "../stationLogger.js";
+import type { WorktreeCreateCoordinator } from "../worktreeCreateCoordinator.js";
 import {
   createWorktreeMutationCoordinator,
   type WorktreeMutationCoordinator,
@@ -89,6 +90,7 @@ import { logReconcileSchedulerProfile } from "./reconcileProfiling.js";
 import {
   type CreateReconcileSchedulerOptions,
   createReconcileScheduler,
+  type ReconcileReadiness,
 } from "./reconcileScheduler.js";
 import { resolveCurrentSessionContext } from "./sessionContext.js";
 import { createSpoolDrainer, type SpoolDrainDeps } from "./spoolDrain.js";
@@ -100,6 +102,7 @@ export type CreateObserverApiOptions = {
   persistenceHealth: PersistenceHealthSource;
   commandQueue: CommandQueue;
   worktreeMutations?: WorktreeMutationCoordinator;
+  worktreeCreates?: WorktreeCreateCoordinator;
   eventBus: ObserverEventBus;
   diagnosticEvidenceSource: DiagnosticEvidenceSource;
   clock?: RuntimeClock;
@@ -121,6 +124,7 @@ export type CreateObserverApiOptions = {
   onShutdownStarted?: () => Promise<void> | void;
   onStop?: () => Promise<void> | void;
   hookReconcileDebounceMs?: number;
+  interactiveReconcileDebounceMs?: number;
   duplicateInspection?: () => Promise<ObserverReapPlan> | undefined;
 };
 
@@ -130,12 +134,19 @@ export type CreateObserverApiOptions = {
  * Wires Observer use cases with supplied durable, local-metadata, and diagnostic-
  * evidence roles, ingress workers, provider-health publication, scheduling, exact
  * build publication, recovery-readiness, coherent recovery-inventory, and recovery-assessment
- * queries, authoritative launch projection and event ordering, read-only singleton diagnostics,
- * and adapter shutdown behind the application API.
+ * queries, authoritative launch projection and event ordering, create-quiescent verification,
+ * read-only singleton diagnostics, and adapter shutdown behind the application API.
  */
 export function createObserverApi(options: CreateObserverApiOptions): ObserverApi {
   const clock = options.clock ?? systemClock;
   const worktreeMutations = options.worktreeMutations ?? createWorktreeMutationCoordinator();
+  const createQuiescence: ReconcileReadiness | undefined =
+    options.worktreeCreates === undefined
+      ? undefined
+      : {
+          isReady: options.worktreeCreates.isIdle,
+          whenReady: options.worktreeCreates.whenIdle,
+        };
   const reconciling = { reconciling: false };
   const providerHealthCache = options.providers?.healthCache;
   const pendingProviderHealthPublications = new Set<Promise<void>>();
@@ -181,6 +192,9 @@ export function createObserverApi(options: CreateObserverApiOptions): ObserverAp
   };
   if (options.hookReconcileDebounceMs !== undefined) {
     schedulerOptions.debounceMs = options.hookReconcileDebounceMs;
+  }
+  if (options.interactiveReconcileDebounceMs !== undefined) {
+    schedulerOptions.interactiveDebounceMs = options.interactiveReconcileDebounceMs;
   }
   if (options.logger !== undefined) {
     schedulerOptions.onError = async (error) => {
@@ -316,7 +330,13 @@ export function createObserverApi(options: CreateObserverApiOptions): ObserverAp
     reportHarnessEvent: async (report: HarnessEventReport): Promise<HarnessEventReportReceipt> =>
       harnessIngressQueue.enqueue(report),
     prepareExternalLaunch: (params) =>
-      prepareExternalLaunchSafe(options, worktreeMutations, reconcileScheduler, params),
+      prepareExternalLaunchSafe(
+        options,
+        worktreeMutations,
+        reconcileScheduler,
+        createQuiescence,
+        params,
+      ),
     reportExternalExit: (params) => reportExternalExitSafe(options, reconcileScheduler, params),
     prepareWorktreeRemoval: (params) =>
       prepareWorktreeRemovalSafe(options, worktreeMutations, params),
@@ -386,6 +406,7 @@ async function prepareExternalLaunchSafe(
   options: CreateObserverApiOptions,
   worktreeMutations: WorktreeMutationCoordinator,
   reconcileScheduler: ReturnType<typeof createReconcileScheduler>,
+  createQuiescence: ReconcileReadiness | undefined,
   params: Parameters<ObserverApi["prepareExternalLaunch"]>[0],
 ): ReturnType<ObserverApi["prepareExternalLaunch"]> {
   const deps = assertProvidersAvailable(options, worktreeMutations);
@@ -418,7 +439,14 @@ async function prepareExternalLaunchSafe(
     options.eventBus.publish(event);
   }
   if (reconcile) {
-    reconcileScheduler.request("agent.prepareExternalLaunch");
+    if (createQuiescence === undefined) {
+      reconcileScheduler.requestInteractive("agent.prepareExternalLaunch");
+    } else {
+      reconcileScheduler.requestInteractiveWhenReady(
+        "agent.prepareExternalLaunch",
+        createQuiescence,
+      );
+    }
   }
   return outcome;
 }

--- a/apps/observer/src/runtime/main.ts
+++ b/apps/observer/src/runtime/main.ts
@@ -45,6 +45,7 @@ import type { ProviderRegistry } from "../providers/registry.js";
 import { createObserverCore, providerProjectsFromConfig } from "../reconcile/core.js";
 import { openObserverSqlite } from "../sqlite.js";
 import type { StationLogger } from "../stationLogger.js";
+import { createWorktreeCreateCoordinator } from "../worktreeCreateCoordinator.js";
 import { createWorktreeMutationCoordinator } from "../worktreeMutationCoordinator.js";
 import { createObserverApi } from "./api.js";
 import { createObserverEventBus } from "./eventBus.js";
@@ -522,6 +523,7 @@ async function runClaimedObserverRuntime(input: {
   await persistence.pruneExpiredProviderObservations(pruneAt);
   const commandQueue = createCommandQueue({ persistence, clock: systemClock, eventBus, logger });
   const worktreeMutations = createWorktreeMutationCoordinator();
+  const worktreeCreates = createWorktreeCreateCoordinator();
   // Fire-and-forget version probes only populate provider-owned cache state.
   void providers.refreshHarnessVersions();
   const featureFlags = createFeatureFlagEvaluator({
@@ -559,6 +561,7 @@ async function runClaimedObserverRuntime(input: {
     projectConfigWriter,
     launchPreflight,
     worktreeMutations,
+    worktreeCreates,
   });
   const eventHooks = createConfiguredEventHooks(config, eventBus, logger);
   const duplicateProcessEvidence =
@@ -665,6 +668,7 @@ async function runClaimedObserverRuntime(input: {
     persistenceHealth: persistence,
     commandQueue,
     worktreeMutations,
+    worktreeCreates,
     eventBus,
     diagnosticEvidenceSource,
     hookSpoolDir: spoolDir,

--- a/apps/observer/src/runtime/reconcileScheduler.ts
+++ b/apps/observer/src/runtime/reconcileScheduler.ts
@@ -2,12 +2,21 @@ import { Effect } from "@station/runtime";
 
 export type ReconcileScheduler = {
   request(reason: string): void;
+  requestInteractive(reason: string): void;
+  requestWhenReady(reason: string, readiness: ReconcileReadiness): void;
+  requestInteractiveWhenReady(reason: string, readiness: ReconcileReadiness): void;
+};
+
+export type ReconcileReadiness = {
+  isReady(): boolean;
+  whenReady(): Promise<void>;
 };
 
 export type CreateReconcileSchedulerOptions = {
   reconcile(reason: string): Promise<unknown>;
   debounceMs?: number;
   backlogDebounceMs?: number;
+  interactiveDebounceMs?: number;
   onError?: (error: unknown) => Promise<void> | void;
   onFlushFinish?: (profile: ReconcileSchedulerFlushProfile) => Promise<void> | void;
 };
@@ -23,39 +32,72 @@ export type ReconcileSchedulerFlushProfile = {
 
 const defaultDebounceMs = 100;
 const defaultBacklogDebounceMs = 1000;
+const defaultInteractiveDebounceMs = 25;
+
+type QueuedReconcileRequest = {
+  reason: string;
+  queuedAt: number;
+  interactive: boolean;
+  readiness?: ReconcileReadiness;
+};
 
 export function createReconcileScheduler(
   options: CreateReconcileSchedulerOptions,
 ): ReconcileScheduler {
   const debounceMs = options.debounceMs ?? defaultDebounceMs;
   const backlogDebounceMs = options.backlogDebounceMs ?? defaultBacklogDebounceMs;
+  const interactiveDebounceMs = options.interactiveDebounceMs ?? defaultInteractiveDebounceMs;
   let running = false;
   let timerScheduled = false;
-  let firstQueuedAt: number | undefined;
-  const queuedReasons: string[] = [];
+  let scheduledFor: number | undefined;
+  let timerGeneration = 0;
+  let waitingForReadiness = false;
+  let readinessGeneration = 0;
+  const queuedRequests: QueuedReconcileRequest[] = [];
 
   return {
-    request: (reason) => {
-      if (queuedReasons.length === 0) {
-        firstQueuedAt = Date.now();
-      }
-      queuedReasons.push(reason);
-      if (running || timerScheduled) {
-        return;
-      }
-      scheduleFlush(debounceMs);
-    },
+    request: (reason) => request({ reason, queuedAt: Date.now(), interactive: false }),
+    requestInteractive: (reason) => request({ reason, queuedAt: Date.now(), interactive: true }),
+    requestWhenReady: (reason, readiness) =>
+      request({ reason, queuedAt: Date.now(), interactive: false, readiness }),
+    requestInteractiveWhenReady: (reason, readiness) =>
+      request({ reason, queuedAt: Date.now(), interactive: true, readiness }),
   };
 
+  function request(queued: QueuedReconcileRequest): void {
+    queuedRequests.push(queued);
+    if (running) return;
+    if (queued.readiness !== undefined && !queued.readiness.isReady()) {
+      armReadinessWait();
+      return;
+    }
+    const delayMs = queued.interactive ? interactiveDebounceMs : debounceMs;
+    if (timerScheduled) {
+      const requestedFor = queued.queuedAt + delayMs;
+      if (queued.interactive && (scheduledFor === undefined || requestedFor < scheduledFor)) {
+        scheduleFlush(delayMs);
+      }
+      return;
+    }
+    scheduleFlush(delayMs);
+  }
+
   function scheduleFlush(delayMs: number): void {
+    const generation = ++timerGeneration;
     timerScheduled = true;
+    scheduledFor = Date.now() + delayMs;
     void sleep(delayMs).then(
       () => {
+        if (generation !== timerGeneration) return;
         timerScheduled = false;
+        scheduledFor = undefined;
         void flush().catch((error: unknown) => reportError(error));
       },
       () => {
-        timerScheduled = false;
+        if (generation === timerGeneration) {
+          timerScheduled = false;
+          scheduledFor = undefined;
+        }
       },
     );
   }
@@ -64,32 +106,87 @@ export function createReconcileScheduler(
     if (running) {
       return;
     }
-    const reasons = queuedReasons.splice(0);
-    if (reasons.length === 0) {
+    const ready: QueuedReconcileRequest[] = [];
+    const blocked: QueuedReconcileRequest[] = [];
+    for (const queued of queuedRequests.splice(0)) {
+      if (queued.readiness === undefined || queued.readiness.isReady()) {
+        ready.push(queued);
+      } else {
+        blocked.push(queued);
+      }
+    }
+    queuedRequests.push(...blocked);
+    if (ready.length === 0) {
+      armReadinessWait();
       return;
     }
-    const queuedAt = firstQueuedAt;
-    firstQueuedAt = undefined;
-    const reason = summarizeReasons(reasons);
+    const queuedAt = Math.min(...ready.map((queued) => queued.queuedAt));
+    const reason = summarizeReasons(ready.map((queued) => queued.reason));
     const startedAt = Date.now();
 
     running = true;
     try {
       await options.reconcile(reason);
     } finally {
-      const queuedAfter = queuedReasons.length;
+      const queuedAfter = queuedRequests.length;
       running = false;
       reportFlushFinish({
         reason,
-        queuedCount: reasons.length,
+        queuedCount: ready.length,
         queuedWhileRunning: queuedAfter,
-        waitMs: queuedAt === undefined ? 0 : Math.max(0, startedAt - queuedAt),
+        waitMs: Math.max(0, startedAt - queuedAt),
         durationMs: Math.max(0, Date.now() - startedAt),
         queuedAfter,
       });
-      if (queuedReasons.length > 0 && !timerScheduled) {
-        scheduleFlush(backlogDebounceMs);
+      if (queuedRequests.length > 0 && !timerScheduled) {
+        if (hasReadyRequest()) {
+          scheduleFlush(hasReadyInteractiveRequest() ? interactiveDebounceMs : backlogDebounceMs);
+        } else {
+          armReadinessWait();
+        }
       }
+    }
+  }
+
+  function hasReadyRequest(): boolean {
+    return queuedRequests.some(
+      (queued) => queued.readiness === undefined || queued.readiness.isReady(),
+    );
+  }
+
+  function hasReadyInteractiveRequest(): boolean {
+    return queuedRequests.some(
+      (queued) =>
+        queued.interactive && (queued.readiness === undefined || queued.readiness.isReady()),
+    );
+  }
+
+  function armReadinessWait(): void {
+    if (waitingForReadiness || queuedRequests.length === 0 || hasReadyRequest()) return;
+    const readiness = [
+      ...new Set(
+        queuedRequests.flatMap((queued) =>
+          queued.readiness === undefined ? [] : [queued.readiness],
+        ),
+      ),
+    ];
+    if (readiness.length === 0) return;
+    waitingForReadiness = true;
+    const generation = ++readinessGeneration;
+    for (const candidate of readiness) {
+      void candidate.whenReady().then(
+        () => readinessSettled(generation),
+        (error: unknown) => readinessSettled(generation, error),
+      );
+    }
+  }
+
+  function readinessSettled(generation: number, error?: unknown): void {
+    if (generation !== readinessGeneration || !waitingForReadiness) return;
+    waitingForReadiness = false;
+    if (error !== undefined) reportError(error);
+    if (!running && !timerScheduled && queuedRequests.length > 0) {
+      scheduleFlush(hasReadyInteractiveRequest() ? interactiveDebounceMs : debounceMs);
     }
   }
 

--- a/apps/observer/src/worktreeCreateCoordinator.ts
+++ b/apps/observer/src/worktreeCreateCoordinator.ts
@@ -1,0 +1,245 @@
+const DEFAULT_MAX_CONCURRENT_CREATES_PER_PROJECT = 4;
+
+export type RunWorktreeProviderCreate = <T>(create: () => Promise<T>) => Promise<T>;
+
+export type WorktreeCreateCoordinator = {
+  run<T>(
+    projectId: string,
+    branch: string,
+    signal: AbortSignal,
+    transaction: (create: RunWorktreeProviderCreate) => Promise<T>,
+  ): Promise<T>;
+  isProjectIdle(projectId: string): boolean;
+  whenProjectIdle(projectId: string): Promise<void>;
+  isIdle(): boolean;
+  whenIdle(): Promise<void>;
+};
+
+export type CreateWorktreeCreateCoordinatorOptions = {
+  maxConcurrentPerProject?: number;
+};
+
+type PermitWaiter = {
+  signal: AbortSignal;
+  resolve(release: () => void): void;
+  reject(error: unknown): void;
+  onAbort(): void;
+};
+
+type BranchState = {
+  owned: boolean;
+  waiting: PermitWaiter[];
+};
+
+type ProjectCreateState = {
+  transactions: number;
+  activeProviderCreates: number;
+  capacityWaiters: PermitWaiter[];
+  branches: Map<string, BranchState>;
+  idleWaiters: Array<() => void>;
+};
+
+/**
+ * POLICY
+ *
+ * Admits provider-neutral worktree-create transactions with FIFO branch ownership and a bounded
+ * per-project provider-call capacity while retaining branch ownership through downstream rollback.
+ */
+export function createWorktreeCreateCoordinator(
+  options: CreateWorktreeCreateCoordinatorOptions = {},
+): WorktreeCreateCoordinator {
+  const maxConcurrent =
+    options.maxConcurrentPerProject ?? DEFAULT_MAX_CONCURRENT_CREATES_PER_PROJECT;
+  if (!Number.isInteger(maxConcurrent) || maxConcurrent < 1) {
+    throw new Error("Worktree create concurrency must be a positive integer.");
+  }
+
+  const projects = new Map<string, ProjectCreateState>();
+  const idleWaiters: Array<() => void> = [];
+  let transactions = 0;
+
+  const stateFor = (projectId: string): ProjectCreateState => {
+    const existing = projects.get(projectId);
+    if (existing !== undefined) return existing;
+    const state: ProjectCreateState = {
+      transactions: 0,
+      activeProviderCreates: 0,
+      capacityWaiters: [],
+      branches: new Map(),
+      idleWaiters: [],
+    };
+    projects.set(projectId, state);
+    return state;
+  };
+
+  const finishTransaction = (projectId: string, state: ProjectCreateState): void => {
+    state.transactions -= 1;
+    transactions -= 1;
+    if (state.transactions === 0) {
+      projects.delete(projectId);
+      for (const resolveIdle of state.idleWaiters.splice(0)) resolveIdle();
+    }
+    if (transactions === 0) {
+      for (const resolveIdle of idleWaiters.splice(0)) resolveIdle();
+    }
+  };
+
+  const admitBranch = (
+    state: ProjectCreateState,
+    branch: string,
+    branchState: BranchState,
+  ): void => {
+    while (!branchState.owned) {
+      const waiter = branchState.waiting.shift();
+      if (waiter === undefined) {
+        state.branches.delete(branch);
+        return;
+      }
+      waiter.signal.removeEventListener("abort", waiter.onAbort);
+      if (waiter.signal.aborted) {
+        rejectAbortedWaiter(waiter);
+        continue;
+      }
+      branchState.owned = true;
+      let released = false;
+      waiter.resolve(() => {
+        if (released) return;
+        released = true;
+        branchState.owned = false;
+        admitBranch(state, branch, branchState);
+      });
+    }
+  };
+
+  const acquireBranch = (
+    state: ProjectCreateState,
+    branch: string,
+    signal: AbortSignal,
+  ): Promise<() => void> => {
+    signal.throwIfAborted();
+    const branchState = state.branches.get(branch) ?? { owned: false, waiting: [] };
+    state.branches.set(branch, branchState);
+    return new Promise<() => void>((resolve, reject) => {
+      const waiter: PermitWaiter = {
+        signal,
+        resolve,
+        reject,
+        onAbort: () => {
+          const index = branchState.waiting.indexOf(waiter);
+          if (index === -1) return;
+          branchState.waiting.splice(index, 1);
+          rejectAbortedWaiter(waiter);
+          admitBranch(state, branch, branchState);
+        },
+      };
+      branchState.waiting.push(waiter);
+      signal.addEventListener("abort", waiter.onAbort, { once: true });
+      admitBranch(state, branch, branchState);
+    });
+  };
+
+  const admitCapacity = (projectId: string, state: ProjectCreateState): void => {
+    while (state.activeProviderCreates < maxConcurrent) {
+      const waiter = state.capacityWaiters.shift();
+      if (waiter === undefined) return;
+      waiter.signal.removeEventListener("abort", waiter.onAbort);
+      if (waiter.signal.aborted) {
+        rejectAbortedWaiter(waiter);
+        continue;
+      }
+      state.activeProviderCreates += 1;
+      let released = false;
+      waiter.resolve(() => {
+        if (released) return;
+        released = true;
+        state.activeProviderCreates -= 1;
+        admitCapacity(projectId, state);
+      });
+    }
+  };
+
+  const acquireCapacity = (
+    projectId: string,
+    state: ProjectCreateState,
+    signal: AbortSignal,
+  ): Promise<() => void> => {
+    signal.throwIfAborted();
+    return new Promise<() => void>((resolve, reject) => {
+      const waiter: PermitWaiter = {
+        signal,
+        resolve,
+        reject,
+        onAbort: () => {
+          const index = state.capacityWaiters.indexOf(waiter);
+          if (index === -1) return;
+          state.capacityWaiters.splice(index, 1);
+          rejectAbortedWaiter(waiter);
+          admitCapacity(projectId, state);
+        },
+      };
+      state.capacityWaiters.push(waiter);
+      signal.addEventListener("abort", waiter.onAbort, { once: true });
+      admitCapacity(projectId, state);
+    });
+  };
+
+  return {
+    async run<T>(
+      projectId: string,
+      branch: string,
+      signal: AbortSignal,
+      transaction: (create: RunWorktreeProviderCreate) => Promise<T>,
+    ): Promise<T> {
+      signal.throwIfAborted();
+      const state = stateFor(projectId);
+      state.transactions += 1;
+      transactions += 1;
+      let releaseBranch: (() => void) | undefined;
+      try {
+        releaseBranch = await acquireBranch(state, branch, signal);
+        signal.throwIfAborted();
+        let providerCreateClaimed = false;
+        const runProviderCreate: RunWorktreeProviderCreate = async (create) => {
+          if (providerCreateClaimed) {
+            throw new Error("A worktree-create transaction may claim exactly one provider create.");
+          }
+          providerCreateClaimed = true;
+          const releaseCapacity = await acquireCapacity(projectId, state, signal);
+          try {
+            signal.throwIfAborted();
+            return await create();
+          } finally {
+            releaseCapacity();
+          }
+        };
+        return await transaction(runProviderCreate);
+      } finally {
+        releaseBranch?.();
+        finishTransaction(projectId, state);
+      }
+    },
+
+    isProjectIdle: (projectId) => !projects.has(projectId),
+
+    whenProjectIdle: (projectId) => {
+      const state = projects.get(projectId);
+      if (state === undefined || state.transactions === 0) return Promise.resolve();
+      return new Promise<void>((resolve) => state.idleWaiters.push(resolve));
+    },
+
+    isIdle: () => transactions === 0,
+
+    whenIdle: () => {
+      if (transactions === 0) return Promise.resolve();
+      return new Promise<void>((resolve) => idleWaiters.push(resolve));
+    },
+  };
+}
+
+function rejectAbortedWaiter(waiter: PermitWaiter): void {
+  try {
+    waiter.signal.throwIfAborted();
+  } catch (error) {
+    waiter.reject(error);
+  }
+}

--- a/apps/observer/test/integration/command-queue.test.ts
+++ b/apps/observer/test/integration/command-queue.test.ts
@@ -436,6 +436,96 @@ describe("observer command queue", () => {
     sqlite.close();
   });
 
+  it("serializes create-owning commands by branch while another branch progresses", async () => {
+    const { sqlite, queue } = createPersistenceAndQueue();
+    const starts: string[] = [];
+    let releaseFirst = () => {};
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    queue.registerHandler("worktree.create", async ({ commandId }) => {
+      starts.push(commandId);
+      await firstBlocked;
+      return { type: "worktree.create", projectId: "web", worktreeId: "wt_auth" };
+    });
+    queue.registerHandler("session.create", async ({ commandId }) => {
+      starts.push(commandId);
+      return {
+        type: "session.create",
+        projectId: "web",
+        worktreeId: "wt_auth_session",
+        sessionId: "ses_auth",
+        requestedPlacement: "detached",
+        resolvedPlacement: {
+          provider: "tmux",
+          targetId: "target_auth",
+          generation: "generation_auth",
+          presentation: "detached",
+        },
+      };
+    });
+    queue.registerHandler("worktree.fork", async ({ commandId }) => {
+      starts.push(commandId);
+      return { type: "worktree.fork", projectId: "web", worktreeId: "wt_payments" };
+    });
+    queue.registerHandler("session.fork", async ({ commandId }) => {
+      starts.push(commandId);
+      return {
+        type: "session.fork",
+        projectId: "web",
+        worktreeId: "wt_auth_fork",
+        sessionId: "ses_auth_fork",
+        requestedPlacement: "detached",
+        resolvedPlacement: {
+          provider: "tmux",
+          targetId: "target_auth_fork",
+          generation: "generation_auth_fork",
+          presentation: "detached",
+        },
+      };
+    });
+
+    await Promise.all([
+      queue.dispatch(createWorktreeCommand),
+      queue.dispatch({
+        type: "session.create",
+        payload: {
+          projectId: "web",
+          branch: "feature/auth",
+          harness: { provider: "codex" },
+          terminal: { provider: "tmux" },
+          placement: { intent: "detached" },
+        },
+      }),
+      queue.dispatch({
+        type: "worktree.fork",
+        payload: {
+          projectId: "web",
+          sourceWorktreeId: "wt_main",
+          branch: "feature/payments",
+        },
+      }),
+      queue.dispatch({
+        type: "session.fork",
+        payload: {
+          projectId: "web",
+          sourceWorktreeId: "wt_main",
+          branch: "feature/auth",
+          terminal: { provider: "tmux" },
+          placement: { intent: "detached" },
+        },
+      }),
+    ]);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(starts).toEqual(["cmd_1", "cmd_3"]);
+    releaseFirst();
+    await queue.drain();
+    expect(starts).toEqual(["cmd_1", "cmd_3", "cmd_2", "cmd_4"]);
+    sqlite.close();
+  });
+
   it("serializes terminal close execution by session scope", async () => {
     const { sqlite, queue } = createPersistenceAndQueue();
     const starts: string[] = [];

--- a/apps/observer/test/integration/external-launch-reconcile.test.ts
+++ b/apps/observer/test/integration/external-launch-reconcile.test.ts
@@ -32,6 +32,10 @@ import {
   providerIngressSpoolDir,
 } from "../../src/internal";
 import type { StationLogger } from "../../src/stationLogger";
+import {
+  createWorktreeCreateCoordinator,
+  type WorktreeCreateCoordinator,
+} from "../../src/worktreeCreateCoordinator";
 import { FakeDiagnosticEvidenceSource } from "../support/diagnosticEvidenceSources.js";
 
 const now = "2026-05-20T12:00:00.000Z";
@@ -62,6 +66,93 @@ const config: StationConfig = {
 // spooled during an agent launch was never flushed. Prove the launch-triggered
 // reconcile drains the spool, the same as api.reconcile does.
 describe("observer external-launch reconcile", () => {
+  it("invalidates an idle edge when a create starts before verification flush", async () => {
+    const stateDir = await mkdtemp(join(tmpdir(), "station-observer-ext-idle-edge-"));
+    const worktreeCreates = createWorktreeCreateCoordinator();
+    const fixture = createFixture(providerIngressSpoolDir(stateDir), {
+      worktreeCreates,
+      hookReconcileDebounceMs: 20,
+      interactiveReconcileDebounceMs: 20,
+    });
+    await fixture.api.reconcile("seed-idle-edge");
+    const scansBeforeLaunch = fixture.worktree.listCalls;
+
+    await fixture.api.prepareExternalLaunch({
+      projectId: "web",
+      worktreeId: "wt_web_feature",
+    });
+    const releaseCreate = deferred<void>();
+    const create = worktreeCreates.run(
+      "web",
+      "later-create",
+      new AbortController().signal,
+      async (runProviderCreate) => {
+        await runProviderCreate(async () => undefined);
+        await releaseCreate.promise;
+      },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(fixture.worktree.listCalls).toBe(scansBeforeLaunch);
+
+    releaseCreate.resolve();
+    await create;
+    await waitFor(() => fixture.worktree.listCalls > scansBeforeLaunch);
+    expect(fixture.worktree.listCalls - scansBeforeLaunch).toBe(1);
+    fixture.sqlite.close();
+  });
+
+  it.each([
+    1, 3, 5, 20,
+  ])("coalesces a %i-launch burst into one create-quiescent verification wave", async (burstSize) => {
+    const stateDir = await mkdtemp(join(tmpdir(), `station-observer-ext-burst-${burstSize}-`));
+    const worktreeCreates = createWorktreeCreateCoordinator();
+    const worktrees = Array.from({ length: burstSize }, (_, index) =>
+      createFakeWorktree({
+        id: `wt_web_burst_${index}`,
+        projectId: "web",
+        branch: `burst-${index}`,
+        path: `/tmp/station/web/burst-${index}`,
+        now,
+      }),
+    );
+    const fixture = createFixture(providerIngressSpoolDir(stateDir), {
+      worktreeCreates,
+      hookReconcileDebounceMs: 0,
+      interactiveReconcileDebounceMs: 0,
+      worktrees,
+    });
+    await fixture.api.reconcile("seed-burst");
+    const scansBeforeLaunch = fixture.worktree.listCalls;
+    const releaseCreate = deferred<void>();
+    const create = worktreeCreates.run(
+      "web",
+      "burst-held-open",
+      new AbortController().signal,
+      async (runProviderCreate) => {
+        await runProviderCreate(async () => undefined);
+        await releaseCreate.promise;
+      },
+    );
+
+    const launches = await Promise.all(
+      worktrees.map((worktree) =>
+        fixture.api.prepareExternalLaunch({
+          projectId: worktree.projectId,
+          worktreeId: worktree.id,
+        }),
+      ),
+    );
+    expect(launches.every((launch) => launch.kind === "prepared")).toBe(true);
+    expect(fixture.worktree.listCalls).toBe(scansBeforeLaunch);
+
+    releaseCreate.resolve();
+    await create;
+    await waitFor(() => fixture.worktree.listCalls > scansBeforeLaunch);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(fixture.worktree.listCalls - scansBeforeLaunch).toBe(1);
+    fixture.sqlite.close();
+  });
+
   it("publishes the prepared launch before verification and recovers the same state on restart", async () => {
     const stateDir = await mkdtemp(join(tmpdir(), "station-observer-ext-"));
     const fixture = createFixture(providerIngressSpoolDir(stateDir));
@@ -636,6 +727,8 @@ function createFixture(
     logger?: StationLogger;
     config?: StationConfig;
     hookReconcileDebounceMs?: number;
+    interactiveReconcileDebounceMs?: number;
+    worktreeCreates?: WorktreeCreateCoordinator;
     worktrees?: WorktreeObservation[];
   } = {},
 ) {
@@ -674,6 +767,7 @@ function createFixture(
     persistence,
     persistenceHealth: persistence,
     commandQueue: queue,
+    ...(options.worktreeCreates === undefined ? {} : { worktreeCreates: options.worktreeCreates }),
     eventBus,
     diagnosticEvidenceSource: new FakeDiagnosticEvidenceSource(),
     hookSpoolDir: spoolDir,
@@ -682,6 +776,9 @@ function createFixture(
     ...(options.hookReconcileDebounceMs === undefined
       ? {}
       : { hookReconcileDebounceMs: options.hookReconcileDebounceMs }),
+    ...(options.interactiveReconcileDebounceMs === undefined
+      ? {}
+      : { interactiveReconcileDebounceMs: options.interactiveReconcileDebounceMs }),
     ...(options.logger === undefined ? {} : { logger: options.logger }),
   });
   return { api, harness, persistence, sqlite, worktree, providers, core, clock, fixtureConfig };
@@ -742,4 +839,12 @@ async function waitFor(predicate: () => boolean | Promise<boolean>): Promise<voi
     await new Promise((resolve) => setTimeout(resolve, 5));
   }
   throw new Error("Timed out waiting for predicate.");
+}
+
+function deferred<T>() {
+  let resolve!: (value?: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
 }

--- a/apps/observer/test/integration/session-commands.test.ts
+++ b/apps/observer/test/integration/session-commands.test.ts
@@ -1189,6 +1189,61 @@ describe("session command vertical slice", () => {
     fixture.sqlite.close();
   });
 
+  it("keeps a cross-command branch blocked until failed-session rollback settles", async () => {
+    const worktree = new FakeWorktreeProvider({ now });
+    const createWorktree = vi.spyOn(worktree, "createWorktree");
+    const removeWorktree = worktree.removeWorktree.bind(worktree);
+    const rollbackStarted = deferred<void>();
+    const releaseRollback = deferred<void>();
+    vi.spyOn(worktree, "removeWorktree").mockImplementation(async (request) => {
+      rollbackStarted.resolve();
+      await releaseRollback.promise;
+      return removeWorktree(request);
+    });
+    const terminal = new FakeTerminalProvider({
+      now,
+      failures: {
+        launchProcess: {
+          tag: "TerminalProviderError",
+          code: "FAKE_TERMINAL_LAUNCH_FAILED",
+          message: "The fake terminal provider could not launch the process.",
+          provider: "fake-terminal",
+        },
+      },
+    });
+    const fixture = createFixture({ worktree, terminal, sessionIds: ["ses_rollback_branch"] });
+
+    const failed = await fixture.queue.dispatch({
+      type: "session.create",
+      payload: {
+        projectId: "web",
+        branch: "rollback-branch",
+        harness: { provider: "fake-harness" },
+        terminal: { provider: "fake-terminal" },
+        placement: { intent: "detached" },
+      },
+    });
+    await rollbackStarted.promise;
+    const following = await fixture.queue.dispatch({
+      type: "worktree.create",
+      payload: { projectId: "web", branch: "rollback-branch" },
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(createWorktree).toHaveBeenCalledTimes(1);
+    releaseRollback.resolve();
+    await fixture.queue.drain();
+    expect(createWorktree).toHaveBeenCalledTimes(2);
+    await expect(fixture.persistence.getCommand(failed.commandId)).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "FAKE_TERMINAL_LAUNCH_FAILED" },
+    });
+    await expect(fixture.persistence.getCommand(following.commandId)).resolves.toMatchObject({
+      status: "succeeded",
+    });
+    fixture.sqlite.close();
+  });
+
   it("does not focus session.create after launch", async () => {
     const terminal = new FakeTerminalProvider({ now });
     const harness = new FakeHarnessProvider({
@@ -3567,6 +3622,22 @@ function persistentManagedTerminal(): ManagedTerminalLifecycle {
   };
 }
 
+function deferred<T>() {
+  let resolve!: (value?: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+async function waitFor(predicate: () => boolean | Promise<boolean>): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("Timed out waiting for predicate.");
+}
+
 const config: StationConfig = {
   schemaVersion: 1,
   workspace: DEFAULT_WORKSPACE_CONFIG,
@@ -3644,6 +3715,54 @@ function healthyHarnessHealth(harness: HarnessProvider): ProviderHealth {
 }
 
 describe("worktree.create command", () => {
+  it("admits four distinct branches to the provider and queues project overflow", async () => {
+    const worktree = new FakeWorktreeProvider({ now });
+    const originalCreate = worktree.createWorktree.bind(worktree);
+    const releases = Array.from({ length: 6 }, () => deferred<void>());
+    const starts: number[] = [];
+    let active = 0;
+    let maximumActive = 0;
+    vi.spyOn(worktree, "createWorktree").mockImplementation(async (request) => {
+      const index = Number(request.branch.replace("bounded-", ""));
+      starts.push(index);
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      try {
+        await releases[index]?.promise;
+        return await originalCreate(request);
+      } finally {
+        active -= 1;
+      }
+    });
+    const fixture = createFixture({ worktree });
+
+    await Promise.all(
+      releases.map((_release, index) =>
+        fixture.queue.dispatch({
+          type: "worktree.create",
+          payload: {
+            projectId: "web",
+            branch: `bounded-${index}`,
+            launchHarness: "fake-harness",
+          },
+        }),
+      ),
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(starts).toEqual([0, 1, 2, 3]);
+    expect(maximumActive).toBe(4);
+
+    releases[0]?.resolve();
+    await waitFor(() => starts.length === 5);
+    expect(starts).toEqual([0, 1, 2, 3, 4]);
+
+    for (const release of releases) release.resolve();
+    await fixture.queue.drain();
+    expect(starts).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(maximumActive).toBe(4);
+    fixture.sqlite.close();
+  });
+
   it("publishes a committed launch-bound create without scanning providers", async () => {
     const worktree = new FakeWorktreeProvider({ now });
     const listWorktrees = vi.spyOn(worktree, "listWorktrees");

--- a/apps/observer/test/unit/reconcileScheduler.test.ts
+++ b/apps/observer/test/unit/reconcileScheduler.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, it } from "vitest";
-import { createReconcileScheduler } from "../../src/runtime/reconcileScheduler";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createReconcileScheduler,
+  type ReconcileReadiness,
+} from "../../src/runtime/reconcileScheduler";
 
 describe("reconcile scheduler", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("coalesces a burst of hook reconcile requests", async () => {
     const reasons: string[] = [];
     const scheduler = createReconcileScheduler({
@@ -141,6 +148,133 @@ describe("reconcile scheduler", () => {
       "hook:opencode:message.part.delta",
     ]);
   });
+
+  it("advances an ordinary pending flush for ready interactive work", async () => {
+    vi.useFakeTimers();
+    const reasons: string[] = [];
+    const scheduler = createReconcileScheduler({
+      debounceMs: 100,
+      interactiveDebounceMs: 25,
+      reconcile: async (reason) => {
+        reasons.push(reason);
+      },
+    });
+
+    scheduler.request("hook:codex:Stop");
+    await vi.advanceTimersByTimeAsync(10);
+    scheduler.requestInteractive("agent.prepareExternalLaunch");
+    await vi.advanceTimersByTimeAsync(24);
+    expect(reasons).toEqual([]);
+    await vi.advanceTimersByTimeAsync(1);
+    await drainMicrotasks();
+    expect(reasons).toEqual(["scheduled:batch(2)"]);
+  });
+
+  it("uses the interactive delay for ready work queued behind a running reconcile", async () => {
+    vi.useFakeTimers();
+    const reasons: string[] = [];
+    const firstReconcile = deferred<void>();
+    const firstStarted = deferred<void>();
+    const scheduler = createReconcileScheduler({
+      debounceMs: 100,
+      backlogDebounceMs: 1000,
+      interactiveDebounceMs: 25,
+      reconcile: async (reason) => {
+        reasons.push(reason);
+        if (reasons.length === 1) {
+          firstStarted.resolve();
+          await firstReconcile.promise;
+        }
+      },
+    });
+
+    scheduler.requestInteractive("agent.prepareExternalLaunch:first");
+    await vi.advanceTimersByTimeAsync(25);
+    await firstStarted.promise;
+    scheduler.request("hook:codex:Stop");
+    scheduler.requestInteractive("agent.prepareExternalLaunch:second");
+    firstReconcile.resolve();
+    await drainMicrotasks();
+    await vi.advanceTimersByTimeAsync(24);
+    expect(reasons).toEqual(["agent.prepareExternalLaunch:first"]);
+    await vi.advanceTimersByTimeAsync(1);
+    await drainMicrotasks();
+    expect(reasons).toEqual(["agent.prepareExternalLaunch:first", "scheduled:batch(2)"]);
+  });
+
+  it("rechecks readiness at flush and defers an invalidated request", async () => {
+    vi.useFakeTimers();
+    const gate = readinessGate(true);
+    const reasons: string[] = [];
+    const scheduler = createReconcileScheduler({
+      debounceMs: 100,
+      reconcile: async (reason) => {
+        reasons.push(reason);
+      },
+    });
+
+    scheduler.requestWhenReady("agent.prepareExternalLaunch", gate.readiness);
+    await vi.advanceTimersByTimeAsync(50);
+    gate.block();
+    await vi.advanceTimersByTimeAsync(50);
+    await drainMicrotasks();
+    expect(reasons).toEqual([]);
+
+    gate.release();
+    await drainMicrotasks();
+    await vi.advanceTimersByTimeAsync(99);
+    expect(reasons).toEqual([]);
+    await vi.advanceTimersByTimeAsync(1);
+    await drainMicrotasks();
+    expect(reasons).toEqual(["agent.prepareExternalLaunch"]);
+  });
+
+  it("runs ready ordinary work without consuming blocked verification", async () => {
+    vi.useFakeTimers();
+    const gate = readinessGate(false);
+    const reasons: string[] = [];
+    const scheduler = createReconcileScheduler({
+      debounceMs: 10,
+      backlogDebounceMs: 10,
+      reconcile: async (reason) => {
+        reasons.push(reason);
+      },
+    });
+
+    scheduler.requestWhenReady("agent.prepareExternalLaunch", gate.readiness);
+    scheduler.request("hook:codex:Stop");
+    await vi.advanceTimersByTimeAsync(10);
+    await drainMicrotasks();
+    expect(reasons).toEqual(["hook:codex:Stop"]);
+
+    gate.release();
+    await drainMicrotasks();
+    await vi.advanceTimersByTimeAsync(10);
+    await drainMicrotasks();
+    expect(reasons).toEqual(["hook:codex:Stop", "agent.prepareExternalLaunch"]);
+  });
+
+  it("coalesces repeated verification requests into one ready wave", async () => {
+    vi.useFakeTimers();
+    const gate = readinessGate(false);
+    const reasons: string[] = [];
+    const scheduler = createReconcileScheduler({
+      debounceMs: 10,
+      reconcile: async (reason) => {
+        reasons.push(reason);
+      },
+    });
+
+    for (let index = 0; index < 20; index += 1) {
+      scheduler.requestWhenReady("agent.prepareExternalLaunch", gate.readiness);
+    }
+    gate.release();
+    await drainMicrotasks();
+    await vi.advanceTimersByTimeAsync(10);
+    await drainMicrotasks();
+
+    expect(reasons).toEqual(["agent.prepareExternalLaunch"]);
+  });
 });
 
 async function drainMicrotasks(): Promise<void> {
@@ -161,4 +295,28 @@ function deferred<T>() {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function readinessGate(initiallyReady: boolean): {
+  readiness: ReconcileReadiness;
+  block(): void;
+  release(): void;
+} {
+  let ready = initiallyReady;
+  let idle = deferred<void>();
+  return {
+    readiness: {
+      isReady: () => ready,
+      whenReady: () => (ready ? Promise.resolve() : idle.promise),
+    },
+    block: () => {
+      if (!ready) return;
+      ready = false;
+      idle = deferred<void>();
+    },
+    release: () => {
+      ready = true;
+      idle.resolve();
+    },
+  };
 }

--- a/apps/observer/test/unit/worktreeCreateCoordinator.test.ts
+++ b/apps/observer/test/unit/worktreeCreateCoordinator.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from "vitest";
+import { createWorktreeCreateCoordinator } from "../../src/worktreeCreateCoordinator";
+
+describe("worktree create coordinator", () => {
+  it("admits at most four provider creates per project in FIFO order", async () => {
+    const coordinator = createWorktreeCreateCoordinator();
+    const releases = Array.from({ length: 6 }, () => deferred<void>());
+    const starts: number[] = [];
+    const runs = releases.map((release, index) =>
+      coordinator.run("web", `branch-${index}`, new AbortController().signal, (create) =>
+        create(async () => {
+          starts.push(index);
+          await release.promise;
+        }),
+      ),
+    );
+    await drainMicrotasks();
+
+    expect(starts).toEqual([0, 1, 2, 3]);
+    releases[0]?.resolve();
+    await drainMicrotasks();
+    expect(starts).toEqual([0, 1, 2, 3, 4]);
+    releases[1]?.resolve();
+    await drainMicrotasks();
+    expect(starts).toEqual([0, 1, 2, 3, 4, 5]);
+
+    for (const release of releases) release.resolve();
+    await Promise.all(runs);
+  });
+
+  it("keeps a same-branch lease through downstream rollback while another branch proceeds", async () => {
+    const coordinator = createWorktreeCreateCoordinator({ maxConcurrentPerProject: 2 });
+    const rollback = deferred<void>();
+    const starts: string[] = [];
+    const first = coordinator.run("web", "shared", new AbortController().signal, async (create) => {
+      await create(async () => {
+        starts.push("session.create");
+      });
+      await rollback.promise;
+      throw new Error("expected downstream failure");
+    });
+    const sameBranch = coordinator.run("web", "shared", new AbortController().signal, (create) =>
+      create(async () => {
+        starts.push("worktree.fork");
+      }),
+    );
+    const otherBranch = coordinator.run("web", "other", new AbortController().signal, (create) =>
+      create(async () => {
+        starts.push("worktree.create");
+      }),
+    );
+    await drainMicrotasks();
+
+    expect(starts).toEqual(["session.create", "worktree.create"]);
+    rollback.resolve();
+    await expect(first).rejects.toThrow("expected downstream failure");
+    await Promise.all([sameBranch, otherBranch]);
+    expect(starts).toEqual(["session.create", "worktree.create", "worktree.fork"]);
+  });
+
+  it("removes a cancelled branch waiter without starting its transaction", async () => {
+    const coordinator = createWorktreeCreateCoordinator({ maxConcurrentPerProject: 1 });
+    const rollback = deferred<void>();
+    const starts: string[] = [];
+    const first = coordinator.run("web", "shared", new AbortController().signal, async (create) => {
+      await create(async () => {
+        starts.push("first");
+      });
+      await rollback.promise;
+    });
+    const cancelled = new AbortController();
+    const second = coordinator.run("web", "shared", cancelled.signal, (create) =>
+      create(async () => {
+        starts.push("cancelled");
+      }),
+    );
+    const third = coordinator.run("web", "shared", new AbortController().signal, (create) =>
+      create(async () => {
+        starts.push("third");
+      }),
+    );
+    await drainMicrotasks();
+
+    cancelled.abort(new Error("cancel queued branch"));
+    await expect(second).rejects.toThrow("cancel queued branch");
+    rollback.resolve();
+    await Promise.all([first, third]);
+    expect(starts).toEqual(["first", "third"]);
+  });
+
+  it("removes a cancelled capacity waiter without consuming the next slot", async () => {
+    const coordinator = createWorktreeCreateCoordinator({ maxConcurrentPerProject: 1 });
+    const firstRelease = deferred<void>();
+    const starts: string[] = [];
+    const first = coordinator.run("web", "first", new AbortController().signal, (create) =>
+      create(async () => {
+        starts.push("first");
+        await firstRelease.promise;
+      }),
+    );
+    const cancelled = new AbortController();
+    const second = coordinator.run("web", "second", cancelled.signal, (create) =>
+      create(async () => {
+        starts.push("cancelled");
+      }),
+    );
+    const third = coordinator.run("web", "third", new AbortController().signal, (create) =>
+      create(async () => {
+        starts.push("third");
+      }),
+    );
+    await drainMicrotasks();
+
+    cancelled.abort(new Error("cancel queued capacity"));
+    await expect(second).rejects.toThrow("cancel queued capacity");
+    firstRelease.resolve();
+    await Promise.all([first, third]);
+    expect(starts).toEqual(["first", "third"]);
+  });
+
+  it("releases provider capacity and branch ownership after failure", async () => {
+    const coordinator = createWorktreeCreateCoordinator({ maxConcurrentPerProject: 1 });
+    const starts: string[] = [];
+    const failed = coordinator.run("web", "shared", new AbortController().signal, (create) =>
+      create(async () => {
+        starts.push("failed");
+        throw new Error("provider failed");
+      }),
+    );
+    const following = coordinator.run("web", "shared", new AbortController().signal, (create) =>
+      create(async () => {
+        starts.push("following");
+      }),
+    );
+
+    await expect(failed).rejects.toThrow("provider failed");
+    await following;
+    expect(starts).toEqual(["failed", "following"]);
+  });
+
+  it("releases provider capacity and branch ownership after active cancellation settles", async () => {
+    const coordinator = createWorktreeCreateCoordinator({ maxConcurrentPerProject: 1 });
+    const controller = new AbortController();
+    const starts: string[] = [];
+    const cancelled = coordinator.run("web", "shared", controller.signal, (create) =>
+      create(
+        () =>
+          new Promise<void>((_resolve, reject) => {
+            starts.push("active");
+            controller.signal.addEventListener("abort", () => reject(controller.signal.reason), {
+              once: true,
+            });
+          }),
+      ),
+    );
+    const following = coordinator.run("web", "shared", new AbortController().signal, (create) =>
+      create(async () => {
+        starts.push("following");
+      }),
+    );
+    await drainMicrotasks();
+
+    controller.abort(new Error("cancel active create"));
+    await expect(cancelled).rejects.toThrow("cancel active create");
+    await following;
+    expect(starts).toEqual(["active", "following"]);
+    expect(coordinator.isIdle()).toBe(true);
+  });
+
+  it("keeps different projects independent", async () => {
+    const coordinator = createWorktreeCreateCoordinator({ maxConcurrentPerProject: 1 });
+    const webRelease = deferred<void>();
+    const starts: string[] = [];
+    const web = coordinator.run("web", "feature", new AbortController().signal, (create) =>
+      create(async () => {
+        starts.push("web");
+        await webRelease.promise;
+      }),
+    );
+    const api = coordinator.run("api", "feature", new AbortController().signal, (create) =>
+      create(async () => {
+        starts.push("api");
+      }),
+    );
+    await drainMicrotasks();
+
+    expect(starts).toEqual(["web", "api"]);
+    webRelease.resolve();
+    await Promise.all([web, api]);
+  });
+
+  it("reports project and global quiescence only after rollback and queued work settle", async () => {
+    const coordinator = createWorktreeCreateCoordinator({ maxConcurrentPerProject: 1 });
+    const rollback = deferred<void>();
+    const web = coordinator.run("web", "feature", new AbortController().signal, async (create) => {
+      await create(async () => undefined);
+      await rollback.promise;
+    });
+    const api = coordinator.run("api", "feature", new AbortController().signal, (create) =>
+      create(async () => undefined),
+    );
+    let webIdle = false;
+    let allIdle = false;
+    const projectIdle = coordinator.whenProjectIdle("web").then(() => {
+      webIdle = true;
+    });
+    const idle = coordinator.whenIdle().then(() => {
+      allIdle = true;
+    });
+    await api;
+    await drainMicrotasks();
+
+    expect(coordinator.isProjectIdle("api")).toBe(true);
+    expect(coordinator.isProjectIdle("web")).toBe(false);
+    expect(coordinator.isIdle()).toBe(false);
+    expect(webIdle).toBe(false);
+    expect(allIdle).toBe(false);
+
+    rollback.resolve();
+    await Promise.all([web, projectIdle, idle]);
+    expect(webIdle).toBe(true);
+    expect(allIdle).toBe(true);
+    expect(coordinator.isIdle()).toBe(true);
+  });
+
+  it("rejects a second provider create call from one transaction", async () => {
+    const coordinator = createWorktreeCreateCoordinator();
+    await expect(
+      coordinator.run("web", "feature", new AbortController().signal, async (create) => {
+        await create(async () => undefined);
+        await create(async () => undefined);
+      }),
+    ).rejects.toThrow("exactly one provider create");
+    expect(coordinator.isIdle()).toBe(true);
+  });
+});
+
+function deferred<T>() {
+  let resolve!: (value?: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+async function drainMicrotasks(): Promise<void> {
+  for (let index = 0; index < 20; index += 1) {
+    await Promise.resolve();
+  }
+}

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -1283,6 +1283,18 @@
           "bindings": ["StationLogger"]
         },
         {
+          "specifier": "../worktreeCreateCoordinator.js",
+          "resolvedPath": "apps/observer/src/worktreeCreateCoordinator.ts",
+          "edgeKind": "runtime",
+          "bindings": ["createWorktreeCreateCoordinator"]
+        },
+        {
+          "specifier": "../worktreeCreateCoordinator.js",
+          "resolvedPath": "apps/observer/src/worktreeCreateCoordinator.ts",
+          "edgeKind": "type-only",
+          "bindings": ["WorktreeCreateCoordinator"]
+        },
+        {
           "specifier": "../worktreeMutationCoordinator.js",
           "resolvedPath": "apps/observer/src/worktreeMutationCoordinator.ts",
           "edgeKind": "runtime",
@@ -1479,7 +1491,7 @@
           "name": "createSessionCreateHandler",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Preflights the selected harness, creates a session worktree on its generated branch, durably seeds its independent title with optional atomic root Group placement or inline Group creation, and launches its primary agent only after explicit placement authorization before worktree mutation and revalidation before terminal mutation; rollback removes only state owned by this command. Success returns the exact created identities, resolved Group identity when grouped, and provider-resolved placement projection."
+          "purpose": "Preflights the selected harness, creates a session worktree on its generated branch, durably seeds its independent title with optional atomic root Group placement or inline Group creation, and launches its primary agent only after explicit placement authorization before worktree mutation and revalidation before terminal mutation. Shared branch ownership spans the complete seed, launch, publication, and rollback transaction while per-project capacity spans only provider creation. Rollback removes only state owned by this command. Success returns the exact created identities, resolved Group identity when grouped, and placement projection."
         },
         {
           "name": "CreateSessionCreateHandlerOptions",
@@ -1583,6 +1595,18 @@
           "bindings": ["StationLogger"]
         },
         {
+          "specifier": "../../worktreeCreateCoordinator.js",
+          "resolvedPath": "apps/observer/src/worktreeCreateCoordinator.ts",
+          "edgeKind": "runtime",
+          "bindings": ["createWorktreeCreateCoordinator"]
+        },
+        {
+          "specifier": "../../worktreeCreateCoordinator.js",
+          "resolvedPath": "apps/observer/src/worktreeCreateCoordinator.ts",
+          "edgeKind": "type-only",
+          "bindings": ["WorktreeCreateCoordinator"]
+        },
+        {
           "specifier": "@station/contracts",
           "resolvedPath": "packages/contracts/src/index.ts",
           "edgeKind": "type-only",
@@ -1603,7 +1627,7 @@
           "name": "createSessionForkHandler",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Resolves and preflights the selected harness, forks an existing worktree onto an internal branch, and atomically seeds its title with the source session's current Group when requested before launching a fresh agent with pre-mutation placement authorization and provider-side revalidation immediately before terminal mutation; cleanup retires only fork-owned state after verified rollback. Success returns the exact created identities, transaction-resolved Group identity when grouped, and the provider-resolved placement projection."
+          "purpose": "Resolves and preflights the selected harness, forks an existing worktree onto an internal branch, and atomically seeds its title with the source session's current Group when requested before launching a fresh agent with pre-mutation placement authorization and provider-side revalidation immediately before terminal mutation. Shared branch ownership spans seed, launch, publication, and verified rollback while per-project capacity spans only provider creation. Cleanup retires only fork-owned state. Success returns the exact created identities, transaction-resolved Group identity when grouped, and the placement projection."
         },
         {
           "name": "CreateSessionForkHandlerOptions",
@@ -1709,6 +1733,18 @@
           "resolvedPath": "apps/observer/src/stationLogger.ts",
           "edgeKind": "type-only",
           "bindings": ["StationLogger"]
+        },
+        {
+          "specifier": "../../worktreeCreateCoordinator.js",
+          "resolvedPath": "apps/observer/src/worktreeCreateCoordinator.ts",
+          "edgeKind": "runtime",
+          "bindings": ["createWorktreeCreateCoordinator"]
+        },
+        {
+          "specifier": "../../worktreeCreateCoordinator.js",
+          "resolvedPath": "apps/observer/src/worktreeCreateCoordinator.ts",
+          "edgeKind": "type-only",
+          "bindings": ["WorktreeCreateCoordinator"]
         },
         {
           "specifier": "@station/contracts",
@@ -2857,7 +2893,7 @@
           "name": "createWorktreeCreateHandler",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Worktree-only half of session.create for Station: create and publish the worktree, preflighting the selected launch harness before mutation when Station will immediately host an agent through prepareExternalLaunch. Exact provider-returned launch evidence commits through the serialized snapshot writer before publication; ambiguous evidence and worktree-only creation retain synchronous reconciliation."
+          "purpose": "Worktree-only half of session.create for Station: create and publish the worktree, preflighting the selected launch harness before mutation when Station will immediately host an agent through prepareExternalLaunch. Exact provider-returned launch evidence commits through the serialized snapshot writer before publication; ambiguous evidence and worktree-only creation retain synchronous reconciliation. Shared branch ownership spans projection, reconciliation, and late cancellation; provider-call capacity spans only the bounded create operation."
         },
         {
           "name": "CreateWorktreeCreateHandlerOptions",
@@ -2922,6 +2958,18 @@
           "bindings": ["StationLogger"]
         },
         {
+          "specifier": "../../worktreeCreateCoordinator.js",
+          "resolvedPath": "apps/observer/src/worktreeCreateCoordinator.ts",
+          "edgeKind": "runtime",
+          "bindings": ["createWorktreeCreateCoordinator"]
+        },
+        {
+          "specifier": "../../worktreeCreateCoordinator.js",
+          "resolvedPath": "apps/observer/src/worktreeCreateCoordinator.ts",
+          "edgeKind": "type-only",
+          "bindings": ["WorktreeCreateCoordinator"]
+        },
+        {
           "specifier": "@station/contracts",
           "resolvedPath": "packages/contracts/src/index.ts",
           "edgeKind": "type-only",
@@ -2948,7 +2996,7 @@
           "name": "createWorktreeForkHandler",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Worktree-only half of session.fork: branch off the source HEAD and seed its working tree (when copyDirty), validating any source-Group inheritance intent while minting no session and launching no terminal so Station can host the inherited harness itself. A selected launch harness is preflighted before mutation. No live-agent guard on the source — the seed is a read-only snapshot. Success returns the exact project and forked-worktree identities."
+          "purpose": "Worktree-only half of session.fork: branch off the source HEAD and seed its working tree (when copyDirty), validating any source-Group inheritance intent while minting no session and launching no terminal so Station can host the inherited harness itself. A selected launch harness is preflighted before mutation. No live-agent guard on the source — the seed is a read-only snapshot. Shared branch ownership spans the completion reconcile while provider-call capacity spans only creation. Success returns the exact project and forked-worktree identities."
         },
         {
           "name": "WorktreeForkHandlerOptions",
@@ -3018,6 +3066,18 @@
           "resolvedPath": "apps/observer/src/stationLogger.ts",
           "edgeKind": "type-only",
           "bindings": ["StationLogger"]
+        },
+        {
+          "specifier": "../../worktreeCreateCoordinator.js",
+          "resolvedPath": "apps/observer/src/worktreeCreateCoordinator.ts",
+          "edgeKind": "runtime",
+          "bindings": ["createWorktreeCreateCoordinator"]
+        },
+        {
+          "specifier": "../../worktreeCreateCoordinator.js",
+          "resolvedPath": "apps/observer/src/worktreeCreateCoordinator.ts",
+          "edgeKind": "type-only",
+          "bindings": ["WorktreeCreateCoordinator"]
         },
         {
           "specifier": "@station/contracts",
@@ -4464,7 +4524,7 @@
           "name": "createObserverApi",
           "kind": "function",
           "role": "COMPOSITION ROOT",
-          "purpose": "Wires Observer use cases with supplied durable, local-metadata, and diagnostic- evidence roles, ingress workers, provider-health publication, scheduling, exact build publication, recovery-readiness, coherent recovery-inventory, and recovery-assessment queries, authoritative launch projection and event ordering, read-only singleton diagnostics, and adapter shutdown behind the application API."
+          "purpose": "Wires Observer use cases with supplied durable, local-metadata, and diagnostic- evidence roles, ingress workers, provider-health publication, scheduling, exact build publication, recovery-readiness, coherent recovery-inventory, and recovery-assessment queries, authoritative launch projection and event ordering, create-quiescent verification, read-only singleton diagnostics, and adapter shutdown behind the application API."
         },
         {
           "name": "CreateObserverApiOptions",
@@ -5629,6 +5689,12 @@
           "kind": "function",
           "role": "USE CASE",
           "purpose": "Admits only canonical requested-provider results from one provider callback."
+        },
+        {
+          "name": "ReconcileReadiness",
+          "kind": "type",
+          "role": null,
+          "purpose": null
         },
         {
           "name": "ReconcileScheduler",
@@ -11332,7 +11398,7 @@
           "name": "createObserverApi",
           "kind": "function",
           "role": "COMPOSITION ROOT",
-          "purpose": "Wires Observer use cases with supplied durable, local-metadata, and diagnostic- evidence roles, ingress workers, provider-health publication, scheduling, exact build publication, recovery-readiness, coherent recovery-inventory, and recovery-assessment queries, authoritative launch projection and event ordering, read-only singleton diagnostics, and adapter shutdown behind the application API."
+          "purpose": "Wires Observer use cases with supplied durable, local-metadata, and diagnostic- evidence roles, ingress workers, provider-health publication, scheduling, exact build publication, recovery-readiness, coherent recovery-inventory, and recovery-assessment queries, authoritative launch projection and event ordering, create-quiescent verification, read-only singleton diagnostics, and adapter shutdown behind the application API."
         },
         {
           "name": "CreateObserverApiOptions",
@@ -11538,7 +11604,7 @@
           "specifier": "./reconcileScheduler.js",
           "resolvedPath": "apps/observer/src/runtime/reconcileScheduler.ts",
           "edgeKind": "type-only",
-          "bindings": ["CreateReconcileSchedulerOptions"]
+          "bindings": ["CreateReconcileSchedulerOptions", "ReconcileReadiness"]
         },
         {
           "specifier": "./sessionContext.js",
@@ -11575,6 +11641,12 @@
           "resolvedPath": "apps/observer/src/stationLogger.ts",
           "edgeKind": "type-only",
           "bindings": ["StationLogger"]
+        },
+        {
+          "specifier": "../worktreeCreateCoordinator.js",
+          "resolvedPath": "apps/observer/src/worktreeCreateCoordinator.ts",
+          "edgeKind": "type-only",
+          "bindings": ["WorktreeCreateCoordinator"]
         },
         {
           "specifier": "../worktreeMutationCoordinator.js",
@@ -12323,6 +12395,12 @@
           "resolvedPath": "apps/observer/src/stationLogger.ts",
           "edgeKind": "type-only",
           "bindings": ["StationLogger"]
+        },
+        {
+          "specifier": "../worktreeCreateCoordinator.js",
+          "resolvedPath": "apps/observer/src/worktreeCreateCoordinator.ts",
+          "edgeKind": "runtime",
+          "bindings": ["createWorktreeCreateCoordinator"]
         },
         {
           "specifier": "../worktreeMutationCoordinator.js",
@@ -13401,6 +13479,12 @@
           "purpose": null
         },
         {
+          "name": "ReconcileReadiness",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
           "name": "ReconcileScheduler",
           "kind": "type",
           "role": null,
@@ -14161,6 +14245,36 @@
           "bindings": ["RuntimeClock"]
         }
       ]
+    },
+    {
+      "path": "apps/observer/src/worktreeCreateCoordinator.ts",
+      "exports": [
+        {
+          "name": "createWorktreeCreateCoordinator",
+          "kind": "function",
+          "role": "POLICY",
+          "purpose": "Admits provider-neutral worktree-create transactions with FIFO branch ownership and a bounded per-project provider-call capacity while retaining branch ownership through downstream rollback."
+        },
+        {
+          "name": "CreateWorktreeCreateCoordinatorOptions",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "RunWorktreeProviderCreate",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "WorktreeCreateCoordinator",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        }
+      ],
+      "imports": []
     },
     {
       "path": "apps/observer/src/worktreeDisplayTitle.ts",
@@ -16179,6 +16293,13 @@
           "kind": "function",
           "role": "USE CASE",
           "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/observer/src/worktreeCreateCoordinator.ts",
+          "declaration": "createWorktreeCreateCoordinator",
+          "kind": "function",
+          "role": "POLICY",
+          "edgeKind": "runtime"
         }
       ]
     },
@@ -16195,13 +16316,20 @@
       "declaration": "createSessionCreateHandler",
       "kind": "function",
       "role": "USE CASE",
-      "purpose": "Preflights the selected harness, creates a session worktree on its generated branch, durably seeds its independent title with optional atomic root Group placement or inline Group creation, and launches its primary agent only after explicit placement authorization before worktree mutation and revalidation before terminal mutation; rollback removes only state owned by this command. Success returns the exact created identities, resolved Group identity when grouped, and provider-resolved placement projection.",
+      "purpose": "Preflights the selected harness, creates a session worktree on its generated branch, durably seeds its independent title with optional atomic root Group placement or inline Group creation, and launches its primary agent only after explicit placement authorization before worktree mutation and revalidation before terminal mutation. Shared branch ownership spans the complete seed, launch, publication, and rollback transaction while per-project capacity spans only provider creation. Rollback removes only state owned by this command. Success returns the exact created identities, resolved Group identity when grouped, and placement projection.",
       "dependencies": [
         {
           "path": "apps/observer/src/commands/terminalOperations.ts",
           "declaration": "ensureAgentWorkspace",
           "kind": "function",
           "role": "USE CASE",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/observer/src/worktreeCreateCoordinator.ts",
+          "declaration": "createWorktreeCreateCoordinator",
+          "kind": "function",
+          "role": "POLICY",
           "edgeKind": "runtime"
         }
       ]
@@ -16211,13 +16339,20 @@
       "declaration": "createSessionForkHandler",
       "kind": "function",
       "role": "USE CASE",
-      "purpose": "Resolves and preflights the selected harness, forks an existing worktree onto an internal branch, and atomically seeds its title with the source session's current Group when requested before launching a fresh agent with pre-mutation placement authorization and provider-side revalidation immediately before terminal mutation; cleanup retires only fork-owned state after verified rollback. Success returns the exact created identities, transaction-resolved Group identity when grouped, and the provider-resolved placement projection.",
+      "purpose": "Resolves and preflights the selected harness, forks an existing worktree onto an internal branch, and atomically seeds its title with the source session's current Group when requested before launching a fresh agent with pre-mutation placement authorization and provider-side revalidation immediately before terminal mutation. Shared branch ownership spans seed, launch, publication, and verified rollback while per-project capacity spans only provider creation. Cleanup retires only fork-owned state. Success returns the exact created identities, transaction-resolved Group identity when grouped, and the placement projection.",
       "dependencies": [
         {
           "path": "apps/observer/src/commands/terminalOperations.ts",
           "declaration": "ensureAgentWorkspace",
           "kind": "function",
           "role": "USE CASE",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/observer/src/worktreeCreateCoordinator.ts",
+          "declaration": "createWorktreeCreateCoordinator",
+          "kind": "function",
+          "role": "POLICY",
           "edgeKind": "runtime"
         }
       ]
@@ -16343,16 +16478,32 @@
       "declaration": "createWorktreeCreateHandler",
       "kind": "function",
       "role": "USE CASE",
-      "purpose": "Worktree-only half of session.create for Station: create and publish the worktree, preflighting the selected launch harness before mutation when Station will immediately host an agent through prepareExternalLaunch. Exact provider-returned launch evidence commits through the serialized snapshot writer before publication; ambiguous evidence and worktree-only creation retain synchronous reconciliation.",
-      "dependencies": []
+      "purpose": "Worktree-only half of session.create for Station: create and publish the worktree, preflighting the selected launch harness before mutation when Station will immediately host an agent through prepareExternalLaunch. Exact provider-returned launch evidence commits through the serialized snapshot writer before publication; ambiguous evidence and worktree-only creation retain synchronous reconciliation. Shared branch ownership spans projection, reconciliation, and late cancellation; provider-call capacity spans only the bounded create operation.",
+      "dependencies": [
+        {
+          "path": "apps/observer/src/worktreeCreateCoordinator.ts",
+          "declaration": "createWorktreeCreateCoordinator",
+          "kind": "function",
+          "role": "POLICY",
+          "edgeKind": "runtime"
+        }
+      ]
     },
     {
       "path": "apps/observer/src/commands/worktree/fork.ts",
       "declaration": "createWorktreeForkHandler",
       "kind": "function",
       "role": "USE CASE",
-      "purpose": "Worktree-only half of session.fork: branch off the source HEAD and seed its working tree (when copyDirty), validating any source-Group inheritance intent while minting no session and launching no terminal so Station can host the inherited harness itself. A selected launch harness is preflighted before mutation. No live-agent guard on the source — the seed is a read-only snapshot. Success returns the exact project and forked-worktree identities.",
-      "dependencies": []
+      "purpose": "Worktree-only half of session.fork: branch off the source HEAD and seed its working tree (when copyDirty), validating any source-Group inheritance intent while minting no session and launching no terminal so Station can host the inherited harness itself. A selected launch harness is preflighted before mutation. No live-agent guard on the source — the seed is a read-only snapshot. Shared branch ownership spans the completion reconcile while provider-call capacity spans only creation. Success returns the exact project and forked-worktree identities.",
+      "dependencies": [
+        {
+          "path": "apps/observer/src/worktreeCreateCoordinator.ts",
+          "declaration": "createWorktreeCreateCoordinator",
+          "kind": "function",
+          "role": "POLICY",
+          "edgeKind": "runtime"
+        }
+      ]
     },
     {
       "path": "apps/observer/src/commands/worktree/remove.ts",
@@ -16851,7 +17002,7 @@
       "declaration": "createObserverApi",
       "kind": "function",
       "role": "COMPOSITION ROOT",
-      "purpose": "Wires Observer use cases with supplied durable, local-metadata, and diagnostic- evidence roles, ingress workers, provider-health publication, scheduling, exact build publication, recovery-readiness, coherent recovery-inventory, and recovery-assessment queries, authoritative launch projection and event ordering, read-only singleton diagnostics, and adapter shutdown behind the application API.",
+      "purpose": "Wires Observer use cases with supplied durable, local-metadata, and diagnostic- evidence roles, ingress workers, provider-health publication, scheduling, exact build publication, recovery-readiness, coherent recovery-inventory, and recovery-assessment queries, authoritative launch projection and event ordering, create-quiescent verification, read-only singleton diagnostics, and adapter shutdown behind the application API.",
       "dependencies": [
         {
           "path": "apps/observer/src/diagnostics/collector.ts",
@@ -17237,6 +17388,13 @@
           "kind": "interface",
           "role": "DRIVEN PORT",
           "edgeKind": "type-only"
+        },
+        {
+          "path": "apps/observer/src/worktreeCreateCoordinator.ts",
+          "declaration": "createWorktreeCreateCoordinator",
+          "kind": "function",
+          "role": "POLICY",
+          "edgeKind": "runtime"
         },
         {
           "path": "packages/contracts/src/observer.ts",
@@ -17768,6 +17926,14 @@
       "kind": "interface",
       "role": "DRIVEN PORT",
       "purpose": "Records Observer operational events without exposing their storage representation or destination.",
+      "dependencies": []
+    },
+    {
+      "path": "apps/observer/src/worktreeCreateCoordinator.ts",
+      "declaration": "createWorktreeCreateCoordinator",
+      "kind": "function",
+      "role": "POLICY",
+      "purpose": "Admits provider-neutral worktree-create transactions with FIFO branch ownership and a bounded per-project provider-call capacity while retaining branch ownership through downstream rollback.",
       "dependencies": []
     },
     {
@@ -18395,7 +18561,7 @@
       "declaration": "WorktrunkProvider",
       "kind": "class",
       "role": "ADAPTER",
-      "purpose": "Translates Worktrunk lifecycle output and commands into Station worktree contracts. Hook diagnostics use an atomic requester runtime when supplied and retain the whole Observer composition expectation as a fallback. List results are returned without retaining inventory; only the Worktrunk project identifier needed to preserve managed-path precedence is memoized. Checkout roots are validated before Worktrunk runs, and removal freshly revalidates native Git identity, path, and branch before mutation.",
+      "purpose": "Translates Worktrunk lifecycle output and commands into Station worktree contracts. Hook diagnostics use an atomic requester runtime when supplied and retain the whole Observer composition expectation as a fallback. List results are returned without retaining inventory; only the Worktrunk project identifier needed to preserve managed-path precedence is memoized. Checkout roots are validated before Worktrunk runs. Concurrent creates share only an in-flight managed-path identity probe and retain their common-case mutation overlap. Reads and removals drain active creates; the exact nested Git sibling-registration race does the same before Worktrunk resumes its half-created branch. Removal freshly revalidates native Git identity, path, and branch before mutation.",
       "dependencies": [
         {
           "path": "packages/contracts/src/observedPaths.ts",

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -18506,7 +18506,7 @@
       "declaration": "TmuxPlacementService",
       "kind": "class",
       "role": "ADAPTER",
-      "purpose": "Proves caller-owned tmux topology on one configured endpoint and applies one-shot sibling or source-free detached placement with exact rollback authority, preserving attached client selection while creating a missing workbench session.",
+      "purpose": "Proves caller-owned tmux topology on one configured endpoint and applies one-shot sibling or source-free detached placement with exact rollback authority, preserving attached client selection while creating a missing workbench session. Detached opens serialize through the workbench existence decision and mutation.",
       "dependencies": [
         {
           "path": "packages/contracts/src/providers.ts",

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -248,6 +248,7 @@ areas contain the following responsibilities:
 | `runtime/` | API assembly, process lifecycle, exact read-only ownership inspection, scheduling, event delivery, server bridge, and external launch | Observer composition plus application operations; transport and infrastructure stay at the edge. Exact inspection consumes purpose-specific status, pidfile, cooperative process, and pinned recovery ports without lifecycle mutation authority. |
 | `stationLogger.ts`, `commands/projectConfigWriter.ts` | Observer-private logging and authoritative project-configuration capabilities | Driven application ports free of JSONL records and configuration/home-path plumbing. |
 | `runtime/logging.ts`, `runtime/projectConfigWriter.ts` | Redacted JSONL writes and `@station/config` project mutation translation | Outbound adapters retaining log, config, and home paths at composition. |
+| `worktreeCreateCoordinator.ts` | branch ownership, per-project create capacity, cancellation, and create-transaction quiescence | Provider-neutral deterministic admission policy shared by all create-owning command use cases; it performs no provider operation or reconciliation and retains a branch until its owning transaction, including rollback, settles. |
 | `providers/` | provider aggregation and health cache | Provider aggregation and health only; provider modules must not own or import application orchestration. |
 | `metadata/` | metadata refresh, repository lookup, local Git execution, and ref watching | The refresh use case depends on path-free local-metadata ports; local Git command and filesystem adapters resolve Station identities privately, while runtime composition selects and shuts down both roles. |
 | `persistence/ports.ts`, `persistence/types.ts` | eight purpose-owned persistence ports, their eight-port composition bundle, the separate persistence-health port, and Observer application records and inputs | Observer-private application boundary; no SQL, SQLite handles, or SQLite row representations. The bundle is composition-only. |
@@ -368,7 +369,8 @@ Application composition proceeds around that boundary in this order:
    ports and `PersistenceHealthSource` to that handle. Runtime composition owns
    the concrete handle lifecycle and distributes narrow application views.
 5. Runtime composition creates the event bus, logging and project-config
-   adapters, command queue, feature evaluator, core, handlers, and configured
+   adapters, command queue, process-lifetime create-admission and worktree-
+   mutation coordinators, feature evaluator, core, handlers, and configured
    event hooks around the provider registry.
 6. Runtime composition captures the resolved state, socket, diagnostics, log,
    and hook-spool locations in the local diagnostic-evidence adapter before
@@ -491,6 +493,18 @@ The handler checks post-provider cancellation after projection or fallback, so a
 completed external mutation is visible even when the command ultimately records
 cancellation.
 
+`worktree.create`, `worktree.fork`, `session.create`, and `session.fork` use one
+project-plus-branch command scope, so same-branch command lifecycle stays FIFO
+across command types while distinct branches can begin independently. Their
+process-lifetime create coordinator independently retains the same branch lease
+through the owning handler's projection, publication, downstream launch, and
+rollback. A separate FIFO capacity admits at most four active provider create
+calls per project; different projects remain independent, and downstream work
+does not occupy provider-call capacity. Cancellation before either admission
+removes that waiter, while an admitted call releases capacity only after the
+provider boundary settles. The coordinator becomes globally idle only after
+queued and active transactions, including rollback, have all completed.
+
 Successful `worktree.create`, `worktree.fork`, `session.create`, `session.fork`,
 and `sessionGroup.create` handlers return strict application identities. Session
 results additionally project only requested `sibling | detached` intent and the
@@ -547,7 +561,14 @@ unreserved commands fail whenever an external Station renderer still owns the
 active terminal. The command refreshes canonical runtime state after renderer settlement, while the
 worktree adapter retains no earlier list as authority and freshly rechecks the expected registration identity, path, and branch immediately
 before mutation so an external checkout replacement cannot reuse the selected
-path and branch as removal identity. Adapter race refusals retain provider-neutral,
+path and branch as removal identity. The Worktrunk adapter keeps common-case
+distinct-branch creates concurrent, but its project-local Git-registry coordinator
+drains those creates before list or removal work. If Worktrunk reports the exact
+nested `git worktree add` sibling-`commondir` initialization race, the same gate
+closes new create admission, drains older attempts, and resumes the requested
+half-created branch without `--create`; ordinary failures are never retried, and
+the normal branch, path, managed-root, and opaque registration checks still decide
+whether recovery is usable. Adapter race refusals retain provider-neutral,
 trace-correlated diagnostic evidence.
 
 ### Session Recovery Cutover
@@ -648,10 +669,18 @@ Narrow authoritative projections do not replace that context, provider-observati
 or reconcile debug evidence. Rejection and projection failure therefore preserve the last
 committed snapshot and require full reconciliation rather than publishing speculative state.
 The scheduler debounces and coalesces reasons while ensuring only one scheduled
-run is active. Startup-compatible requests may join the startup flight; other
-direct requests retain the rule that their scan starts at or after the request.
-Provider read failures degrade health and contribute errors without fabricating
-successful observations.
+run is active. A prepared launch submits a 25ms interactive conditional
+verification request against process-global create quiescence; ready interactive
+work can advance an ordinary pending timer and uses the shorter follow-up delay
+behind a running scan. The scheduler rechecks quiescence at flush rather than
+trusting an earlier idle edge; a create that begins before flush leaves
+verification queued until a later true idle transition. Ready hook or metadata
+reasons may still run without consuming the blocked verification, and repeated
+launch requests from one burst coalesce into one verification wave.
+Startup-compatible requests may join the startup flight; other direct requests
+retain the rule that their scan starts at or after the request. Provider read
+failures degrade health and contribute errors without fabricating successful
+observations.
 
 ### Provider Hook And Harness Report Ingress
 
@@ -945,10 +974,10 @@ expires.
 | Socket ownership evidence | Connect success proves listening. Only `ECONNREFUSED`, or Bun's existing-path `ENOENT`, plus strict zero-holder `lsof` evidence proves stale. Permission failures, timeouts, live holders, evidence failure, path replacement, and non-socket collisions are inaccessible and authorize no spawn, unlink, stop, or signal. |
 | Stale lifecycle evidence | Start, stop, and restart may repair a strict pidfile only after a claim-serialized admission and fresh agreement on socket state, exact pidfile bytes, process existence, and exact process identity classification. The compare/remove commit is atomic and restores non-matching evidence; two bounded attempts never adopt a successor identity. Cancellation and deadline checks prevent entering the commit, while an entered atomic commit drains. Exact live or unavailable ownership refuses visibly. Repair is idempotent, never signals, and leaves socket unlink to the successful binder's fresh holder/path checks. The typed stop summary is transport output only and adds no persisted state or migration. |
 | Observer build ordering | Health and pidfile `version` carry display SemVer plus reserved `station.<sha256>` build metadata derived from both repository inputs and production package outputs. Exact identified selectors attach. At one display version, the lexicographically greater immutable build identity is the only candidate allowed to replace; the loser and any missing legacy identity refuse, so neither silently delegates to different code. Each source process verifies the published identity once before adopting it and reuses that selector without further Git or hash I/O for its lifetime. Different display versions retain SemVer precedence and the existing exact-string equal-precedence tiebreak, except that the declared public reset orders `0.0.0-pre-alpha.*` after internal `0.7.1-rc.*` previews. The pure update convergence policy may use this build-only precedence classification for an exact selected Observer build; the dependency carries no PID, start-time, lifecycle capability, or replacement authority. An explicit restart from a higher build cooperatively stops the health-pinned incumbent before spawning its successor, which lets an already installed launcher replace the Observer even when the old process executable names the now-replaced installation path. Lower-build restarts still refuse. Automatic handoff and signal recovery continue to require complete executable-provenance evidence, and replacement never uses automatic SIGKILL. |
-| Command ordering | Commands serialize by session, worktree, project, terminal target, or command-specific fallback scope. Different scopes can execute concurrently. |
+| Command ordering | Commands serialize by session, worktree, project, terminal target, or command-specific fallback scope. All four create-owning commands share project-plus-branch scope; the create coordinator additionally retains same-branch ownership through rollback and admits provider calls through one FIFO four-per-project capacity. Cancellation removes queued branch or capacity admission without consuming it, and different projects remain independent. |
 | Managed target release | Station target IDs are deterministic per worktree, so external release is compare-and-delete on target, expected Station session, and binding generation. Tokenless Host exits reconcile instead of releasing. A delayed old exit or failed-launch cleanup cannot remove a replacement binding; `false` proves absence or supersession, while rejection leaves cleanup uncertain. |
 | Command timeout and cancellation | Handlers receive a signal combining the runtime timeout and queue shutdown. Concrete provider adapters own bounded external settlement; command use cases pass cancellation and normalize failures without starting another provider-operation timer. A handler with a non-cancellable durable section calls `beginCommit` after read-only validation and immediately before its first write; cancellation may prevent entry, but the queue drains a begun commit to one completion. Other cancellation remains cooperative, and the process shutdown backstop handles ignored signals. |
-| Snapshot writer ordering | Full reconciles, exact worktree-create and prepared managed-launch projections, Group mutation commits, and harness-report authorization plus base projection share a non-poisoning promise chain. Create and launch events publish only after their projection commit; a projected launch orders its worktree event before its session event and schedules verification afterward. Rejected projections retain the current snapshot and use reconciliation fallback or verification. A Group mutation projects only its command project and never scans providers, repairs other durable state, or publishes a reconcile event. Readiness persistence revalidates the live snapshot after its write. Scheduled reconcile requests coalesce; queued work after a run receives a later flush. |
+| Snapshot writer ordering | Full reconciles, exact worktree-create and prepared managed-launch projections, Group mutation commits, and harness-report authorization plus base projection share a non-poisoning promise chain. Create and launch events publish only after their projection commit; a projected launch orders its worktree event before its session event and schedules verification afterward. Rejected projections retain the current snapshot and use reconciliation fallback or verification. A Group mutation projects only its command project and never scans providers, repairs other durable state, or publishes a reconcile event. Readiness persistence revalidates the live snapshot after its write. Scheduled reconcile requests coalesce; interactive launch verification rechecks global create quiescence at flush, and a stale idle edge remains queued for a later wave. |
 | Persisted harness compatibility | A harness adapter may use a provider-local strict schema to reject recognizable observations accepted by an earlier build. Unparseable legacy data remains admitted. Reconcile excludes only provider-rejected observations, then atomically replaces the affected session's derived native binding and readiness from the remaining admitted history; a succeeded acknowledgement remains authoritative. |
 | Provider reads | Reads are timeboxed, retried at the runtime boundary, and concurrency-limited. Every worktree-project, terminal-provider, and harness-provider read produces explicit completeness evidence. Failures become provider health and reconcile errors; worktree failures scope Group absence authority by project, while terminal or harness failures block it globally. |
 | Harness ingress | First-party hook transports delegate delivery and spooling to `stn-ingress`. Known build/schema/handoff incompatibility rejects without spooling. One Observer worker processes a bounded pending map; new reports can replace pending work for the same key, and a full map rejects unrelated work with a backpressure error. |
@@ -1181,7 +1210,7 @@ participate. Nonliteral dynamic module edges fail because their ownership cannot
 be resolved. External imports such as `node:sqlite` remain recorded external
 edges rather than source-cycle members.
 
-The current Observer graph contains 146 production modules and no strongly
+The current Observer graph contains 170 production modules and no strongly
 connected component. `migrations/migration.ts` now owns
 `ObserverSqliteMigration`, so numbered migration declarations do not depend on
 their ordered aggregator. `reconcile/reconcileResult.ts` owns

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -206,7 +206,7 @@ ownership even where current ownership is still a deviation.
 | Harness status delivery | Driving | harness event report ingress | harness hooks, provider hook adapters, protocol clients | Reports are deduplicated, queued, projected, persisted, and followed by reconcile. |
 | Worktree operations | Driven | `WorktreeProvider` | Worktrunk and test adapters | Fresh list evidence and mutations only; Observer snapshots own current session selection, callers supply project context for mutation, and adapters retain no second worktree inventory. |
 | Terminal operations | Driven | `TerminalProvider` | tmux, Station terminal, and test adapters | Ordinary topology and lifecycle are provider-owned; implementing this port does not advertise placement support. Optional reconcile-aware discovery refuses retained adapter hints as indeterminate, while ordinary callers may still inspect them; Observer admits targets into the current graph and debug evidence only from a complete result. |
-| Terminal placement | Driven | `TerminalPlacementPort` | tmux and test adapters | Explicit companion role registered only beside the same ordinary terminal id. Caller fields are untrusted claims; tmux proves one configured endpoint, socket/server/pane/process identity, and bounded ancestry, mints a ten-minute one-shot authority, and revalidates immediately before mutation. Sibling and detached never fall back to a current, recent, focused, or alternate-server target. Station registers no placement role. |
+| Terminal placement | Driven | `TerminalPlacementPort` | tmux and test adapters | Explicit companion role registered only beside the same ordinary terminal id. Caller fields are untrusted claims; tmux proves one configured endpoint, socket/server/pane/process identity, and bounded ancestry, mints a ten-minute one-shot authority, and revalidates immediately before mutation. The tmux adapter serializes detached opens through its workbench existence decision and mutation so cold creation is single-flight. Sibling and detached never fall back to a current, recent, focused, or alternate-server target. Station registers no placement role. |
 | Managed terminal lifecycle | Driven | `ManagedTerminalLifecycle` | Station terminal adapter, optionally backed by Station Host | Explicit injected role returning only an opaque target identity and declaring whether launched processes persist beyond the caller; Host backing may add spawn/list/close/attachment lifecycle, while Station retains native presentation and host-backed targets remain externally non-focusable. Complete target observations may contribute debug-only `hasManagedAttachment` as true, false, or absent for currently issuable, definitively absent, or unknown/inapplicable attachment evidence; activation still resolves the opaque attachment afresh. |
 | Harness operations | Driven | `HarnessProvider`, `SessionRecoveryArtifactLocator` | Claude, Codex, Cursor, OpenCode, Pi, scripted, and test adapters | Strong purpose-owned ports: discovery returns provider-normalized current run status; `hookHealth()` returns strict read-only hook evidence; `reconcileHooks()` delegates mutation and post-write verification to the integration; separate hook adapters own event parsing; and harness providers retain compatibility admission and exact recovery-artifact location. Unsupported capabilities remain explicit provider-neutral outcomes. |
 | Repository metadata | Driven | `RepositoryProvider` | GitHub and test repository adapters | Adapters declare deterministic remote support; provider-neutral metadata policy selects zero or one match and rejects overlaps. |
@@ -504,6 +504,9 @@ does not occupy provider-call capacity. Cancellation before either admission
 removes that waiter, while an admitted call releases capacity only after the
 provider boundary settles. The coordinator becomes globally idle only after
 queued and active transactions, including rollback, have all completed.
+Distinct session branches may therefore reach terminal placement concurrently;
+the tmux adapter independently serializes detached opens through the workbench
+existence decision and mutation without widening provider-create ownership.
 
 Successful `worktree.create`, `worktree.fork`, `session.create`, `session.fork`,
 and `sessionGroup.create` handlers return strict application identities. Session
@@ -564,9 +567,11 @@ before mutation so an external checkout replacement cannot reuse the selected
 path and branch as removal identity. The Worktrunk adapter keeps common-case
 distinct-branch creates concurrent, but its project-local Git-registry coordinator
 drains those creates before list or removal work. If Worktrunk reports the exact
-nested `git worktree add` sibling-`commondir` initialization race, the same gate
-closes new create admission, drains older attempts, and resumes the requested
-half-created branch without `--create`; ordinary failures are never retried, and
+nested `git worktree add` sibling-`commondir` initialization race, including one
+of the observed missing-file messages for a registry identity distinct from the
+requested target, the same gate closes new create admission, drains older attempts,
+and resumes the requested half-created branch without `--create`; permission,
+I/O, and other ordinary failures are never retried, and
 the normal branch, path, managed-root, and opaque registration checks still decide
 whether recovery is usable. Adapter race refusals retain provider-neutral,
 trace-correlated diagnostic evidence.

--- a/integrations/terminal/tmux/src/placement/service.ts
+++ b/integrations/terminal/tmux/src/placement/service.ts
@@ -65,6 +65,7 @@ export type TmuxPlacementServiceOptions = {
  * Proves caller-owned tmux topology on one configured endpoint and applies
  * one-shot sibling or source-free detached placement with exact rollback authority,
  * preserving attached client selection while creating a missing workbench session.
+ * Detached opens serialize through the workbench existence decision and mutation.
  */
 export class TmuxPlacementService implements TerminalPlacementPort {
   readonly id: ProviderId = "tmux";
@@ -77,6 +78,7 @@ export class TmuxPlacementService implements TerminalPlacementPort {
   readonly #cleanup: TmuxPlacementCleanup;
   readonly #authorities: TmuxPlacementAuthorityStore;
   readonly #newBindingToken: () => string;
+  #detachedOpenTail: Promise<void> = Promise.resolve();
 
   constructor(options: TmuxPlacementServiceOptions = {}) {
     this.#config = resolveTmuxWorkbenchConfig(options.config);
@@ -138,6 +140,23 @@ export class TmuxPlacementService implements TerminalPlacementPort {
     if (sessionId === undefined) {
       throw placementRejected("Placed workspaces require an explicit Station session identity.");
     }
+    if (request.placement.intent === "detached") {
+      const opened = this.#detachedOpenTail.then(() =>
+        this.#openPlacedWorkspace(request, sessionId),
+      );
+      this.#detachedOpenTail = opened.then(
+        () => undefined,
+        () => undefined,
+      );
+      return opened;
+    }
+    return this.#openPlacedWorkspace(request, sessionId);
+  }
+
+  async #openPlacedWorkspace(
+    request: OpenPlacedWorkspaceRequest,
+    sessionId: string,
+  ): Promise<OpenPlacedWorkspaceResult> {
     const bindingToken = this.#newBindingToken();
     let expectedGeneration: string | undefined;
     let siblingProof: TmuxPrivateProof | undefined;

--- a/integrations/terminal/tmux/test/unit/placement.test.ts
+++ b/integrations/terminal/tmux/test/unit/placement.test.ts
@@ -158,6 +158,38 @@ describe("TmuxPlacementService", () => {
     expect(fixture.clients).toEqual([sourceClient]);
   });
 
+  it("serializes concurrent detached opens through missing workbench creation", async () => {
+    const firstMutation = Promise.withResolvers<void>();
+    const releaseFirstMutation = Promise.withResolvers<void>();
+    let mutationCount = 0;
+    const fixture = placementFixture({
+      workbenchAbsent: true,
+      beforeOpenMutation: async () => {
+        mutationCount += 1;
+        if (mutationCount !== 1) return;
+        firstMutation.resolve();
+        await releaseFirstMutation.promise;
+      },
+    });
+
+    const first = openWorkspace(fixture, "ses_cold_first", { intent: "detached" });
+    await firstMutation.promise;
+    const second = openWorkspace(fixture, "ses_cold_second", { intent: "detached" });
+    await new Promise((resolve) => setImmediate(resolve));
+    const coldSessionChecks = fixture.calls.filter(
+      (call) => tmuxArgs(call)[0] === "has-session",
+    ).length;
+    releaseFirstMutation.resolve();
+
+    await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+    expect(coldSessionChecks).toBe(1);
+    expect(
+      fixture.calls
+        .map((call) => tmuxArgs(call)[0])
+        .filter((command) => command === "new-session" || command === "new-window"),
+    ).toEqual(["new-session", "new-window"]);
+  });
+
   it("never restores exited, replaced, or newly attached client identities", async () => {
     const replaced = { ...sourceClient, clientName: "/dev/ttys002", clientPid: 301 };
     const exited = { ...sourceClient, clientName: "/dev/ttys003", clientPid: 302 };
@@ -374,6 +406,7 @@ function placementFixture(
     exitClientsBeforeRestore?: boolean;
     restoreClients?: boolean;
     restoreClientsAfterRollback?: boolean;
+    beforeOpenMutation?: () => Promise<void>;
   } = {},
 ) {
   const calls: ExternalCommandInput[] = [];
@@ -473,6 +506,7 @@ function placementFixture(
         args[0] === "new-window" ||
         (args[0] === "if-shell" && args.join(" ").includes("new-window"))
       ) {
+        await options.beforeOpenMutation?.();
         if (rejectOpenGuard && args[0] === "if-shell") {
           rejectOpenGuard = false;
           return tmuxCommandResult(input, "__station_open_guard_rejected__");

--- a/integrations/worktree/worktrunk/src/commandFailure.ts
+++ b/integrations/worktree/worktrunk/src/commandFailure.ts
@@ -1,3 +1,4 @@
+import { basename } from "node:path";
 import { stripVTControlCharacters } from "node:util";
 import type {
   DiagnosticDetail,
@@ -79,7 +80,10 @@ export function worktrunkCommandFailure(
   });
 }
 
-export function isWorktrunkConcurrentCreateRegistryFailure(error: WorktrunkProviderError): boolean {
+export function isWorktrunkConcurrentCreateRegistryFailure(
+  error: WorktrunkProviderError,
+  requestedBranch: string,
+): boolean {
   for (const detail of error.diagnosticDetails ?? []) {
     if (detail.type !== "external_command" || detail.operation !== "provider.worktrunk.switch") {
       continue;
@@ -87,15 +91,33 @@ export function isWorktrunkConcurrentCreateRegistryFailure(error: WorktrunkProvi
     const diagnostic = stripVTControlCharacters(
       [detail.stdoutSnippet, detail.stderrSnippet].filter((part) => part !== undefined).join("\n"),
     );
+    const escapedBranch = escapeRegExp(requestedBranch);
+    const createWrapper = new RegExp(
+      `^Failed to create worktree for ${escapedBranch}(?: from base \\S+)?$`,
+      "im",
+    );
+    const nestedCreate = new RegExp(
+      `^git worktree add\\b[^\\r\\n]*\\s-b\\s+${escapedBranch}\\s+--\\s+(\\S+)`,
+      "im",
+    ).exec(diagnostic);
+    const missingCommonDir =
+      /^fatal: failed to read .*\.git[\\/]worktrees[\\/]([^\\/\r\n]+)[\\/]commondir: (?:No such file or directory|Undefined error: 0)$/im.exec(
+        diagnostic,
+      );
     if (
-      /failed to create worktree/i.test(diagnostic) &&
-      /fatal: failed to read .*\.git\/worktrees\/[^/\r\n]+\/commondir:/i.test(diagnostic) &&
-      /git worktree add\b/i.test(diagnostic)
+      createWrapper.test(diagnostic) &&
+      nestedCreate !== null &&
+      missingCommonDir !== null &&
+      missingCommonDir[1] !== basename(nestedCreate[1] ?? "")
     ) {
       return true;
     }
   }
   return false;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function enrichedCommandDiagnostic(

--- a/integrations/worktree/worktrunk/src/commandFailure.ts
+++ b/integrations/worktree/worktrunk/src/commandFailure.ts
@@ -79,6 +79,25 @@ export function worktrunkCommandFailure(
   });
 }
 
+export function isWorktrunkConcurrentCreateRegistryFailure(error: WorktrunkProviderError): boolean {
+  for (const detail of error.diagnosticDetails ?? []) {
+    if (detail.type !== "external_command" || detail.operation !== "provider.worktrunk.switch") {
+      continue;
+    }
+    const diagnostic = stripVTControlCharacters(
+      [detail.stdoutSnippet, detail.stderrSnippet].filter((part) => part !== undefined).join("\n"),
+    );
+    if (
+      /failed to create worktree/i.test(diagnostic) &&
+      /fatal: failed to read .*\.git\/worktrees\/[^/\r\n]+\/commondir:/i.test(diagnostic) &&
+      /git worktree add\b/i.test(diagnostic)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function enrichedCommandDiagnostic(
   input: WorktrunkCommandFailureInput,
 ): ExternalCommandDiagnosticDetail {

--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -355,7 +355,7 @@ export class WorktrunkProvider implements WorktreeProvider {
         ),
       (error) =>
         error instanceof WorktrunkProviderError &&
-        isWorktrunkConcurrentCreateRegistryFailure(error),
+        isWorktrunkConcurrentCreateRegistryFailure(error, request.branch),
       () =>
         this.#run(
           this.#args([

--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -39,7 +39,10 @@ import {
   toIsoTimestamp,
 } from "@station/runtime";
 import { missingWorktrunkAutomationFlagSupport, worktrunkAutomationMode } from "./automation.js";
-import { worktrunkCommandFailure } from "./commandFailure.js";
+import {
+  isWorktrunkConcurrentCreateRegistryFailure,
+  worktrunkCommandFailure,
+} from "./commandFailure.js";
 import {
   type CheckWorktrunkDependencyOptions,
   checkWorktrunkDependency,
@@ -55,6 +58,10 @@ import {
   type WorktrunkHookExpectation,
   type WorktrunkProviderOptions,
 } from "./types.js";
+import {
+  createWorktreeRegistryMutationCoordinator,
+  type WorktreeRegistryMutationCoordinator,
+} from "./worktreeRegistryMutationCoordinator.js";
 
 type WorktrunkRunPolicy = {
   retries?: number;
@@ -83,7 +90,10 @@ type StaleRegistrationInspection =
  * Hook diagnostics use an atomic requester runtime when supplied and retain the whole Observer composition
  * expectation as a fallback. List results are returned without retaining inventory; only the Worktrunk
  * project identifier needed to preserve managed-path precedence is memoized. Checkout roots are validated
- * before Worktrunk runs, and removal freshly revalidates native Git identity, path, and branch before mutation.
+ * before Worktrunk runs. Concurrent creates share only an in-flight managed-path identity probe and retain
+ * their common-case mutation overlap. Reads and removals drain active creates; the exact nested Git
+ * sibling-registration race does the same before Worktrunk resumes its half-created branch. Removal freshly
+ * revalidates native Git identity, path, and branch before mutation.
  */
 export class WorktrunkProvider implements WorktreeProvider {
   readonly id: ProviderId = "worktrunk";
@@ -98,6 +108,8 @@ export class WorktrunkProvider implements WorktreeProvider {
   readonly #resolveRegistrationIdentity: (worktreePath: string) => Promise<string | undefined>;
   readonly #platform: NodeJS.Platform;
   readonly #managedPathProjectIdentifiers = new Map<string, string | null>();
+  readonly #managedPathProjectIdentifierProbes = new Map<string, Promise<void>>();
+  readonly #registryMutations: WorktreeRegistryMutationCoordinator;
 
   constructor(options: WorktrunkProviderOptions = {}) {
     this.#command = options.command ?? process.env.STATION_WORKTRUNK_BIN ?? "wt";
@@ -110,6 +122,7 @@ export class WorktrunkProvider implements WorktreeProvider {
     this.#resolveRegistrationIdentity =
       options.resolveRegistrationIdentity ?? nativeGitRegistrationIdentity;
     this.#platform = options.platform ?? process.platform;
+    this.#registryMutations = createWorktreeRegistryMutationCoordinator();
   }
 
   capabilities(): WorktreeCapabilities {
@@ -255,7 +268,9 @@ export class WorktrunkProvider implements WorktreeProvider {
   }
 
   async listWorktrees(project: ProviderProjectConfig): Promise<WorktreeObservation[]> {
-    return this.#listWorktrees(project, { retries: 1 });
+    return this.#registryMutations.runExclusive(project.id, () =>
+      this.#listWorktrees(project, { retries: 1 }),
+    );
   }
 
   async #listWorktrees(
@@ -314,25 +329,51 @@ export class WorktrunkProvider implements WorktreeProvider {
     const base = request.base ?? request.project.worktrunk.base;
     const pathEnv = worktreePathEnv(request.project, request.branch, request.path);
     const managedPathArgs = await this.#managedWorktreePathArgs(request.project, pathEnv);
-    const output = await this.#run(
-      this.#args([
-        ...managedPathArgs,
-        "switch",
-        ...this.#automationHookArgs(),
-        "--create",
-        request.branch,
-        ...(base === undefined ? [] : ["--base", base]),
-        "--no-cd",
-        "--format=json",
-      ]),
-      request.project.root,
-      {
-        code: "WORKTRUNK_COMMAND_FAILED",
-        message: "Worktrunk failed to create a worktree.",
-        ...(base === undefined ? {} : { unresolvedBase: base }),
-      },
-      {},
-      pathEnv,
+    const automationArgs = this.#automationHookArgs();
+    const output = await this.#registryMutations.runCreate(
+      request.project.id,
+      () =>
+        this.#run(
+          this.#args([
+            ...managedPathArgs,
+            "switch",
+            ...automationArgs,
+            "--create",
+            request.branch,
+            ...(base === undefined ? [] : ["--base", base]),
+            "--no-cd",
+            "--format=json",
+          ]),
+          request.project.root,
+          {
+            code: "WORKTRUNK_COMMAND_FAILED",
+            message: "Worktrunk failed to create a worktree.",
+            ...(base === undefined ? {} : { unresolvedBase: base }),
+          },
+          {},
+          pathEnv,
+        ),
+      (error) =>
+        error instanceof WorktrunkProviderError &&
+        isWorktrunkConcurrentCreateRegistryFailure(error),
+      () =>
+        this.#run(
+          this.#args([
+            ...managedPathArgs,
+            "switch",
+            ...automationArgs,
+            request.branch,
+            "--no-cd",
+            "--format=json",
+          ]),
+          request.project.root,
+          {
+            code: "WORKTRUNK_COMMAND_FAILED",
+            message: "Worktrunk failed to finish a worktree after a concurrent Git registry race.",
+          },
+          {},
+          pathEnv,
+        ),
     );
 
     const commandObservations = parseCommandObservation(output.stdout, {
@@ -454,6 +495,12 @@ export class WorktrunkProvider implements WorktreeProvider {
   }
 
   async removeWorktree(request: RemoveWorktreeRequest): Promise<RemoveWorktreeResult> {
+    return this.#registryMutations.runExclusive(request.project.id, () =>
+      this.#removeWorktree(request),
+    );
+  }
+
+  async #removeWorktree(request: RemoveWorktreeRequest): Promise<RemoveWorktreeResult> {
     const project = request.project;
     await this.#assertProjectRootUsable(project);
     if (!isSafeWorktrunkObservationPath(request.expectedPath)) {
@@ -564,7 +611,7 @@ export class WorktrunkProvider implements WorktreeProvider {
       return [];
     }
     if (!this.#managedPathProjectIdentifiers.has(project.id)) {
-      await this.#readWorktrees(project, { retries: 0 });
+      await this.#ensureManagedPathProjectIdentifier(project);
     }
     const identifier = this.#managedPathProjectIdentifiers.get(project.id);
     if (identifier === undefined || identifier === null) {
@@ -572,6 +619,23 @@ export class WorktrunkProvider implements WorktreeProvider {
     }
     // Worktrunk applies a user [projects.<id>] path after the environment, so use its higher-precedence command config too.
     return ["--config-set", worktrunkProjectPathOverride(identifier, worktreePath)];
+  }
+
+  async #ensureManagedPathProjectIdentifier(project: ProviderProjectConfig): Promise<void> {
+    const current = this.#managedPathProjectIdentifierProbes.get(project.id);
+    if (current !== undefined) {
+      await current;
+      return;
+    }
+    const probe = this.#readWorktrees(project, { retries: 0 }).then(() => undefined);
+    this.#managedPathProjectIdentifierProbes.set(project.id, probe);
+    try {
+      await probe;
+    } finally {
+      if (this.#managedPathProjectIdentifierProbes.get(project.id) === probe) {
+        this.#managedPathProjectIdentifierProbes.delete(project.id);
+      }
+    }
   }
 
   #automationHookArgs(): string[] {

--- a/integrations/worktree/worktrunk/src/worktreeRegistryMutationCoordinator.ts
+++ b/integrations/worktree/worktrunk/src/worktreeRegistryMutationCoordinator.ts
@@ -1,0 +1,133 @@
+export type WorktreeRegistryMutationCoordinator = {
+  runCreate<T>(
+    projectId: string,
+    attempt: () => Promise<T>,
+    shouldRecover: (error: unknown) => boolean,
+    recover: (error: unknown) => Promise<T>,
+  ): Promise<T>;
+  runExclusive<T>(projectId: string, operation: () => Promise<T>): Promise<T>;
+};
+
+type ExclusiveRequest = {
+  run(): Promise<void>;
+};
+
+type ProjectMutationState = {
+  activeCreates: number;
+  runningExclusive: boolean;
+  exclusiveQueue: ExclusiveRequest[];
+  createWaiters: Array<() => void>;
+};
+
+/**
+ * Coordinates Worktrunk operations around Git's non-atomic worktree registry. Normal creates keep
+ * their measured overlap. Reads, removals, and recovery of a proven half-created branch close new
+ * create admission and drain older creates so they observe a settled registry.
+ */
+export function createWorktreeRegistryMutationCoordinator(): WorktreeRegistryMutationCoordinator {
+  const projects = new Map<string, ProjectMutationState>();
+
+  const stateFor = (projectId: string): ProjectMutationState => {
+    const existing = projects.get(projectId);
+    if (existing !== undefined) return existing;
+    const state: ProjectMutationState = {
+      activeCreates: 0,
+      runningExclusive: false,
+      exclusiveQueue: [],
+      createWaiters: [],
+    };
+    projects.set(projectId, state);
+    return state;
+  };
+
+  const finishIfIdle = (projectId: string, state: ProjectMutationState): void => {
+    if (
+      state.activeCreates === 0 &&
+      !state.runningExclusive &&
+      state.exclusiveQueue.length === 0 &&
+      state.createWaiters.length === 0
+    ) {
+      projects.delete(projectId);
+    }
+  };
+
+  const admitCreates = (state: ProjectMutationState): void => {
+    if (state.runningExclusive || state.exclusiveQueue.length > 0) return;
+    const waiters = state.createWaiters.splice(0);
+    // Reserve each admission before resolving it so a new caller cannot observe a false idle gap.
+    state.activeCreates += waiters.length;
+    for (const resolve of waiters) resolve();
+  };
+
+  const drainExclusive = (projectId: string, state: ProjectMutationState): void => {
+    if (state.runningExclusive || state.activeCreates > 0 || state.exclusiveQueue.length === 0) {
+      return;
+    }
+    state.runningExclusive = true;
+    void (async () => {
+      while (state.exclusiveQueue.length > 0) {
+        const request = state.exclusiveQueue.shift();
+        if (request !== undefined) await request.run();
+      }
+      state.runningExclusive = false;
+      admitCreates(state);
+      finishIfIdle(projectId, state);
+    })();
+  };
+
+  const acquireCreate = (state: ProjectMutationState): Promise<void> => {
+    if (!state.runningExclusive && state.exclusiveQueue.length === 0) {
+      state.activeCreates += 1;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => state.createWaiters.push(resolve));
+  };
+
+  const queueExclusive = <T>(
+    projectId: string,
+    state: ProjectMutationState,
+    operation: () => Promise<T>,
+  ): Promise<T> =>
+    new Promise<T>((resolve, reject) => {
+      state.exclusiveQueue.push({
+        run: async () => {
+          try {
+            resolve(await operation());
+          } catch (error) {
+            reject(error);
+          }
+        },
+      });
+      drainExclusive(projectId, state);
+    });
+
+  return {
+    async runCreate<T>(
+      projectId: string,
+      attempt: () => Promise<T>,
+      shouldRecover: (error: unknown) => boolean,
+      recover: (error: unknown) => Promise<T>,
+    ): Promise<T> {
+      const state = stateFor(projectId);
+      await acquireCreate(state);
+      let recovery: Promise<T> | undefined;
+      try {
+        return await attempt();
+      } catch (error) {
+        if (!shouldRecover(error)) throw error;
+        // Queue before releasing this attempt; this closes admission without an observable gap.
+        recovery = queueExclusive(projectId, state, () => recover(error));
+      } finally {
+        state.activeCreates -= 1;
+        drainExclusive(projectId, state);
+        finishIfIdle(projectId, state);
+      }
+      return recovery;
+    },
+
+    runExclusive<T>(projectId: string, operation: () => Promise<T>): Promise<T> {
+      const state = stateFor(projectId);
+      return queueExclusive(projectId, state, operation);
+    },
+  };
+}

--- a/integrations/worktree/worktrunk/test/unit/commandFailure.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/commandFailure.test.ts
@@ -4,7 +4,10 @@ import {
   safeErrorFromUnknown,
 } from "@station/runtime";
 import { describe, expect, it } from "vitest";
-import { worktrunkCommandFailure } from "../../src/commandFailure.js";
+import {
+  isWorktrunkConcurrentCreateRegistryFailure,
+  worktrunkCommandFailure,
+} from "../../src/commandFailure.js";
 
 const fallback = {
   code: "WORKTRUNK_COMMAND_FAILED" as const,
@@ -144,5 +147,59 @@ describe("Worktrunk command failure mapping", () => {
       code: "WORKTRUNK_CANCELLED",
       message: "Worktrunk command was cancelled.",
     });
+  });
+
+  it("recognizes only the nested Git sibling-registration create race", () => {
+    const race = mapFailure(
+      safeErrorFromUnknown(
+        externalCommandErrorFromUnknown(
+          {
+            code: 128,
+            stderr: [
+              "Failed to create worktree for feature from base main",
+              "fatal: failed to read .git/worktrees/sibling/commondir: No such file or directory",
+              "Failed command, exit code 128:",
+              "git worktree add -b feature -- /tmp/project/feature main",
+            ].join("\n"),
+          },
+          {
+            command: "wt",
+            args: ["switch", "--create", "feature"],
+            cwd: "/tmp/project",
+          },
+        ),
+        {
+          tag: "WorktreeProviderError",
+          code: fallback.code,
+          message: fallback.message,
+          provider: "worktrunk",
+        },
+      ),
+    );
+    const unrelated = mapFailure(
+      safeErrorFromUnknown(
+        externalCommandErrorFromUnknown(
+          {
+            code: 128,
+            stderr:
+              "fatal: failed to read .git/worktrees/sibling/commondir: No such file or directory",
+          },
+          {
+            command: "wt",
+            args: ["switch", "--create", "feature"],
+            cwd: "/tmp/project",
+          },
+        ),
+        {
+          tag: "WorktreeProviderError",
+          code: fallback.code,
+          message: fallback.message,
+          provider: "worktrunk",
+        },
+      ),
+    );
+
+    expect(isWorktrunkConcurrentCreateRegistryFailure(race)).toBe(true);
+    expect(isWorktrunkConcurrentCreateRegistryFailure(unrelated)).toBe(false);
   });
 });

--- a/integrations/worktree/worktrunk/test/unit/commandFailure.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/commandFailure.test.ts
@@ -8,6 +8,7 @@ import {
   isWorktrunkConcurrentCreateRegistryFailure,
   worktrunkCommandFailure,
 } from "../../src/commandFailure.js";
+import { WorktrunkProviderError } from "../../src/errors.js";
 
 const fallback = {
   code: "WORKTRUNK_COMMAND_FAILED" as const,
@@ -150,56 +151,69 @@ describe("Worktrunk command failure mapping", () => {
   });
 
   it("recognizes only the nested Git sibling-registration create race", () => {
-    const race = mapFailure(
-      safeErrorFromUnknown(
-        externalCommandErrorFromUnknown(
-          {
-            code: 128,
-            stderr: [
-              "Failed to create worktree for feature from base main",
-              "fatal: failed to read .git/worktrees/sibling/commondir: No such file or directory",
-              "Failed command, exit code 128:",
-              "git worktree add -b feature -- /tmp/project/feature main",
-            ].join("\n"),
-          },
-          {
-            command: "wt",
-            args: ["switch", "--create", "feature"],
-            cwd: "/tmp/project",
-          },
-        ),
-        {
-          tag: "WorktreeProviderError",
-          code: fallback.code,
-          message: fallback.message,
-          provider: "worktrunk",
-        },
-      ),
-    );
-    const unrelated = mapFailure(
-      safeErrorFromUnknown(
-        externalCommandErrorFromUnknown(
-          {
-            code: 128,
-            stderr:
-              "fatal: failed to read .git/worktrees/sibling/commondir: No such file or directory",
-          },
-          {
-            command: "wt",
-            args: ["switch", "--create", "feature"],
-            cwd: "/tmp/project",
-          },
-        ),
-        {
-          tag: "WorktreeProviderError",
-          code: fallback.code,
-          message: fallback.message,
-          provider: "worktrunk",
-        },
-      ),
-    );
+    for (const missingFile of ["No such file or directory", "Undefined error: 0"]) {
+      const race = registryCreateFailure([
+        "Failed to create worktree for feature from base main",
+        `fatal: failed to read .git/worktrees/sibling/commondir: ${missingFile}`,
+        "Failed command, exit code 128:",
+        "git worktree add -b feature -- /tmp/project/feature main",
+      ]);
+      expect(isWorktrunkConcurrentCreateRegistryFailure(race, "feature")).toBe(true);
+    }
 
-    expect(isWorktrunkConcurrentCreateRegistryFailure(race)).toBe(true);
-    expect(isWorktrunkConcurrentCreateRegistryFailure(unrelated)).toBe(false);
+    for (const ordinaryFailure of [
+      "Permission denied",
+      "Input/output error",
+      "Operation not permitted",
+    ]) {
+      const failure = registryCreateFailure([
+        "Failed to create worktree for feature from base main",
+        `fatal: failed to read .git/worktrees/sibling/commondir: ${ordinaryFailure}`,
+        "Failed command, exit code 128:",
+        "git worktree add -b feature -- /tmp/project/feature main",
+      ]);
+      expect(isWorktrunkConcurrentCreateRegistryFailure(failure, "feature")).toBe(false);
+    }
+
+    const ownRegistration = registryCreateFailure([
+      "Failed to create worktree for feature from base main",
+      "fatal: failed to read .git/worktrees/feature/commondir: No such file or directory",
+      "Failed command, exit code 128:",
+      "git worktree add -b feature -- /tmp/project/feature main",
+    ]);
+    expect(isWorktrunkConcurrentCreateRegistryFailure(ownRegistration, "feature")).toBe(false);
+
+    const mismatchedCreate = registryCreateFailure([
+      "Failed to create worktree for other from base main",
+      "fatal: failed to read .git/worktrees/sibling/commondir: No such file or directory",
+      "Failed command, exit code 128:",
+      "git worktree add -b other -- /tmp/project/other main",
+    ]);
+    expect(isWorktrunkConcurrentCreateRegistryFailure(mismatchedCreate, "feature")).toBe(false);
   });
 });
+
+function registryCreateFailure(stderr: string[]): WorktrunkProviderError {
+  const failure = mapFailure(
+    safeErrorFromUnknown(
+      externalCommandErrorFromUnknown(
+        Object.assign(new Error("wt failed"), { code: 128, stderr: stderr.join("\n") }),
+        {
+          command: "wt",
+          args: ["switch", "--create", "feature"],
+          cwd: "/tmp/project",
+        },
+      ),
+      {
+        tag: "WorktreeProviderError",
+        code: fallback.code,
+        message: fallback.message,
+        provider: "worktrunk",
+      },
+    ),
+  );
+  if (!(failure instanceof WorktrunkProviderError)) {
+    throw new Error("Expected a Worktrunk provider failure.");
+  }
+  return failure;
+}

--- a/integrations/worktree/worktrunk/test/unit/provider.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/provider.test.ts
@@ -704,6 +704,41 @@ describe("WorktrunkProvider", () => {
     expect(calls.indexOf("settled:older")).toBeLessThan(calls.indexOf("recovery:raced"));
   });
 
+  it.each([
+    "Permission denied",
+    "Input/output error",
+  ])("retains an ordinary commondir failure without recovery: %s", async (failureText) => {
+    const calls: string[][] = [];
+    const provider = testProvider({
+      command: "wt",
+      useLifecycleHooks: false,
+      clock: { now: () => new Date(now) },
+      runner: async (input) => {
+        if (input.command === "git") return result(input, "false\n");
+        calls.push(input.args ?? []);
+        throw Object.assign(new Error("wt failed"), {
+          code: 128,
+          stderr: [
+            "Failed to create worktree for feature from base main",
+            `fatal: failed to read .git/worktrees/sibling/commondir: ${failureText}`,
+            "Failed command, exit code 128:",
+            "git worktree add -b feature -- /tmp/station/web/feature main",
+          ].join("\n"),
+        });
+      },
+    });
+
+    await expect(provider.createWorktree({ project, branch: "feature" })).rejects.toMatchObject({
+      code: "WORKTRUNK_COMMAND_FAILED",
+      diagnosticDetails: [
+        expect.objectContaining({ stderrSnippet: expect.stringContaining(failureText) }),
+      ],
+    });
+    expect(calls).toEqual([
+      ["switch", "--no-hooks", "--create", "feature", "--base", "main", "--no-cd", "--format=json"],
+    ]);
+  });
+
   it("drains active creates before removal revalidation touches the Git registry", async () => {
     const targetPath = "/tmp/station/web/.worktrees/target";
     const createPath = "/tmp/station/web/.worktrees/new";

--- a/integrations/worktree/worktrunk/test/unit/provider.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/provider.test.ts
@@ -368,6 +368,76 @@ describe("WorktrunkProvider", () => {
     });
   });
 
+  it("shares the in-flight managed-path identity probe before concurrent creates", async () => {
+    const managedProject = {
+      ...project,
+      worktrunk: {
+        ...project.worktrunk,
+        managedRoot: "/tmp/home/.worktrees/web",
+        includeMain: false,
+        includeExternal: false,
+      },
+    };
+    const listStarted = Promise.withResolvers<void>();
+    const releaseList = Promise.withResolvers<void>();
+    const createsSaturated = Promise.withResolvers<void>();
+    const releaseCreates = Promise.withResolvers<void>();
+    let listCalls = 0;
+    let activeCreates = 0;
+    let maxActiveCreates = 0;
+    const provider = testProvider({
+      command: "wt",
+      useLifecycleHooks: false,
+      clock: { now: () => new Date(now) },
+      runner: async (input) => {
+        if (input.command === "git") return result(input, "false\n");
+        if (input.args?.includes("list")) {
+          listCalls += 1;
+          listStarted.resolve();
+          await releaseList.promise;
+          return result(
+            input,
+            JSON.stringify([
+              {
+                path: "/tmp/station/web",
+                branch: "main",
+                is_main: true,
+                repo: { host: "github.com", owner: "acme", name: "web" },
+              },
+            ]),
+          );
+        }
+        activeCreates += 1;
+        maxActiveCreates = Math.max(maxActiveCreates, activeCreates);
+        if (activeCreates === 2) createsSaturated.resolve();
+        await releaseCreates.promise;
+        activeCreates -= 1;
+        const branchIndex = input.args?.indexOf("--create") ?? -1;
+        const branch = input.args?.[branchIndex + 1];
+        return result(
+          input,
+          JSON.stringify([{ path: input.env?.WORKTRUNK_WORKTREE_PATH, branch }]),
+        );
+      },
+    });
+
+    const first = provider.createWorktree({ project: managedProject, branch: "first" });
+    const second = provider.createWorktree({ project: managedProject, branch: "second" });
+    await listStarted.promise;
+    await Promise.resolve();
+    expect(listCalls).toBe(1);
+    releaseList.resolve();
+    await createsSaturated.promise;
+    releaseCreates.resolve();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      expect.objectContaining({ branch: "first" }),
+      expect.objectContaining({ branch: "second" }),
+    ]);
+    expect(listCalls).toBe(1);
+    expect(maxActiveCreates).toBe(2);
+  });
+
   it("overrides path-keyed Worktrunk project templates for repositories without remotes", async () => {
     const calls: ExternalCommandInput[] = [];
     const managedProject = {
@@ -573,6 +643,124 @@ describe("WorktrunkProvider", () => {
         "--format=json",
       ],
     ]);
+  });
+
+  it("drains concurrent creates before resuming a branch left by Git registry initialization", async () => {
+    const calls: string[] = [];
+    const bothStarted = Promise.withResolvers<void>();
+    const releaseOlder = Promise.withResolvers<void>();
+    let activeInitials = 0;
+    const provider = testProvider({
+      command: "wt",
+      useLifecycleHooks: false,
+      clock: { now: () => new Date(now) },
+      runner: async (input) => {
+        if (input.command === "git") return result(input, "false\n");
+        const args = input.args ?? [];
+        const branch = args.find((arg) => arg === "raced" || arg === "older");
+        const initial = args.includes("--create");
+        if (initial) {
+          activeInitials += 1;
+          calls.push(`initial:${branch}`);
+          if (activeInitials === 2) bothStarted.resolve();
+          await bothStarted.promise;
+          if (branch === "older") {
+            await releaseOlder.promise;
+            calls.push("settled:older");
+            activeInitials -= 1;
+            return result(
+              input,
+              JSON.stringify([{ path: "/tmp/station/web/older", branch: "older" }]),
+            );
+          }
+          activeInitials -= 1;
+          throw Object.assign(new Error("wt failed"), {
+            code: 128,
+            stderr: [
+              "Failed to create worktree for raced from base main",
+              "fatal: failed to read .git/worktrees/older/commondir: Undefined error: 0",
+              "Failed command, exit code 128:",
+              "git worktree add -b raced -- /tmp/station/web/raced main",
+            ].join("\n"),
+          });
+        }
+        calls.push(`recovery:${branch}`);
+        return result(input, JSON.stringify([{ path: "/tmp/station/web/raced", branch: "raced" }]));
+      },
+    });
+
+    const older = provider.createWorktree({ project, branch: "older" });
+    const raced = provider.createWorktree({ project, branch: "raced" });
+    await bothStarted.promise;
+    await Promise.resolve();
+    expect(calls).toEqual(expect.arrayContaining(["initial:older", "initial:raced"]));
+    expect(calls).not.toContain("recovery:raced");
+    releaseOlder.resolve();
+
+    await expect(Promise.all([older, raced])).resolves.toEqual([
+      expect.objectContaining({ branch: "older", path: "/tmp/station/web/older" }),
+      expect.objectContaining({ branch: "raced", path: "/tmp/station/web/raced" }),
+    ]);
+    expect(calls.indexOf("settled:older")).toBeLessThan(calls.indexOf("recovery:raced"));
+  });
+
+  it("drains active creates before removal revalidation touches the Git registry", async () => {
+    const targetPath = "/tmp/station/web/.worktrees/target";
+    const createPath = "/tmp/station/web/.worktrees/new";
+    const createStarted = Promise.withResolvers<void>();
+    const releaseCreate = Promise.withResolvers<void>();
+    const calls: string[] = [];
+    const provider = testProvider({
+      command: "wt",
+      useLifecycleHooks: false,
+      clock: { now: () => new Date(now) },
+      runner: async (input) => {
+        if (input.command === "git") return result(input, "false\n");
+        if (input.args?.includes("list")) {
+          calls.push("list");
+          return result(
+            input,
+            JSON.stringify([
+              { path: targetPath, branch: "target" },
+              { path: createPath, branch: "new" },
+            ]),
+          );
+        }
+        if (input.args?.includes("--create")) {
+          calls.push("create:start");
+          createStarted.resolve();
+          await releaseCreate.promise;
+          calls.push("create:settled");
+          return result(input, JSON.stringify([{ path: createPath, branch: "new" }]));
+        }
+        calls.push("remove");
+        return result(input, "{}");
+      },
+    });
+    const [target] = await provider.listWorktrees(tmpProject);
+    expect(target).toBeDefined();
+    if (target === undefined) throw new Error("Expected a selected removal target.");
+    calls.length = 0;
+
+    const creating = provider.createWorktree({ project: tmpProject, branch: "new" });
+    await createStarted.promise;
+    const removing = provider.removeWorktree({
+      project: tmpProject,
+      worktreeId: target.id,
+      expectedPath: target.path,
+      expectedBranch: target.branch,
+      expectedRegistrationIdentity: target.registrationIdentity ?? "missing-registration",
+      force: true,
+    });
+    await Promise.resolve();
+    expect(calls).toEqual(["create:start"]);
+    releaseCreate.resolve();
+
+    await expect(Promise.all([creating, removing])).resolves.toEqual([
+      expect.objectContaining({ branch: "new" }),
+      { worktreeId: target.id, removed: true },
+    ]);
+    expect(calls).toEqual(["create:start", "create:settled", "list", "remove"]);
   });
 
   it("retains a created worktree when its Git registration cannot be verified", async () => {

--- a/integrations/worktree/worktrunk/test/unit/worktreeRegistryMutationCoordinator.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/worktreeRegistryMutationCoordinator.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import { createWorktreeRegistryMutationCoordinator } from "../../src/worktreeRegistryMutationCoordinator.js";
+
+describe("Worktree registry mutation coordinator", () => {
+  it("keeps normal attempts concurrent", async () => {
+    const coordinator = createWorktreeRegistryMutationCoordinator();
+    const saturated = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    let active = 0;
+    let maxActive = 0;
+    const attempt = async (value: string): Promise<string> => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      if (active === 2) saturated.resolve();
+      await release.promise;
+      active -= 1;
+      return value;
+    };
+
+    const first = coordinator.runCreate(
+      "web",
+      () => attempt("first"),
+      () => false,
+      attempt,
+    );
+    const second = coordinator.runCreate(
+      "web",
+      () => attempt("second"),
+      () => false,
+      attempt,
+    );
+    await saturated.promise;
+    release.resolve();
+
+    await expect(Promise.all([first, second])).resolves.toEqual(["first", "second"]);
+    expect(maxActive).toBe(2);
+  });
+
+  it("drains older attempts and blocks newer admission around exact recovery", async () => {
+    const coordinator = createWorktreeRegistryMutationCoordinator();
+    const olderStarted = Promise.withResolvers<void>();
+    const releaseOlder = Promise.withResolvers<void>();
+    const failed = Promise.withResolvers<void>();
+    const recoveryStarted = Promise.withResolvers<void>();
+    const releaseRecovery = Promise.withResolvers<void>();
+    const events: string[] = [];
+    const registryRace = new Error("registry race");
+
+    const older = coordinator.runCreate(
+      "web",
+      async () => {
+        events.push("attempt:older");
+        olderStarted.resolve();
+        await releaseOlder.promise;
+        events.push("settled:older");
+        return "older";
+      },
+      (error) => error === registryRace,
+      async () => "unused",
+    );
+    const raced = coordinator.runCreate(
+      "web",
+      async () => {
+        await olderStarted.promise;
+        events.push("attempt:raced");
+        failed.resolve();
+        throw registryRace;
+      },
+      (error) => error === registryRace,
+      async () => {
+        events.push("recovery:raced");
+        recoveryStarted.resolve();
+        await releaseRecovery.promise;
+        return "recovered";
+      },
+    );
+    await failed.promise;
+    await Promise.resolve();
+    await Promise.resolve();
+    const newer = coordinator.runCreate(
+      "web",
+      async () => {
+        events.push("attempt:newer");
+        return "newer";
+      },
+      () => false,
+      async () => "unused",
+    );
+
+    expect(events).toEqual(["attempt:older", "attempt:raced"]);
+    releaseOlder.resolve();
+    await recoveryStarted.promise;
+    expect(events).toEqual(["attempt:older", "attempt:raced", "settled:older", "recovery:raced"]);
+    releaseRecovery.resolve();
+
+    await expect(Promise.all([older, raced, newer])).resolves.toEqual([
+      "older",
+      "recovered",
+      "newer",
+    ]);
+    expect(events).toEqual([
+      "attempt:older",
+      "attempt:raced",
+      "settled:older",
+      "recovery:raced",
+      "attempt:newer",
+    ]);
+  });
+
+  it("drains creates before an exclusive registry operation and blocks newer creates", async () => {
+    const coordinator = createWorktreeRegistryMutationCoordinator();
+    const createStarted = Promise.withResolvers<void>();
+    const releaseCreate = Promise.withResolvers<void>();
+    const releaseExclusive = Promise.withResolvers<void>();
+    const events: string[] = [];
+    const active = coordinator.runCreate(
+      "web",
+      async () => {
+        events.push("create:active");
+        createStarted.resolve();
+        await releaseCreate.promise;
+        events.push("create:settled");
+      },
+      () => false,
+      async () => undefined,
+    );
+    await createStarted.promise;
+    const exclusive = coordinator.runExclusive("web", async () => {
+      events.push("exclusive");
+      await releaseExclusive.promise;
+    });
+    const newer = coordinator.runCreate(
+      "web",
+      async () => {
+        events.push("create:newer");
+      },
+      () => false,
+      async () => undefined,
+    );
+
+    expect(events).toEqual(["create:active"]);
+    releaseCreate.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(events).toEqual(["create:active", "create:settled", "exclusive"]);
+    releaseExclusive.resolve();
+
+    await Promise.all([active, exclusive, newer]);
+    expect(events).toEqual(["create:active", "create:settled", "exclusive", "create:newer"]);
+  });
+});


### PR DESCRIPTION
## What this fixes

Station must let distinct Quick Session branches progress concurrently without weakening canonical worktree, session, terminal, rollback, or reconciliation semantics. Project-wide serialization discarded most of the measured burst-performance gain, while unconstrained overlap can collide in the Git registry, let delayed verification observe an incomplete create transaction, or race cold tmux workbench creation.

Worktrunk recovery must also remain limited to the exact concurrent sibling-registration race. Permission and I/O failures retain their original diagnostics and are never converted into a non-create recovery attempt.

Closes #768.

## What changed

- Add one process-lifetime create coordinator with a four-call per-project provider bound, independent project capacity, and FIFO same-branch ownership across `worktree.create`, `worktree.fork`, `session.create`, and `session.fork`.
- Retain each branch lease through publication or rollback while limiting capacity only around the external provider create call.
- Delay post-launch all-project verification until global create quiescence, recheck readiness when the timer flushes, and coalesce each burst into one verification wave.
- Serialize tmux detached opens only across the workbench existence decision and mutation, making cold startup single-flight without widening worktree-create ownership.
- Recover Worktrunk creation only when its wrapper and nested Git command identify the requested branch, a distinct sibling registry identity is missing, and the diagnostic uses one of the observed missing-file signatures.
- Preserve current shutdown behavior by composing the readiness-aware reconcile scheduler with the newer in-flight shutdown drain from `main`.

## Testing

- 79 focused unit tests pass for create scheduling, cold tmux placement, exact Worktrunk recovery classification, ordinary error retention, and reconcile scheduler shutdown/readiness behavior.
- `bun run test:all` passes build, full typecheck, lint and architecture validation, 3,436 unit tests, 199 contract tests, 909 integration tests, 189 diagnostics tests, and all scripted-agent tests. The setup lane passes 28 of 30 tests; the two local-only failures are the documented Node 26 versus required Node 24 bootstrap mismatch and terminal OSC-8 capability mismatch.
- All 27 production Observer E2E tests pass, and installer smoke passes.
- Observer architecture generation/check is byte-current and conformant.
- Earlier real Worktrunk 0.72 / Git 2.50 stress completed 200 candidate creates across ten four-wide bursts with exact branch, path, Git-registration, and cleanup evidence; one naturally occurring sibling-registration race recovered.

## Safety and scope

This does not add native Git creation or reduce distinct-branch provider concurrency. Tmux serialization covers only detached placement mutation. Worktrunk recovery is fail-closed on diagnostic drift, and the normal branch, path, managed-root, and opaque registration checks still decide whether recovered output is usable.

## User-visible behavior

Rapid distinct-branch Quick Sessions progress four at a time. Cold tmux startup no longer causes otherwise valid sessions to fail and roll back, duplicate branches remain ordered, and ordinary Worktrunk filesystem failures keep their original diagnostic.