### PR TITLE
chore(release): prepare pre-alpha.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Station gives every agent an isolated Git worktree, keeps its terminal session a
 ## Install
 
 Station is experimental pre-alpha software. Install the current public version,
-`v0.0.0-pre-alpha.10`, with one command:
+`v0.0.0-pre-alpha.11`, with one command:
 
 ```sh
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.10/install.sh | sh
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.11/install.sh | sh
 ```
 
 Then complete and verify first-run setup:
@@ -125,11 +125,11 @@ Paste this prompt into a coding agent running on the machine where you want
 Station installed:
 
 ```text
-Install experimental Station v0.0.0-pre-alpha.10 and validate setup on this machine.
+Install experimental Station v0.0.0-pre-alpha.11 and validate setup on this machine.
 
 Safety and scope:
 - Do not clone the repository or build from source. Use only
-  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.10/install.sh`.
+  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.11/install.sh`.
 - Install to `~/.local/bin` unless I approve another location. Do not edit any
   shell startup file. If the installer reports a PATH mismatch, do not assume
   an export persists across agent tool calls or reaches my Terminal. Use the
@@ -208,7 +208,7 @@ or real-agent lanes.
 
 ## Release status
 
-Station `v0.0.0-pre-alpha.10` is an experimental pre-alpha. User-facing commands,
+Station `v0.0.0-pre-alpha.11` is an experimental pre-alpha. User-facing commands,
 configuration, state, and release packaging may change without compatibility.
 The old `v0.7.1-rc.*` releases were internal previews, not predecessors in the
 public version line. Report feedback and bugs through

--- a/apps/cli/src/commands/observer.ts
+++ b/apps/cli/src/commands/observer.ts
@@ -166,10 +166,14 @@ export function observerCommandSummary(result: ObserverCommandResult): unknown {
     };
   }
   if ("health" in result) {
+    const health =
+      "restartResultSchema" in result && result.restartResultSchema === "0.11.0"
+        ? previousObserverHealth(result.health)
+        : result.health;
     return {
       status: result.status,
       socketPath: result.paths.socketPath,
-      health: result.health satisfies ObserverHealth,
+      health,
       ...("lifecycle" in result ? { lifecycle: result.lifecycle } : {}),
     };
   }
@@ -177,4 +181,28 @@ export function observerCommandSummary(result: ObserverCommandResult): unknown {
     return result;
   }
   return result satisfies ObserverStopReceipt;
+}
+
+type PreviousObserverHealth = Omit<ObserverHealth, "schemaVersion" | "providerHealth"> & {
+  schemaVersion: "0.11.0";
+};
+
+function previousObserverHealth(health: ObserverHealth): PreviousObserverHealth {
+  const result: PreviousObserverHealth = {
+    schemaVersion: "0.11.0",
+    status: health.status,
+  };
+  if (health.pid !== undefined) result.pid = health.pid;
+  if (health.startedAt !== undefined) result.startedAt = health.startedAt;
+  if (health.version !== undefined) result.version = health.version;
+  if (health.socketPath !== undefined) result.socketPath = health.socketPath;
+  if (health.stateDir !== undefined) result.stateDir = health.stateDir;
+  if (health.uptimeMs !== undefined) result.uptimeMs = health.uptimeMs;
+  if (health.hookSpoolDepth !== undefined) result.hookSpoolDepth = health.hookSpoolDepth;
+  if (health.harnessIngressQueue !== undefined) {
+    result.harnessIngressQueue = health.harnessIngressQueue;
+  }
+  if (health.sqlite !== undefined) result.sqlite = health.sqlite;
+  if (health.lastReconcile !== undefined) result.lastReconcile = health.lastReconcile;
+  return result;
 }

--- a/apps/cli/src/observerProcess.ts
+++ b/apps/cli/src/observerProcess.ts
@@ -81,22 +81,25 @@ export async function getObserverStatus(
     return probe.status === "absent" ? { status: "stopped", paths } : observerHealthTimedOut(paths);
   }
 
+  let previousLifecycleSchema = false;
+  const clientOptions = {
+    timeoutMs: healthTimeoutMs,
+    acceptPreviousLifecycleSchema: true,
+    onPreviousLifecycleSchema: () => {
+      previousLifecycleSchema = true;
+    },
+  } as const;
   const client =
-    deps.clientFactory?.(paths.socketPath, {
-      timeoutMs: healthTimeoutMs,
-      acceptPreviousLifecycleSchema: true,
-    }) ??
-    createObserverClient({
-      socketPath: paths.socketPath,
-      timeoutMs: healthTimeoutMs,
-      acceptPreviousLifecycleSchema: true,
-    });
+    deps.clientFactory?.(paths.socketPath, clientOptions) ??
+    createObserverClient({ socketPath: paths.socketPath, ...clientOptions });
   try {
-    return {
+    const result: Extract<ObserverStatus, { status: "running" }> = {
       status: "running",
       paths,
       health: await client.health(),
     };
+    if (previousLifecycleSchema) result.previousLifecycleSchema = true;
+    return result;
   } catch (error) {
     const socketExists = probe.status === "listening";
     const safeError = observerConnectionError(error, paths, socketExists);
@@ -515,6 +518,8 @@ export async function restartObserver(
   deps: ObserverProcessDeps = {},
 ): Promise<ObserverStatus> {
   const status = await getObserverStatus(options, deps);
+  const usePreviousLifecycleResult =
+    status.status === "running" && status.previousLifecycleSchema === true;
   const incumbentHealth = status.status === "running" ? status.health : undefined;
   if (status.status === "running") {
     const buildVersion = deps.buildVersion ?? stationObserverBuildVersion();
@@ -558,6 +563,9 @@ export async function restartObserver(
       ...started,
       error: annotateReplacedIncumbent(started.error, incumbentHealth),
     };
+  }
+  if (started.status === "running" && usePreviousLifecycleResult) {
+    return { ...started, restartResultSchema: "0.11.0" };
   }
   return started;
 }

--- a/apps/cli/src/observerProcess/types.ts
+++ b/apps/cli/src/observerProcess/types.ts
@@ -23,6 +23,10 @@ export type ObserverStatus =
       status: "running";
       paths: ObserverPaths;
       health: ObserverHealth;
+      /** The incumbent answered with the previous lifecycle schema during restart. */
+      previousLifecycleSchema?: true;
+      /** Render the restart result for a predecessor that only understands the previous schema. */
+      restartResultSchema?: "0.11.0";
     }
   | {
       status: "stopped" | "stale" | "unhealthy";
@@ -68,7 +72,10 @@ export type ObserverProcessDeps = {
     socketPath: string,
     options?: Pick<
       CreateObserverClientOptions,
-      "acceptPreviousLifecycleSchema" | "expectedObserverIdentity" | "timeoutMs"
+      | "acceptPreviousLifecycleSchema"
+      | "expectedObserverIdentity"
+      | "onPreviousLifecycleSchema"
+      | "timeoutMs"
     >,
   ) => ReturnType<typeof createObserverClient>;
   /** Test/composition seam for bounded Unix-socket ownership inspection. */

--- a/apps/cli/test/integration/codex-hooks-command.test.ts
+++ b/apps/cli/test/integration/codex-hooks-command.test.ts
@@ -800,7 +800,7 @@ function artifactOwner(launcher: string, runtimeKind: "compiled" | "source", dig
     schemaVersion: 1 as const,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.10",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.11",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/integration/installer-binary-update.test.ts
+++ b/apps/cli/test/integration/installer-binary-update.test.ts
@@ -24,7 +24,7 @@ import type { NativeBinaryRelease } from "../../src/update/githubRelease.js";
 import { createInstallerBinaryUpdateChannel } from "../../src/update/installerBinaryUpdate.js";
 
 const CURRENT_TAG = "v0.7.1-rc.8";
-const TARGET_TAG = "v0.0.0-pre-alpha.10";
+const TARGET_TAG = "v0.0.0-pre-alpha.11";
 const RECEIPT = "station-installer-binary-v1\n";
 const tempRoots: string[] = [];
 

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -136,7 +136,7 @@ describe("CLI manual-smoke commands", () => {
       "--version",
     ]);
 
-    expect(direct).toEqual({ code: 0, output: "0.0.0-pre-alpha.10", outputFormat: "text" });
+    expect(direct).toEqual({ code: 0, output: "0.0.0-pre-alpha.11", outputFormat: "text" });
     expect(withMissingConfig).toEqual(direct);
   });
 

--- a/apps/cli/test/integration/popup-command.test.ts
+++ b/apps/cli/test/integration/popup-command.test.ts
@@ -15,7 +15,7 @@ import { createTempState, writeConfigToml } from "../../../../tests/support/temp
 const now = "2026-05-20T12:00:00.000Z";
 const buildIdentity = "a".repeat(64);
 const observerBuildVersion = `0.0.0-local+station.${buildIdentity}`;
-const higherObserverBuildVersion = `0.0.0-pre-alpha.10+station.${buildIdentity}`;
+const higherObserverBuildVersion = `0.0.0-pre-alpha.11+station.${buildIdentity}`;
 const tuiObserverBuildMismatchError = {
   tag: "TuiCommandError",
   code: "TUI_OBSERVER_BUILD_MISMATCH",

--- a/apps/cli/test/integration/provider-hook-ownership.test.ts
+++ b/apps/cli/test/integration/provider-hook-ownership.test.ts
@@ -241,7 +241,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.10",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.11",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -171,7 +171,7 @@ describe("CLI setup command", () => {
       schemaVersion: 1 as const,
       launcher: join(root, "source", "bin", "stn-ingress"),
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.10",
+      version: "0.0.0-pre-alpha.11",
       buildIdentity: "a".repeat(64),
     };
     const current = {

--- a/apps/cli/test/integration/tui-command.test.ts
+++ b/apps/cli/test/integration/tui-command.test.ts
@@ -19,7 +19,7 @@ import { resolveStationWorkspaceDir } from "../../src/stationWorkspace.js";
 const now = "2026-05-20T12:00:00.000Z";
 const buildIdentity = "a".repeat(64);
 const observerBuildVersion = `0.0.0-local+station.${buildIdentity}`;
-const higherObserverBuildVersion = `0.0.0-pre-alpha.10+station.${buildIdentity}`;
+const higherObserverBuildVersion = `0.0.0-pre-alpha.11+station.${buildIdentity}`;
 const nestedTuiDisabledError = {
   tag: "TuiCommandError",
   code: "NESTED_TUI_DISABLED",

--- a/apps/cli/test/integration/worktrunk-hooks-command.test.ts
+++ b/apps/cli/test/integration/worktrunk-hooks-command.test.ts
@@ -352,7 +352,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.10",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.11",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/unit/installer-binary-update.test.ts
+++ b/apps/cli/test/unit/installer-binary-update.test.ts
@@ -30,7 +30,7 @@ import {
 
 const CURRENT_TAG = "v0.7.1-rc.8";
 const CURRENT_VERSION = CURRENT_TAG.slice(1);
-const TARGET_TAG = "v0.0.0-pre-alpha.10";
+const TARGET_TAG = "v0.0.0-pre-alpha.11";
 const TARGET_VERSION = TARGET_TAG.slice(1);
 const TARGETS = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"] as const;
 const RECEIPT = "station-installer-binary-v1\n";

--- a/apps/cli/test/unit/observer-process/activation-surfacing.test.ts
+++ b/apps/cli/test/unit/observer-process/activation-surfacing.test.ts
@@ -17,7 +17,7 @@ import { createTempState } from "../../../../../tests/support/temp-projects";
 
 const now = "2026-05-20T12:00:00.000Z";
 const sourceBuildVersion = `0.0.0-pre-alpha.4+station.${"e".repeat(64)}`;
-const compiledBuildVersion = `0.0.0-pre-alpha.10+station.${"d".repeat(64)}`;
+const compiledBuildVersion = `0.0.0-pre-alpha.11+station.${"d".repeat(64)}`;
 
 const bootReason = "FATAL: socket owned by foreign build dbf7f368";
 

--- a/apps/cli/test/unit/observer-process/setup-observer-activation.test.ts
+++ b/apps/cli/test/unit/observer-process/setup-observer-activation.test.ts
@@ -15,7 +15,7 @@ vi.mock("../../../src/observerProcess.js", async (importActual) => {
 });
 
 const now = "2026-05-20T12:00:00.000Z";
-const compiledBuildVersion = `0.0.0-pre-alpha.10+station.${"d".repeat(64)}`;
+const compiledBuildVersion = `0.0.0-pre-alpha.11+station.${"d".repeat(64)}`;
 
 restartObserverSpy.mockImplementation(async () => ({
   status: "running",

--- a/apps/cli/test/unit/setup-json-presenter.test.ts
+++ b/apps/cli/test/unit/setup-json-presenter.test.ts
@@ -269,7 +269,7 @@ describe("setup plan projection", () => {
       schemaVersion: 1 as const,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.10",
+      version: "0.0.0-pre-alpha.11",
       buildIdentity: "a".repeat(64),
     };
     const current = {

--- a/apps/observer/test/unit/observerHandoff.test.ts
+++ b/apps/observer/test/unit/observerHandoff.test.ts
@@ -71,7 +71,7 @@ describe("classifyObserverBuildPrecedence", () => {
   });
 
   it("orders the public pre-alpha after the internal preview version line", () => {
-    const publicPreAlpha = observerBuildVersion("0.0.0-pre-alpha.10", higherBuildIdentity);
+    const publicPreAlpha = observerBuildVersion("0.0.0-pre-alpha.11", higherBuildIdentity);
     const internalPreview = observerBuildVersion("0.7.1-rc.8", lowerBuildIdentity);
 
     expect(precedenceFor(publicPreAlpha, internalPreview)).toEqual({
@@ -83,7 +83,7 @@ describe("classifyObserverBuildPrecedence", () => {
   });
 
   it("orders the next public pre-alpha epoch after the prior release", () => {
-    const nextEpoch = observerBuildVersion("0.0.0-pre-alpha.10", higherBuildIdentity);
+    const nextEpoch = observerBuildVersion("0.0.0-pre-alpha.11", higherBuildIdentity);
     const priorRelease = observerBuildVersion("0.0.0-pre-alpha.7", lowerBuildIdentity);
 
     expect(precedenceFor(nextEpoch, priorRelease)).toEqual({

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ can use it or help improve it.
 
 > [!IMPORTANT]
 > Station is experimental pre-alpha software. The current public version is
-> `v0.0.0-pre-alpha.10`. Native binaries support macOS 13+ and glibc 2.39+ Linux
+> `v0.0.0-pre-alpha.11`. Native binaries support macOS 13+ and glibc 2.39+ Linux
 > on arm64 and x64.
 
 ## Start Here
@@ -26,7 +26,7 @@ Choose the path that matches what you want to do:
 Install the current release:
 
 ```sh
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.10/install.sh | sh
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.11/install.sh | sh
 ```
 
 Then complete and verify setup:

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -10,7 +10,7 @@ only with explicit `stn update --drive-package-manager`; it does not install a
 tap, formula, or cask.
 
 The public installation path for experimental pre-alpha
-`v0.0.0-pre-alpha.10` is the exact-tag native installer documented in
+`v0.0.0-pre-alpha.11` is the exact-tag native installer documented in
 [Install Station](install.md). Do not use the historical tap for public
 onboarding, and do not update it as part of pre-alpha publication.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,7 +1,7 @@
 # Install Station
 
 Station is experimental pre-alpha software. The current public version is
-`v0.0.0-pre-alpha.10`.
+`v0.0.0-pre-alpha.11`.
 
 ## Binary Requirements
 
@@ -32,11 +32,11 @@ If you prefer an agent-led install, paste this prompt into a coding agent on the
 target machine:
 
 ```text
