### PR TITLE
chore(release): prepare pre-alpha.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Station gives every agent an isolated Git worktree, keeps its terminal session a
 ## Install
 
 Station is experimental pre-alpha software. Install the current public version,
-`v0.0.0-pre-alpha.13`, with one command:
+`v0.0.0-pre-alpha.14`, with one command:
 
 ```sh
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.13/install.sh | sh
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14/install.sh | sh
 ```
 
 Then complete and verify first-run setup:
@@ -125,11 +125,11 @@ Paste this prompt into a coding agent running on the machine where you want
 Station installed:
 
 ```text
-Install experimental Station v0.0.0-pre-alpha.13 and validate setup on this machine.
+Install experimental Station v0.0.0-pre-alpha.14 and validate setup on this machine.
 
 Safety and scope:
 - Do not clone the repository or build from source. Use only
-  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.13/install.sh`.
+  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14/install.sh`.
 - Install to `~/.local/bin` unless I approve another location. Do not edit any
   shell startup file. If the installer reports a PATH mismatch, do not assume
   an export persists across agent tool calls or reaches my Terminal. Use the
@@ -208,7 +208,7 @@ or real-agent lanes.
 
 ## Release status
 
-Station `v0.0.0-pre-alpha.13` is an experimental pre-alpha. User-facing commands,
+Station `v0.0.0-pre-alpha.14` is an experimental pre-alpha. User-facing commands,
 configuration, state, and release packaging may change without compatibility.
 The old `v0.7.1-rc.*` releases were internal previews, not predecessors in the
 public version line. Report feedback and bugs through

--- a/apps/cli/test/integration/codex-hooks-command.test.ts
+++ b/apps/cli/test/integration/codex-hooks-command.test.ts
@@ -800,7 +800,7 @@ function artifactOwner(launcher: string, runtimeKind: "compiled" | "source", dig
     schemaVersion: 1 as const,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.13",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/integration/installer-binary-update.test.ts
+++ b/apps/cli/test/integration/installer-binary-update.test.ts
@@ -24,7 +24,7 @@ import type { NativeBinaryRelease } from "../../src/update/githubRelease.js";
 import { createInstallerBinaryUpdateChannel } from "../../src/update/installerBinaryUpdate.js";
 
 const CURRENT_TAG = "v0.7.1-rc.8";
-const TARGET_TAG = "v0.0.0-pre-alpha.13";
+const TARGET_TAG = "v0.0.0-pre-alpha.14";
 const RECEIPT = "station-installer-binary-v1\n";
 const tempRoots: string[] = [];
 

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -136,7 +136,7 @@ describe("CLI manual-smoke commands", () => {
       "--version",
     ]);
 
-    expect(direct).toEqual({ code: 0, output: "0.0.0-pre-alpha.13", outputFormat: "text" });
+    expect(direct).toEqual({ code: 0, output: "0.0.0-pre-alpha.14", outputFormat: "text" });
     expect(withMissingConfig).toEqual(direct);
   });
 

--- a/apps/cli/test/integration/popup-command.test.ts
+++ b/apps/cli/test/integration/popup-command.test.ts
@@ -15,7 +15,7 @@ import { createTempState, writeConfigToml } from "../../../../tests/support/temp
 const now = "2026-05-20T12:00:00.000Z";
 const buildIdentity = "a".repeat(64);
 const observerBuildVersion = `0.0.0-local+station.${buildIdentity}`;
-const higherObserverBuildVersion = `0.0.0-pre-alpha.13+station.${buildIdentity}`;
+const higherObserverBuildVersion = `0.0.0-pre-alpha.14+station.${buildIdentity}`;
 const tuiObserverBuildMismatchError = {
   tag: "TuiCommandError",
   code: "TUI_OBSERVER_BUILD_MISMATCH",

--- a/apps/cli/test/integration/provider-hook-ownership.test.ts
+++ b/apps/cli/test/integration/provider-hook-ownership.test.ts
@@ -241,7 +241,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.13",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -171,7 +171,7 @@ describe("CLI setup command", () => {
       schemaVersion: 1 as const,
       launcher: join(root, "source", "bin", "stn-ingress"),
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.13",
+      version: "0.0.0-pre-alpha.14",
       buildIdentity: "a".repeat(64),
     };
     const current = {

--- a/apps/cli/test/integration/tui-command.test.ts
+++ b/apps/cli/test/integration/tui-command.test.ts
@@ -19,7 +19,7 @@ import { resolveStationWorkspaceDir } from "../../src/stationWorkspace.js";
 const now = "2026-05-20T12:00:00.000Z";
 const buildIdentity = "a".repeat(64);
 const observerBuildVersion = `0.0.0-local+station.${buildIdentity}`;
-const higherObserverBuildVersion = `0.0.0-pre-alpha.13+station.${buildIdentity}`;
+const higherObserverBuildVersion = `0.0.0-pre-alpha.14+station.${buildIdentity}`;
 const nestedTuiDisabledError = {
   tag: "TuiCommandError",
   code: "NESTED_TUI_DISABLED",

--- a/apps/cli/test/integration/worktrunk-hooks-command.test.ts
+++ b/apps/cli/test/integration/worktrunk-hooks-command.test.ts
@@ -352,7 +352,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.13",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/unit/installer-binary-update.test.ts
+++ b/apps/cli/test/unit/installer-binary-update.test.ts
@@ -30,7 +30,7 @@ import {
 
 const CURRENT_TAG = "v0.7.1-rc.8";
 const CURRENT_VERSION = CURRENT_TAG.slice(1);
-const TARGET_TAG = "v0.0.0-pre-alpha.13";
+const TARGET_TAG = "v0.0.0-pre-alpha.14";
 const TARGET_VERSION = TARGET_TAG.slice(1);
 const TARGETS = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"] as const;
 const RECEIPT = "station-installer-binary-v1\n";

--- a/apps/cli/test/unit/observer-process/activation-surfacing.test.ts
+++ b/apps/cli/test/unit/observer-process/activation-surfacing.test.ts
@@ -17,7 +17,7 @@ import { createTempState } from "../../../../../tests/support/temp-projects";
 
 const now = "2026-05-20T12:00:00.000Z";
 const sourceBuildVersion = `0.0.0-pre-alpha.4+station.${"e".repeat(64)}`;
-const compiledBuildVersion = `0.0.0-pre-alpha.13+station.${"d".repeat(64)}`;
+const compiledBuildVersion = `0.0.0-pre-alpha.14+station.${"d".repeat(64)}`;
 
 const bootReason = "FATAL: socket owned by foreign build dbf7f368";
 

--- a/apps/cli/test/unit/observer-process/setup-observer-activation.test.ts
+++ b/apps/cli/test/unit/observer-process/setup-observer-activation.test.ts
@@ -15,7 +15,7 @@ vi.mock("../../../src/observerProcess.js", async (importActual) => {
 });
 
 const now = "2026-05-20T12:00:00.000Z";
-const compiledBuildVersion = `0.0.0-pre-alpha.13+station.${"d".repeat(64)}`;
+const compiledBuildVersion = `0.0.0-pre-alpha.14+station.${"d".repeat(64)}`;
 
 restartObserverSpy.mockImplementation(async () => ({
   status: "running",

--- a/apps/cli/test/unit/setup-json-presenter.test.ts
+++ b/apps/cli/test/unit/setup-json-presenter.test.ts
@@ -269,7 +269,7 @@ describe("setup plan projection", () => {
       schemaVersion: 1 as const,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.13",
+      version: "0.0.0-pre-alpha.14",
       buildIdentity: "a".repeat(64),
     };
     const current = {

--- a/apps/observer/test/unit/observerHandoff.test.ts
+++ b/apps/observer/test/unit/observerHandoff.test.ts
@@ -71,7 +71,7 @@ describe("classifyObserverBuildPrecedence", () => {
   });
 
   it("orders the public pre-alpha after the internal preview version line", () => {
-    const publicPreAlpha = observerBuildVersion("0.0.0-pre-alpha.13", higherBuildIdentity);
+    const publicPreAlpha = observerBuildVersion("0.0.0-pre-alpha.14", higherBuildIdentity);
     const internalPreview = observerBuildVersion("0.7.1-rc.8", lowerBuildIdentity);
 
     expect(precedenceFor(publicPreAlpha, internalPreview)).toEqual({
@@ -83,7 +83,7 @@ describe("classifyObserverBuildPrecedence", () => {
   });
 
   it("orders the next public pre-alpha epoch after the prior release", () => {
-    const nextEpoch = observerBuildVersion("0.0.0-pre-alpha.13", higherBuildIdentity);
+    const nextEpoch = observerBuildVersion("0.0.0-pre-alpha.14", higherBuildIdentity);
     const priorRelease = observerBuildVersion("0.0.0-pre-alpha.7", lowerBuildIdentity);
 
     expect(precedenceFor(nextEpoch, priorRelease)).toEqual({

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ can use it or help improve it.
 
 > [!IMPORTANT]
 > Station is experimental pre-alpha software. The current public version is
-> `v0.0.0-pre-alpha.13`. Native binaries support macOS 13+ and glibc 2.39+ Linux
+> `v0.0.0-pre-alpha.14`. Native binaries support macOS 13+ and glibc 2.39+ Linux
 > on arm64 and x64.
 
 ## Start Here
@@ -26,7 +26,7 @@ Choose the path that matches what you want to do:
 Install the current release:
 
 ```sh
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.13/install.sh | sh
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14/install.sh | sh
 ```
 
 Then complete and verify setup:

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -10,7 +10,7 @@ only with explicit `stn update --drive-package-manager`; it does not install a
 tap, formula, or cask.
 
 The public installation path for experimental pre-alpha
-`v0.0.0-pre-alpha.13` is the exact-tag native installer documented in
+`v0.0.0-pre-alpha.14` is the exact-tag native installer documented in
 [Install Station](install.md). Do not use the historical tap for public
 onboarding, and do not update it as part of pre-alpha publication.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,7 +1,7 @@
 # Install Station
 
 Station is experimental pre-alpha software. The current public version is
-`v0.0.0-pre-alpha.13`.
+`v0.0.0-pre-alpha.14`.
 
 ## Binary Requirements
 
@@ -32,11 +32,11 @@ If you prefer an agent-led install, paste this prompt into a coding agent on the
 target machine:
 
 ```text
