### PR TITLE
test(harness): restore real session-create launch fixtures

### DIFF
--- a/tests/agent/real/codex/codex-session-create.test.ts
+++ b/tests/agent/real/codex/codex-session-create.test.ts
@@ -1,9 +1,9 @@
 import { execFile } from "node:child_process";
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { access, chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import { createCodexHarnessProvider } from "@station/codex";
+import { createCodexHarnessProvider, installCodexHooks } from "@station/codex";
 import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 import { writeDebugBundle } from "@station/observability";
 import {
@@ -45,14 +45,43 @@ describeRealCodex("real Codex session.create", () => {
     const root = await mkdtemp(join(tmpdir(), "station-real-codex-"));
     const stateDir = join(root, "state");
     const diagnosticsDir = join(stateDir, "diagnostics");
+    const hookSpoolDir = join(stateDir, "spool", "hooks");
     const worktreePath = join(root, "worktree");
+    const codexHome = join(root, "codex-home");
+    const hookScriptPath = join(stateDir, "hooks", "station-codex-hook.sh");
+    const observerSocketPath = join(root, "observer.sock");
+    const ingressBin = join(process.cwd(), "bin", "stn-ingress");
+    const artifactOwner = {
+      schemaVersion: 1 as const,
+      launcher: ingressBin,
+      runtimeKind: "source" as const,
+      version: "0.0.0-real-test",
+      buildIdentity: "a".repeat(64),
+    };
     const sessionName = `station-codex-${process.pid}-${Date.now()}`;
     const shimLog = join(root, "codex-shim.log");
     const shimPath = join(root, "codex-shim");
     await mkdir(stateDir, { recursive: true });
+    await mkdir(hookSpoolDir, { recursive: true });
     await mkdir(worktreePath, { recursive: true });
+    await mkdir(codexHome, { recursive: true });
     await execFileAsync("git", ["init"], { cwd: worktreePath, timeout: 10_000 });
-    await writeCodexShim({ shimPath, shimLog, realCodexBin: codexBin });
+    await linkCodexAuth(codexHome);
+    const previousCodexHome = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = codexHome;
+    cleanupTasks.push(async () => {
+      if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = previousCodexHome;
+    });
+    await installCodexHooks({
+      hookScriptPath,
+      observerSocketPath,
+      stateDir,
+      hookSpoolDir,
+      hookBin: ingressBin,
+      artifactOwner,
+    });
+    await writeCodexShim({ shimPath, shimLog, realCodexBin: codexBin, codexHome });
 
     cleanupTasks.push(async () => {
       await execFileAsync(tmuxBin, ["kill-session", "-t", sessionName], {
@@ -97,7 +126,13 @@ describeRealCodex("real Codex session.create", () => {
       harnesses: [
         createCodexHarnessProvider({
           command: shimPath,
+          installHooks: true,
+          hookBin: ingressBin,
+          artifactOwner,
           noAltScreen: true,
+          observerSocketPath,
+          stateDir,
+          hookSpoolDir,
           now: () => new Date(now),
         }),
       ],
@@ -142,13 +177,13 @@ describeRealCodex("real Codex session.create", () => {
         },
       });
       await queue.drain();
+      expect(await persistence.getCommand(receipt.commandId)).toMatchObject({
+        status: "succeeded",
+      });
       await waitForShimLog(shimLog);
 
       const snapshot = await pollForCodexRow(core);
 
-      expect(await persistence.getCommand(receipt.commandId)).toMatchObject({
-        status: "succeeded",
-      });
       expect(await readFile(shimLog, "utf8")).toContain("--cd");
       expect(snapshot.rows[0]?.agent).toMatchObject({
         harness: "codex",
@@ -179,19 +214,28 @@ async function writeCodexShim(input: {
   shimPath: string;
   shimLog: string;
   realCodexBin: string;
+  codexHome: string;
 }): Promise<void> {
   const script = `#!/usr/bin/env bash
 set -euo pipefail
+export CODEX_HOME=${JSON.stringify(input.codexHome)}
 {
   printf 'cwd=%s\\n' "$PWD"
   for arg in "$@"; do
     printf 'arg=%s\\n' "$arg"
   done
 } >> ${JSON.stringify(input.shimLog)}
-exec ${JSON.stringify(input.realCodexBin)} "$@"
+exec ${JSON.stringify(input.realCodexBin)} --dangerously-bypass-hook-trust "$@"
 `;
   await writeFile(input.shimPath, script, "utf8");
   await chmod(input.shimPath, 0o755);
+}
+
+async function linkCodexAuth(codexHome: string): Promise<void> {
+  const sourceHome = process.env.CODEX_HOME ?? join(homedir(), ".codex");
+  const source = join(sourceHome, "auth.json");
+  await access(source);
+  await symlink(source, join(codexHome, "auth.json"));
 }
 
 async function waitForShimLog(path: string): Promise<void> {

--- a/tests/agent/real/cursor/cursor-session-create.test.ts
+++ b/tests/agent/real/cursor/cursor-session-create.test.ts
@@ -54,13 +54,41 @@ describeRealCursor("real Cursor session.create launch lane", () => {
     const root = await mkdtemp(join(tmpdir(), "station-real-cursor-"));
     const stateDir = join(root, "state");
     const diagnosticsDir = join(stateDir, "diagnostics");
+    const hookSpoolDir = join(stateDir, "spool", "hooks");
     const worktreePath = join(root, "worktree");
+    const configPath = join(root, "station.config.toml");
+    const cursorHooksPath = join(root, "cursor", "hooks.json");
+    const hookScriptPath = join(stateDir, "hooks", "station-cursor-hook.sh");
+    const observerSocketPath = join(root, "observer.sock");
+    const ingressBin = join(process.cwd(), "bin", "stn-ingress");
     const sessionName = `station-cursor-${process.pid}-${Date.now()}`;
     const shimLog = join(root, "cursor-shim.log");
     const shimPath = join(root, "cursor-shim");
     await mkdir(stateDir, { recursive: true });
+    await mkdir(hookSpoolDir, { recursive: true });
     await mkdir(worktreePath, { recursive: true });
     await execFileAsync("git", ["init"], { cwd: worktreePath, timeout: 10_000 });
+    await writeStationConfigToml({
+      configPath,
+      root,
+      stateDir,
+      socketPath: observerSocketPath,
+    });
+    const previousCursorHooksPath = process.env.STATION_CURSOR_HOOKS_PATH;
+    process.env.STATION_CURSOR_HOOKS_PATH = cursorHooksPath;
+    cleanupTasks.push(async () => {
+      if (previousCursorHooksPath === undefined) delete process.env.STATION_CURSOR_HOOKS_PATH;
+      else process.env.STATION_CURSOR_HOOKS_PATH = previousCursorHooksPath;
+    });
+    await installCursorHooks({
+      cursorHooksPath,
+      hookScriptPath,
+      stationConfigPath: configPath,
+      observerSocketPath,
+      stateDir,
+      hookSpoolDir,
+      hookBin: ingressBin,
+    });
     await writeCursorShim({ shimPath, shimLog, realCursorBin: cursorBin });
 
     cleanupTasks.push(async () => {
@@ -106,6 +134,12 @@ describeRealCursor("real Cursor session.create launch lane", () => {
       harnesses: [
         createCursorHarnessProvider({
           command: shimPath,
+          installHooks: true,
+          hookBin: ingressBin,
+          configPath,
+          observerSocketPath,
+          stateDir,
+          hookSpoolDir,
           now: () => new Date(now),
         }),
       ],
@@ -150,6 +184,9 @@ describeRealCursor("real Cursor session.create launch lane", () => {
         },
       });
       await queue.drain();
+      expect(await persistence.getCommand(receipt.commandId)).toMatchObject({
+        status: "succeeded",
+      });
       const launchLog = await waitForCursorLaunchLog(shimLog);
       const snapshot = await pollForCursorRow(core);
       const pane = await inspectTmuxPane({
@@ -157,9 +194,6 @@ describeRealCursor("real Cursor session.create launch lane", () => {
         targetId: await cursorTargetId(terminal),
       });
 
-      expect(await persistence.getCommand(receipt.commandId)).toMatchObject({
-        status: "succeeded",
-      });
       expect(launchLog).toContain("arg=--workspace");
       expect(launchLog).toContain(`arg=${worktreePath}`);
       expect(launchLog).toContain("env.STATION_HARNESS_PROVIDER=cursor");
@@ -513,7 +547,7 @@ async function cursorTargetId(terminal: TmuxProvider): Promise<string> {
 }
 
 function tmuxPaneId(targetId: string): string {
-  const [provider, _sessionId, _windowId, paneId, ...extra] = targetId.split(":");
+  const [provider, _generation, _sessionId, _windowId, paneId, ...extra] = targetId.split(":");
   if (provider !== "tmux" || paneId === undefined || extra.length > 0) {
     throw new Error(`Invalid tmux target id: ${targetId}`);
   }

--- a/tests/agent/real/opencode/opencode-session-create.test.ts
+++ b/tests/agent/real/opencode/opencode-session-create.test.ts
@@ -115,6 +115,8 @@ describeRealOpenCode("real OpenCode session.create", () => {
       harnesses: [
         createOpenCodeHarnessProvider({
           command: shimPath,
+          installHooks: true,
+          env: { OPENCODE_CONFIG_DIR: opencodeConfigDir },
           configPath,
           observerSocketPath: join(root, "observer.sock"),
           stateDir,
@@ -163,12 +165,12 @@ describeRealOpenCode("real OpenCode session.create", () => {
         },
       });
       await queue.drain();
-      const launchLog = await waitForOpenCodeLaunchLog(shimLog);
-      const snapshot = await pollForOpenCodeRow(core);
-
       expect(await persistence.getCommand(receipt.commandId)).toMatchObject({
         status: "succeeded",
       });
+      const launchLog = await waitForOpenCodeLaunchLog(shimLog);
+      const snapshot = await pollForOpenCodeRow(core);
+
       expect(launchLog).toContain("env.STATION_HARNESS_PROVIDER=opencode");
       expect(launchLog).toContain("env.STATION_SESSION_ID=ses_real_opencode_session");
       expect(launchLog).toContain("env.STATION_OBSERVER_SOCKET_PATH=");


### PR DESCRIPTION
## What this fixes\n\nThe real Codex, Cursor, and OpenCode session-create lanes stopped before launching because their fixtures no longer satisfied current hook readiness checks. That made provider launch behavior indistinguishable from stale test setup and blocked the acceptance matrix.\n\n## What changed\n\n- installs each provider hook or plugin into a private temporary runtime\n- points provider preflight at the same isolated hook paths and enables hook checks\n- gives Codex a private authenticated home without copying credentials\n- accepts generation-qualified tmux target IDs in the Cursor fixture\n- asserts command success before waiting for launch output\n\n## Testing\n\n- all package typechecks\n- Biome and architecture checks\n- focused real Codex session-create launch\n- focused real Cursor session-create launch\n- focused real OpenCode session-create launch\n\nCloses #775