### PR TITLE
fix(setup): restore exact pinned Bun bootstrap

### DIFF
--- a/scripts/setup/bootstrap.sh
+++ b/scripts/setup/bootstrap.sh
@@ -50,9 +50,9 @@ if prefix="$(brew --prefix node@24 2>/dev/null)" && [ -x "$prefix/bin/node" ]; t
 fi
 
 required_bun_version="$(node "$repo_root/scripts/bun-version.mjs" --print)"
-# Homebrew provides the bootstrap executable; repository work always runs under
-# the exact packageManager version even after Homebrew's formula advances.
-bun_runtime=(bun x "bun@$required_bun_version")
+# Node provides the bootstrap executable; repository work always runs under the
+# exact packageManager version even after Homebrew's Bun formula advances.
+bun_runtime=(npx --yes "bun@$required_bun_version")
 active_bun_version="$("${bun_runtime[@]}" --version)"
 if [[ "$active_bun_version" != "$required_bun_version" ]]; then
   echo "Could not activate repository Bun $required_bun_version (found $active_bun_version)." >&2

--- a/tests/diagnostics/bootstrap-bun-runtime.test.ts
+++ b/tests/diagnostics/bootstrap-bun-runtime.test.ts
@@ -46,10 +46,10 @@ describe("bootstrap exact Bun runtime", () => {
         'if [ "$1" = "--prefix" ] && [ "$2" = "node@24" ]; then exit 1; fi',
         "exit 2",
       ]);
-      writeExecutable(join(ambientBin, "bun"), [
+      writeExecutable(join(ambientBin, "npx"), [
         "#!/bin/sh",
         "set -eu",
-        'if [ "$1" != "x" ] || [ "$2" != "bun@1.4.0" ]; then exit 64; fi',
+        'if [ "$1" != "--yes" ] || [ "$2" != "bun@1.4.0" ]; then exit 64; fi',
         "shift 2",
         'PATH="$STATION_BOOTSTRAP_BUN_LOCATOR:$PATH"',
         "export PATH",


### PR DESCRIPTION
## What this fixes

The checkout bootstrap could no longer activate the repository-pinned Bun because `bun x bun@1.4.0` does not resolve the `bun` package executable. Fresh setup therefore stopped before dependency installation and build.

## What changed

- activate the exact package-manager version through Node's supported `npx --yes bun@<version>` path
- retain the explicit runtime-version check before any workspace operation
- keep nested bare `bun` commands bound to the selected 1.4.0 runtime in the diagnostic contract

## Testing

- focused bootstrap runtime diagnostic: 1/1 passed
- complete setup E2E lane: 30/30 passed
- repository lint and architecture checks passed

Closes #771