### PR TITLE
chore(release): prepare pre-alpha.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Station gives every agent an isolated Git worktree, keeps its terminal session a
 ## Install
 
 Station is experimental pre-alpha software. Install the current public version,
-`v0.0.0-pre-alpha.9`, with one command:
+`v0.0.0-pre-alpha.10`, with one command:
 
 ```sh
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.9/install.sh | sh
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.10/install.sh | sh
 ```
 
 Then complete and verify first-run setup:
@@ -125,11 +125,11 @@ Paste this prompt into a coding agent running on the machine where you want
 Station installed:
 
 ```text
-Install experimental Station v0.0.0-pre-alpha.9 and validate setup on this machine.
+Install experimental Station v0.0.0-pre-alpha.10 and validate setup on this machine.
 
 Safety and scope:
 - Do not clone the repository or build from source. Use only
-  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.9/install.sh`.
+  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.10/install.sh`.
 - Install to `~/.local/bin` unless I approve another location. Do not edit any
   shell startup file. If the installer reports a PATH mismatch, do not assume
   an export persists across agent tool calls or reaches my Terminal. Use the
@@ -208,7 +208,7 @@ or real-agent lanes.
 
 ## Release status
 
-Station `v0.0.0-pre-alpha.9` is an experimental pre-alpha. User-facing commands,
+Station `v0.0.0-pre-alpha.10` is an experimental pre-alpha. User-facing commands,
 configuration, state, and release packaging may change without compatibility.
 The old `v0.7.1-rc.*` releases were internal previews, not predecessors in the
 public version line. Report feedback and bugs through

--- a/apps/cli/test/integration/codex-hooks-command.test.ts
+++ b/apps/cli/test/integration/codex-hooks-command.test.ts
@@ -800,7 +800,7 @@ function artifactOwner(launcher: string, runtimeKind: "compiled" | "source", dig
     schemaVersion: 1 as const,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.9",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.10",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/integration/installer-binary-update.test.ts
+++ b/apps/cli/test/integration/installer-binary-update.test.ts
@@ -24,7 +24,7 @@ import type { NativeBinaryRelease } from "../../src/update/githubRelease.js";
 import { createInstallerBinaryUpdateChannel } from "../../src/update/installerBinaryUpdate.js";
 
 const CURRENT_TAG = "v0.7.1-rc.8";
-const TARGET_TAG = "v0.0.0-pre-alpha.9";
+const TARGET_TAG = "v0.0.0-pre-alpha.10";
 const RECEIPT = "station-installer-binary-v1\n";
 const tempRoots: string[] = [];
 

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -136,7 +136,7 @@ describe("CLI manual-smoke commands", () => {
       "--version",
     ]);
 
-    expect(direct).toEqual({ code: 0, output: "0.0.0-pre-alpha.9", outputFormat: "text" });
+    expect(direct).toEqual({ code: 0, output: "0.0.0-pre-alpha.10", outputFormat: "text" });
     expect(withMissingConfig).toEqual(direct);
   });
 

--- a/apps/cli/test/integration/popup-command.test.ts
+++ b/apps/cli/test/integration/popup-command.test.ts
@@ -15,7 +15,7 @@ import { createTempState, writeConfigToml } from "../../../../tests/support/temp
 const now = "2026-05-20T12:00:00.000Z";
 const buildIdentity = "a".repeat(64);
 const observerBuildVersion = `0.0.0-local+station.${buildIdentity}`;
-const higherObserverBuildVersion = `0.0.0-pre-alpha.9+station.${buildIdentity}`;
+const higherObserverBuildVersion = `0.0.0-pre-alpha.10+station.${buildIdentity}`;
 const tuiObserverBuildMismatchError = {
   tag: "TuiCommandError",
   code: "TUI_OBSERVER_BUILD_MISMATCH",

--- a/apps/cli/test/integration/provider-hook-ownership.test.ts
+++ b/apps/cli/test/integration/provider-hook-ownership.test.ts
@@ -241,7 +241,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.9",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.10",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -171,7 +171,7 @@ describe("CLI setup command", () => {
       schemaVersion: 1 as const,
       launcher: join(root, "source", "bin", "stn-ingress"),
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.9",
+      version: "0.0.0-pre-alpha.10",
       buildIdentity: "a".repeat(64),
     };
     const current = {

--- a/apps/cli/test/integration/tui-command.test.ts
+++ b/apps/cli/test/integration/tui-command.test.ts
@@ -19,7 +19,7 @@ import { resolveStationWorkspaceDir } from "../../src/stationWorkspace.js";
 const now = "2026-05-20T12:00:00.000Z";
 const buildIdentity = "a".repeat(64);
 const observerBuildVersion = `0.0.0-local+station.${buildIdentity}`;
-const higherObserverBuildVersion = `0.0.0-pre-alpha.9+station.${buildIdentity}`;
+const higherObserverBuildVersion = `0.0.0-pre-alpha.10+station.${buildIdentity}`;
 const nestedTuiDisabledError = {
   tag: "TuiCommandError",
   code: "NESTED_TUI_DISABLED",

--- a/apps/cli/test/integration/worktrunk-hooks-command.test.ts
+++ b/apps/cli/test/integration/worktrunk-hooks-command.test.ts
@@ -352,7 +352,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.9",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.10",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/unit/installer-binary-update.test.ts
+++ b/apps/cli/test/unit/installer-binary-update.test.ts
@@ -30,7 +30,7 @@ import {
 
 const CURRENT_TAG = "v0.7.1-rc.8";
 const CURRENT_VERSION = CURRENT_TAG.slice(1);
-const TARGET_TAG = "v0.0.0-pre-alpha.9";
+const TARGET_TAG = "v0.0.0-pre-alpha.10";
 const TARGET_VERSION = TARGET_TAG.slice(1);
 const TARGETS = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"] as const;
 const RECEIPT = "station-installer-binary-v1\n";

--- a/apps/cli/test/unit/observer-process/activation-surfacing.test.ts
+++ b/apps/cli/test/unit/observer-process/activation-surfacing.test.ts
@@ -17,7 +17,7 @@ import { createTempState } from "../../../../../tests/support/temp-projects";
 
 const now = "2026-05-20T12:00:00.000Z";
 const sourceBuildVersion = `0.0.0-pre-alpha.4+station.${"e".repeat(64)}`;
-const compiledBuildVersion = `0.0.0-pre-alpha.9+station.${"d".repeat(64)}`;
+const compiledBuildVersion = `0.0.0-pre-alpha.10+station.${"d".repeat(64)}`;
 
 const bootReason = "FATAL: socket owned by foreign build dbf7f368";
 

--- a/apps/cli/test/unit/observer-process/setup-observer-activation.test.ts
+++ b/apps/cli/test/unit/observer-process/setup-observer-activation.test.ts
@@ -15,7 +15,7 @@ vi.mock("../../../src/observerProcess.js", async (importActual) => {
 });
 
 const now = "2026-05-20T12:00:00.000Z";
-const compiledBuildVersion = `0.0.0-pre-alpha.9+station.${"d".repeat(64)}`;
+const compiledBuildVersion = `0.0.0-pre-alpha.10+station.${"d".repeat(64)}`;
 
 restartObserverSpy.mockImplementation(async () => ({
   status: "running",

--- a/apps/cli/test/unit/setup-json-presenter.test.ts
+++ b/apps/cli/test/unit/setup-json-presenter.test.ts
@@ -269,7 +269,7 @@ describe("setup plan projection", () => {
       schemaVersion: 1 as const,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.9",
+      version: "0.0.0-pre-alpha.10",
       buildIdentity: "a".repeat(64),
     };
     const current = {

--- a/apps/observer/test/unit/observerHandoff.test.ts
+++ b/apps/observer/test/unit/observerHandoff.test.ts
@@ -71,7 +71,7 @@ describe("classifyObserverBuildPrecedence", () => {
   });
 
   it("orders the public pre-alpha after the internal preview version line", () => {
-    const publicPreAlpha = observerBuildVersion("0.0.0-pre-alpha.9", higherBuildIdentity);
+    const publicPreAlpha = observerBuildVersion("0.0.0-pre-alpha.10", higherBuildIdentity);
     const internalPreview = observerBuildVersion("0.7.1-rc.8", lowerBuildIdentity);
 
     expect(precedenceFor(publicPreAlpha, internalPreview)).toEqual({
@@ -83,7 +83,7 @@ describe("classifyObserverBuildPrecedence", () => {
   });
 
   it("orders the next public pre-alpha epoch after the prior release", () => {
-    const nextEpoch = observerBuildVersion("0.0.0-pre-alpha.9", higherBuildIdentity);
+    const nextEpoch = observerBuildVersion("0.0.0-pre-alpha.10", higherBuildIdentity);
     const priorRelease = observerBuildVersion("0.0.0-pre-alpha.7", lowerBuildIdentity);
 
     expect(precedenceFor(nextEpoch, priorRelease)).toEqual({

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ can use it or help improve it.
 
 > [!IMPORTANT]
 > Station is experimental pre-alpha software. The current public version is
-> `v0.0.0-pre-alpha.9`. Native binaries support macOS 13+ and glibc 2.39+ Linux
+> `v0.0.0-pre-alpha.10`. Native binaries support macOS 13+ and glibc 2.39+ Linux
 > on arm64 and x64.
 
 ## Start Here
@@ -26,7 +26,7 @@ Choose the path that matches what you want to do:
 Install the current release:
 
 ```sh
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.9/install.sh | sh
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.10/install.sh | sh
 ```
 
 Then complete and verify setup:

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -10,7 +10,7 @@ only with explicit `stn update --drive-package-manager`; it does not install a
 tap, formula, or cask.
 
 The public installation path for experimental pre-alpha
-`v0.0.0-pre-alpha.9` is the exact-tag native installer documented in
+`v0.0.0-pre-alpha.10` is the exact-tag native installer documented in
 [Install Station](install.md). Do not use the historical tap for public
 onboarding, and do not update it as part of pre-alpha publication.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,7 +1,7 @@
 # Install Station
 
 Station is experimental pre-alpha software. The current public version is
-`v0.0.0-pre-alpha.9`.
+`v0.0.0-pre-alpha.10`.
 
 ## Binary Requirements
 
@@ -32,11 +32,11 @@ If you prefer an agent-led install, paste this prompt into a coding agent on the
 target machine:
 
 ```text