-Install experimental Station v0.0.0-pre-alpha.13 and validate setup on this machine.
+Install experimental Station v0.0.0-pre-alpha.14 and validate setup on this machine.
 
 Safety and scope:
 - Do not clone the repository or build from source. Use only
-  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.13/install.sh`.
+  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14/install.sh`.
 - Install to `~/.local/bin` unless I approve another location. Do not edit any
   shell startup file. If the installer reports a PATH mismatch, do not assume
   an export persists across agent tool calls or reaches my Terminal. Use the
@@ -70,10 +70,10 @@ choices.
 From any directory, run:
 
 ```bash
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.13/install.sh | sh
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14/install.sh | sh
 ```
 
-The released `install.sh` is stamped with `v0.0.0-pre-alpha.13`. With no
+The released `install.sh` is stamped with `v0.0.0-pre-alpha.14`. With no
 arguments it downloads only that tag's matching native archive and
 `SHA256SUMS` over unauthenticated HTTPS. The old `v0.7.1-rc.*` releases were
 internal previews, not predecessors in the public version line.
@@ -137,7 +137,7 @@ it separately.
 Pass an absolute or home-relative path through the exact installer:
 
 ```bash
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.13/install.sh | \
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14/install.sh | \
   sh -s -- --install-dir "$HOME/bin"
 ```
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,6 +1,6 @@
 # Limitations and Workarounds
 
