### PR TITLE
test(harness): compose real event ingress fixtures

### DIFF
--- a/tests/agent/real/cursor/cursor-session-create.test.ts
+++ b/tests/agent/real/cursor/cursor-session-create.test.ts
@@ -4,7 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
-import { createCursorHarnessProvider, installCursorHooks } from "@station/cursor";
+import {
+  createCursorHarnessProvider,
+  cursorHookAdapter,
+  installCursorHooks,
+} from "@station/cursor";
 import { writeDebugBundle } from "@station/observability";
 import {
   collectDiagnosticSnapshot,
@@ -277,6 +281,7 @@ describeRealCursor("real Cursor session.create launch lane", () => {
     }
     testConfig.observer.socketPath = socketPath;
     const providers = new ProviderRegistry({
+      hookAdapters: [cursorHookAdapter],
       worktree: new FakeWorktreeProvider({
         now,
         worktrees: [
@@ -345,6 +350,29 @@ describeRealCursor("real Cursor session.create launch lane", () => {
 
     try {
       await core.reconcile("real-cursor-hook-initial");
+      const hookEnv = {
+        STATION_PROJECT_ID: "web",
+        STATION_WORKTREE_ID: "wt_real_cursor_hook",
+        STATION_WORKTREE_PATH: worktreePath,
+        STATION_SESSION_ID: "ses_real_cursor_hook",
+        STATION_HARNESS_PROVIDER: "cursor",
+        STATION_TERMINAL_PROVIDER: "tmux",
+        STATION_TERMINAL_TARGET_ID: "real-cursor-hook-target",
+        STATION_CONFIG_PATH: configPath,
+        STATION_OBSERVER_SOCKET_PATH: socketPath,
+        STATION_HOOK_SPOOL_DIR: hookSpoolDir,
+      };
+      expect(
+        await runHookScript(
+          hookScriptPath,
+          JSON.stringify({
+            hook_event_name: "sessionStart",
+            cwd: worktreePath,
+            session_id: "cursor_session_real",
+          }),
+          hookEnv,
+        ),
+      ).toEqual({ code: 0, stdout: "", stderr: "" });
       const result = await runHookScript(
         hookScriptPath,
         JSON.stringify({
@@ -353,21 +381,11 @@ describeRealCursor("real Cursor session.create launch lane", () => {
           cwd: worktreePath,
           session_id: "cursor_session_real",
         }),
-        {
-          STATION_PROJECT_ID: "web",
-          STATION_WORKTREE_ID: "wt_real_cursor_hook",
-          STATION_WORKTREE_PATH: worktreePath,
-          STATION_SESSION_ID: "ses_real_cursor_hook",
-          STATION_HARNESS_PROVIDER: "cursor",
-          STATION_TERMINAL_PROVIDER: "tmux",
-          STATION_TERMINAL_TARGET_ID: "real-cursor-hook-target",
-          STATION_CONFIG_PATH: configPath,
-          STATION_OBSERVER_SOCKET_PATH: socketPath,
-          STATION_HOOK_SPOOL_DIR: hookSpoolDir,
-        },
+        hookEnv,
       );
 
       expect(result).toEqual({ code: 0, stdout: "", stderr: "" });
+      await api.reconcile("real-cursor-hook-ingress");
       const snapshot = await core.reconcile("real-cursor-hook-observed");
       expect(snapshot.rows[0]?.agent).toMatchObject({
         harness: "cursor",

--- a/tests/agent/real/opencode/opencode-event-capture.test.ts
+++ b/tests/agent/real/opencode/opencode-event-capture.test.ts
@@ -16,7 +16,11 @@ import {
   ProviderRegistry,
   startObserverServer,
 } from "@station/observer/internal";
-import { createOpenCodeHarnessProvider, installOpenCodePlugin } from "@station/opencode";
+import {
+  createOpenCodeHarnessProvider,
+  installOpenCodePlugin,
+  openCodeHookAdapter,
+} from "@station/opencode";
 import {
   createFakeTerminalTarget,
   createFakeWorktree,
@@ -76,6 +80,7 @@ describeRealOpenCode("real OpenCode event capture", () => {
     const persistence = createSqliteObserverPersistence({ sqlite, clock, idFactory });
     const eventBus = createObserverEventBus();
     const providers = new ProviderRegistry({
+      hookAdapters: [openCodeHookAdapter],
       worktree: new FakeWorktreeProvider({
         now,
         worktrees: [
@@ -161,6 +166,7 @@ describeRealOpenCode("real OpenCode event capture", () => {
           STATION_WORKTREE_PATH: worktreePath,
           STATION_SESSION_ID: "ses_real_opencode",
           STATION_HARNESS_PROVIDER: "opencode",
+          STATION_INGRESS_BIN: join(process.cwd(), "bin", "stn-ingress"),
           STATION_TERMINAL_PROVIDER: "tmux",
           STATION_TERMINAL_TARGET_ID: "real-opencode-target",
           STATION_OBSERVER_SOCKET_PATH: socketPath,
@@ -171,6 +177,7 @@ describeRealOpenCode("real OpenCode event capture", () => {
       });
 
       expect(run.exitCode, run.stderr).toBe(0);
+      await api.reconcile("real-opencode-completion-spool");
       const observation = await pollForOpenCodeStatusObservation(persistence);
       expect(observation.payload).toMatchObject({
         provider: "opencode",
@@ -180,7 +187,6 @@ describeRealOpenCode("real OpenCode event capture", () => {
           source: "harness_event",
         }),
       });
-      await api.reconcile("real-opencode-completion-spool");
       await pollForOpenCodeReadiness(persistence);
       const snapshot = await core.reconcile("real-opencode-observed");
       expect(snapshot.rows[0]?.agent).toMatchObject({

--- a/tests/agent/real/pi/pi-session-create.test.ts
+++ b/tests/agent/real/pi/pi-session-create.test.ts
@@ -18,7 +18,7 @@ import {
   registerObserverCommandHandlers,
   startObserverServer,
 } from "@station/observer/internal";
-import { createPiHarnessProvider } from "@station/pi";
+import { createPiHarnessProvider, piHookAdapter } from "@station/pi";
 import { stationObserverBuildVersion } from "@station/runtime";
 import {
   createFakeTerminalTarget,
@@ -257,6 +257,7 @@ describeRealPi("real Pi session.create launch lane", () => {
       socketPath,
     };
     const providers = new ProviderRegistry({
+      hookAdapters: [piHookAdapter],
       worktree: new FakeWorktreeProvider({
         now,
         worktrees: [
@@ -349,6 +350,7 @@ describeRealPi("real Pi session.create launch lane", () => {
       });
 
       expect(run.exitCode, run.stderr).toBe(0);
+      await api.reconcile("real-pi-callback-ingress");
       const settledObservation = await pollForPiSettlement(persistence);
       const observations = await persistence.listProviderObservations();
       const piObservations = observations.filter(


### PR DESCRIPTION
## What this fixes

The real Cursor, Pi, and OpenCode event-ingress gates did not compose the same adapter and queue boundaries used by the Observer, so accepted provider events could not become provider observations during the tests.

## What changed

- register each providers production hook adapter in its real fixture
- drain the public Observer reconcile queue before asserting persisted observations
- model the Cursor start-to-stop lifecycle instead of using a completion event to establish an idle execution
- route OpenCode through the exact isolated stn-ingress binary

## Testing

- real Cursor hook ingress: pass
- real Pi settled-turn ingress: pass
- real OpenCode plugin ingress: pass
- typecheck: 46/46 tasks pass
- Biome on all three files: pass

Closes #777
Closes #778
Closes #779