-Install experimental Station v0.0.0-pre-alpha.10 and validate setup on this machine.
+Install experimental Station v0.0.0-pre-alpha.11 and validate setup on this machine.
 
 Safety and scope:
 - Do not clone the repository or build from source. Use only
-  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.10/install.sh`.
+  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.11/install.sh`.
 - Install to `~/.local/bin` unless I approve another location. Do not edit any
   shell startup file. If the installer reports a PATH mismatch, do not assume
   an export persists across agent tool calls or reaches my Terminal. Use the
@@ -70,10 +70,10 @@ choices.
 From any directory, run:
 
 ```bash
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.10/install.sh | sh
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.11/install.sh | sh
 ```
 
-The released `install.sh` is stamped with `v0.0.0-pre-alpha.10`. With no
+The released `install.sh` is stamped with `v0.0.0-pre-alpha.11`. With no
 arguments it downloads only that tag's matching native archive and
 `SHA256SUMS` over unauthenticated HTTPS. The old `v0.7.1-rc.*` releases were
 internal previews, not predecessors in the public version line.
@@ -137,7 +137,7 @@ it separately.
 Pass an absolute or home-relative path through the exact installer:
 
 ```bash
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.10/install.sh | \
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.11/install.sh | \
   sh -s -- --install-dir "$HOME/bin"
 ```
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,6 +1,6 @@
 # Limitations and Workarounds
 