-Station `v0.0.0-pre-alpha.13` is experimental pre-alpha software. This page
+Station `v0.0.0-pre-alpha.14` is experimental pre-alpha software. This page
 lists user-visible constraints and the available operational workaround for
 each one.
 

--- a/integrations/harness/claude/test/unit/hooks.test.ts
+++ b/integrations/harness/claude/test/unit/hooks.test.ts
@@ -354,7 +354,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.13",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/cursor/test/unit/hooks.test.ts
+++ b/integrations/harness/cursor/test/unit/hooks.test.ts
@@ -419,7 +419,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.13",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/opencode/test/unit/pluginInstall.test.ts
+++ b/integrations/harness/opencode/test/unit/pluginInstall.test.ts
@@ -643,7 +643,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.13",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/opencode/test/unit/provider.test.ts
+++ b/integrations/harness/opencode/test/unit/provider.test.ts
@@ -301,7 +301,7 @@ describe("OpenCodeHarnessProvider", () => {
       schemaVersion: 1 as const,
       launcher: join(root, "requester", "bin", "stn-ingress"),
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.13",
+      version: "0.0.0-pre-alpha.14",
       buildIdentity: "a".repeat(64),
     };
 

--- a/integrations/worktree/worktrunk/test/unit/hooks.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/hooks.test.ts
@@ -266,7 +266,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.13",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "station",
-  "version": "0.0.0-pre-alpha.13",
+  "version": "0.0.0-pre-alpha.14",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -122,7 +122,7 @@ describe("contract schemas", () => {
       schemaVersion: 1,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source",
-      version: "0.0.0-pre-alpha.13",
+      version: "0.0.0-pre-alpha.14",
       buildIdentity: "a".repeat(64),
     } as const;
     const current = {

--- a/packages/contracts/test/schema/diagnostics-schema.test.ts
+++ b/packages/contracts/test/schema/diagnostics-schema.test.ts
@@ -238,7 +238,7 @@ describe("diagnostics schemas", () => {
         schemaVersion: 1,
         launcher: "/checkout/station/bin/stn-ingress",
         runtimeKind: "source",
-        version: "0.0.0-pre-alpha.13",
+        version: "0.0.0-pre-alpha.14",
         buildIdentity: "a".repeat(64),
       },
     };

--- a/packages/harness-shared/test/unit/provider.test.ts
+++ b/packages/harness-shared/test/unit/provider.test.ts
@@ -146,7 +146,7 @@ describe("createTerminalBoundHarnessProvider", () => {
       schemaVersion: 1 as const,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.13",
+      version: "0.0.0-pre-alpha.14",
       buildIdentity: "a".repeat(64),
     };
 

--- a/packages/runtime/src/buildInfo.ts
+++ b/packages/runtime/src/buildInfo.ts
@@ -28,7 +28,7 @@ export type StationBuildInfo = {
 export function stationBuildInfo(): StationBuildInfo {
   return {
     version:
-      typeof STATION_BUILD_VERSION === "undefined" ? "0.0.0-pre-alpha.13" : STATION_BUILD_VERSION,
+      typeof STATION_BUILD_VERSION === "undefined" ? "0.0.0-pre-alpha.14" : STATION_BUILD_VERSION,
     compiled: isCompiledBinary(),
     buildIdentity:
       typeof STATION_BUILD_IDENTITY === "undefined"

--- a/packages/runtime/test/unit/buildInfo.test.ts
+++ b/packages/runtime/test/unit/buildInfo.test.ts
@@ -34,14 +34,14 @@ describe("station build info", () => {
     expect(isCompiledBinary()).toBe(false);
     expect(verifyBuildIdentity).not.toHaveBeenCalled();
     expect(stationBuildInfo()).toEqual({
-      version: "0.0.0-pre-alpha.13",
+      version: "0.0.0-pre-alpha.14",
       compiled: false,
       buildIdentity,
     });
-    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.13+station.${buildIdentity}`);
-    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.13+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.14+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.14+station.${buildIdentity}`);
     expect(stationBuildInfo()).toEqual({
-      version: "0.0.0-pre-alpha.13",
+      version: "0.0.0-pre-alpha.14",
       compiled: false,
       buildIdentity,
     });

--- a/scripts/test-runners/run-update-smoke.mjs
+++ b/scripts/test-runners/run-update-smoke.mjs
@@ -1674,11 +1674,7 @@ function assertUpdateReport(report, input, installedBinary, configPath) {
       "completed",
       "completed",
       "completed",
-      refusal
-        ? "failed"
-        : !input.busyHost && input.target.mode === "public"
-          ? "skipped"
-          : "completed",
+      refusal ? "failed" : "completed",
     ],
     `${input.name} exact update step outcomes`,
   );

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -79,9 +79,9 @@ describe("release readiness docs", () => {
         "let your agent install and validate station",
       );
       expect(prompt).toContain(
-        "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.13/install.sh",
+        "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14/install.sh",
       );
-      expect(prompt).toContain("v0.0.0-pre-alpha.13");
+      expect(prompt).toContain("v0.0.0-pre-alpha.14");
       expect(prompt).toContain("stn setup check --json");
       expect(prompt).toContain("stn doctor");
       expect(prompt).toContain("summary.requiredOk: true");
@@ -236,9 +236,9 @@ describe("release readiness docs", () => {
       ].map(read),
     );
     const packageJson = await readPackageManifest();
-    const exactVersion = "v0.0.0-pre-alpha.13";
+    const exactVersion = "v0.0.0-pre-alpha.14";
     const exactInstallerUrl =
-      "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.13/install.sh";
+      "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14/install.sh";
 
     for (const [path, document] of [
       ["README.md", readme],
@@ -373,7 +373,7 @@ describe("release readiness docs", () => {
       expect(promote).toContain(target);
     }
 
-    expect(packageJson.version).toBe("0.0.0-pre-alpha.13");
+    expect(packageJson.version).toBe("0.0.0-pre-alpha.14");
     expect(packageJson.scripts["smoke:install"]).toBe(
       "node scripts/test-runners/run-install-smoke.mjs",
     );


### PR DESCRIPTION
## What this fixes
The immutable pre-alpha.13 promotion exposed a release-gate mismatch: the current schema-v4 update path completes the no-Host crossover from the newest immutable predecessor, while the gate still expected `skipped` for public targets. That prevented trustworthy public post-promotion verification.

## What changed
- Require `host-handoff: completed` for current schema-v4 no-Host update acceptance; retain the legacy schema compatibility assertion.
- Roll the release version and exact installer references from `0.0.0-pre-alpha.13` to `0.0.0-pre-alpha.14`.

## Testing
- `bun run build`
- `bun run lint`
- `bunx vitest run --config config/vitest/vitest.diagnostics.config.ts tests/diagnostics/ci-workflow-policy.test.ts tests/diagnostics/release-readiness-docs.test.ts --testTimeout=15000`
- `node scripts/build-identity.mjs --check`

## Safety and scope
Pre-alpha.13 remains published and immutable. This is a forward-only release correction; no prior tag, draft, or asset is replaced.