### PR TITLE
fix(worktrunk): await checkout removal

### DIFF
--- a/apps/cli/test/unit/observerProviders.test.ts
+++ b/apps/cli/test/unit/observerProviders.test.ts
@@ -657,7 +657,7 @@ describe("observer providers", () => {
         [
           "switch --no-hooks --create feature --base main --no-cd --format=json",
           "list --format=json",
-          `-C ${createdWorktreePath} remove --no-hooks --format=json`,
+          `-C ${createdWorktreePath} remove --no-hooks --foreground --format=json`,
           "",
         ].join("\n"),
       );

--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -536,7 +536,7 @@ export class WorktrunkProvider implements WorktreeProvider {
         "remove",
         ...this.#automationHookArgs(),
         ...removalFlags,
-        // Omit --foreground so staged-trash cleanup can remain detached after logical removal.
+        "--foreground",
         "--format=json",
       ]),
       undefined,

--- a/integrations/worktree/worktrunk/test/unit/provider.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/provider.test.ts
@@ -226,6 +226,7 @@ describe("WorktrunkProvider", () => {
       "-C",
       physical,
       "remove",
+      "--foreground",
       "--format=json",
     ]);
   });
@@ -562,7 +563,15 @@ describe("WorktrunkProvider", () => {
     expect(calls.map((call) => call.args)).toEqual([
       ["switch", "--create", "feature", "--base", "main", "--no-cd", "--format=json"],
       ["list", "--format=json"],
-      ["-C", "/tmp/station/web/feature", "remove", "--force", "--force-delete", "--format=json"],
+      [
+        "-C",
+        "/tmp/station/web/feature",
+        "remove",
+        "--force",
+        "--force-delete",
+        "--foreground",
+        "--format=json",
+      ],
     ]);
   });
 
@@ -639,7 +648,16 @@ describe("WorktrunkProvider", () => {
     expect(calls.map((call) => call.args)).toEqual([
       ["list", "--format=json"],
       ["list", "--format=json"],
-      ["-C", linkedPath, "remove", "--no-hooks", "--force", "--no-delete-branch", "--format=json"],
+      [
+        "-C",
+        linkedPath,
+        "remove",
+        "--no-hooks",
+        "--force",
+        "--no-delete-branch",
+        "--foreground",
+        "--format=json",
+      ],
     ]);
   });
 
@@ -879,7 +897,7 @@ describe("WorktrunkProvider", () => {
     expect(calls.map((call) => call.args)).toEqual([
       ["switch", "--no-hooks", "--create", "feature", "--base", "main", "--no-cd", "--format=json"],
       ["list", "--format=json"],
-      ["-C", "/tmp/station/web/feature", "remove", "--no-hooks", "--format=json"],
+      ["-C", "/tmp/station/web/feature", "remove", "--no-hooks", "--foreground", "--format=json"],
     ]);
   });
 
@@ -919,7 +937,7 @@ describe("WorktrunkProvider", () => {
     expect(calls.map((call) => call.args)).toEqual([
       ["switch", "--yes", "--create", "feature", "--base", "main", "--no-cd", "--format=json"],
       ["list", "--format=json"],
-      ["-C", "/tmp/station/web/feature", "remove", "--yes", "--format=json"],
+      ["-C", "/tmp/station/web/feature", "remove", "--yes", "--foreground", "--format=json"],
     ]);
   });
 
@@ -1548,7 +1566,13 @@ describe("WorktrunkProvider", () => {
       tag: "WorktreeProviderError",
       code: "WORKTRUNK_TIMEOUT",
     });
-    expect(removeArgs).toEqual(["-C", "/tmp/station/web/feature", "remove", "--format=json"]);
+    expect(removeArgs).toEqual([
+      "-C",
+      "/tmp/station/web/feature",
+      "remove",
+      "--foreground",
+      "--format=json",
+    ]);
     expect(aborted).toBe(true);
   });
 


### PR DESCRIPTION
## What this fixes

Worktrunk 0.64 can finish its logical unregister step before asynchronous trash cleanup removes the selected checkout directory. Station therefore reported a completed worktree removal while the directory could still exist.

## What changed

- run the existing exact Worktrunk remove command with `--foreground`
- preserve the selected-path, shared-branch, hook, force, and timeout behavior
- update argv coverage for every remove mode

## Testing

- Worktrunk provider unit suite: 38/38 passed
- real Worktrunk safety lane: 2/2 passed
- integration typecheck passed
- repository lint and architecture checks passed

Closes #772