### PR TITLE
fix(codex): accept app-server emission timestamps

### DIFF
--- a/integrations/harness/codex/src/appServer/parse.ts
+++ b/integrations/harness/codex/src/appServer/parse.ts
@@ -10,6 +10,7 @@ const CodexAppServerMessageSchema = z
     method: nonEmptyStringSchema,
     id: requestIdSchema.optional(),
     params: z.unknown().optional(),
+    emittedAtMs: z.number().int().nonnegative().optional(),
   })
   .strict();
 

--- a/integrations/harness/codex/test/unit/appServerEvents.test.ts
+++ b/integrations/harness/codex/test/unit/appServerEvents.test.ts
@@ -341,6 +341,26 @@ describe("Codex app-server event parsing", () => {
       }),
     ).toThrowError(CodexHarnessProviderError);
   });
+
+  it("accepts the current envelope timestamp without weakening strict parsing", () => {
+    const message = {
+      method: "item/completed",
+      emittedAtMs: 1781712000000,
+      params: {
+        threadId: "thr_plan",
+        turnId: "turn_1",
+        item: { id: "item_plan_1", type: "plan" },
+      },
+    };
+
+    expect(parseCodexAppServerEvent(message)).toMatchObject({
+      kind: "item-completed",
+      itemType: "plan",
+    });
+    expect(() => parseCodexAppServerEvent({ ...message, unexpected: true })).toThrowError(
+      CodexHarnessProviderError,
+    );
+  });
 });
 
 function context() {


### PR DESCRIPTION
## What this fixes

Codex app-server now includes an envelope-level emission timestamp. Station's intentionally strict parser rejected that current message shape before it could normalize completed plan items, blocking the real Luna acceptance lane.

Closes #776.

## What changed

- accept optional non-negative integer `emittedAtMs` on the app-server envelope
- keep the envelope strict; unrelated keys still raise the typed provider error
- cover the captured current shape and strict rejection together

## Testing

- Codex app-server event unit tests: 8 passed
- `@station/codex` typecheck
- repository lint and Observer architecture checks

## User-visible behavior

Current Codex plan events can again reach Station attention normalization. Manually run the real Codex app-server plan lane with Luna xhigh and confirm a completed plan item becomes high-confidence plan-approval attention.

## Safety and scope

The timestamp is accepted but not propagated; provider-neutral observations and unknown-key rejection are unchanged.