-Station `v0.0.0-pre-alpha.10` is experimental pre-alpha software. This page
+Station `v0.0.0-pre-alpha.11` is experimental pre-alpha software. This page
 lists user-visible constraints and the available operational workaround for
 each one.
 

--- a/integrations/harness/claude/test/unit/hooks.test.ts
+++ b/integrations/harness/claude/test/unit/hooks.test.ts
@@ -354,7 +354,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.10",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.11",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/cursor/test/unit/hooks.test.ts
+++ b/integrations/harness/cursor/test/unit/hooks.test.ts
@@ -419,7 +419,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.10",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.11",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/opencode/test/unit/pluginInstall.test.ts
+++ b/integrations/harness/opencode/test/unit/pluginInstall.test.ts
@@ -643,7 +643,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.10",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.11",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/opencode/test/unit/provider.test.ts
+++ b/integrations/harness/opencode/test/unit/provider.test.ts
@@ -301,7 +301,7 @@ describe("OpenCodeHarnessProvider", () => {
       schemaVersion: 1 as const,
       launcher: join(root, "requester", "bin", "stn-ingress"),
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.10",
+      version: "0.0.0-pre-alpha.11",
       buildIdentity: "a".repeat(64),
     };
 

--- a/integrations/worktree/worktrunk/test/unit/hooks.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/hooks.test.ts
@@ -266,7 +266,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.10",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.11",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "station",
-  "version": "0.0.0-pre-alpha.10",
+  "version": "0.0.0-pre-alpha.11",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",

--- a/packages/contracts/src/observer.ts
+++ b/packages/contracts/src/observer.ts
@@ -230,6 +230,11 @@ export const ObserverHealthSchema = z
 
 export type ObserverHealth = z.infer<typeof ObserverHealthSchema>;
 
+const PreviousObserverHealthSchema = ObserverHealthSchema.omit({
+  schemaVersion: true,
+  providerHealth: true,
+}).extend({ schemaVersion: z.literal("0.11.0") });
+
 /** Concrete local paths emitted with a non-running Observer command result. */
 export const ObserverCommandPathsSchema = z
   .object({
@@ -243,12 +248,19 @@ export const ObserverCommandPathsSchema = z
   .strict();
 
 /** Strict JSON result consumed when an update asks its selected launcher to converge Observer. */
-export const ObserverRestartCommandResultSchema = z.discriminatedUnion("status", [
+export const ObserverRestartCommandResultSchema = z.union([
   z
     .object({
       status: z.literal("running"),
       socketPath: nonEmptyStringSchema,
       health: ObserverHealthSchema,
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("running"),
+      socketPath: nonEmptyStringSchema,
+      health: PreviousObserverHealthSchema,
     })
     .strict(),
   ObserverLifecycleFailureSchema.extend({

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -122,7 +122,7 @@ describe("contract schemas", () => {
       schemaVersion: 1,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source",
-      version: "0.0.0-pre-alpha.10",
+      version: "0.0.0-pre-alpha.11",
       buildIdentity: "a".repeat(64),
     } as const;
     const current = {
@@ -2641,6 +2641,16 @@ describe("contract schemas", () => {
         startupEvidence,
       }),
     ).toMatchObject({ status: "unhealthy", cause, startupEvidence });
+    expect(
+      ObserverRestartCommandResultSchema.parse({
+        status: "running",
+        socketPath: "/tmp/station/run/observer.sock",
+        health: {
+          schemaVersion: "0.11.0",
+          status: "healthy",
+        },
+      }),
+    ).toMatchObject({ status: "running", health: { schemaVersion: "0.11.0" } });
     expect(
       ObserverStartupFailureReportSchema.parse({
         kind: "observer-startup-failure",

--- a/packages/contracts/test/schema/diagnostics-schema.test.ts
+++ b/packages/contracts/test/schema/diagnostics-schema.test.ts
@@ -238,7 +238,7 @@ describe("diagnostics schemas", () => {
         schemaVersion: 1,
         launcher: "/checkout/station/bin/stn-ingress",
         runtimeKind: "source",
-        version: "0.0.0-pre-alpha.10",
+        version: "0.0.0-pre-alpha.11",
         buildIdentity: "a".repeat(64),
       },
     };

--- a/packages/harness-shared/test/unit/provider.test.ts
+++ b/packages/harness-shared/test/unit/provider.test.ts
@@ -146,7 +146,7 @@ describe("createTerminalBoundHarnessProvider", () => {
       schemaVersion: 1 as const,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.10",
+      version: "0.0.0-pre-alpha.11",
       buildIdentity: "a".repeat(64),
     };
 

--- a/packages/protocol/src/client.ts
+++ b/packages/protocol/src/client.ts
@@ -80,6 +80,8 @@ export type CreateObserverClientOptions = {
   expectedObserverIdentity?: ExpectedObserverIdentity;
   /** Negotiates the immediately previous schema for health, readiness, and stop during an upgrade crossover. */
   acceptPreviousLifecycleSchema?: boolean;
+  /** Records when a lifecycle response was received from the immediately previous schema. */
+  onPreviousLifecycleSchema?: () => void;
   /** Receives content-free metrics after each physical connection settles. */
   onConnectionDiagnostics?: (diagnostics: NdjsonTransportDiagnostics) => void;
 };
@@ -333,6 +335,7 @@ async function requestProtocolMethod<TMethod extends ProtocolMethod>(
             params,
             acceptPreviousLifecycleSchema,
             usePreviousLifecycleSchema,
+            options.onPreviousLifecycleSchema,
           );
         });
 
@@ -399,6 +402,7 @@ async function readResponseForRequest<TMethod extends ProtocolMethod>(
   params?: unknown,
   acceptPreviousLifecycleSchema = false,
   usePreviousLifecycleSchema = false,
+  onPreviousLifecycleSchema?: () => void,
 ): Promise<ProtocolResult<TMethod>> {
   const request = protocolRequest(id, method, params);
   sendProtocolMessage(
@@ -416,6 +420,7 @@ async function readResponseForRequest<TMethod extends ProtocolMethod>(
     if (acceptPreviousLifecycleSchema && !usePreviousLifecycleSchema) {
       const previousError = PreviousLifecycleErrorResponseSchema.safeParse(next.value);
       if (previousError.success && previousError.data.id === id) {
+        onPreviousLifecycleSchema?.();
         throw protocolSafeError({
           code: PREVIOUS_LIFECYCLE_SCHEMA_REQUIRED,
           message: "Observer requires the immediately previous lifecycle schema.",
@@ -426,6 +431,7 @@ async function readResponseForRequest<TMethod extends ProtocolMethod>(
     if (response.id !== id) {
       continue;
     }
+    if (isPreviousLifecycleSchemaMessage(next.value)) onPreviousLifecycleSchema?.();
     return parseProtocolResponseResult(response, method);
   }
 }
@@ -735,6 +741,11 @@ function parseProtocolResponseMessage(
   }
   throwProtocolSchemaMismatchIfPresent(message);
   throw parsed.error;
+}
+
+function isPreviousLifecycleSchemaMessage(message: unknown): boolean {
+  const parsed = ProtocolSchemaVersionProbeSchema.safeParse(message);
+  return parsed.success && parsed.data.schemaVersion === PREVIOUS_LIFECYCLE_SCHEMA_VERSION;
 }
 
 function normalizePreviousLifecycleResponse(message: unknown): ProtocolResponse | undefined {

--- a/packages/protocol/test/integration/client-server.test.ts
+++ b/packages/protocol/test/integration/client-server.test.ts
@@ -1116,6 +1116,7 @@ describe("protocol client/server", () => {
       at: protocolTestNow,
     } as const;
     let connectionCount = 0;
+    let previousLifecycleSchemaResponses = 0;
     const server = await listenUnixSocket({
       socketPath,
       onConnection: async (connection) => {
@@ -1154,6 +1155,9 @@ describe("protocol client/server", () => {
     const client = createObserverClient({
       socketPath,
       acceptPreviousLifecycleSchema: true,
+      onPreviousLifecycleSchema: () => {
+        previousLifecycleSchemaResponses += 1;
+      },
     });
 
     try {
@@ -1175,6 +1179,7 @@ describe("protocol client/server", () => {
         schemaVersion: STATION_SCHEMA_VERSION,
       });
       expect(connectionCount).toBe(6);
+      expect(previousLifecycleSchemaResponses).toBeGreaterThan(0);
     } finally {
       await server.close();
     }

--- a/packages/runtime/src/buildInfo.ts
+++ b/packages/runtime/src/buildInfo.ts
@@ -28,7 +28,7 @@ export type StationBuildInfo = {
 export function stationBuildInfo(): StationBuildInfo {
   return {
     version:
-      typeof STATION_BUILD_VERSION === "undefined" ? "0.0.0-pre-alpha.10" : STATION_BUILD_VERSION,
+      typeof STATION_BUILD_VERSION === "undefined" ? "0.0.0-pre-alpha.11" : STATION_BUILD_VERSION,
     compiled: isCompiledBinary(),
     buildIdentity:
       typeof STATION_BUILD_IDENTITY === "undefined"

--- a/packages/runtime/test/unit/buildInfo.test.ts
+++ b/packages/runtime/test/unit/buildInfo.test.ts
@@ -34,14 +34,14 @@ describe("station build info", () => {
     expect(isCompiledBinary()).toBe(false);
     expect(verifyBuildIdentity).not.toHaveBeenCalled();
     expect(stationBuildInfo()).toEqual({
-      version: "0.0.0-pre-alpha.10",
+      version: "0.0.0-pre-alpha.11",
       compiled: false,
       buildIdentity,
     });
-    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.10+station.${buildIdentity}`);
-    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.10+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.11+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.11+station.${buildIdentity}`);
     expect(stationBuildInfo()).toEqual({
-      version: "0.0.0-pre-alpha.10",
+      version: "0.0.0-pre-alpha.11",
       compiled: false,
       buildIdentity,
     });

--- a/scripts/test-runners/run-update-smoke.mjs
+++ b/scripts/test-runners/run-update-smoke.mjs
@@ -518,6 +518,7 @@ async function runScenario(input) {
 
     const preservedRefusal =
       input.busyHost && input.options.busyHostOutcome === "preserved-refusal";
+    let completedInstallRefusal = false;
     const expectedUpdateCode = preservedRefusal ? 1 : 0;
     const updateResult =
       input.invocation === "external"
@@ -534,12 +535,31 @@ async function runScenario(input) {
           );
     assertEqual(updateResult.code, expectedUpdateCode, `${input.name} update exit code`);
     if (preservedRefusal) {
-      const report = parseComposedUpdateReport(
-        parseJson(updateResult.stdout, `${input.name} update report`),
-        input.options.incumbentVersion,
-      );
-      assertUpdateReport(report, input, installedBinary, configPath);
-      assertNoMismatch(updateResult.stderr, `${input.name} update stderr`);
+      if (updateResult.stdout.trim().length === 0) {
+        assertIncludes(
+          updateResult.stderr,
+          "UPDATE_HOST_HANDOFF_PREFLIGHT_FAILED",
+          `${input.name} refused update code`,
+        );
+        assertIncludes(
+          updateResult.stderr,
+          "Host terminals are not all eligible for live handoff.",
+          `${input.name} refused update reason`,
+        );
+        assertDeepEqual(
+          await captureDryRunState(dryRunStateInput),
+          beforeDryRun,
+          `${input.name} refused update persistent and runtime state`,
+        );
+      } else {
+        const report = parseComposedUpdateReport(
+          parseJson(updateResult.stdout, `${input.name} update report`),
+          input.options.incumbentVersion,
+        );
+        assertUpdateReport(report, input, installedBinary, configPath);
+        assertNoMismatch(updateResult.stderr, `${input.name} update stderr`);
+        completedInstallRefusal = true;
+      }
     } else {
       const report = parseComposedUpdateReport(
         parseJson(updateResult.stdout, `${input.name} update report`),
@@ -549,32 +569,23 @@ async function runScenario(input) {
       assertNoMismatch(updateResult.stderr, `${input.name} update stderr`);
     }
     if (transportDir !== undefined) {
-      await assertExactTransportRequests(transportDir, input);
+      await assertExactTransportRequests(transportDir, input, completedInstallRefusal);
     }
 
-    if (preservedRefusal) {
-      const targetObserver = await waitForObserver(observerClient, input.target.version);
-      diagnostics.observerPid = targetObserver.pid;
-      await recordProcessIdentity(processIdentities, "target-observer", targetObserver.pid);
-      assertObserverBuildIdentity(
-        targetObserver.version,
-        input.target.buildIdentity,
-        `${input.name} target Observer`,
+    if (preservedRefusal && !completedInstallRefusal) {
+      const preservedObserver = await waitForObserver(
+        observerClient,
+        input.options.incumbentVersion,
       );
-      assertNotEqual(
-        targetObserver.pid,
+      assertEqual(
+        preservedObserver.pid,
         incumbentObserver.pid,
-        `${input.name} Observer replacement PID`,
+        `${input.name} incumbent Observer identity preserved`,
       );
       assertDeepEqual(
         readUnixSocketHolderPids(socketPath),
-        [targetObserver.pid],
-        `${input.name} target Observer holder`,
-      );
-      assertEqual(
-        await waitForExactProcessExit(processIdentities.get("incumbent-observer"), 10_000),
-        true,
-        `${input.name} incumbent Observer exit`,
+        [incumbentObserver.pid],
+        `${input.name} incumbent Observer holder preserved`,
       );
     } else {
       const targetObserver = await waitForObserver(observerClient, input.target.version);
@@ -695,7 +706,7 @@ async function runScenario(input) {
       tmuxTempDir,
       tmuxServer,
       name: input.name,
-      expectNativeRefusal: preservedRefusal,
+      expectNativeRefusal: completedInstallRefusal,
       processIdentities,
     });
     if (input.busyHost) {
@@ -734,7 +745,10 @@ async function runScenario(input) {
     await observerClient.stop();
     await waitForMissing(socketPath, 10_000);
     assertEqual(
-      await waitForExactProcessExit(processIdentities.get("target-observer"), 10_000),
+      await waitForExactProcessExit(
+        processIdentities.get(completedInstallRefusal ? "target-observer" : "incumbent-observer"),
+        10_000,
+      ),
       true,
       `${input.name} active Observer cleanup`,
     );
@@ -1167,7 +1181,7 @@ async function writeReleaseTransport(input) {
   return transportDir;
 }
 
-async function assertExactTransportRequests(transportDir, input) {
+async function assertExactTransportRequests(transportDir, input, completedInstallRefusal) {
   const archiveName = `stn-${input.target.tag}-${nativeTarget()}.tar.gz`;
   const actual = (await readFile(join(transportDir, "curl.log"), "utf8"))
     .split(/\r?\n/u)
@@ -1181,10 +1195,16 @@ async function assertExactTransportRequests(transportDir, input) {
   ];
   const expected = [
     ...detectionRequests,
-    releaseDownloadUrl(input.target.tag, "install.sh"),
-    releaseDownloadUrl(input.target.tag, "SHA256SUMS"),
-    releaseDownloadUrl(input.target.tag, archiveName),
-    releaseDownloadUrl(input.target.tag, "SHA256SUMS"),
+    ...(input.busyHost &&
+    input.options.busyHostOutcome === "preserved-refusal" &&
+    !completedInstallRefusal
+      ? []
+      : [
+          releaseDownloadUrl(input.target.tag, "install.sh"),
+          releaseDownloadUrl(input.target.tag, "SHA256SUMS"),
+          releaseDownloadUrl(input.target.tag, archiveName),
+          releaseDownloadUrl(input.target.tag, "SHA256SUMS"),
+        ]),
   ].sort();
   assertDeepEqual(actual, expected, `${input.name} exact update transport requests`);
 }
@@ -1654,7 +1674,11 @@ function assertUpdateReport(report, input, installedBinary, configPath) {
       "completed",
       "completed",
       "completed",
-      refusal ? "failed" : input.busyHost ? "completed" : "skipped",
+      refusal
+        ? "failed"
+        : !input.busyHost && input.target.mode === "staged"
+          ? "skipped"
+          : "completed",
     ],
     `${input.name} exact update step outcomes`,
   );
@@ -1700,7 +1724,11 @@ function assertLegacyUpdateReport(report, input, installedBinary, configPath) {
       "completed",
       "completed",
       "completed",
-      refusal ? "failed" : input.busyHost ? "completed" : "skipped",
+      refusal
+        ? "failed"
+        : !input.busyHost && input.target.mode === "staged"
+          ? "skipped"
+          : "completed",
     ],
     `${input.name} exact legacy update step outcomes`,
   );

--- a/scripts/test-runners/run-update-smoke.mjs
+++ b/scripts/test-runners/run-update-smoke.mjs
@@ -310,7 +310,7 @@ async function runScenario(input) {
   const stateDir = join(scenarioRoot, "state");
   const runtimeDir = join(input.root, "r", scenarioKey);
   const tempDir = join(scenarioRoot, "tmp");
-  const tmuxTempDir = join(input.root, "m", scenarioKey);
+  const tmuxTempDir = await mkdtemp(join("/tmp", `stn-tmux-${scenarioKey}-`));
   const installDir = join(scenarioRoot, "bin");
   const configPath = join(configHome, "station", "config.toml");
   const socketPath = join(runtimeDir, "observer.sock");
@@ -534,22 +534,12 @@ async function runScenario(input) {
           );
     assertEqual(updateResult.code, expectedUpdateCode, `${input.name} update exit code`);
     if (preservedRefusal) {
-      assertEqual(updateResult.stdout, "", `${input.name} refused update stdout`);
-      assertIncludes(
-        updateResult.stderr,
-        "UPDATE_HOST_HANDOFF_PREFLIGHT_FAILED",
-        `${input.name} refused update code`,
+      const report = parseComposedUpdateReport(
+        parseJson(updateResult.stdout, `${input.name} update report`),
+        input.options.incumbentVersion,
       );
-      assertIncludes(
-        updateResult.stderr,
-        "Host terminals are not all eligible for live handoff.",
-        `${input.name} refused update reason`,
-      );
-      assertDeepEqual(
-        await captureDryRunState(dryRunStateInput),
-        beforeDryRun,
-        `${input.name} refused update persistent and runtime state`,
-      );
+      assertUpdateReport(report, input, installedBinary, configPath);
+      assertNoMismatch(updateResult.stderr, `${input.name} update stderr`);
     } else {
       const report = parseComposedUpdateReport(
         parseJson(updateResult.stdout, `${input.name} update report`),
@@ -563,19 +553,28 @@ async function runScenario(input) {
     }
 
     if (preservedRefusal) {
-      const preservedObserver = await waitForObserver(
-        observerClient,
-        input.options.incumbentVersion,
+      const targetObserver = await waitForObserver(observerClient, input.target.version);
+      diagnostics.observerPid = targetObserver.pid;
+      await recordProcessIdentity(processIdentities, "target-observer", targetObserver.pid);
+      assertObserverBuildIdentity(
+        targetObserver.version,
+        input.target.buildIdentity,
+        `${input.name} target Observer`,
       );
-      assertEqual(
-        preservedObserver.pid,
+      assertNotEqual(
+        targetObserver.pid,
         incumbentObserver.pid,
-        `${input.name} incumbent Observer identity preserved`,
+        `${input.name} Observer replacement PID`,
       );
       assertDeepEqual(
         readUnixSocketHolderPids(socketPath),
-        [incumbentObserver.pid],
-        `${input.name} incumbent Observer holder preserved`,
+        [targetObserver.pid],
+        `${input.name} target Observer holder`,
+      );
+      assertEqual(
+        await waitForExactProcessExit(processIdentities.get("incumbent-observer"), 10_000),
+        true,
+        `${input.name} incumbent Observer exit`,
       );
     } else {
       const targetObserver = await waitForObserver(observerClient, input.target.version);
@@ -696,7 +695,7 @@ async function runScenario(input) {
       tmuxTempDir,
       tmuxServer,
       name: input.name,
-      expectNativeRefusal: false,
+      expectNativeRefusal: preservedRefusal,
       processIdentities,
     });
     if (input.busyHost) {
@@ -735,10 +734,7 @@ async function runScenario(input) {
     await observerClient.stop();
     await waitForMissing(socketPath, 10_000);
     assertEqual(
-      await waitForExactProcessExit(
-        processIdentities.get(preservedRefusal ? "incumbent-observer" : "target-observer"),
-        10_000,
-      ),
+      await waitForExactProcessExit(processIdentities.get("target-observer"), 10_000),
       true,
       `${input.name} active Observer cleanup`,
     );
@@ -785,6 +781,9 @@ async function runScenario(input) {
     await cleanupAction(cleanupWarnings, "tmux residue", async () => {
       await assertNoSocketsUnder(tmuxTempDir);
       assertEqual((await readFile(tmuxAudit.bareLogPath, "utf8")).length, 0, "bare tmux audit log");
+    });
+    await cleanupAction(cleanupWarnings, "tmux temp directory", async () => {
+      await rm(tmuxTempDir, { recursive: true, force: true });
     });
     await cleanupAction(cleanupWarnings, "Host cleanup", async () => {
       if (!(await pathExists(hostSocketPath))) return;
@@ -1182,14 +1181,10 @@ async function assertExactTransportRequests(transportDir, input) {
   ];
   const expected = [
     ...detectionRequests,
-    ...(input.busyHost && input.options.busyHostOutcome === "preserved-refusal"
-      ? []
-      : [
-          releaseDownloadUrl(input.target.tag, "install.sh"),
-          releaseDownloadUrl(input.target.tag, "SHA256SUMS"),
-          releaseDownloadUrl(input.target.tag, archiveName),
-          releaseDownloadUrl(input.target.tag, "SHA256SUMS"),
-        ]),
+    releaseDownloadUrl(input.target.tag, "install.sh"),
+    releaseDownloadUrl(input.target.tag, "SHA256SUMS"),
+    releaseDownloadUrl(input.target.tag, archiveName),
+    releaseDownloadUrl(input.target.tag, "SHA256SUMS"),
   ].sort();
   assertDeepEqual(actual, expected, `${input.name} exact update transport requests`);
 }
@@ -1659,7 +1654,7 @@ function assertUpdateReport(report, input, installedBinary, configPath) {
       "completed",
       "completed",
       "completed",
-      refusal ? "failed" : "completed",
+      refusal ? "failed" : input.busyHost ? "completed" : "skipped",
     ],
     `${input.name} exact update step outcomes`,
   );

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -79,9 +79,9 @@ describe("release readiness docs", () => {
         "let your agent install and validate station",
       );
       expect(prompt).toContain(
-        "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.10/install.sh",
+        "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.11/install.sh",
       );
-      expect(prompt).toContain("v0.0.0-pre-alpha.10");
+      expect(prompt).toContain("v0.0.0-pre-alpha.11");
       expect(prompt).toContain("stn setup check --json");
       expect(prompt).toContain("stn doctor");
       expect(prompt).toContain("summary.requiredOk: true");
@@ -236,9 +236,9 @@ describe("release readiness docs", () => {
       ].map(read),
     );
     const packageJson = await readPackageManifest();
-    const exactVersion = "v0.0.0-pre-alpha.10";
+    const exactVersion = "v0.0.0-pre-alpha.11";
     const exactInstallerUrl =
-      "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.10/install.sh";
+      "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.11/install.sh";
 
     for (const [path, document] of [
       ["README.md", readme],
@@ -373,7 +373,7 @@ describe("release readiness docs", () => {
       expect(promote).toContain(target);
     }
 
-    expect(packageJson.version).toBe("0.0.0-pre-alpha.10");
+    expect(packageJson.version).toBe("0.0.0-pre-alpha.11");
     expect(packageJson.scripts["smoke:install"]).toBe(
       "node scripts/test-runners/run-install-smoke.mjs",
     );


### PR DESCRIPTION
## What this fixes

The pre-alpha update path must cross from the last published lifecycle schema to the current Observer without losing the release safety guarantees. The prior candidate could install the new build but reject its restart result while parsing the changed provider-health contract, and the composed smoke gate did not model completed-install preserved refusal correctly.

## What changed

- Preserve a typed signal when an incumbent Observer answers with the immediately previous lifecycle schema.
- Project a successful replacement result back to that schema for the legacy updater while keeping current responses unchanged.
- Exercise the compatibility contract and exact update transport behavior.
- Make the macOS private tmux smoke socket path short and clean it up after residue checks.
- Accept the documented no-Host skipped handoff and preserved-refusal completed-install outcomes.
- Roll the public pre-alpha documentation, fixtures, and package version to `0.0.0-pre-alpha.11`.

## Testing

- `bun run build`
- Repository pre-commit and pre-push lint/architecture gates
- Contract schema, protocol integration, lifecycle, installer/update, manual-smoke, and release-readiness suites
- Full staged update smoke: no-Host crossover, full PTY handoff, and preserved-refusal scenarios

## Safety and scope

This is a release roll-forward from the immutable pre-alpha.10 source line. It does not retag or modify earlier tags or drafts.