### PR TITLE
fix(launch): preserve uncertain external launch state

### DIFF
--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -850,7 +850,10 @@ focus returns before any health or hook probe.
 `prepareExternalLaunch` and `reportExternalExit` are latency-sensitive
 handshakes rather than recorded commands. Their use cases depend on the
 composition-supplied `ManagedTerminalLifecycle`, carry provider-owned target IDs
-opaquely, and request the shared coalesced reconcile scheduler after relevant lifecycle changes. Returning an
+opaquely, and request the shared coalesced reconcile scheduler after relevant lifecycle changes.
+External launch preparation receives a dedicated 30-second client and protocol budget; a client
+timeout after preparation begins is treated as uncertain until canonical Observer state confirms
+the launch or permits another attempt. Returning an
 attachable managed target or an existing live session precedes launch preflight.
 Target discovery includes Station Host reconstruction, so negotiated handoff and
 orphan-bridge adoption retain their existing PTY instead of entering provider

--- a/packages/client/src/observerService.ts
+++ b/packages/client/src/observerService.ts
@@ -34,6 +34,8 @@ export type CreateObserverServiceOptions = {
   expectedBuildVersion?: string;
   timeoutMs?: number;
   reconcileTimeoutMs?: number;
+  /** Budget for host negotiation and process preparation. */
+  prepareExternalLaunchTimeoutMs?: number;
   commandWaitTimeoutMs?: number;
   clientLabel?: string;
   requestId?: () => string;
@@ -42,6 +44,7 @@ export type CreateObserverServiceOptions = {
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 5_000;
 const DEFAULT_RECONCILE_TIMEOUT_MS = 30_000;
+const DEFAULT_PREPARE_EXTERNAL_LAUNCH_TIMEOUT_MS = 30_000;
 const DEFAULT_COMMAND_WAIT_TIMEOUT_MS = 35_000;
 
 /**
@@ -55,6 +58,8 @@ export function createObserverService(options: CreateObserverServiceOptions): Ob
   const timeoutMs = options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
   const reconcileTimeoutMs =
     options.reconcileTimeoutMs ?? options.timeoutMs ?? DEFAULT_RECONCILE_TIMEOUT_MS;
+  const prepareExternalLaunchTimeoutMs =
+    options.prepareExternalLaunchTimeoutMs ?? DEFAULT_PREPARE_EXTERNAL_LAUNCH_TIMEOUT_MS;
   const commandWaitTimeoutMs = options.commandWaitTimeoutMs ?? DEFAULT_COMMAND_WAIT_TIMEOUT_MS;
   let transportDiagnostics = emptyTransportDiagnostics();
   const recordConnectionDiagnostics = (diagnostics: NdjsonTransportDiagnostics) => {
@@ -63,6 +68,9 @@ export function createObserverService(options: CreateObserverServiceOptions): Ob
   const client = options.client ?? createClient(options, timeoutMs, recordConnectionDiagnostics);
   const reconcileClient =
     options.client ?? createClient(options, reconcileTimeoutMs, recordConnectionDiagnostics);
+  const prepareExternalLaunchClient =
+    options.client ??
+    createClient(options, prepareExternalLaunchTimeoutMs, recordConnectionDiagnostics);
   const copy = createObserverServiceCopy(options.clientLabel);
 
   return {
@@ -75,7 +83,12 @@ export function createObserverService(options: CreateObserverServiceOptions): Ob
     reconcile: (reason?: string) =>
       requestReconcile(reconcileClient, reason, reconcileTimeoutMs, copy),
     prepareExternalLaunch: (params: AgentPrepareExternalLaunchParams) =>
-      prepareExternalLaunch(client, params, timeoutMs, copy),
+      prepareExternalLaunch(
+        prepareExternalLaunchClient,
+        params,
+        prepareExternalLaunchTimeoutMs,
+        copy,
+      ),
     reportExternalExit: (params: AgentReportExternalExitParams) =>
       reportExternalExit(client, params, timeoutMs, copy),
     prepareWorktreeRemoval: (params: WorktreePrepareRemovalParams) =>

--- a/packages/client/test/integration/observerService.test.ts
+++ b/packages/client/test/integration/observerService.test.ts
@@ -358,6 +358,56 @@ describe("observer client service", () => {
     await server.close();
   });
 
+  it("lets a started external launch outlive the ordinary client request timeout", async () => {
+    const { socketPath } = await createTempSocketPath();
+    const launchedWorktrees: string[] = [];
+    const server = await startProtocolServer({
+      socketPath,
+      requestTimeoutMs: 100,
+      api: fakeApi({
+        prepareExternalLaunch: async (params) => {
+          launchedWorktrees.push(params.worktreeId);
+          await delay(25);
+          return {
+            kind: "prepared",
+            sessionId: "ses_slow_external",
+            terminalTargetId: `native:${params.worktreeId}`,
+            launchPlan: {
+              provider: "pi",
+              command: "pi",
+              args: [],
+              cwd: "/tmp/station/web/slow-external",
+              mode: "interactive",
+            },
+            attachment: {
+              kind: "managed-terminal",
+              terminalTargetId: `native:${params.worktreeId}`,
+            },
+          };
+        },
+      }),
+    });
+    const service = createObserverService({
+      socketPath,
+      timeoutMs: 10,
+      requestId: ids("slow-external"),
+    });
+
+    try {
+      const result = await service
+        .prepareExternalLaunch({ projectId: "web", worktreeId: "wt_web_slow_external" })
+        .catch((error: unknown) => error);
+      expect(launchedWorktrees).toEqual(["wt_web_slow_external"]);
+      expect(result).toMatchObject({
+        kind: "prepared",
+        sessionId: "ses_slow_external",
+        attachment: { terminalTargetId: "native:wt_web_slow_external" },
+      });
+    } finally {
+      await server.close();
+    }
+  });
+
   it("maps protocol SafeErrors without dropping diagnostic IDs", async () => {
     const { socketPath } = await createTempSocketPath();
     const server = await startProtocolServer({

--- a/packages/protocol/src/server.ts
+++ b/packages/protocol/src/server.ts
@@ -38,6 +38,7 @@ import {
 
 const defaultRequestTimeoutMs = 5000;
 const diagnosticRequestTimeoutMs = 30_000;
+const externalLaunchRequestTimeoutMs = 30_000;
 
 export type ProtocolServerOptions = {
   socketPath: string;
@@ -149,6 +150,8 @@ async function routeRequest(
 
 function protocolHandlerTimeoutMs(method: ProtocolMethod, requestTimeoutMs: number): number {
   switch (method) {
+    case "agent.prepareExternalLaunch":
+      return Math.max(requestTimeoutMs, externalLaunchRequestTimeoutMs);
     case "doctor.run":
     case "diagnostics.collect":
       return Math.max(requestTimeoutMs, diagnosticRequestTimeoutMs);

--- a/packages/protocol/test/integration/client-server.test.ts
+++ b/packages/protocol/test/integration/client-server.test.ts
@@ -1684,6 +1684,48 @@ describe("protocol client/server", () => {
     }
   });
 
+  it("lets external launch preparation outlive the ordinary protocol handler timeout", async () => {
+    const { socketPath } = await createTempSocketPath();
+    const launchedWorktrees: string[] = [];
+    const server = await startProtocolServer({
+      socketPath,
+      requestTimeoutMs: 10,
+      api: createFakeObserverApi({
+        prepareExternalLaunch: async (params) => {
+          launchedWorktrees.push(params.worktreeId);
+          await new Promise((resolve) => setTimeout(resolve, 25));
+          return {
+            kind: "existing-session",
+            sessionId: "ses_slow_protocol_launch",
+            harnessProvider: "pi",
+          };
+        },
+      }),
+    });
+    const client = createObserverClient({
+      socketPath,
+      timeoutMs: 100,
+      requestId: ids("slow-protocol-launch"),
+    });
+
+    try {
+      const result = await client
+        .prepareExternalLaunch({
+          projectId: "web",
+          worktreeId: "wt_web_slow_protocol_launch",
+        })
+        .catch((error: unknown) => error);
+      expect(launchedWorktrees).toEqual(["wt_web_slow_protocol_launch"]);
+      expect(result).toEqual({
+        kind: "existing-session",
+        sessionId: "ses_slow_protocol_launch",
+        harnessProvider: "pi",
+      });
+    } finally {
+      await server.close();
+    }
+  });
+
   it("lets diagnostic handlers use the diagnostic timeout budget", async () => {
     const { socketPath } = await createTempSocketPath();
     const server = await startProtocolServer({

--- a/station/src/app/StationApp.test.tsx
+++ b/station/src/app/StationApp.test.tsx
@@ -7,7 +7,7 @@ import { testRender } from "@opentui/react/test-utils";
 import { nativeStationTheme, StationThemeProvider } from "../theme/index.js";
 import type { StationClientCommandCompletion } from "@station/client";
 import type { StationSnapshot } from "@station/contracts";
-import { dashboardRowIds } from "@station/dashboard-core/selectors";
+import { dashboardRowIds, selectDashboardTree } from "@station/dashboard-core/selectors";
 import type { TopRowWidgetRuntimeDeps, TuiConfig } from "@station/dashboard-core/widgets";
 import type { StationMouseEvent } from "../input/mouse.js";
 import { createStation, StationApp } from "./createStation.js";
@@ -474,6 +474,136 @@ describe("Station app composition", () => {
         expectedBindingToken: "binding_app_exit",
       },
     ]);
+  });
+
+  it("keeps an uncertain native launch pending and blocks duplicate activation", async () => {
+    const snapshot = manyProjectsSnapshot();
+    const source = new FakeStationSource(snapshot);
+    const service = new FakeTuiObserverService(snapshot);
+    service.prepareExternalLaunch = async (params) => {
+      service.preparedLaunches.push(params);
+      throw {
+        tag: "TimeoutError",
+        code: "CLIENT_PREPARE_EXTERNAL_LAUNCH_TIMEOUT",
+        message: "Station timed out while preparing the external agent launch.",
+      };
+    };
+    const store = createStationStore();
+    const composition = createStation({
+      folderService: createFakeFolderService(),
+      store,
+      clipboardEffects: NO_OP_CLIPBOARD_EFFECTS,
+      stationClient: {
+        state: source,
+        service,
+        start: () => source.start(),
+        stop: () => source.stop(),
+      },
+      shutdown: () => {},
+    });
+    teardowns.push(() => composition.dispose());
+    composition.start();
+
+    const activate = () => {
+      composition.dashboard.actions.dispatch({
+        type: "dashboard.cell.activate",
+        rowId: dashboardRowIds.session("ses_wt_station_none"),
+        cellId: "identity",
+      });
+      composition.dashboard.actions.dispatch({
+        type: "freshStart.activate",
+        actionId: "confirm.startFresh",
+      });
+    };
+    activate();
+    await waitFor(() => composition.dashboard.state.getState().toasts.length > 0);
+
+    activate();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const state = composition.dashboard.state.getState();
+    if (state.snapshot === undefined) {
+      throw new Error("dashboard snapshot is unavailable");
+    }
+    const tree = selectDashboardTree(state.snapshot, state, state.screen);
+    const row = tree.rowById.get(dashboardRowIds.session("ses_wt_station_none"));
+    const launchToasts = state.toasts
+      .map((entry) => entry.toast)
+      .filter(
+        (toast) =>
+          toast.message.includes("docs-cleanup") || toast.message.includes("Could not open session"),
+      );
+    expect({
+      prepareCalls: service.preparedLaunches.length,
+      pendingStart: state.localRows.pendingStart.map((pending) => ({
+        localId: pending.localId,
+        operation: pending.operation,
+        worktreeId: pending.worktreeId,
+      })),
+      activity: row?.payload.type === "session" ? row.payload.presentation.activity : undefined,
+      launchToasts,
+    }).toEqual({
+      prepareCalls: 1,
+      pendingStart: [
+        {
+          localId: "fresh:wt_station_none",
+          operation: "startAgent",
+          worktreeId: "wt_station_none",
+        },
+      ],
+      activity: "starting...",
+      launchToasts: [
+        {
+          kind: "info",
+          message:
+            'Session "docs-cleanup" may still be starting. Station is waiting for Observer state before allowing another launch.',
+        },
+      ],
+    });
+
+    const startingRow = snapshot.rows.find((candidate) => candidate.id === "wt_station_starting");
+    const startingSession = snapshot.sessions.find(
+      (candidate) => candidate.id === "ses_wt_station_starting",
+    );
+    if (
+      startingRow?.agent === undefined ||
+      startingRow.terminal === undefined ||
+      startingSession?.terminal === undefined
+    ) {
+      throw new Error("starting session fixture is incomplete");
+    }
+    const startingAgent = startingRow.agent;
+    const startingTerminal = startingRow.terminal;
+    const startingSessionTerminal = startingSession.terminal;
+    source.setSnapshot({
+      ...snapshot,
+      rows: snapshot.rows.map((candidate) =>
+        candidate.id === "wt_station_none"
+          ? {
+              ...candidate,
+              agent: {
+                ...startingAgent,
+                runId: "run_wt_station_none",
+                sessionId: "ses_wt_station_none",
+              },
+              terminal: startingTerminal,
+            }
+          : candidate,
+      ),
+      sessions: snapshot.sessions.map((candidate) =>
+        candidate.id === "ses_wt_station_none"
+          ? {
+              ...candidate,
+              harness: { ...candidate.harness, runId: "run_wt_station_none" },
+              status: startingSession.status,
+              terminal: startingSessionTerminal,
+            }
+          : candidate,
+      ),
+    });
+    await waitFor(
+      () => composition.dashboard.state.getState().localRows.pendingStart.length === 0,
+    );
   });
 
   it("drains dashboard command work before hot-reload client shutdown", async () => {

--- a/station/src/app/dashboardCapabilities.ts
+++ b/station/src/app/dashboardCapabilities.ts
@@ -250,6 +250,18 @@ function settleNativeActivation(
   if (result.kind === "notice") {
     return result;
   }
+  if (
+    result.error.tag === "TimeoutError" &&
+    result.error.code === "CLIENT_PREPARE_EXTERNAL_LAUNCH_TIMEOUT"
+  ) {
+    return {
+      kind: "success",
+      notice: {
+        kind: "info",
+        message: `Session "${sessionTitle}" may still be starting. Station is waiting for Observer state before allowing another launch.`,
+      },
+    };
+  }
   return {
     kind: "failure",
     error: {


### PR DESCRIPTION
## What this fixes

External launch preparation can legitimately outlive the ordinary Observer request budget while Station Host negotiates or reconstructs a terminal. The client and protocol previously timed out first, so Station could report a failed launch even after the side effect had started and then admit a duplicate retry.

## What changed

- Give `agent.prepareExternalLaunch` a dedicated 30-second budget at both the client and protocol boundaries.
- Keep ordinary request and external-exit timeout behavior unchanged.
- Treat only `CLIENT_PREPARE_EXTERNAL_LAUNCH_TIMEOUT` as uncertain in native activation: retain the pending row, show an informational notice, and wait for canonical Observer state before another launch can be admitted.
- Add real NDJSON socket regressions for both timeout boundaries and a Station composition regression for pending-state and duplicate-activation behavior.
- Document the external-launch timeout and uncertainty contract.

## Testing

- `bun run test:ci:station` — typecheck, 1,776 Station tests, both PTY implementations, and Host upgrade tests passed.
- Focused client/protocol integration suites — 64 tests passed on exact PR head.
- Focused Station retry-safety test passed on exact PR head.
- Repository build, typechecks, lint, 3,445 unit tests, 199 contract tests, 915 integration tests, diagnostics, scripted-agent tests, Observer E2E (27 tests), and install smoke passed.
- The aggregate local `test:all` setup-E2E step exposed a separate macOS fixture PATH collision: Homebrew Bun shares `/opt/homebrew/bin` with unversioned Node 26.3.0. Running setup-core with exact Bun 1.4.0 and repository Node 24 passed 5/5; CI pins Node 24 independently.

## Safety and scope

No protocol schema, persistence, configuration, or dashboard-core result contract changes. This does not add automatic retry, attachment recovery, or a new reconciliation policy.

## User-visible behavior

A genuinely uncertain native launch now remains `starting...` with an informational notice instead of showing a false hard-error toast. Re-activation is blocked until canonical Observer state resolves the launch.