### PR TITLE
fix(tui): preserve terminal-default popup fallback

### DIFF
--- a/station/src/theme/terminalPalette/controller.test.ts
+++ b/station/src/theme/terminalPalette/controller.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { CliRenderEvents } from "@opentui/core";
-import { nativeStationTheme } from "../builtInTheme.js";
 import { createStationThemeController, type StationThemeRenderer } from "./controller.js";
+import { resolveEmbeddedStationTheme } from "./theme.js";
 import {
   darkTerminalColors,
   lightTerminalColors,
@@ -97,6 +97,16 @@ async function waitFor(assertion: () => boolean): Promise<void> {
 }
 
 describe("Station theme controller", () => {
+  it("starts with a terminal-default embedded canvas", () => {
+    const controller = createStationThemeController(new FakeThemeRenderer());
+
+    expect(controller.getSnapshot()).toBe(resolveEmbeddedStationTheme(null));
+    expect(controller.getSnapshot().surfaces.canvas).toMatchObject({
+      kind: "terminal-default",
+      channel: "background",
+    });
+  });
+
   it("publishes the initial valid observation", async () => {
     const renderer = new FakeThemeRenderer();
     renderer.enqueue(darkTerminalColors);
@@ -117,13 +127,13 @@ describe("Station theme controller", () => {
     failedRenderer.enqueueFailure(new Error("palette unavailable"));
     const failed = createStationThemeController(failedRenderer);
     await failed.start();
-    expect(failed.getSnapshot()).toBe(nativeStationTheme);
+    expect(failed.getSnapshot()).toBe(resolveEmbeddedStationTheme(null));
 
     const malformedRenderer = new FakeThemeRenderer();
     malformedRenderer.enqueue(malformedTerminalColors);
     const malformed = createStationThemeController(malformedRenderer);
     await malformed.start();
-    expect(malformed.getSnapshot()).toBe(nativeStationTheme);
+    expect(malformed.getSnapshot()).toBe(resolveEmbeddedStationTheme(null));
   });
 
   it("recovers from a rejected query on the next theme invalidation", async () => {
@@ -131,7 +141,7 @@ describe("Station theme controller", () => {
     renderer.enqueueFailure(new Error("palette unavailable"));
     const controller = createStationThemeController(renderer);
     await controller.start();
-    expect(controller.getSnapshot()).toBe(nativeStationTheme);
+    expect(controller.getSnapshot()).toBe(resolveEmbeddedStationTheme(null));
 
     renderer.enqueue(darkTerminalColors);
     renderer.enqueue(lightTerminalColors);
@@ -285,7 +295,7 @@ describe("Station theme controller", () => {
     initial.resolve(darkTerminalColors);
     await started;
 
-    expect(controller.getSnapshot()).toBe(nativeStationTheme);
+    expect(controller.getSnapshot()).toBe(resolveEmbeddedStationTheme(null));
   });
 
   it("makes repeated start and dispose calls safe", async () => {

--- a/station/src/theme/terminalPalette/controller.ts
+++ b/station/src/theme/terminalPalette/controller.ts
@@ -1,5 +1,4 @@
 import { CliRenderEvents } from "@opentui/core";
-import { nativeStationTheme } from "../builtInTheme.js";
 import type { StationTerminalTheme, StationTheme } from "../types.js";
 import {
   parseStationTerminalPaletteObservation,
@@ -33,7 +32,7 @@ export type StationThemeController = Readonly<{
 export function createStationThemeController(
   renderer: StationThemeRenderer,
 ): StationThemeController {
-  let snapshot: StationTheme = nativeStationTheme;
+  let snapshot: StationTheme = resolveEmbeddedStationTheme(null);
   let observationSignature: string | null = null;
   let generation = 0;
   let started = false;

--- a/station/src/theme/terminalPalette/theme.test.ts
+++ b/station/src/theme/terminalPalette/theme.test.ts
@@ -74,16 +74,25 @@ describe("terminal palette theme construction", () => {
   });
 
   it("selects one whole fallback for absent or unreadable embedded evidence", () => {
-    expect(resolveEmbeddedStationTheme(undefined)).toBe(nativeStationTheme);
-    expect(resolveEmbeddedStationTheme(null)).toBe(nativeStationTheme);
+    const fallback = resolveEmbeddedStationTheme(null);
+
+    expect(resolveEmbeddedStationTheme(undefined)).toBe(fallback);
     expect(
       resolveEmbeddedStationTheme(observation(lowContrastTerminalColors)),
-    ).toBe(nativeStationTheme);
+    ).toBe(fallback);
+    expect(fallback.surfaces.canvas).toMatchObject({
+      kind: "terminal-default",
+      channel: "background",
+    });
+    expect(fallback.text.primary).toMatchObject({
+      kind: "terminal-default",
+      channel: "foreground",
+    });
   });
 
   it("guards direct construction against unreadable default contrast", () => {
     expect(createTerminalPaletteTheme(observation(lowContrastTerminalColors))).toBe(
-      nativeStationTheme,
+      resolveEmbeddedStationTheme(null),
     );
   });
 

--- a/station/src/theme/terminalPalette/theme.ts
+++ b/station/src/theme/terminalPalette/theme.ts
@@ -81,12 +81,16 @@ export function terminalPalettePolarity(
     : "light";
 }
 
+const embeddedStationFallbackTheme = createReadableTerminalPaletteTheme(
+  nativeStationTheme.terminal,
+);
+
 /** Resolves complete embedded palette evidence or the whole built-in fallback theme. */
 export function resolveEmbeddedStationTheme(
   observation: StationTerminalTheme | null | undefined,
 ): StationTheme {
   if (observation === undefined || observation === null) {
-    return nativeStationTheme;
+    return embeddedStationFallbackTheme;
   }
   return createTerminalPaletteTheme(observation);
 }
@@ -100,8 +104,14 @@ export function createTerminalPaletteTheme(
     STATION_TEXT_CONTRAST_RATIO
   ) {
     // Whole-theme fallback prevents terminal surfaces from mixing with unrelated Station roles.
-    return nativeStationTheme;
+    return embeddedStationFallbackTheme;
   }
+  return createReadableTerminalPaletteTheme(observation);
+}
+
+function createReadableTerminalPaletteTheme(
+  observation: StationTerminalTheme,
+): StationTheme {
   const foreground = observation.defaultForeground;
   const background = observation.defaultBackground;
   const defaultForeground = terminalDefaultColor("foreground", foreground);


### PR DESCRIPTION
## What this fixes

The standalone dashboard starts before it has terminal palette evidence. It previously seeded that interval with Station's native RGB canvas, so a real tmux popup visibly painted an explicit background even though embedded mode is required to preserve the terminal-default canvas.

Closes #774.

## What changed

- initialize the embedded theme through the same terminal-default fallback used for absent observations
- derive that fallback through the existing readable-palette construction so all semantic roles remain usable
- preserve the current complete fallback for malformed or low-contrast terminal evidence
- cover initial controller state and fallback behavior directly

## Testing

- 67 focused terminal-palette, controller, and fullscreen-dashboard tests passed
- Station TypeScript check passed
- repository lint and Observer architecture checks passed
- full Station renderer, PTY, Bun PTY, and Host-upgrade lane passed before the conflict-free rebase
- exact real tmux dashboard advanced past the terminal-default background assertion; its later frame comparison is independently tracked by #795

## User-visible behavior

Standalone and popup Station no longer flash or retain Station's RGB canvas before terminal colors are observed. Manually open the popup in a terminal with a non-native background and confirm the dashboard canvas keeps that terminal background from its first frame.

## Safety and scope

This changes only the embedded-theme fallback. Explicit complete terminal observations and native Station theme behavior are unchanged.