-Install experimental Station v0.0.0-pre-alpha.9 and validate setup on this machine.
+Install experimental Station v0.0.0-pre-alpha.10 and validate setup on this machine.
 
 Safety and scope:
 - Do not clone the repository or build from source. Use only
-  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.9/install.sh`.
+  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.10/install.sh`.
 - Install to `~/.local/bin` unless I approve another location. Do not edit any
   shell startup file. If the installer reports a PATH mismatch, do not assume
   an export persists across agent tool calls or reaches my Terminal. Use the
@@ -70,10 +70,10 @@ choices.
 From any directory, run:
 
 ```bash
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.9/install.sh | sh
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.10/install.sh | sh
 ```
 
-The released `install.sh` is stamped with `v0.0.0-pre-alpha.9`. With no
+The released `install.sh` is stamped with `v0.0.0-pre-alpha.10`. With no
 arguments it downloads only that tag's matching native archive and
 `SHA256SUMS` over unauthenticated HTTPS. The old `v0.7.1-rc.*` releases were
 internal previews, not predecessors in the public version line.
@@ -137,7 +137,7 @@ it separately.
 Pass an absolute or home-relative path through the exact installer:
 
 ```bash
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.9/install.sh | \
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.10/install.sh | \
   sh -s -- --install-dir "$HOME/bin"
 ```
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,6 +1,6 @@
 # Limitations and Workarounds
 
