### PR TITLE
test(tmux): reject popup binary version drift

### DIFF
--- a/integrations/terminal/tmux/test/integration/popup-real.test.ts
+++ b/integrations/terminal/tmux/test/integration/popup-real.test.ts
@@ -18,6 +18,7 @@ import {
 import { startProtocolServer, type UnixSocketServer } from "@station/protocol";
 import {
   environmentWithoutGitLocals,
+  parseStationObserverBuildVersion,
   resolveExecutablePath,
   stationObserverBuildVersion,
 } from "@station/runtime";
@@ -297,6 +298,16 @@ describeRealTmux("real tmux dev popup routing", () => {
         `Compiled CLI not found at ${builtBinaryPath}; run bun run build:binary first.`,
       );
     });
+    const { stdout: binaryVersionOutput } = await execFileAsync(builtBinaryPath, ["--version"], {
+      timeout: 10_000,
+    });
+    const binaryVersion = binaryVersionOutput.trim();
+    const sourceVersion = parseStationObserverBuildVersion(stationObserverBuildVersion()).version;
+    if (binaryVersion !== sourceVersion) {
+      throw new Error(
+        `Compiled CLI version ${binaryVersion} does not match source version ${sourceVersion}; rebuild with bun run build:binary -- --version ${sourceVersion}.`,
+      );
+    }
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## What this fixes

The real tmux popup lane could combine a source-generated managed binding with a compiled CLI carrying a different display version. That made the intentional signature check select the config-aware fallback and misreported correct production behavior as a warm-popup failure.

Closes #797.

## What changed

- probe the compiled CLI display version before creating any real tmux fixture
- compare it with the source display version used to generate the binding signature
- fail early with both versions and the exact rebuild command when they differ
- leave production signature validation unchanged

## Testing

- matching `0.0.0-pre-alpha.8.2` source and binary: focused compiled managed-binding real test passed
- mismatched `0.0.0-pre-alpha.8.2` source and `0.0.0-local` binary: lane failed before fixture creation with the new diagnostic
- `bun run typecheck --filter=@station/tmux`
- Biome and repository architecture checks

## User-visible behavior

No product behavior changes. Real tmux acceptance failures now distinguish a stale binary from a popup routing defect.
