### PR TITLE
fix(cli): secure observer socket directory

### DIFF
--- a/apps/cli/src/observerProcess/startup.ts
+++ b/apps/cli/src/observerProcess/startup.ts
@@ -1,4 +1,4 @@
-import { mkdir } from "node:fs/promises";
+import { chmod, mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
 import {
   OBSERVER_STARTUP_BOOT_LOG_TAIL_MAX_BYTES,
@@ -95,7 +95,9 @@ export async function startObserverProcess(
     async ({ signal }) => {
       try {
         await mkdir(input.paths.stateDir, { recursive: true, mode: 0o700 });
-        await mkdir(dirname(input.paths.socketPath), { recursive: true, mode: 0o700 });
+        const socketDir = dirname(input.paths.socketPath);
+        await mkdir(socketDir, { recursive: true, mode: 0o700 });
+        await chmod(socketDir, 0o700);
         const spawnInput: SpawnObserverInput = {
           paths: input.paths,
           startupTimeoutMs: input.timeoutMs,

--- a/apps/cli/test/unit/observer-process/startup.test.ts
+++ b/apps/cli/test/unit/observer-process/startup.test.ts
@@ -1,5 +1,5 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { chmod, mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { startObserver } from "@station/cli";
 import type { ChildProcessLike } from "@station/cli/internal";
 import type { ObserverHealth, SafeError } from "@station/contracts";
@@ -68,6 +68,33 @@ function unavailableClientFactory(message = "stopped") {
 }
 
 describe("CLI observer process startup", () => {
+  it("narrows an existing socket directory before spawning", async () => {
+    const fixture = await createTempState();
+    const socketDir = dirname(fixture.socketPath);
+    await mkdir(socketDir, { recursive: true });
+    await chmod(socketDir, 0o755);
+    let modeAtSpawn: number | undefined;
+    let spawned = false;
+
+    const result = await startObserver(
+      { config: fixture.config, timeoutMs: 10_000 },
+      {
+        spawnObserver: async () => {
+          modeAtSpawn = (await stat(socketDir)).mode & 0o777;
+          spawned = true;
+          return fakeChild();
+        },
+        clientFactory: fakeClientFactory(async () => {
+          if (!spawned) throw new Error("stopped");
+          return healthyObserver();
+        }),
+      },
+    );
+
+    expect(result).toMatchObject({ status: "running" });
+    expect(modeAtSpawn).toBe(0o700);
+  });
+
   it("recomputes the child startup timeout immediately before spawn", async () => {
     const fixture = await createTempState();
     const deadlineMs = Date.now() + 10_000;


### PR DESCRIPTION
## What this fixes

Observer startup correctly refuses a socket directory that is not private, but CLI startup only applied mode `0700` when creating a missing directory. An existing directory created under the process umask could remain `0755`, preventing isolated popup and binding flows from starting their Observer.

## What changed

- explicitly narrow the exact resolved Observer socket directory to `0700` before spawning
- keep the Observer boot-claim ownership validation unchanged and fail closed
- add a startup regression that begins with an existing `0755` directory and observes `0700` at spawn

## Testing

- CLI Observer startup unit suite: 29/29 passed
- CLI package typecheck passed
- repository lint and architecture checks passed
- real tmux client-scoped popup case passes and Observer-backed cases now start; the independent compiled nested-client failure remains outside this patch

Addresses #773