### PR TITLE
test(setup): match exact Worktrunk command

### DIFF
--- a/apps/cli/test/unit/setup-checks.test.ts
+++ b/apps/cli/test/unit/setup-checks.test.ts
@@ -905,9 +905,9 @@ describe("setup dependency checks", () => {
       resolvedPath: worktrunkCommand,
     });
     expect(facts.worktrunkShellIntegration.status).toBe("ok");
-    expect(calls.filter((call) => call.command.includes("wt")).map((call) => call.command)).toEqual(
-      [worktrunkCommand, worktrunkCommand],
-    );
+    expect(
+      calls.filter((call) => call.command === worktrunkCommand).map((call) => call.command),
+    ).toEqual([worktrunkCommand, worktrunkCommand]);
   });
 
   it("derives Worktrunk hook pre-approval mode from existing config", async () => {


### PR DESCRIPTION
## What this fixes

The setup unit suite could fail when a random sandbox path happened to contain `wt`, because its Worktrunk-call assertion used substring matching over every command path.

## What changed

- Match the configured Worktrunk executable exactly when selecting calls for the assertion.
- Keep the expected readiness and shell-check call count unchanged.

## Testing

- `bun x vitest run --config config/vitest/vitest.unit.config.ts apps/cli/test/unit/setup-checks.test.ts` (99 passed)
- `bun run lint`
