### PR TITLE
perf(tmux): bake configured popup geometry into the fast binding

### DIFF
--- a/apps/cli/src/commands/setup/checks/system.ts
+++ b/apps/cli/src/commands/setup/checks/system.ts
@@ -5,11 +5,7 @@ import { isAbsolute, join } from "node:path";
 import { resolveObserverPaths } from "@station/config";
 import { unixSocketHolderEvidencePath } from "@station/protocol";
 import { type ExternalCommandRunner, isCompiledBinary } from "@station/runtime";
-import {
-  buildManagedFastPopupRunShellCommand,
-  defaultTmuxWorkbenchConfig,
-  resolveTmuxWorkbenchConfig,
-} from "@station/tmux";
+import { buildManagedFastPopupRunShellCommand, resolveTmuxWorkbenchConfig } from "@station/tmux";
 import type { CliEnv } from "../../../env.js";
 import { isStationUiInstalled } from "../../../stationWorkspace.js";
 import type {
@@ -235,15 +231,22 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
   };
   const resolvedTmuxCommand =
     tmux.resolvedPath ?? (isAbsolute(tmux.command) ? tmux.command : undefined);
-  const managedFastPopup = usesManagedFastPopupDefaults(config);
+  const managedFastPopup = supportsManagedFastPopup(config);
   const configAwarePopup = options.configPath !== undefined || !managedFastPopup;
   if (options.tmuxPopupOwnerRoot !== undefined && configAwarePopup) {
     tmuxBindingOptions.runShellCommand = tmuxPopupRunShellCommand(launcherCommand, config.path);
   } else if (options.tmuxPopupOwnerRoot !== undefined && resolvedTmuxCommand !== undefined) {
+    const resolvedTmux = resolveTmuxWorkbenchConfig(
+      config.status === "valid" ? config.tmux : undefined,
+    );
     const fastBindingOptions: Parameters<typeof buildManagedFastPopupRunShellCommand>[0] = {
       installedRoot: options.tmuxPopupOwnerRoot,
       fallbackAlias: launcherCommand,
       tmuxCommand: resolvedTmuxCommand,
+      popupWidth: resolvedTmux.popupWidth,
+      popupHeight: resolvedTmux.popupHeight,
+      popupPosition: resolvedTmux.popupPosition,
+      popupStatusBar: resolvedTmux.popupStatusBar,
     };
     if (config.status === "valid") {
       fastBindingOptions.configPath = config.path;
@@ -328,17 +331,10 @@ async function resolveTmuxLauncherCommand(input: ResolveTmuxLauncherCommandInput
     : setupLauncherExecutable(input.launchers.tmuxPopup);
 }
 
-function usesManagedFastPopupDefaults(config: SetupConfigFact): boolean {
+function supportsManagedFastPopup(config: SetupConfigFact): boolean {
   if (config.status === "missing") return true;
   if (config.status !== "valid") return false;
-  const tmux = resolveTmuxWorkbenchConfig(config.tmux);
-  return (
-    tmux.popupScope === "server" &&
-    tmux.popupWidth === defaultTmuxWorkbenchConfig.popupWidth &&
-    tmux.popupHeight === defaultTmuxWorkbenchConfig.popupHeight &&
-    tmux.popupPosition === defaultTmuxWorkbenchConfig.popupPosition &&
-    tmux.popupStatusBar === defaultTmuxWorkbenchConfig.popupStatusBar
-  );
+  return resolveTmuxWorkbenchConfig(config.tmux).popupScope === "server";
 }
 
 async function canExecute(

--- a/apps/cli/test/unit/setup-checks.test.ts
+++ b/apps/cli/test/unit/setup-checks.test.ts
@@ -396,6 +396,68 @@ describe("setup dependency checks", () => {
     );
   }, 15_000);
 
+  it("bakes configured popup geometry into the fast compiled binding at the default config location", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const home = join(root, "home");
+    const defaultConfigPath = join(home, ".config/station/config.toml");
+    const installedRoot = join(root, "installed");
+    const popupAlias = join(installedRoot, "stn-tmux-popup");
+    await mkdir(repo, { recursive: true });
+
+    const factsFor = (popup: Parameters<typeof configToml>[1]) =>
+      collectSetupFacts({
+        mode: "check",
+        cwd: repo,
+        homeDir: home,
+        compiled: true,
+        tmuxPopupOwnerRoot: installedRoot,
+        env: { PATH: "/fake/bin" },
+        runner: fakeRunner([], {
+          "git rev-parse --show-toplevel": repo,
+          "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+          "wt --version": "worktrunk 1.2.3\n",
+          "tmux -V": "tmux 3.5a\n",
+          "codex --version": "codex 0.1.0\n",
+        }),
+        access: fakeAccess([
+          "/fake/bin/wt",
+          "/fake/bin/tmux",
+          "/fake/bin/hunk",
+          "/fake/bin/stn",
+          "/fake/bin/stn-ingress",
+          popupAlias,
+        ]),
+        fs: readOnlyFs({ [defaultConfigPath]: configToml(repo, popup) }),
+      });
+
+    const geometry = await factsFor({
+      popupWidth: "60%",
+      popupHeight: "70%",
+      popupPosition: "P",
+      popupStatusBar: true,
+    });
+    expect(geometry.tmuxBinding.runShellCommand).toBe(
+      buildManagedFastPopupRunShellCommand({
+        installedRoot,
+        fallbackAlias: popupAlias,
+        tmuxCommand: "/fake/bin/tmux",
+        configPath: defaultConfigPath,
+        popupWidth: "60%",
+        popupHeight: "70%",
+        popupPosition: "P",
+        popupStatusBar: true,
+      }),
+    );
+    expect(geometry.tmuxBinding.runShellCommand).toContain("station-popup-binding");
+
+    const clientScope = await factsFor({ popupScope: "client" });
+    expect(clientScope.tmuxBinding.runShellCommand).toBe(
+      tmuxPopupRunShellCommand(popupAlias, defaultConfigPath),
+    );
+    expect(clientScope.tmuxBinding.runShellCommand).toContain("STATION_DISABLE_FAST_POPUP=1");
+  }, 15_000);
+
   it.each([
     {
       label: "custom geometry",
@@ -409,7 +471,9 @@ describe("setup dependency checks", () => {
       label: "visible popup status bar",
       popup: { popupStatusBar: true },
     },
-  ])("uses the config-aware popup alias for compiled bindings with $label", async ({ popup }) => {
+  ])("config-aware alias for compiled bindings with an explicit --config and $label", async ({
+    popup,
+  }) => {
     const root = await tempRoot(tempRoots);
     const repo = join(root, "repo");
     const home = join(root, "home");

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -149,9 +149,9 @@ placement; its renderer-managed launch path is separate.
 | `workbench_socket_path` | string | Optional fixed tmux socket endpoint. `~` and relative paths resolve against the directory containing the global `config.toml`. When set, all tmux terminal operations use `tmux -S`; caller `TMUX` values remain evidence only. Popup ownership stays on the invoking tmux server and ignores this setting. |
 | `window_naming` | `project-branch` | Single-value enum. |
 | `primary_agent_pane` | bool | |
-| `popup_width` / `popup_height` / `popup_position` | string | Free-form, e.g. `"50%"`, `"C"`. |
-| `popup_status_bar` | bool | Show the persistent popup's nested tmux status bar. Defaults to `false`; this never changes the invoking tmux session's status bar. Rerun `stn setup` after changing it so an installed popup binding uses the config-aware launch path when needed. |
-| `popup_scope` | `server` \| `client` | Popup ownership scope. Defaults to `server`, preserving one popup and warm renderer per tmux server and transferring it between clients. `client` creates an independent popup and warm renderer for each tmux client. Close existing popups before changing this value, then rerun `stn setup` to refresh an installed popup binding; an open renderer retains the scope it started with until dismissed. |
+| `popup_width` / `popup_height` / `popup_position` | string | Free-form, e.g. `"50%"`, `"C"`. Baked into the fast popup binding; rerun `stn setup` after changing them so the regenerated binding carries the new geometry. |
+| `popup_status_bar` | bool | Show the persistent popup's nested tmux status bar. Defaults to `false`; this never changes the invoking tmux session's status bar. Baked into the fast popup binding; rerun `stn setup` after changing it so the regenerated binding carries the new value. |
+| `popup_scope` | `server` \| `client` | Popup ownership scope. Defaults to `server`, preserving one popup and warm renderer per tmux server and transferring it between clients. `client` creates an independent popup and warm renderer for each tmux client, and is the only popup setting that keeps the config-aware (non-fast) launch path, because its ownership names are per-client runtime hashes. Close existing popups before changing this value, then rerun `stn setup` to refresh an installed popup binding; an open renderer retains the scope it started with until dismissed. |
 
 ### `[harness.<id>]` — agent harnesses (optional)
 

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -18528,7 +18528,7 @@
       "declaration": "buildManagedFastPopupRunShellCommand",
       "kind": "function",
       "role": "ADAPTER",
-      "purpose": "Translates the server-scoped installed popup owner into a silent tmux warm-path command that falls back to the exact compiled alias whenever its versioned route cannot be acted on safely.",
+      "purpose": "Translates the server-scoped installed popup owner into a silent tmux warm-path command that falls back to the exact compiled alias whenever its versioned route cannot be acted on safely. Configured popup geometry and status bar are baked into the warm-path `display-popup`, defaulting to `defaultTmuxWorkbenchConfig`; only `popup_scope = \"client\"` needs the runtime config-aware path.",
       "dependencies": []
     },
     {

--- a/docs/system-dependencies.md
+++ b/docs/system-dependencies.md
@@ -121,16 +121,18 @@ server. Reloading after a key change can leave the old key active until
 `tmux unbind-key <old-key>` or a server restart; Station does not unbind a key
 whose ownership it cannot prove.
 
-For a compiled install with the default popup settings, the generated fast command
+For a compiled install, the generated fast command
 uses the canonical installed directory, the exact sibling `stn-tmux-popup`
 alias, and the resolved tmux executable. First use can invoke that full CLI
 fallback to initialize the hidden UI; a valid warm use directly attaches or
 toggles it without loading config or starting Bun or the Observer. Configured
-custom geometry, `popup_scope = "client"`, and `popup_status_bar = true` use the
-config-aware sibling alias instead so every open reads those settings; setup with
-an explicit `--config` path also uses that alias so an existing hidden UI cannot
-mask a config change. Rerun `stn setup` after changing any of these settings so the
-managed binding is regenerated. Controlled
+popup geometry (`popup_width`/`popup_height`/`popup_position`) and
+`popup_status_bar` are baked into that fast command, so they no longer force the
+slower path. Only `popup_scope = "client"` uses the config-aware sibling alias
+instead — its per-client session and option names are derived at runtime and
+cannot be a static script; setup with an explicit `--config` path also uses that
+alias so an existing hidden UI cannot mask a config change. Rerun `stn setup`
+after changing any of these settings so the managed binding is regenerated. Controlled
 binding failures are silent, return success to tmux, and show at most a
 temporary status-line message. Run `stn popup` directly for ordinary diagnostic
 output.

--- a/integrations/terminal/tmux/src/popup/args.ts
+++ b/integrations/terminal/tmux/src/popup/args.ts
@@ -1,9 +1,8 @@
-import { shellQuote } from "../shell.js";
+import { safeShellTokenPattern, shellQuote } from "../shell.js";
 import { resolveTmuxWorkbenchConfig } from "../topology.js";
 import { defaultPersistentPopupSessionName } from "./constants.js";
 import type { BuildTmuxPopupArgsOptions, TmuxPopupState } from "./types.js";
 
-const safeShellTokenPattern = /^[A-Za-z0-9_@%+=,./:-]+$/;
 const persistentPopupAttachFeatures = "hyperlinks";
 
 function buildPopupTuiCommand(options: { focusClientId?: string; tuiCommand: string }): string {

--- a/integrations/terminal/tmux/src/popup/fastBinding.ts
+++ b/integrations/terminal/tmux/src/popup/fastBinding.ts
@@ -1,5 +1,6 @@
 import { isAbsolute, join } from "node:path";
-import { shellQuote } from "../shell.js";
+import { safeShellTokenPattern, shellQuote } from "../shell.js";
+import { defaultTmuxWorkbenchConfig } from "../topology.js";
 import {
   activePopupClaimOption,
   activePopupClientOption,
@@ -24,6 +25,10 @@ export type BuildManagedFastPopupRunShellCommandOptions = {
   fallbackAlias: string;
   installedRoot: string;
   tmuxCommand: string;
+  popupWidth?: string;
+  popupHeight?: string;
+  popupPosition?: string;
+  popupStatusBar?: boolean;
 };
 
 function containsUnsafeShellValue(value: string): boolean {
@@ -54,6 +59,11 @@ function validateManagedBindingOptions(options: BuildManagedFastPopupRunShellCom
     (!isAbsolute(options.configPath) || containsUnsafeShellValue(options.configPath))
   ) {
     throw new Error("Station popup binding requires a safe absolute config path.");
+  }
+  for (const geometry of [options.popupWidth, options.popupHeight, options.popupPosition]) {
+    if (geometry !== undefined && !safeShellTokenPattern.test(geometry)) {
+      throw new Error("Station popup binding requires safe popup geometry tokens.");
+    }
   }
 }
 
@@ -104,6 +114,8 @@ function expectedPersistentPopupSignature(options: {
  *
  * Translates the server-scoped installed popup owner into a silent tmux warm-path command that
  * falls back to the exact compiled alias whenever its versioned route cannot be acted on safely.
+ * Configured popup geometry and status bar are baked into the warm-path `display-popup`, defaulting
+ * to `defaultTmuxWorkbenchConfig`; only `popup_scope = "client"` needs the runtime config-aware path.
  */
 export function buildManagedFastPopupRunShellCommand(
   options: BuildManagedFastPopupRunShellCommandOptions,
@@ -119,6 +131,16 @@ export function buildManagedFastPopupRunShellCommand(
   const configPath = escapeTmuxFormat(options.configPath ?? "");
   const tmuxCommand = escapeTmuxFormat(options.tmuxCommand);
   const nestedTmuxCommand = escapeTmuxFormat(tmuxCommand);
+  const popupWidth = escapeTmuxFormat(options.popupWidth ?? defaultTmuxWorkbenchConfig.popupWidth);
+  const popupHeight = escapeTmuxFormat(
+    options.popupHeight ?? defaultTmuxWorkbenchConfig.popupHeight,
+  );
+  const popupPosition = escapeTmuxFormat(
+    options.popupPosition ?? defaultTmuxWorkbenchConfig.popupPosition,
+  );
+  const popupStatus =
+    (options.popupStatusBar ?? defaultTmuxWorkbenchConfig.popupStatusBar) ? "on" : "off";
+  const includePosition = popupPosition.length > 0 && popupPosition !== "C";
   const attachCommand = [
     "env -u TMUX",
     shellQuote(nestedTmuxCommand),
@@ -141,6 +163,9 @@ expected_root_sha=${shellQuote(expectedRootSha256)}
 expected_session_sha=${shellQuote(expectedSessionSha256)}
 expected_signature_sha=${shellQuote(expectedSignatureSha256)}
 attach_arg=${shellQuote(shellQuote(attachCommand))}
+popup_width=${shellQuote(popupWidth)}
+popup_height=${shellQuote(popupHeight)}
+popup_status=${shellQuote(popupStatus)}${includePosition ? `\npopup_position=${shellQuote(popupPosition)}` : ""}
 fmt='#'
 sep=$(printf '\\037')
 trap 'exit 0' HUP INT TERM
@@ -275,10 +300,10 @@ run_action() {
   prefix="set-option -gq ${activePopupClaimOption} $new_claim ; set-option -gq ${activePopupClientOption} $claim_target_client ; set-option -gq ${focusPopupClientOption} $claim_target_client"
   case "$action_kind" in
     open)
-      action="$prefix ; set-option -t $session_name mouse on ; set-option -t $session_name status off ; display-popup -c $client_name -w 50% -h 50% -E $attach_arg ; $finish"
+      action="$prefix ; set-option -t $session_name mouse on ; set-option -t $session_name status $popup_status ; display-popup -c $client_name -w $popup_width -h $popup_height${includePosition ? " -x $popup_position" : ""} -E $attach_arg ; $finish"
       ;;
     replace)
-      action="$prefix ; display-popup -c $previous_client -C ; set-option -t $session_name mouse on ; set-option -t $session_name status off ; display-popup -c $client_name -w 50% -h 50% -E $attach_arg ; $finish"
+      action="$prefix ; display-popup -c $previous_client -C ; set-option -t $session_name mouse on ; set-option -t $session_name status $popup_status ; display-popup -c $client_name -w $popup_width -h $popup_height${includePosition ? " -x $popup_position" : ""} -E $attach_arg ; $finish"
       ;;
     close)
       action="$prefix ; display-popup -c $previous_client -C ; $finish"

--- a/integrations/terminal/tmux/src/shell.ts
+++ b/integrations/terminal/tmux/src/shell.ts
@@ -1,3 +1,5 @@
 export function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
+
+export const safeShellTokenPattern = /^[A-Za-z0-9_@%+=,./:-]+$/;

--- a/integrations/terminal/tmux/test/unit/popup-fast-binding.test.ts
+++ b/integrations/terminal/tmux/test/unit/popup-fast-binding.test.ts
@@ -302,6 +302,44 @@ describe("managed tmux popup fast binding", () => {
       );
     }
   });
+
+  it("bakes configured geometry and status bar into the open action", async () => {
+    const fixture = await createFixture({}, "managed bin", undefined, undefined, {
+      popupWidth: "60%",
+      popupHeight: "70%",
+      popupPosition: "P",
+      popupStatusBar: true,
+    });
+    await expect(runBinding(fixture)).resolves.toMatchObject({ code: 0 });
+    const action = (await fixture.calls())[1]?.args.at(-2) ?? "";
+    expect(action).toContain("display-popup -c /dev/ttys001 -w 60% -h 70% -x P -E");
+    expect(action).toContain("set-option -t _station-ui status on");
+  });
+
+  it("omits -x for the centered default position", async () => {
+    const fixture = await createFixture();
+    await expect(runBinding(fixture)).resolves.toMatchObject({ code: 0 });
+    const action = (await fixture.calls())[1]?.args.at(-2) ?? "";
+    expect(action).toContain("display-popup -c /dev/ttys001 -w 50% -h 50% -E");
+    expect(action).not.toContain(" -x ");
+    expect(action).toContain("set-option -t _station-ui status off");
+  });
+
+  it("rejects unsafe popup geometry tokens", () => {
+    const options = {
+      fallbackAlias: "/opt/station/stn-tmux-popup",
+      installedRoot: "/opt/station",
+      tmuxCommand: "/opt/homebrew/bin/tmux",
+    };
+    for (const bad of ["50 %", "50%;touch x", "#{session_name}", "", "$(id)"]) {
+      expect(() => buildManagedFastPopupRunShellCommand({ ...options, popupWidth: bad })).toThrow(
+        "safe popup geometry tokens",
+      );
+      expect(() =>
+        buildManagedFastPopupRunShellCommand({ ...options, popupPosition: bad }),
+      ).toThrow("safe popup geometry tokens");
+    }
+  });
 });
 
 type Fixture = {
@@ -317,6 +355,10 @@ async function createFixture(
   directoryName = "managed bin",
   configPath?: string,
   registeredConfigPath = configPath,
+  geometry: Pick<
+    Parameters<typeof buildManagedFastPopupRunShellCommand>[0],
+    "popupWidth" | "popupHeight" | "popupPosition" | "popupStatusBar"
+  > = {},
 ): Promise<Fixture> {
   const tempRoot = await mkdtemp(join(tmpdir(), "station-fast-binding-"));
   fixtureRoots.add(tempRoot);
@@ -398,6 +440,7 @@ exit \${FAKE_FALLBACK_EXIT:-0}
     fallbackAlias,
     installedRoot,
     tmuxCommand,
+    ...geometry,
   };
   if (configPath !== undefined) commandOptions.configPath = configPath;
   return {


### PR DESCRIPTION
## What this fixes

The tmux popup dashboard has two compiled binding forms. The **fast binding** is a pure-tmux script that warm-attaches the persistent `_station-ui` renderer without launching `stn`, Bun, or the Observer. The **config-aware binding** runs the full `stn` CLI on every open. In an isolated benchmark the difference is large and consistent:

| Path | Config-aware (slow) | Fast |
| --- | --- | --- |
| Popup open | ~217ms, spawns `stn` every open | ~23ms, no `stn` spawn |
| Chord-close | ~176ms | ~27ms (tmux-native, same as `Q`) |

`stn setup` selected the slow form whenever `popup_width`/`popup_height`/`popup_position`, `popup_status_bar`, or `popup_scope` differed from defaults. So any user with custom popup geometry (e.g. `popup_width = "60%"`) silently lost the fast path and paid the `stn` cold-start (~160ms, ~85% of the open) on every open.

Geometry and status bar are static values that never needed the runtime-config path — only `popup_scope = "client"` genuinely does, because its tmux session and option names are per-client sha256 hashes computed at runtime and cannot be a script generated once at setup time.

## What changed

- The fast binding generator now bakes configured geometry into its warm-path `display-popup`: `-w`/`-h`, a conditional `-x` position (added only for a non-centered position, matching the config-aware path), and `status on|off`. Values default to `defaultTmuxWorkbenchConfig`, so a default config produces the same warm-path commands as before.
- Geometry strings are validated as safe single tmux tokens at generation time (they are interpolated into a shell string that becomes a tmux command), rejecting whitespace/metacharacters.
- Setup's fast-vs-config-aware gate is relaxed to keep only `popup_scope = "client"` on the config-aware path; an explicit `--config` still forces it as before.
- The shared safe-token pattern moves to `shell.ts` (next to `shellQuote`), deduping an identical copy in `args.ts`.
- Docs updated (`system-dependencies.md`, `configuration.md`) plus the regenerated observer-architecture manifest for the adapter's JSDoc.

## User-visible behavior

Users with custom popup geometry keep their geometry and get the fast (~23ms) open once they rebuild and re-run a plain `stn setup` (no `--config` flag) to regenerate the binding. Default configs are unchanged. `popup_scope = "client"` still uses the config-aware binding.

## Testing

- `bun test` unit suites for the tmux integration and CLI setup checks (geometry/status baking, `-x` omission for centered default, unsafe-geometry validation, and a default-location fast-geometry decision case): 304 passing.
- Typecheck and the full lint gate (biome, custom checks, observer-architecture manifest) pass.
- Open/close latency figures above come from an isolated tmux benchmark (private tmux server + observer) comparing the config-aware binding against a warm attach.

https://claude.ai/code/session_01EomQqwi7iwXDzv3Ph6X8Mi