-Station `v0.0.0-pre-alpha.9` is experimental pre-alpha software. This page
+Station `v0.0.0-pre-alpha.10` is experimental pre-alpha software. This page
 lists user-visible constraints and the available operational workaround for
 each one.
 

--- a/integrations/harness/claude/test/unit/hooks.test.ts
+++ b/integrations/harness/claude/test/unit/hooks.test.ts
@@ -354,7 +354,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.9",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.10",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/cursor/test/unit/hooks.test.ts
+++ b/integrations/harness/cursor/test/unit/hooks.test.ts
@@ -419,7 +419,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.9",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.10",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/opencode/test/unit/pluginInstall.test.ts
+++ b/integrations/harness/opencode/test/unit/pluginInstall.test.ts
@@ -643,7 +643,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.9",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.10",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/opencode/test/unit/provider.test.ts
+++ b/integrations/harness/opencode/test/unit/provider.test.ts
@@ -301,7 +301,7 @@ describe("OpenCodeHarnessProvider", () => {
       schemaVersion: 1 as const,
       launcher: join(root, "requester", "bin", "stn-ingress"),
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.9",
+      version: "0.0.0-pre-alpha.10",
       buildIdentity: "a".repeat(64),
     };
 

--- a/integrations/worktree/worktrunk/test/unit/hooks.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/hooks.test.ts
@@ -266,7 +266,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.9",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.10",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "station",
-  "version": "0.0.0-pre-alpha.9",
+  "version": "0.0.0-pre-alpha.10",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -122,7 +122,7 @@ describe("contract schemas", () => {
       schemaVersion: 1,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source",
-      version: "0.0.0-pre-alpha.9",
+      version: "0.0.0-pre-alpha.10",
       buildIdentity: "a".repeat(64),
     } as const;
     const current = {

--- a/packages/contracts/test/schema/diagnostics-schema.test.ts
+++ b/packages/contracts/test/schema/diagnostics-schema.test.ts
@@ -238,7 +238,7 @@ describe("diagnostics schemas", () => {
         schemaVersion: 1,
         launcher: "/checkout/station/bin/stn-ingress",
         runtimeKind: "source",
-        version: "0.0.0-pre-alpha.9",
+        version: "0.0.0-pre-alpha.10",
         buildIdentity: "a".repeat(64),
       },
     };

--- a/packages/harness-shared/test/unit/provider.test.ts
+++ b/packages/harness-shared/test/unit/provider.test.ts
@@ -146,7 +146,7 @@ describe("createTerminalBoundHarnessProvider", () => {
       schemaVersion: 1 as const,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.9",
+      version: "0.0.0-pre-alpha.10",
       buildIdentity: "a".repeat(64),
     };
 

--- a/packages/protocol/src/client.ts
+++ b/packages/protocol/src/client.ts
@@ -12,7 +12,15 @@ import type {
   StationEvent,
   TerminalCallerContextRequest,
 } from "@station/contracts";
-import { STATION_SCHEMA_VERSION, StationEventSchema } from "@station/contracts";
+import {
+  ObserverHealthSchema,
+  ObserverStopReceiptSchema,
+  ProviderHealthSchema,
+  ProviderIdSchema,
+  SessionRecoveryReadinessSchema,
+  STATION_SCHEMA_VERSION,
+  StationEventSchema,
+} from "@station/contracts";
 import { Effect, isSafeError, runRuntimeBoundaryWithTimeout } from "@station/runtime";
 import { z } from "zod";
 import {
@@ -70,7 +78,7 @@ export type CreateObserverClientOptions = {
   expectedBuildVersion?: string;
   /** Exact process identity required before an ownership-changing operation. */
   expectedObserverIdentity?: ExpectedObserverIdentity;
-  /** Negotiates the immediately previous schema for health and stop during an upgrade crossover. */
+  /** Negotiates the immediately previous schema for health, readiness, and stop during an upgrade crossover. */
   acceptPreviousLifecycleSchema?: boolean;
   /** Receives content-free metrics after each physical connection settles. */
   onConnectionDiagnostics?: (diagnostics: NdjsonTransportDiagnostics) => void;
@@ -106,7 +114,7 @@ const PreviousLifecycleSuccessResponseSchema = z
     schemaVersion: z.literal(PREVIOUS_LIFECYCLE_SCHEMA_VERSION),
     jsonrpc: JsonRpcVersionSchema,
     id: z.string().min(1),
-    result: z.object({ schemaVersion: z.literal(PREVIOUS_LIFECYCLE_SCHEMA_VERSION) }).passthrough(),
+    result: z.unknown(),
   })
   .strict();
 const PreviousLifecycleErrorResponseSchema = z
@@ -117,6 +125,38 @@ const PreviousLifecycleErrorResponseSchema = z
     error: z.unknown(),
   })
   .strict();
+const PreviousProviderHealthSchema = ProviderHealthSchema.omit({ provider: true }).extend({
+  providerId: ProviderIdSchema,
+});
+const PreviousObserverHealthSchema = ObserverHealthSchema.omit({
+  schemaVersion: true,
+  providerHealth: true,
+})
+  .extend({
+    schemaVersion: z.literal(PREVIOUS_LIFECYCLE_SCHEMA_VERSION),
+    providerHealth: z.record(ProviderIdSchema, PreviousProviderHealthSchema).optional(),
+  })
+  .transform(({ schemaVersion: _schemaVersion, providerHealth, ...health }) => {
+    const normalizedProviderHealth =
+      providerHealth === undefined
+        ? undefined
+        : Object.fromEntries(
+            Object.entries(providerHealth).map(([providerId, entry]) => {
+              const { providerId: _legacyProviderId, ...provider } = entry;
+              return [providerId, { ...provider, provider: providerId }];
+            }),
+          );
+    return {
+      ...health,
+      schemaVersion: STATION_SCHEMA_VERSION,
+      ...(normalizedProviderHealth === undefined
+        ? {}
+        : { providerHealth: normalizedProviderHealth }),
+    };
+  });
+const PreviousObserverStopReceiptSchema = ObserverStopReceiptSchema.omit({
+  schemaVersion: true,
+}).extend({ schemaVersion: z.literal(PREVIOUS_LIFECYCLE_SCHEMA_VERSION) });
 
 /**
  * ADAPTER
@@ -266,7 +306,9 @@ async function requestProtocolMethod<TMethod extends ProtocolMethod>(
     method === "observer.health" ? undefined : resolveExpectedObserver(options);
   const acceptPreviousLifecycleSchema =
     options.acceptPreviousLifecycleSchema === true &&
-    (method === "observer.health" || method === "observer.stop");
+    (method === "observer.health" ||
+      method === "session.recoveryReadiness" ||
+      method === "observer.stop");
   const result = await runRuntimeBoundaryWithTimeout(
     protocolClientBoundary(method, requestTimeoutMs(options)),
     async ({ signal }) => {
@@ -698,10 +740,12 @@ function parseProtocolResponseMessage(
 function normalizePreviousLifecycleResponse(message: unknown): ProtocolResponse | undefined {
   const success = PreviousLifecycleSuccessResponseSchema.safeParse(message);
   if (success.success) {
+    const result = normalizePreviousLifecycleResult(success.data.result);
+    if (result === undefined) return undefined;
     const normalized = ProtocolResponseSchema.safeParse({
       ...success.data,
       schemaVersion: STATION_SCHEMA_VERSION,
-      result: { ...success.data.result, schemaVersion: STATION_SCHEMA_VERSION },
+      result,
     });
     return normalized.success ? normalized.data : undefined;
   }
@@ -712,6 +756,22 @@ function normalizePreviousLifecycleResponse(message: unknown): ProtocolResponse 
     schemaVersion: STATION_SCHEMA_VERSION,
   });
   return normalized.success ? normalized.data : undefined;
+}
+
+function normalizePreviousLifecycleResult(result: unknown): unknown | undefined {
+  const health = PreviousObserverHealthSchema.safeParse(result);
+  if (health.success) return ObserverHealthSchema.parse(health.data);
+
+  const stop = PreviousObserverStopReceiptSchema.safeParse(result);
+  if (stop.success) {
+    return ObserverStopReceiptSchema.parse({
+      ...stop.data,
+      schemaVersion: STATION_SCHEMA_VERSION,
+    });
+  }
+
+  const readiness = SessionRecoveryReadinessSchema.safeParse(result);
+  return readiness.success ? readiness.data : undefined;
 }
 
 function parseProtocolEventEnvelope(message: unknown) {

--- a/packages/protocol/test/integration/client-server.test.ts
+++ b/packages/protocol/test/integration/client-server.test.ts
@@ -1079,6 +1079,107 @@ describe("protocol client/server", () => {
     }
   });
 
+  it("normalizes previous health provider IDs and readiness responses", async () => {
+    const { socketPath } = await createTempSocketPath();
+    const previousRequestSchema = z
+      .object({
+        schemaVersion: z.literal("0.11.0"),
+        jsonrpc: z.literal("2.0"),
+        id: z.string().min(1),
+        method: z.enum(["observer.health", "session.recoveryReadiness", "observer.stop"]),
+      })
+      .strict();
+    const legacyHealth = {
+      schemaVersion: "0.11.0",
+      status: "healthy",
+      pid: 42,
+      startedAt: protocolTestNow,
+      version: "0.0.0",
+      providerHealth: {
+        tmux: {
+          providerId: "tmux",
+          providerType: "terminal",
+          status: "healthy",
+          lastCheckedAt: protocolTestNow,
+        },
+      },
+    } as const;
+    const readiness = {
+      resumeEnabled: true,
+      canonicalTitleImport: true,
+      managedTerminal: { provider: "native", canLaunchProcessPersistently: true },
+      harnesses: [],
+    } as const;
+    const legacyStop = {
+      schemaVersion: "0.11.0",
+      stopped: true,
+      at: protocolTestNow,
+    } as const;
+    let connectionCount = 0;
+    const server = await listenUnixSocket({
+      socketPath,
+      onConnection: async (connection) => {
+        connectionCount += 1;
+        const iterator = connection.messages()[Symbol.asyncIterator]();
+        const request = (await iterator.next()).value;
+        if (connectionCount % 2 === 1) {
+          const currentRequest = ProtocolRequestSchema.parse(request);
+          connection.send({
+            schemaVersion: "0.11.0",
+            jsonrpc: "2.0",
+            id: currentRequest.id,
+            error: {
+              tag: "ProtocolError",
+              code: "PROTOCOL_ERROR",
+              message: "Invalid protocol request.",
+            },
+          });
+          return;
+        }
+
+        const previousRequest = previousRequestSchema.parse(request);
+        connection.send({
+          schemaVersion: "0.11.0",
+          jsonrpc: "2.0",
+          id: previousRequest.id,
+          result:
+            previousRequest.method === "observer.health"
+              ? legacyHealth
+              : previousRequest.method === "observer.stop"
+                ? legacyStop
+                : readiness,
+        });
+      },
+    });
+    const client = createObserverClient({
+      socketPath,
+      acceptPreviousLifecycleSchema: true,
+    });
+
+    try {
+      await expect(client.health()).resolves.toEqual({
+        ...legacyHealth,
+        schemaVersion: STATION_SCHEMA_VERSION,
+        providerHealth: {
+          tmux: {
+            provider: "tmux",
+            providerType: "terminal",
+            status: "healthy",
+            lastCheckedAt: protocolTestNow,
+          },
+        },
+      });
+      await expect(client.getSessionRecoveryReadiness()).resolves.toEqual(readiness);
+      await expect(client.stop()).resolves.toEqual({
+        ...legacyStop,
+        schemaVersion: STATION_SCHEMA_VERSION,
+      });
+      expect(connectionCount).toBe(6);
+    } finally {
+      await server.close();
+    }
+  });
+
   it("checks legacy process health and stops it on one connection", async () => {
     const { socketPath } = await createTempSocketPath();
     const expectedObserverIdentity = {

--- a/packages/runtime/src/buildInfo.ts
+++ b/packages/runtime/src/buildInfo.ts
@@ -28,7 +28,7 @@ export type StationBuildInfo = {
 export function stationBuildInfo(): StationBuildInfo {
   return {
     version:
-      typeof STATION_BUILD_VERSION === "undefined" ? "0.0.0-pre-alpha.9" : STATION_BUILD_VERSION,
+      typeof STATION_BUILD_VERSION === "undefined" ? "0.0.0-pre-alpha.10" : STATION_BUILD_VERSION,
     compiled: isCompiledBinary(),
     buildIdentity:
       typeof STATION_BUILD_IDENTITY === "undefined"

--- a/packages/runtime/test/unit/buildInfo.test.ts
+++ b/packages/runtime/test/unit/buildInfo.test.ts
@@ -34,14 +34,14 @@ describe("station build info", () => {
     expect(isCompiledBinary()).toBe(false);
     expect(verifyBuildIdentity).not.toHaveBeenCalled();
     expect(stationBuildInfo()).toEqual({
-      version: "0.0.0-pre-alpha.9",
+      version: "0.0.0-pre-alpha.10",
       compiled: false,
       buildIdentity,
     });
-    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.9+station.${buildIdentity}`);
-    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.9+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.10+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.10+station.${buildIdentity}`);
     expect(stationBuildInfo()).toEqual({
-      version: "0.0.0-pre-alpha.9",
+      version: "0.0.0-pre-alpha.10",
       compiled: false,
       buildIdentity,
     });

--- a/scripts/test-runners/run-update-smoke.mjs
+++ b/scripts/test-runners/run-update-smoke.mjs
@@ -397,7 +397,11 @@ async function runScenario(input) {
     );
     diagnostics.observerPid = incumbentObserver.pid;
     await recordProcessIdentity(processIdentities, "incumbent-observer", incumbentObserver.pid);
-    observerClient = createObserverClient({ socketPath, timeoutMs: 5000 });
+    observerClient = createObserverClient({
+      socketPath,
+      timeoutMs: 5000,
+      acceptPreviousLifecycleSchema: true,
+    });
 
     if (input.busyHost) {
       incumbentHostProcess = spawn(
@@ -1005,6 +1009,7 @@ async function captureDryRunState(input) {
     socketPath: input.socketPath,
     timeoutMs: 5000,
     expectedBuildVersion: input.observerBuildVersion,
+    acceptPreviousLifecycleSchema: true,
   });
   const observerHealth = await observer.health();
   const observerIdentity = {

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -79,9 +79,9 @@ describe("release readiness docs", () => {
         "let your agent install and validate station",
       );
       expect(prompt).toContain(
-        "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.9/install.sh",
+        "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.10/install.sh",
       );
-      expect(prompt).toContain("v0.0.0-pre-alpha.9");
+      expect(prompt).toContain("v0.0.0-pre-alpha.10");
       expect(prompt).toContain("stn setup check --json");
       expect(prompt).toContain("stn doctor");
       expect(prompt).toContain("summary.requiredOk: true");
@@ -236,9 +236,9 @@ describe("release readiness docs", () => {
       ].map(read),
     );
     const packageJson = await readPackageManifest();
-    const exactVersion = "v0.0.0-pre-alpha.9";
+    const exactVersion = "v0.0.0-pre-alpha.10";
     const exactInstallerUrl =
-      "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.9/install.sh";
+      "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.10/install.sh";
 
     for (const [path, document] of [
       ["README.md", readme],
@@ -373,7 +373,7 @@ describe("release readiness docs", () => {
       expect(promote).toContain(target);
     }
 
-    expect(packageJson.version).toBe("0.0.0-pre-alpha.9");
+    expect(packageJson.version).toBe("0.0.0-pre-alpha.10");
     expect(packageJson.scripts["smoke:install"]).toBe(
       "node scripts/test-runners/run-install-smoke.mjs",
     );


### PR DESCRIPTION
## What this fixes
The `.8.2` predecessor exposes the `.11` lifecycle schema while current Station expects `.12`. That blocked exact predecessor update crossover because health, readiness, and stop responses were rejected at the protocol boundary.

## What changed
- Roll the release version and all checked-in release fixtures/docs to `0.0.0-pre-alpha.10`.
- Accept the immediately previous lifecycle schema during explicit update/restart crossover.
- Normalize predecessor provider health from `providerId` to the current `provider` contract and normalize readiness/stop receipts.
- Opt the update-smoke lifecycle and dry-run probes into the existing compatibility negotiation.
- Add an integration proof covering health, readiness, and stop fallback responses.

## Testing
- Repository pre-commit and pre-push checks passed: Biome, raw-literal checks, and Observer architecture validation.
- `bun run build` passed for all workspace packages.
- Protocol integration suite passed: 44 tests.
- Disposable direct crossover passed with the published `v0.0.0-pre-alpha.8.2` arm64 artifact, active Host, and live PTY.
- The hosted release workflow will validate native compiled artifacts, exact predecessor update/install behavior, and the six-asset draft before promotion.

## Safety and scope
- `v0.0.0-pre-alpha.9` remains immutable and is not retagged or replaced; this is the required roll-forward candidate.
- Compatibility is opt-in and limited to lifecycle health, readiness, and stop operations used during upgrade crossover.
