### PR TITLE
feat(tui): configure post-create focus and dismissal

### DIFF
--- a/apps/cli/test/integration/session-create-fork-command.test.ts
+++ b/apps/cli/test/integration/session-create-fork-command.test.ts
@@ -1,3 +1,4 @@
+import { appendFile } from "node:fs/promises";
 import type {
   CommandReceipt,
   CommandRecord,
@@ -48,6 +49,11 @@ describe("session create and fork commands", () => {
   it("creates detached with exact options, safe output, durable identities, and no focus", async () => {
     const fixture = await createTempState();
     const configPath = await writeConfigToml(fixture.root, fixture.config);
+    await appendFile(
+      configPath,
+      "\n[tui.session_create]\nfocus_created_session = true\ndismiss_dashboard = true\n",
+      "utf8",
+    );
     const initial = creationSnapshot();
     const commands: StationCommand[] = [];
     const result = detachedCreateResult("group_root");
@@ -107,6 +113,7 @@ describe("session create and fork commands", () => {
         },
       ]);
       expect("focus" in firstCommand(commands).payload.terminal).toBe(false);
+      expect(commands.some((command) => command.type === "terminal.focus")).toBe(false);
       expect(cliResult).toMatchObject({
         code: 0,
         correlation: { status: "succeeded", commandId: "cmd_create", traceId: "trc_creation" },
@@ -135,6 +142,9 @@ describe("session create and fork commands", () => {
 
   it("forks beside fresh caller authority while keeping code source, harness, and Group exact", async () => {
     const fixture = await createTempState();
+    fixture.config.tui = {
+      sessionCreate: { focusCreatedSession: true, dismissDashboard: true },
+    };
     const initial = creationSnapshot();
     const commands: StationCommand[] = [];
     const result = siblingForkResult();
@@ -184,6 +194,7 @@ describe("session create and fork commands", () => {
           },
         },
       ]);
+      expect(commands.some((command) => command.type === "terminal.focus")).toBe(false);
       const command = firstCommand(commands);
       expect(command.type).toBe("session.fork");
       if (command.type !== "session.fork") throw new Error("Expected session.fork.");

--- a/apps/cli/test/unit/real-station-config-support.test.ts
+++ b/apps/cli/test/unit/real-station-config-support.test.ts
@@ -53,6 +53,11 @@ describe("real Station config support", () => {
       repo,
       harnessProvider: "scripted",
       scriptedCommand: "/usr/local/bin/node",
+      sessionCreatePolicy: {
+        focusCreatedSession: true,
+        dismissDashboard: true,
+        terminals: { tmux: { dismissDashboard: false } },
+      },
     });
     endpointRoots.push(fixture.tmuxEndpoint.rootPath);
 
@@ -72,6 +77,10 @@ describe("real Station config support", () => {
       `[terminal.tmux]\ncommand = ${JSON.stringify(fixture.tmuxEndpoint.wrapperPath)}\nworkbench_socket_path = ${JSON.stringify(fixture.tmuxEndpoint.socketPath)}`,
     );
     expect(config).toContain('[harness.scripted]\nenabled = true\ncommand = "/usr/local/bin/node"');
+    expect(config).toContain(
+      "[tui.session_create]\nfocus_created_session = true\ndismiss_dashboard = true",
+    );
+    expect(config).toContain("[tui.session_create.terminals.tmux]\ndismiss_dashboard = false");
 
     const second = await writeRealStationConfig({
       env,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -363,11 +363,40 @@ with:
 command = 'base="$(git merge-base origin/main HEAD 2>/dev/null || true)"; [ -n "$base" ] || base=HEAD; hunk diff "$base" --watch --no-exclude-untracked'
 ```
 
-### `[tui]` — runtime TUI widgets (optional, best-effort)
+### `[tui]` — shared dashboard behavior and widgets (optional, best-effort)
 
-> **Decorative widgets only** — not the same as `[workspace]`. `[tui]` is the
-> clock/weather strip; `[workspace]` is interaction behavior (scroll, welcome,
-> automations). They never overlap.
+`[tui]` applies to both the native Station overlay and standalone/fullscreen/tmux
+dashboards. `[workspace]` remains native-only pane and overlay behavior.
+
+`[tui.session_create]` controls what the renderer does after any dashboard-driven
+New Session, Quick Session, or Quick Group creation succeeds. Both global values
+default to `true`. A terminal table inherits any omitted value from the resolved
+global policy:
+
+```toml
+[tui.session_create]
+focus_created_session = true
+dismiss_dashboard = true
+
+[tui.session_create.terminals.tmux]
+dismiss_dashboard = false
+
+[tui.session_create.terminals.native]
+focus_created_session = true
+dismiss_dashboard = true
+```
+
+| Key | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `focus_created_session` | bool | `true` | Focus the exact canonical session created by the completed dashboard operation. |
+| `dismiss_dashboard` | bool | `true` | Dismiss only after focus succeeds when focus is enabled; otherwise dismiss immediately after creation settles. |
+
+Terminal keys are Station terminal provider IDs such as `tmux` and `native`, not
+terminal-emulator brands. Unknown provider IDs are accepted for future adapters.
+The config is resolved once when a renderer starts; an open renderer does not
+live-reload policy changes. As with the rest of `[tui]`, an unknown field or
+non-boolean policy value invalidates the complete best-effort section, emits the
+`[tui]` warning, and uses the default `true`/`true` policy.
 
 `[tui].widgets` configures the shared title strip in both the native Station
 overlay and the standalone dashboard used by fullscreen and tmux popup launches.
@@ -665,6 +694,7 @@ right observer/session. `STATION_STATE_DIR` is a hook-script fallback for
 | Tune the observer daemon | `config.toml` | `[observer]` |
 | React to observer events with a command | `config.toml` | `[[hooks.event]]` |
 | Change scrollback depth, scroll behavior, the welcome screen, or pane automations | `config.toml` | `[workspace]` |
+| Configure dashboard post-create focus/dismissal | `config.toml` | `[tui.session_create]` |
 | Add a clock/weather widget | `config.toml` | `[tui].widgets` |
 | Set log/DB retention caps | `config.toml` | `[observability.retention]` |
 | Toggle a feature flag | `config.toml` | `[feature_flags]` |
@@ -680,10 +710,11 @@ section hard-fails validation, the TUI keeps running with workspace defaults and
 a warning before rendering. Fix the core config error to restore custom scroll,
 welcome, and automation settings.
 
-**`[tui]` vs `[workspace]`?** `[tui]` is decorative title widgets shared by the
-native overlay and standalone/fullscreen/tmux dashboards; `[workspace]` is
-native-UI-only interaction behavior (scroll/welcome/automations). Both live in
-`config.toml`; only the TUI consumes their display and interaction behavior.
+**`[tui]` vs `[workspace]`?** `[tui]` owns dashboard behavior shared by the
+native overlay and standalone/fullscreen/tmux dashboards, including post-create
+policy and title widgets. `[workspace]` is native-UI-only interaction behavior
+(scroll/welcome/automations). Both live in `config.toml`; only the TUI consumes
+their display and interaction behavior.
 
 **Why is `permission_mode = "auto"` rejected?** `auto` is Claude-only — valid only
 under `[harness.claude]`, never as a global default or for other harnesses.

--- a/docs/dashboard-architecture.md
+++ b/docs/dashboard-architecture.md
@@ -68,7 +68,7 @@ client-owned source; dashboard queries are reserved for reads where local
 filter, focus, screen, or optimistic state participates.
 
 Semantic execution enters through capabilities selected at composition
-(activation, managed sessions, worktree removal, dismissal, shell), never through state
+(activation, managed sessions, created-session UI policy, worktree removal, dismissal, shell), never through state
 replacement or synthetic key replay. Observer-backed worktree removal first
 obtains authoritative validation and an opaque worktree reservation, then invokes
 optional renderer PTY settlement, dispatches the reservation-qualified command,
@@ -84,13 +84,28 @@ Its Group field selects Ungrouped, a current same-project root Group
 by stable ID, or a trimmed inline-create draft. Snapshot replacement preserves
 the stable selection through rename and resets missing, cross-project, or newly
 nested Groups to Ungrouped. Submission retains and disables the sheet until the
-single operation settles; success follows the composition's existing open/focus
-path, while failure restores Group or Create focus and reports one bounded toast.
+single operation settles; success closes the sheet before applying the renderer-resolved
+post-create focus/dismiss policy, while failure restores Group or Create focus and reports one bounded toast.
 Native deliberate creation waits for the first canonical snapshot carrying the
 requested Group relationship and performs one explicit load after timeout. If
 launch succeeded but visibility remains uncertain—or safe cleanup retained the
 fresh worktree—the operation closes with a warning instead of permitting a
 duplicate branch submission.
+
+Successful managed creation may return one dashboard-local
+`createdSession.applyUiPolicy` command containing exact canonical Project,
+worktree, session, branch, and terminal-provider identity plus resolved booleans.
+It is data-only UI state, never a protocol command or durable result. The central
+operation runner settles the sheet or optimistic row before invoking one
+renderer capability. Focus precedes dismissal when both are enabled; disposal
+discards a late command. A focus or dismissal failure reports one error without
+turning the successful create into a retryable operation.
+
+Quick Session in Group defers that exact command through its version-checked
+membership update. It removes the targeted row and selects the canonical member
+before applying UI policy. Correlation, Group disappearance, membership, or
+final-convergence failure preserves surviving canonical data and discards the
+UI command; post-create UI failure never rolls back creation or membership.
 
 Group Settings is one stable-ID screen per canonical Group, with General,
 Sessions, and Remove Group sections. Activating the Group `[▾]` control opens a

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -5,8 +5,10 @@ Status: current contributor reference for the OpenTUI Station terminal UI in `st
 Station is the terminal UI client. It renders observer snapshots and events, owns local interaction state, and dispatches typed observer commands. It does not derive runtime truth from providers. The classic Ink TUI (`apps/tui`) was retired; Station is now the sole terminal UI.
 
 Observer-backed dashboard Create and Fork commands explicitly request detached
-placement. They do not infer a terminal origin, change focus, or dispatch a
-follow-up `terminal.focus`; terminal focus remains a separate user action.
+placement. Fork remains detached and does not change focus. Successful UI-driven
+Create follows the renderer-resolved `[tui.session_create]` policy through a
+separate exact-target UI command; that policy never enters the Observer create
+payload or durable command result.
 
 ## Renderer And Entry Points
 
@@ -18,9 +20,10 @@ the Bun-executed `@station/workspace` package in the root workspace (see
 - `station/src/dashboardRenderer/main.tsx` — the standalone observer-backed dashboard (live
   observer data and commands, no panes).
 
-Both entry points load `[tui].widgets` from the runtime config and render the same
-configured-widget title strip; widget settings update that shared config when a
-config path is available.
+Both entry points load `[tui]` once at renderer start. They render the same
+configured-widget title strip and resolve the same post-create policy; widget
+settings update the shared config when a config path is available, while an open
+renderer does not live-reload post-create policy.
 
 Launch is driven by `apps/cli/src/commands/tui.ts`. The launcher mints one
 `uiRunId` per renderer child, records exact spawn/exit code/signal evidence in
@@ -401,7 +404,7 @@ reattach; pane borders and neighboring panes must remain unlinked.
 - OpenTUI/React components should stay plain and readable. Runtime orchestration belongs in services or the dashboard runtime, not presentation components.
 - Selectors, screen transitions, command builders, event reducers, and fixtures should stay pure TypeScript. The render-framework-free dashboard logic lives in `@station/dashboard-core` and is consumed by the OpenTUI render layer.
 - Dashboard key/behavior is shared, not feature-gated: reducers and render/input leaves never select filter behavior or inspect feature flags; session and optimistic-row matching remains centralized in the pure persistent-filter projection.
-- Each renderer composition owns one `DashboardRuntime`: `state` exposes only Zustand-compatible `getState`, `getInitialState`, and `subscribe`; `actions` is the sole external dashboard mutation authority; `start` is one-shot/idempotent and `dispose` is asynchronous and repeat-safe. Disposal closes actions and effect admission immediately, detaches canonical-source and directory-polling subscriptions once, clears owned timers, blocks late async state writes, and returns one promise that drains all already-started bounded work with settled outcomes. Construction requires the composition's `StationClientStateSource`, convergence-safe `ObserverService`, renderer-supplied `TuiFolderService`, and every `DashboardCapabilities` group: session activation, managed session execution, worktree removal, shell opening, and dashboard dismissal. Dashboard-core never creates fallback capabilities, a filesystem adapter, a fallback client runtime, or an independent runtime snapshot. The private Zustand store and reducers use mutable `DashboardState`; neither that model nor `setState` crosses the dashboard-core boundary.
+- Each renderer composition owns one `DashboardRuntime`: `state` exposes only Zustand-compatible `getState`, `getInitialState`, and `subscribe`; `actions` is the sole external dashboard mutation authority; `start` is one-shot/idempotent and `dispose` is asynchronous and repeat-safe. Disposal closes actions and effect admission immediately, detaches canonical-source and directory-polling subscriptions once, clears owned timers, blocks late async state writes, and returns one promise that drains all already-started bounded work with settled outcomes. Construction requires the composition's `StationClientStateSource`, convergence-safe `ObserverService`, renderer-supplied `TuiFolderService`, and every `DashboardCapabilities` group: session activation, managed session execution, created-session UI policy, worktree removal, shell opening, and dashboard dismissal. Dashboard-core never creates fallback capabilities, a filesystem adapter, a fallback client runtime, or an independent runtime snapshot. The private Zustand store and reducers use mutable `DashboardState`; neither that model nor `setState` crosses the dashboard-core boundary.
 - `@station/client` owns canonical in-process snapshot and connection truth. Its runtime-backed service commits snapshot loads and reconcile results to that same state source before resolving. Snapshot-only native and standalone consumers read `StationClientStateSource`; dashboard-core mirrors the exact snapshot identity only to combine it with screens, filter, focus, collapse, semantic visibility, widgets, optimistic rows, and toasts. Station alone owns scroll coordinates.
 - `DashboardStateSource` returns `DashboardStateView`, a recursively readonly type projection that includes snapshots, screens, local rows, widgets, arrays, maps, and sets. The projection preserves the store's exact object and notification identities: it performs no runtime copying, freezing, or proxying. Dashboard readers and Station consumers must accept the exported readonly view types rather than importing private mutable state models.
 - Presentation receives the readonly `DashboardStateSource` for dashboard projection and the canonical client source where snapshot-only rendering requires it. Input adapters receive only their explicit dashboard state and action capabilities, while native and standalone composition roots alone own full runtime lifecycle and inject terminal-specific implementations of the semantic capability groups. Config persistence receives only the dashboard subscription and `pushToast` capability it needs.
@@ -623,10 +626,13 @@ and resize preserve semantic focus while Station follows the focused measured bo
 
 Activating a Group's responsive `[qs]`/`[quick session]` action launches an ordinary Quick Session without embedding Group placement in
 the create request. While pending, its targeted local row is rendered inside the expanded Group. On
-successful launch, dashboard-core reloads canonical truth, correlates the new session by Project and
-generated branch, reads the latest Group version, and records one expected membership addition. It
-never retries a successful launch: load, correlation, conflict, or convergence failure preserves the
-created session, removes stale targeted presentation, focuses canonical truth, and reports the error.
+successful launch, dashboard-core uses the create result's exact canonical session, Project,
+worktree, branch, and terminal-provider identity, reads the latest Group version, and records one
+expected membership addition. Its created-session UI command remains deferred until canonical
+membership has converged and the optimistic row is removed. It never retries a successful launch:
+load, identity, conflict, or convergence failure preserves the created session, removes stale
+targeted presentation, focuses canonical truth, reports the error, and discards the deferred UI
+command.
 
 Activating a Project's `[▾]` opens a right-edge anchored menu with Quick Group, New Group…, Set
 default agent, and Project settings… in that order. Up/Down wraps, Enter activates, `G` selects Quick
@@ -706,12 +712,14 @@ header `menu` cell when opened from native context.
 
 Quick Group creates a durable `Quick Group <six-hex-token>` first, then invokes the ordinary Quick
 Session capability with the Project defaults. After the client has loaded canonical launch truth,
-dashboard-core correlates the issued Project and hidden branch and records one expected Group
+dashboard-core validates the exact durable create identity and records one expected Group
 membership update. A targeted pending row bridges the launch under the new Group without changing
 canonical counts or showing a duplicate project-root row. Launch failure leaves the valid empty
-Group and ordinary failed-row/toast feedback; correlation or membership failure never retries or
-rolls back the Group or session and focuses their canonical surviving destination. Successful
-membership removes the transient row and focuses the canonical session without activating it again.
+Group and ordinary failed-row/toast feedback; identity or membership failure never retries or rolls
+back the Group or session and focuses their canonical surviving destination. Successful membership
+removes the transient row, selects the canonical session, and only then applies the unchanged
+renderer-resolved focus/dismiss policy. Named New Group with Quick session enabled uses the same
+ordering.
 
 The zero-project dashboard renders **Add your first project** as a pointer
 target that dispatches `dashboard.addProject`, producing the same Add Project

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -71,6 +71,19 @@ welcome_on_boot = true      # show the welcome intro over the restored layout on
 #   [[workspace.automations.steps]]
 #   command = 'base="$(git merge-base origin/main HEAD 2>/dev/null || true)"; [ -n "$base" ] || base=HEAD; hunk diff "$base" --watch --no-exclude-untracked'
 
+# Dashboard behavior after New Session, Quick Session, or Quick Group creation.
+[tui.session_create]
+focus_created_session = true
+dismiss_dashboard = true
+
+# Terminal-provider overrides inherit omitted values from the global policy.
+[tui.session_create.terminals.tmux]
+dismiss_dashboard = false
+
+[tui.session_create.terminals.native]
+focus_created_session = true
+dismiss_dashboard = true
+
 [[hooks.event]]
 id = "notify-agent-state"
 events = ["worktree.agentStateChanged"]

--- a/packages/config/src/load/index.ts
+++ b/packages/config/src/load/index.ts
@@ -124,7 +124,7 @@ function collectTuiWorkspaceDiagnostics(
       code: "CONFIG_TUI_SECTION_INVALID",
       message: `The [tui] section is invalid (${formatZodError(
         tuiResult.error,
-      )}) and was ignored; using widget defaults.`,
+      )}) and was ignored; using TUI defaults.`,
       severity: "warn",
       configPath,
     });

--- a/packages/config/src/load/normalize.ts
+++ b/packages/config/src/load/normalize.ts
@@ -127,7 +127,37 @@ function normalizeTuiConfig(value: unknown): unknown {
   return normalizeObject(
     value,
     {},
-    { widgets: normalizeTuiWidgetConfigs, island: normalizeTuiIslandConfig },
+    {
+      widgets: normalizeTuiWidgetConfigs,
+      island: normalizeTuiIslandConfig,
+      sessionCreate: normalizeTuiSessionCreateConfig,
+    },
+  );
+}
+
+function normalizeTuiSessionCreateConfig(value: unknown): unknown {
+  return normalizeObject(
+    value,
+    {
+      focus_created_session: "focusCreatedSession",
+      dismiss_dashboard: "dismissDashboard",
+    },
+    { terminals: normalizeTuiSessionCreateTerminalConfigs },
+  );
+}
+
+function normalizeTuiSessionCreateTerminalConfigs(value: unknown): unknown {
+  if (!isRecord(value)) {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value).map(([providerId, policy]) => [
+      providerId,
+      normalizeObject(policy, {
+        focus_created_session: "focusCreatedSession",
+        dismiss_dashboard: "dismissDashboard",
+      }),
+    ]),
   );
 }
 

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -199,6 +199,8 @@ export const HooksConfigSchema = z
 export type {
   TuiConfig,
   TuiIslandConfig,
+  TuiSessionCreateConfig,
+  TuiSessionCreatePolicyConfig,
   TuiTimezoneZone,
   TuiWidgetConfig,
 } from "@station/contracts";

--- a/packages/config/test/unit/config-schema.test.ts
+++ b/packages/config/test/unit/config-schema.test.ts
@@ -238,6 +238,36 @@ describe("config schemas", () => {
     ).toEqual({ widgets: [] });
   });
 
+  it("validates strict session-create policy and arbitrary terminal provider ids", async () => {
+    expect(
+      TuiConfigSchema.parse({
+        sessionCreate: {
+          focusCreatedSession: false,
+          terminals: {
+            tmux: { dismissDashboard: false },
+            future: { focusCreatedSession: true },
+          },
+        },
+      }).sessionCreate,
+    ).toEqual({
+      focusCreatedSession: false,
+      terminals: {
+        tmux: { dismissDashboard: false },
+        future: { focusCreatedSession: true },
+      },
+    });
+    expect(
+      TuiConfigSchema.safeParse({
+        sessionCreate: { focusCreatedSession: "yes" },
+      }).success,
+    ).toBe(false);
+    expect(
+      TuiConfigSchema.safeParse({
+        sessionCreate: { terminals: { tmux: { dismissDashboard: true, extra: true } } },
+      }).success,
+    ).toBe(false);
+  });
+
   it("validates explicit project recovery breadcrumb opt-in", () => {
     const project = ProjectConfigSchema.parse({
       id: "web",

--- a/packages/config/test/unit/load-config.test.ts
+++ b/packages/config/test/unit/load-config.test.ts
@@ -672,6 +672,63 @@ ${projectToml("web", root)}
     expect(loaded.config.tui?.island).toEqual({ restCounts: true, projectRollup: false });
   });
 
+  it("normalizes global and partial terminal session-create policy", async () => {
+    const tempDir = await makeTempDir();
+    const root = await makeProjectRoot(tempDir, "web");
+
+    const loaded = await loadConfigFromToml(
+      `
+schema_version = 1
+
+[defaults]
+worktree_provider = "worktrunk"
+terminal = "tmux"
+harness = "codex"
+layout = "agent-build-shell"
+
+[tui.session_create]
+focus_created_session = false
+dismiss_dashboard = true
+
+[tui.session_create.terminals.tmux]
+dismiss_dashboard = false
+
+[tui.session_create.terminals.future]
+focus_created_session = true
+
+${projectToml("web", root)}
+`,
+      { configPath: join(tempDir, "config.toml"), homeDir: tempDir },
+    );
+
+    expect(loaded.config.tui?.sessionCreate).toEqual({
+      focusCreatedSession: false,
+      dismissDashboard: true,
+      terminals: {
+        tmux: { dismissDashboard: false },
+        future: { focusCreatedSession: true },
+      },
+    });
+  });
+
+  it.each([
+    '[tui.session_create]\nfocus_created_session = "yes"',
+    "[tui.session_create]\nunknown = true",
+    '[tui.session_create.terminals.tmux]\ndismiss_dashboard = "yes"',
+  ])("drops invalid session-create policy with the [tui] diagnostic", async (policyToml) => {
+    const tempDir = await makeTempDir();
+    const root = await makeProjectRoot(tempDir, "web");
+    const loaded = await loadConfigFromToml(
+      `${baseToml(projectToml("web", root))}\n${policyToml}\n`,
+      { configPath: join(tempDir, "config.toml"), homeDir: tempDir },
+    );
+
+    expect(loaded.config.tui).toBeUndefined();
+    expect(loaded.diagnostics).toContainEqual(
+      expect.objectContaining({ code: "CONFIG_TUI_SECTION_INVALID", severity: "warn" }),
+    );
+  });
+
   it.each([
     [
       "unknown widget type",

--- a/packages/config/test/unit/project-mutation.test.ts
+++ b/packages/config/test/unit/project-mutation.test.ts
@@ -541,6 +541,12 @@ city = "New York, NY"
 
 [tui.island]
 rest_counts = true
+
+[tui.session_create]
+focus_created_session = false
+
+[tui.session_create.terminals.tmux]
+dismiss_dashboard = false
 `,
       "utf8",
     );
@@ -555,9 +561,18 @@ rest_counts = true
     expect(source).not.toContain("[[tui.widgets]]");
     expect(source).toContain("widgets = []");
     expect(source).toContain("[tui.island]\nrest_counts = true");
+    expect(source).toContain("[tui.session_create]\nfocus_created_session = false");
+    expect(source).toContain("[tui.session_create.terminals.tmux]\ndismiss_dashboard = false");
 
     const loaded = await loadConfig({ configPath, homeDir: tempDir });
-    expect(loaded.config.tui).toEqual({ widgets: [], island: { restCounts: true } });
+    expect(loaded.config.tui).toEqual({
+      widgets: [],
+      island: { restCounts: true },
+      sessionCreate: {
+        focusCreatedSession: false,
+        terminals: { tmux: { dismissDashboard: false } },
+      },
+    });
   });
 
   it("replaces a multi-line inline widgets array with nested brackets", async () => {

--- a/packages/contracts/src/tuiConfig.ts
+++ b/packages/contracts/src/tuiConfig.ts
@@ -1,12 +1,29 @@
 import { z } from "zod";
+import { ProviderIdSchema } from "./ids.js";
 import { nonEmptyStringSchema } from "./shared.js";
 
 /**
  * Shared `[tui]` configuration shapes. `@station/config` owns loading and
  * persisting config.toml and re-exports these schemas; dashboard-core depends
  * on the shapes only, through contracts, so its emitted declarations never
- * reference a package it does not declare.
+ * reference a package it does not declare. Session-create terminal entries are
+ * partial overrides whose omitted values inherit the resolved global policy.
  */
+
+export const TuiSessionCreatePolicyConfigSchema = z
+  .object({
+    focusCreatedSession: z.boolean().optional(),
+    dismissDashboard: z.boolean().optional(),
+  })
+  .strict();
+
+export type TuiSessionCreatePolicyConfig = z.infer<typeof TuiSessionCreatePolicyConfigSchema>;
+
+export const TuiSessionCreateConfigSchema = TuiSessionCreatePolicyConfigSchema.extend({
+  terminals: z.record(ProviderIdSchema, TuiSessionCreatePolicyConfigSchema).optional(),
+}).strict();
+
+export type TuiSessionCreateConfig = z.infer<typeof TuiSessionCreateConfigSchema>;
 
 export const TuiTimeWidgetConfigSchema = z
   .object({
@@ -101,6 +118,7 @@ export const TuiConfigSchema = z
   .object({
     widgets: z.array(TuiWidgetConfigSchema).optional(),
     island: TuiIslandConfigSchema.optional(),
+    sessionCreate: TuiSessionCreateConfigSchema.optional(),
   })
   .strict();
 

--- a/packages/dashboard-core/src/entrypoints/runtime.ts
+++ b/packages/dashboard-core/src/entrypoints/runtime.ts
@@ -19,6 +19,13 @@ export type { DashboardActions } from "../state/actions.js";
 export type { DashboardFocusTarget } from "../state/capabilities/activation.js";
 export { createObserverActivationCapabilities } from "../state/capabilities/activation.js";
 export type {
+  CreatedSessionCapabilities,
+  CreatedSessionUiCommand,
+  CreatedSessionUiPolicy,
+  ObserverCreatedSessionCapabilitiesOptions,
+} from "../state/capabilities/createdSession.js";
+export { createObserverCreatedSessionCapabilities } from "../state/capabilities/createdSession.js";
+export type {
   DashboardCapabilities,
   DashboardExecutionHandle,
   DashboardExecutionResult,

--- a/packages/dashboard-core/src/state/capabilities/createdSession.ts
+++ b/packages/dashboard-core/src/state/capabilities/createdSession.ts
@@ -1,0 +1,200 @@
+import {
+  executeObserverCommand,
+  type ObserverCommandExecutionResult,
+  type StationClientStateSource,
+} from "@station/client";
+import type {
+  ProjectId,
+  ProviderId,
+  SafeError,
+  SessionId,
+  StationCommand,
+  TerminalFocusOrigin,
+  WorktreeId,
+} from "@station/contracts";
+import { toSafeError } from "../../services/errors/errors.js";
+import type { ObserverService } from "../../services/types.js";
+import type { DashboardFocusTarget } from "./activation.js";
+import type { DashboardExecutionResult } from "./execution.js";
+
+/** Renderer-resolved behavior applied after one exact managed session creation. */
+export type CreatedSessionUiPolicy = {
+  focusCreatedSession: boolean;
+  dismissDashboard: boolean;
+};
+
+/**
+ * Dashboard-local, data-only effect bound to one canonical create result.
+ * This command is never persisted, dispatched to Observer, or placed on a wire contract.
+ */
+export type CreatedSessionUiCommand = {
+  type: "createdSession.applyUiPolicy";
+  target: {
+    sessionId: SessionId;
+    projectId: ProjectId;
+    worktreeId: WorktreeId;
+    branch: string;
+    terminalProvider: ProviderId;
+  };
+  policy: CreatedSessionUiPolicy;
+};
+
+/** Exact-target renderer authority for focus-before-dismiss post-create behavior. */
+export type CreatedSessionCapabilities = {
+  applyUiPolicy(command: CreatedSessionUiCommand): Promise<DashboardExecutionResult>;
+};
+
+export type ObserverCreatedSessionCapabilitiesOptions = {
+  service: ObserverService;
+  source: StationClientStateSource;
+  clientLabel?: string;
+  focusOrigin?: TerminalFocusOrigin;
+  resolveFocusTarget?: () => Promise<DashboardFocusTarget | undefined>;
+  dismissDashboard(): Promise<void>;
+};
+
+/**
+ * Create the standalone exact-session effect. Its focus path can only dispatch
+ * `terminal.focus`; it cannot start, resume, or otherwise repair the target.
+ * Dismissal runs only after confirmed focus success when both policy flags are true.
+ */
+export function createObserverCreatedSessionCapabilities(
+  options: ObserverCreatedSessionCapabilitiesOptions,
+): CreatedSessionCapabilities {
+  return {
+    applyUiPolicy: (command) => applyObserverCreatedSessionPolicy(options, command),
+  };
+}
+
+async function applyObserverCreatedSessionPolicy(
+  options: ObserverCreatedSessionCapabilitiesOptions,
+  command: CreatedSessionUiCommand,
+): Promise<DashboardExecutionResult> {
+  if (!command.policy.focusCreatedSession) {
+    if (command.policy.dismissDashboard) {
+      try {
+        await options.dismissDashboard();
+      } catch (error: unknown) {
+        return executionFailure(error);
+      }
+    }
+    return { kind: "success" };
+  }
+
+  const targetError = validateExactFocusableTarget(options.source, command);
+  if (targetError !== undefined) {
+    return failure(targetError);
+  }
+
+  try {
+    const focusTarget = await resolveConfiguredFocusTarget(options);
+    const focusCommand: Extract<StationCommand, { type: "terminal.focus" }> = {
+      type: "terminal.focus",
+      payload: {
+        sessionId: command.target.sessionId,
+        ...(focusTarget === undefined ? {} : { origin: focusTarget.origin }),
+      },
+    };
+    const execution = await executeObserverCommand(options.service, focusCommand, {
+      waitForCompletion: true,
+      clientLabel: options.clientLabel ?? "TUI",
+    });
+    const focusFailure = observerFocusFailure(execution);
+    if (focusFailure !== undefined) {
+      return failure(focusFailure);
+    }
+    if (command.policy.dismissDashboard) {
+      const dismiss = focusTarget?.onFocusSuccess ?? options.dismissDashboard;
+      await dismiss();
+    }
+    return { kind: "success" };
+  } catch (error: unknown) {
+    return executionFailure(error);
+  }
+}
+
+function validateExactFocusableTarget(
+  source: StationClientStateSource,
+  command: CreatedSessionUiCommand,
+): SafeError | undefined {
+  const snapshot = source.getState().snapshot;
+  const session = snapshot?.sessions.find(
+    (candidate) =>
+      candidate.id === command.target.sessionId &&
+      candidate.projectId === command.target.projectId &&
+      candidate.worktreeId === command.target.worktreeId,
+  );
+  const row = snapshot?.rows.find(
+    (candidate) =>
+      candidate.id === command.target.worktreeId &&
+      candidate.projectId === command.target.projectId &&
+      candidate.branch === command.target.branch,
+  );
+  if (
+    session === undefined ||
+    row === undefined ||
+    session.terminal?.provider !== command.target.terminalProvider
+  ) {
+    return createdSessionError(
+      "CREATED_SESSION_TARGET_MISMATCH",
+      "The created session no longer matches its canonical terminal target.",
+    );
+  }
+  if (session.terminal.focusable !== true) {
+    return createdSessionError(
+      "CREATED_SESSION_NOT_FOCUSABLE",
+      `The created session cannot be focused from the dashboard's "${command.target.terminalProvider}" terminal context.`,
+    );
+  }
+  return undefined;
+}
+
+function observerFocusFailure(
+  execution: ObserverCommandExecutionResult<Extract<StationCommand, { type: "terminal.focus" }>>,
+): SafeError | undefined {
+  if (execution.status === "succeeded") return undefined;
+  if (execution.status === "rejected") {
+    return (
+      execution.receipt.error ??
+      createdSessionError(
+        "CREATED_SESSION_FOCUS_REJECTED",
+        "Focusing the created session was rejected.",
+      )
+    );
+  }
+  if (execution.status === "accepted") {
+    return createdSessionError(
+      "CREATED_SESSION_FOCUS_UNCONFIRMED",
+      "Focusing the created session was not confirmed.",
+    );
+  }
+  return execution.error;
+}
+
+function resolveConfiguredFocusTarget(
+  options: ObserverCreatedSessionCapabilitiesOptions,
+): Promise<DashboardFocusTarget | undefined> {
+  if (options.resolveFocusTarget !== undefined) {
+    return options.resolveFocusTarget();
+  }
+  return Promise.resolve(
+    options.focusOrigin === undefined ? undefined : { origin: options.focusOrigin },
+  );
+}
+
+function executionFailure(error: unknown): DashboardExecutionResult {
+  return failure(toSafeError(error, { clientLabel: "TUI" }));
+}
+
+function failure(error: SafeError): DashboardExecutionResult {
+  return { kind: "failure", error, disposition: "remove-immediately" };
+}
+
+function createdSessionError(code: string, message: string): SafeError {
+  return {
+    tag: "TuiCreatedSessionError",
+    code,
+    message,
+    hint: "The session was created successfully and remains available in the dashboard.",
+  };
+}

--- a/packages/dashboard-core/src/state/capabilities/execution.ts
+++ b/packages/dashboard-core/src/state/capabilities/execution.ts
@@ -1,6 +1,7 @@
 import type { SafeError } from "@station/contracts";
 import type { ClientNotice } from "../../services/types.js";
 import type { SessionActivationCapabilities } from "./activation.js";
+import type { CreatedSessionCapabilities, CreatedSessionUiCommand } from "./createdSession.js";
 import type { DashboardDismissalCapabilities } from "./dismissal.js";
 import type { ManagedSessionCapabilities } from "./managedSessions.js";
 import type { DashboardShellCapabilities } from "./shell.js";
@@ -9,6 +10,7 @@ import type { WorktreeRemovalCapabilities } from "./worktreeRemoval.js";
 /** The renderer-selected capability groups required by every dashboard runtime. */
 export type DashboardCapabilities = {
   activation: SessionActivationCapabilities;
+  createdSession: CreatedSessionCapabilities;
   managedSessions: ManagedSessionCapabilities;
   worktreeRemoval: WorktreeRemovalCapabilities;
   shell: DashboardShellCapabilities;
@@ -26,7 +28,12 @@ export type DashboardExecutionFailureDisposition = "remove-immediately" | "retai
 
 /** Typed completion; successful work may carry a non-retryable warning for partial visibility. */
 export type DashboardExecutionResult =
-  | { kind: "success"; notice?: ClientNotice }
+  | {
+      kind: "success";
+      notice?: ClientNotice;
+      /** UI-only post-create effect; never part of Observer or durable command results. */
+      createdSessionCommand?: CreatedSessionUiCommand;
+    }
   | { kind: "notice"; notice: ClientNotice }
   | {
       kind: "failure";

--- a/packages/dashboard-core/src/state/capabilities/managedSessions.ts
+++ b/packages/dashboard-core/src/state/capabilities/managedSessions.ts
@@ -1,17 +1,23 @@
-import { executeObserverCommand, type ObserverCommandExecutionResult } from "@station/client";
+import {
+  executeObserverCommand,
+  type ObserverCommandExecutionResult,
+  type StationClientStateSource,
+} from "@station/client";
 import type {
   ProjectView,
   ProviderId,
   SafeError,
+  SessionCreateCommandResult,
   SessionGroupPlacementIntent,
   SourceSessionGroupPlacementIntent,
   StationCommand,
-  TerminalFocusOrigin,
+  StationSnapshot,
 } from "@station/contracts";
+import { withTimeout } from "@station/runtime";
 import { toSafeError } from "../../services/errors/errors.js";
 import type { ObserverService } from "../../services/types.js";
 import { buildCreateSessionCommand, buildForkSessionCommand } from "../commandBuilders.js";
-import type { DashboardFocusTarget } from "./activation.js";
+import type { CreatedSessionUiPolicy } from "./createdSession.js";
 import {
   type DashboardExecutionHandle,
   type DashboardExecutionResult,
@@ -48,16 +54,17 @@ export type ManagedSessionCapabilities = {
 /** Options for framework-neutral Observer-backed managed-session execution. */
 export type ObserverManagedSessionCapabilitiesOptions = {
   service: ObserverService;
+  source: StationClientStateSource;
   clientLabel?: string;
-  focusOrigin?: TerminalFocusOrigin;
-  resolveFocusTarget?: () => Promise<DashboardFocusTarget | undefined>;
+  policyForTerminalProvider(provider: ProviderId): CreatedSessionUiPolicy;
 };
 
 /**
  * Create Observer-backed managed-session execution without dashboard state access.
  *
  * Deliberate Create retains its sheet without an optimistic row, Quick retains failed
- * optimistic rows, and Fork preserves its existing no-row behavior.
+ * optimistic rows, and Fork preserves its existing no-row behavior. Create and Quick
+ * share one canonical-result path that produces only a data-only UI command.
  */
 export function createObserverManagedSessionCapabilities(
   options: ObserverManagedSessionCapabilitiesOptions,
@@ -92,11 +99,7 @@ async function runCreate(
     if (command.type !== "session.create") {
       return invalidCommandFailure("session.create", disposition);
     }
-    const result = await dispatchAndWait(options, command, disposition);
-    if (result.kind !== "success") {
-      return result;
-    }
-    return { kind: "success" };
+    return await dispatchCreateAndWait(options, command, request, disposition);
   } catch (error: unknown) {
     return {
       kind: "failure",
@@ -127,9 +130,205 @@ async function runFork(
   return dispatchAndWait(options, command, "remove-immediately");
 }
 
+const CREATED_SESSION_APPEAR_TIMEOUT_MS = 10_000;
+
+async function dispatchCreateAndWait(
+  options: ObserverManagedSessionCapabilitiesOptions,
+  command: Extract<StationCommand, { type: "session.create" }>,
+  request: CreateManagedSessionRequest,
+  disposition: "remove-immediately" | "retain-failed",
+): Promise<DashboardExecutionResult> {
+  const execution = await executeObserverCommand(options.service, command, {
+    clientLabel: options.clientLabel ?? "TUI",
+  });
+  if (execution.status !== "succeeded") {
+    if (execution.status === "accepted") {
+      return createdSessionUnconfirmed(
+        "The session was created, but completion was not confirmed.",
+      );
+    }
+    return {
+      kind: "failure",
+      error:
+        execution.status === "rejected"
+          ? rejectedCommandError(command.type, execution)
+          : execution.error,
+      disposition,
+    };
+  }
+
+  const result = execution.result;
+  const resultError = validateCreateResult(command, request, result);
+  if (resultError !== undefined || result === undefined) {
+    return createdSessionUnconfirmed(
+      resultError ?? "The session was created, but its durable identity was not returned.",
+    );
+  }
+
+  let created = await waitForCanonicalCreatedSession(options.source, request, result);
+  if (created === undefined) {
+    try {
+      created = resolveCanonicalCreatedSession(
+        await options.service.loadSnapshot(),
+        request,
+        result,
+      );
+    } catch {
+      // Creation already succeeded; the bounded notice below is the only safe outcome.
+    }
+  }
+  if (created === undefined) {
+    return createdSessionUnconfirmed(
+      "The session was created, but its canonical dashboard identity did not converge.",
+    );
+  }
+
+  return {
+    kind: "success",
+    createdSessionCommand: {
+      type: "createdSession.applyUiPolicy",
+      target: {
+        sessionId: result.sessionId,
+        projectId: result.projectId,
+        worktreeId: result.worktreeId,
+        branch: created.branch,
+        terminalProvider: result.resolvedPlacement.provider,
+      },
+      policy: options.policyForTerminalProvider(result.resolvedPlacement.provider),
+    },
+  };
+}
+
+function validateCreateResult(
+  command: Extract<StationCommand, { type: "session.create" }>,
+  request: CreateManagedSessionRequest,
+  result: SessionCreateCommandResult | undefined,
+): string | undefined {
+  if (result === undefined) return undefined;
+  if (
+    result.projectId !== request.project.id ||
+    result.resolvedPlacement.provider !== command.payload.terminal.provider
+  ) {
+    return "The session was created, but its durable identity did not match the request.";
+  }
+  if (request.group?.kind === "existing" && result.resolvedGroupId !== request.group.groupId) {
+    return "The session was created, but its durable Group placement did not match the request.";
+  }
+  if (request.group?.kind === "create" && result.resolvedGroupId === undefined) {
+    return "The session was created, but its durable Group identity was missing.";
+  }
+  if (request.group === undefined && result.resolvedGroupId !== undefined) {
+    return "The session was created, but its durable Group placement was unexpected.";
+  }
+  return undefined;
+}
+
+async function waitForCanonicalCreatedSession(
+  source: StationClientStateSource,
+  request: CreateManagedSessionRequest,
+  result: SessionCreateCommandResult,
+): Promise<{ branch: string } | undefined> {
+  const existing = resolveCanonicalCreatedSession(source.getState().snapshot, request, result);
+  if (existing !== undefined) return existing;
+
+  try {
+    return await withTimeout(
+      ({ signal }) =>
+        new Promise((resolve) => {
+          let settled = false;
+          let unsubscribe = (): void => undefined;
+          const settle = (target: { branch: string } | undefined): void => {
+            if (settled) return;
+            settled = true;
+            signal.removeEventListener("abort", onAbort);
+            unsubscribe();
+            resolve(target);
+          };
+          const onAbort = (): void => settle(undefined);
+
+          signal.addEventListener("abort", onAbort, { once: true });
+          unsubscribe = source.subscribe(() => {
+            const target = resolveCanonicalCreatedSession(
+              source.getState().snapshot,
+              request,
+              result,
+            );
+            if (target !== undefined) settle(target);
+          });
+
+          const target = resolveCanonicalCreatedSession(
+            source.getState().snapshot,
+            request,
+            result,
+          );
+          if (target !== undefined) settle(target);
+        }),
+      {
+        timeoutMs: CREATED_SESSION_APPEAR_TIMEOUT_MS,
+        error: {
+          tag: "RuntimeError",
+          code: "CREATED_SESSION_WAIT_FAILED",
+          message: "Waiting for the created session failed.",
+        },
+        timeoutError: {
+          tag: "TimeoutError",
+          code: "CREATED_SESSION_WAIT_TIMEOUT",
+          message: "The created session did not converge before the deadline.",
+        },
+      },
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveCanonicalCreatedSession(
+  snapshot: StationSnapshot | undefined,
+  request: CreateManagedSessionRequest,
+  result: SessionCreateCommandResult,
+): { branch: string } | undefined {
+  const session = snapshot?.sessions.find(
+    (candidate) =>
+      candidate.id === result.sessionId &&
+      candidate.projectId === result.projectId &&
+      candidate.worktreeId === result.worktreeId &&
+      candidate.terminal?.provider === result.resolvedPlacement.provider,
+  );
+  const row = snapshot?.rows.find(
+    (candidate) =>
+      candidate.id === result.worktreeId &&
+      candidate.projectId === result.projectId &&
+      candidate.branch === request.hiddenBranch,
+  );
+  if (session === undefined || row === undefined) return undefined;
+
+  const owningGroup = snapshot?.sessionGroups.find((group) =>
+    group.sessionIds.includes(result.sessionId),
+  );
+  if (result.resolvedGroupId === undefined) {
+    return owningGroup === undefined ? { branch: row.branch } : undefined;
+  }
+  return owningGroup?.id === result.resolvedGroupId &&
+    owningGroup.projectId === result.projectId &&
+    owningGroup.parentGroupId === undefined
+    ? { branch: row.branch }
+    : undefined;
+}
+
+function createdSessionUnconfirmed(message: string): DashboardExecutionResult {
+  return {
+    kind: "success",
+    notice: {
+      kind: "error",
+      message,
+      hint: "Refresh the dashboard before creating another session.",
+    },
+  };
+}
+
 async function dispatchAndWait(
   options: ObserverManagedSessionCapabilitiesOptions,
-  command: Extract<StationCommand, { type: "session.create" | "session.fork" }>,
+  command: Extract<StationCommand, { type: "session.fork" }>,
   disposition: "remove-immediately" | "retain-failed",
 ): Promise<DashboardExecutionResult> {
   const execution = await executeObserverCommand(options.service, command, {

--- a/packages/dashboard-core/src/state/operations/capabilityOperation.ts
+++ b/packages/dashboard-core/src/state/operations/capabilityOperation.ts
@@ -1,6 +1,7 @@
 import type { SafeError } from "@station/contracts";
 import type { StoreApi } from "zustand/vanilla";
 import { safeErrorToToast, toSafeError } from "../../services/errors/errors.js";
+import type { CreatedSessionUiCommand } from "../capabilities/createdSession.js";
 import type {
   DashboardCapabilities,
   DashboardExecutionHandle,
@@ -27,10 +28,12 @@ import type { DashboardCapabilityOperation } from "./types.js";
 
 /**
  * Scope-bound executor returning the settled capability result after applying optimistic and
- * feedback policy, so composite operations can continue from the same execution.
+ * feedback policy, so composite operations can continue from the same execution. Created-session
+ * commands execute after local settlement, or remain owned by a compound Group operation.
  */
 export type DashboardCapabilityOperationRunner = {
   run(operation: DashboardCapabilityOperation): Promise<DashboardExecutionResult>;
+  executeCreatedSession(command: CreatedSessionUiCommand): Promise<DashboardExecutionResult>;
 };
 
 export function createDashboardCapabilityOperationRunner(input: {
@@ -43,7 +46,7 @@ export function createDashboardCapabilityOperationRunner(input: {
     getStore: input.getStore,
     scope: input.scope,
   });
-  return {
+  const runner: DashboardCapabilityOperationRunner = {
     run: (operation) =>
       runDashboardCapabilityOperation({
         store: input.getStore(),
@@ -52,8 +55,18 @@ export function createDashboardCapabilityOperationRunner(input: {
         clientLabel: input.clientLabel,
         scope: input.scope,
         expiry,
+        executeCreatedSession: (command) => runner.executeCreatedSession(command),
+      }),
+    executeCreatedSession: (command) =>
+      executeCreatedSessionCommand({
+        store: input.getStore(),
+        capabilities: input.capabilities,
+        command,
+        clientLabel: input.clientLabel,
+        scope: input.scope,
       }),
   };
+  return runner;
 }
 
 function markCreateSessionRowFailed(
@@ -88,6 +101,7 @@ async function runDashboardCapabilityOperation(input: {
   clientLabel: string;
   scope: DashboardRuntimeEffectScope;
   expiry: FailedCreateExpiryScheduler;
+  executeCreatedSession(command: CreatedSessionUiCommand): Promise<DashboardExecutionResult>;
 }): Promise<DashboardExecutionResult> {
   const { store, capabilities, operation, clientLabel, scope, expiry } = input;
   let handle: DashboardExecutionHandle;
@@ -171,7 +185,17 @@ async function runDashboardCapabilityOperation(input: {
     scope.commit(() =>
       settleDashboardCapabilityOperation({ store, operation, handle, result, expiry }),
     );
-    return result;
+    if (
+      result.kind !== "success" ||
+      result.createdSessionCommand === undefined ||
+      (operation.type === "quickCreateManagedSession" && operation.targetGroupId !== undefined)
+    ) {
+      return result;
+    }
+    if (!scope.isOpen()) {
+      return successWithoutCreatedSessionCommand(result);
+    }
+    return input.executeCreatedSession(result.createdSessionCommand);
   } catch (error: unknown) {
     const result: DashboardExecutionResult = {
       kind: "failure",
@@ -187,6 +211,40 @@ async function runDashboardCapabilityOperation(input: {
     });
     return result;
   }
+}
+
+async function executeCreatedSessionCommand(input: {
+  store: StoreApi<DashboardState>;
+  capabilities: DashboardCapabilities;
+  command: CreatedSessionUiCommand;
+  clientLabel: string;
+  scope: DashboardRuntimeEffectScope;
+}): Promise<DashboardExecutionResult> {
+  if (!input.scope.isOpen()) return { kind: "success" };
+
+  let result: DashboardExecutionResult;
+  try {
+    result = await input.capabilities.createdSession.applyUiPolicy(input.command);
+  } catch (error: unknown) {
+    result = {
+      kind: "failure",
+      error: toSafeError(error, { clientLabel: input.clientLabel }),
+      disposition: "remove-immediately",
+    };
+  }
+  if (result.kind === "success") return result;
+
+  const notice = result.kind === "notice" ? result.notice : safeErrorToToast(result.error);
+  input.scope.commit(() => input.store.setState(addTuiToast(input.store.getState(), notice)));
+  return { kind: "success", notice };
+}
+
+function successWithoutCreatedSessionCommand(
+  result: Extract<DashboardExecutionResult, { kind: "success" }>,
+): DashboardExecutionResult {
+  return result.notice === undefined
+    ? { kind: "success" }
+    : { kind: "success", notice: result.notice };
 }
 
 function applyCapabilityOptimisticState(

--- a/packages/dashboard-core/src/state/operations/groupQuickSession.ts
+++ b/packages/dashboard-core/src/state/operations/groupQuickSession.ts
@@ -2,6 +2,7 @@ import type { SafeError, SessionId, StationSnapshot } from "@station/contracts";
 import type { StoreApi } from "zustand/vanilla";
 import { safeErrorToToast, toSafeError } from "../../services/errors/errors.js";
 import type { ObserverService } from "../../services/types.js";
+import type { CreatedSessionUiCommand } from "../capabilities/createdSession.js";
 import { buildUpdateSessionGroupMembershipCommand } from "../commandBuilders.js";
 import { focusDashboardGroup, focusDashboardSession } from "../dashboardFocus.js";
 import { removeCreateSessionLocalRow } from "../localRows.js";
@@ -14,8 +15,9 @@ import { executeDashboardCommandError } from "./commandExecutionError.js";
 import type { CreateQuickSessionInGroupOperation } from "./types.js";
 
 /**
- * Launches one ordinary Quick Session, then records one latest-version Group membership update;
- * post-launch failures preserve the created session and never retry the launch.
+ * Launches one ordinary Quick Session, then records one latest-version Group membership update.
+ * The exact created-session UI command remains deferred until canonical membership and local row
+ * settlement complete; post-launch failures preserve the created session and never retry it.
  */
 export async function runQuickSessionInGroupOperation(input: {
   store: StoreApi<DashboardState>;
@@ -53,6 +55,14 @@ export async function runQuickSessionInGroupOperation(input: {
     scope.commit(() => focusGroup(store, operation));
     return;
   }
+  const createdSessionCommand = capabilityResult.createdSessionCommand;
+  if (createdSessionCommand === undefined) {
+    scope.commit(() => {
+      removeTargetedRow(store, operation.localId);
+      focusGroup(store, operation);
+    });
+    return;
+  }
 
   let launchedSnapshot: StationSnapshot;
   try {
@@ -67,11 +77,7 @@ export async function runQuickSessionInGroupOperation(input: {
   }
   if (!scope.isOpen()) return;
   scope.commit(() => store.setState(replaceSnapshot(store.getState(), launchedSnapshot)));
-  const sessionResolution = resolveLaunchedSession(
-    launchedSnapshot,
-    operation.project.id,
-    operation.hiddenBranch,
-  );
+  const sessionResolution = resolveLaunchedSession(launchedSnapshot, createdSessionCommand);
   if (sessionResolution.kind === "failure") {
     scope.commit(() => {
       removeTargetedRow(store, operation.localId);
@@ -121,31 +127,44 @@ export async function runQuickSessionInGroupOperation(input: {
   const convergedGroup = store
     .getState()
     .snapshot?.sessionGroups.find((group) => group.id === operation.groupId);
+  if (convergedGroup?.sessionIds.includes(sessionResolution.sessionId) !== true) {
+    scope.commit(() => {
+      removeTargetedRow(store, operation.localId);
+      focusCanonicalSessionOrGroup(store, sessionResolution.sessionId, operation);
+      addErrorToast(store, convergenceError("The new session did not converge into its Group."));
+    });
+    return;
+  }
   scope.commit(() => {
     removeTargetedRow(store, operation.localId);
     focusCanonicalSessionOrGroup(store, sessionResolution.sessionId, operation);
-    if (convergedGroup?.sessionIds.includes(sessionResolution.sessionId) !== true) {
-      addErrorToast(store, convergenceError("The new session did not converge into its Group."));
-    }
   });
+  if (!scope.isOpen()) return;
+  await capabilities.executeCreatedSession(createdSessionCommand);
 }
 
 function resolveLaunchedSession(
   snapshot: StationSnapshot,
-  projectId: string,
-  branch: string,
+  command: CreatedSessionUiCommand,
 ): { kind: "success"; sessionId: SessionId } | { kind: "failure"; error: SafeError } {
-  const rowsById = new Map(snapshot.rows.map((row) => [row.id, row]));
-  const candidates = snapshot.sessions.filter((session) => {
-    const row = rowsById.get(session.worktreeId);
-    return session.projectId === projectId && row?.branch === branch;
-  });
-  const candidate = candidates[0];
-  return candidates.length === 1 && candidate !== undefined
-    ? { kind: "success", sessionId: candidate.id }
+  const session = snapshot.sessions.find(
+    (candidate) =>
+      candidate.id === command.target.sessionId &&
+      candidate.projectId === command.target.projectId &&
+      candidate.worktreeId === command.target.worktreeId &&
+      candidate.terminal?.provider === command.target.terminalProvider,
+  );
+  const row = snapshot.rows.find(
+    (candidate) =>
+      candidate.id === command.target.worktreeId &&
+      candidate.projectId === command.target.projectId &&
+      candidate.branch === command.target.branch,
+  );
+  return session !== undefined && row !== undefined
+    ? { kind: "success", sessionId: session.id }
     : {
         kind: "failure",
-        error: convergenceError("The new session could not be identified uniquely."),
+        error: convergenceError("The new session's exact canonical identity did not converge."),
       };
 }
 

--- a/packages/dashboard-core/test/support/fakeClientStateSource.ts
+++ b/packages/dashboard-core/test/support/fakeClientStateSource.ts
@@ -107,15 +107,17 @@ function createLegacyTestCapabilities(options: {
   if (options.onFocusSuccess !== undefined)
     activationOptions.onFocusSuccess = options.onFocusSuccess;
   const managedOptions: Parameters<typeof createObserverManagedSessionCapabilities>[0] = {
+    source: options.source,
     service: options.service,
     clientLabel: "TUI test",
+    policyForTerminalProvider: () => ({
+      focusCreatedSession: true,
+      dismissDashboard: true,
+    }),
   };
-  if (options.focusOrigin !== undefined) managedOptions.focusOrigin = options.focusOrigin;
-  if (options.resolveFocusTarget !== undefined) {
-    managedOptions.resolveFocusTarget = options.resolveFocusTarget;
-  }
   return {
     activation: createObserverActivationCapabilities(activationOptions),
+    createdSession: createFakeDashboardCapabilities().createdSession,
     managedSessions: createObserverManagedSessionCapabilities(managedOptions),
     worktreeRemoval: createObserverWorktreeRemovalCapabilities({
       service: options.service,

--- a/packages/dashboard-core/test/support/fakeDashboardCapabilities.ts
+++ b/packages/dashboard-core/test/support/fakeDashboardCapabilities.ts
@@ -1,7 +1,9 @@
 import type { SessionActivationRequest } from "../../src/state/capabilities/activation.js";
+import type { CreatedSessionUiCommand } from "../../src/state/capabilities/createdSession.js";
 import type {
   DashboardCapabilities,
   DashboardExecutionHandle,
+  DashboardExecutionResult,
 } from "../../src/state/capabilities/execution.js";
 import { dashboardExecution } from "../../src/state/capabilities/execution.js";
 import type {
@@ -19,6 +21,7 @@ export class FakeDashboardCapabilities implements DashboardCapabilities {
   readonly removeWorktreeRequests: RemoveWorktreeRequest[] = [];
   readonly shellRequests: OpenDashboardShellRequest[] = [];
   readonly rendererExitCodes: number[] = [];
+  readonly createdSessionCommands: CreatedSessionUiCommand[] = [];
   dashboardDismissals = 0;
 
   activationHandle: (request: SessionActivationRequest) => DashboardExecutionHandle = () =>
@@ -36,11 +39,21 @@ export class FakeDashboardCapabilities implements DashboardCapabilities {
   dismissHandle: () => DashboardExecutionHandle = () => dashboardExecution({ kind: "success" });
   exitHandle: (exitCode: number) => DashboardExecutionHandle = () =>
     dashboardExecution({ kind: "success" });
+  createdSessionResult: (
+    command: CreatedSessionUiCommand,
+  ) => Promise<DashboardExecutionResult> | DashboardExecutionResult = () => ({ kind: "success" });
 
   readonly activation = {
     activate: (request: SessionActivationRequest): DashboardExecutionHandle => {
       this.activationRequests.push(request);
       return this.activationHandle(request);
+    },
+  };
+
+  readonly createdSession = {
+    applyUiPolicy: async (command: CreatedSessionUiCommand) => {
+      this.createdSessionCommands.push(command);
+      return this.createdSessionResult(command);
     },
   };
 

--- a/packages/dashboard-core/test/unit/entrypoints.public.test.ts
+++ b/packages/dashboard-core/test/unit/entrypoints.public.test.ts
@@ -19,6 +19,7 @@ const PRIVATE_MODELS = [
 const RUNTIME_VALUES = [
   "createDashboardRuntime",
   "createObserverActivationCapabilities",
+  "createObserverCreatedSessionCapabilities",
   "createObserverManagedSessionCapabilities",
   "dashboardExecution",
 ];

--- a/packages/dashboard-core/test/unit/state/capabilities/observerCreatedSession.test.ts
+++ b/packages/dashboard-core/test/unit/state/capabilities/observerCreatedSession.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import {
+  type CreatedSessionUiCommand,
+  createObserverCreatedSessionCapabilities,
+} from "../../../../src/state/capabilities/createdSession.js";
+import { createCommandSnapshot } from "../../../fixtures/snapshots.js";
+import { FakeClientStateSource } from "../../../support/fakeClientStateSource.js";
+import { FakeTuiObserverService } from "../../../support/fakeObserverService.js";
+
+function setup(policy: CreatedSessionUiCommand["policy"]) {
+  const snapshot = createCommandSnapshot("idle");
+  const service = new FakeTuiObserverService(snapshot);
+  const effects: string[] = [];
+  const capability = createObserverCreatedSessionCapabilities({
+    source: new FakeClientStateSource(snapshot),
+    service,
+    resolveFocusTarget: async () => ({
+      origin: { provider: "tmux", clientId: "client-1" },
+      onFocusSuccess: async () => {
+        effects.push("target-dismiss");
+      },
+    }),
+    dismissDashboard: async () => {
+      effects.push("renderer-dismiss");
+    },
+  });
+  const command: CreatedSessionUiCommand = {
+    type: "createdSession.applyUiPolicy",
+    target: {
+      sessionId: "ses_wt_web_idle",
+      projectId: "web",
+      worktreeId: "wt_web_idle",
+      branch: "fix-nav-mobile",
+      terminalProvider: "tmux",
+    },
+    policy,
+  };
+  return { service, effects, capability, command };
+}
+
+describe("observer created-session capability", () => {
+  it("does nothing for false/false", async () => {
+    const fixture = setup({ focusCreatedSession: false, dismissDashboard: false });
+
+    await expect(fixture.capability.applyUiPolicy(fixture.command)).resolves.toEqual({
+      kind: "success",
+    });
+    expect(fixture.service.dispatched).toEqual([]);
+    expect(fixture.effects).toEqual([]);
+  });
+
+  it("dismisses without focus for false/true", async () => {
+    const fixture = setup({ focusCreatedSession: false, dismissDashboard: true });
+
+    await fixture.capability.applyUiPolicy(fixture.command);
+    expect(fixture.service.dispatched).toEqual([]);
+    expect(fixture.effects).toEqual(["renderer-dismiss"]);
+  });
+
+  it("waits for exact focus and suppresses dismissal for true/false", async () => {
+    const fixture = setup({ focusCreatedSession: true, dismissDashboard: false });
+
+    await expect(fixture.capability.applyUiPolicy(fixture.command)).resolves.toEqual({
+      kind: "success",
+    });
+    expect(fixture.service.dispatched).toEqual([
+      {
+        type: "terminal.focus",
+        payload: {
+          sessionId: "ses_wt_web_idle",
+          origin: { provider: "tmux", clientId: "client-1" },
+        },
+      },
+    ]);
+    expect(fixture.service.waitedForCommandIds).toEqual(["cmd_tui_1"]);
+    expect(fixture.effects).toEqual([]);
+  });
+
+  it("uses the exact focus-target callback after confirmed focus for true/true", async () => {
+    const fixture = setup({ focusCreatedSession: true, dismissDashboard: true });
+
+    await fixture.capability.applyUiPolicy(fixture.command);
+    expect(fixture.effects).toEqual(["target-dismiss"]);
+  });
+
+  it("fails closed when canonical identity no longer matches", async () => {
+    const fixture = setup({ focusCreatedSession: true, dismissDashboard: true });
+    fixture.command.target.worktreeId = "wt_other";
+
+    await expect(fixture.capability.applyUiPolicy(fixture.command)).resolves.toMatchObject({
+      kind: "failure",
+      error: { code: "CREATED_SESSION_TARGET_MISMATCH" },
+    });
+    expect(fixture.service.dispatched).toEqual([]);
+    expect(fixture.effects).toEqual([]);
+  });
+
+  it("retains the dashboard when the exact target is not focusable", async () => {
+    const fixture = setup({ focusCreatedSession: true, dismissDashboard: true });
+    const snapshot = createCommandSnapshot("idle");
+    fixture.capability = createObserverCreatedSessionCapabilities({
+      source: new FakeClientStateSource({
+        ...snapshot,
+        sessions: snapshot.sessions.map((session) =>
+          session.terminal === undefined
+            ? session
+            : { ...session, terminal: { ...session.terminal, focusable: false } },
+        ),
+      }),
+      service: fixture.service,
+      dismissDashboard: async () => {
+        fixture.effects.push("renderer-dismiss");
+      },
+    });
+
+    await expect(fixture.capability.applyUiPolicy(fixture.command)).resolves.toMatchObject({
+      kind: "failure",
+      error: { code: "CREATED_SESSION_NOT_FOCUSABLE" },
+    });
+    expect(fixture.service.dispatched).toEqual([]);
+    expect(fixture.effects).toEqual([]);
+  });
+
+  it("does not dismiss when exact focus fails", async () => {
+    const fixture = setup({ focusCreatedSession: true, dismissDashboard: true });
+    fixture.service.nextCompletion = {
+      status: "failed",
+      commandId: "cmd_tui_1",
+      error: {
+        tag: "CommandExecutionError",
+        code: "FOCUS_FAILED",
+        message: "Focus failed.",
+      },
+    };
+
+    await expect(fixture.capability.applyUiPolicy(fixture.command)).resolves.toMatchObject({
+      kind: "failure",
+      error: { code: "FOCUS_FAILED" },
+    });
+    expect(fixture.effects).toEqual([]);
+  });
+
+  it("reports renderer dismissal failure after a no-focus success", async () => {
+    const fixture = setup({ focusCreatedSession: false, dismissDashboard: true });
+    fixture.capability = createObserverCreatedSessionCapabilities({
+      source: new FakeClientStateSource(createCommandSnapshot("idle")),
+      service: fixture.service,
+      dismissDashboard: async () => {
+        throw new Error("IPC closed.");
+      },
+    });
+
+    await expect(fixture.capability.applyUiPolicy(fixture.command)).resolves.toMatchObject({
+      kind: "failure",
+      error: { message: "The TUI could not complete the observer operation." },
+    });
+    expect(fixture.service.dispatched).toEqual([]);
+  });
+});

--- a/packages/dashboard-core/test/unit/state/capabilities/observerManagedSessions.test.ts
+++ b/packages/dashboard-core/test/unit/state/capabilities/observerManagedSessions.test.ts
@@ -1,14 +1,28 @@
 import { describe, expect, it } from "vitest";
 import { createObserverManagedSessionCapabilities } from "../../../../src/state/capabilities/managedSessions.js";
 import { createCommandSnapshot } from "../../../fixtures/snapshots.js";
+import { FakeClientStateSource } from "../../../support/fakeClientStateSource.js";
 import { FakeTuiObserverService } from "../../../support/fakeObserverService.js";
+
+function createCapability(snapshot: ReturnType<typeof createCommandSnapshot>) {
+  const service = new FakeTuiObserverService(snapshot);
+  const capability = createObserverManagedSessionCapabilities({
+    service,
+    source: new FakeClientStateSource(snapshot),
+    policyForTerminalProvider: () => ({
+      focusCreatedSession: true,
+      dismissDashboard: false,
+    }),
+  });
+  return { service, capability };
+}
 
 describe("observer managed-session capability", () => {
   it("creates from product values without an optimistic row and returns the bounded failure", async () => {
     const snapshot = createCommandSnapshot("idle");
     const project = snapshot.projects[0];
     if (project === undefined) throw new Error("project fixture missing");
-    const service = new FakeTuiObserverService(snapshot);
+    const { service, capability } = createCapability(snapshot);
     service.nextCompletion = {
       status: "failed",
       commandId: "cmd_tui_1",
@@ -18,8 +32,6 @@ describe("observer managed-session capability", () => {
         message: "Create failed.",
       },
     };
-    const capability = createObserverManagedSessionCapabilities({ service });
-
     const handle = capability.create({
       project,
       title: "Feature session",
@@ -50,14 +62,12 @@ describe("observer managed-session capability", () => {
     const snapshot = createCommandSnapshot("idle");
     const project = snapshot.projects[0];
     if (project === undefined) throw new Error("project fixture missing");
-    const service = new FakeTuiObserverService(snapshot);
+    const { service, capability } = createCapability(snapshot);
     service.nextCompletion = {
       status: "failed",
       commandId: "cmd_tui_quick",
       error: { tag: "CommandExecutionError", code: "CREATE_FAILED", message: "Create failed." },
     };
-    const capability = createObserverManagedSessionCapabilities({ service });
-
     const handle = capability.quickCreate({
       project,
       title: "Quick session",
@@ -76,8 +86,7 @@ describe("observer managed-session capability", () => {
     const snapshot = createCommandSnapshot("idle");
     const project = snapshot.projects[0];
     if (project === undefined) throw new Error("project fixture missing");
-    const service = new FakeTuiObserverService(snapshot);
-    const capability = createObserverManagedSessionCapabilities({ service });
+    const { service, capability } = createCapability(snapshot);
 
     const handle = capability.fork({
       project,
@@ -109,6 +118,94 @@ describe("observer managed-session capability", () => {
         harness: { provider: "codex" },
         placement: { intent: "detached" },
       },
+    });
+  });
+
+  it("returns one exact data-only UI command from the durable create result", async () => {
+    const snapshot = createCommandSnapshot("idle");
+    const project = snapshot.projects[0];
+    if (project === undefined) throw new Error("project fixture missing");
+    const { service, capability } = createCapability(snapshot);
+    service.nextCompletion = {
+      status: "succeeded",
+      commandId: "cmd_tui_1",
+      result: {
+        type: "session.create",
+        projectId: "web",
+        worktreeId: "wt_web_idle",
+        sessionId: "ses_wt_web_idle",
+        requestedPlacement: "detached",
+        resolvedPlacement: {
+          provider: "tmux",
+          targetId: "tmux:web:fix-nav-mobile",
+          generation: "1",
+          presentation: "detached",
+        },
+      },
+    };
+
+    await expect(
+      capability.quickCreate({
+        project,
+        title: "Quick session",
+        hiddenBranch: "fix-nav-mobile",
+        harness: "codex",
+      }).completion,
+    ).resolves.toEqual({
+      kind: "success",
+      createdSessionCommand: {
+        type: "createdSession.applyUiPolicy",
+        target: {
+          sessionId: "ses_wt_web_idle",
+          projectId: "web",
+          worktreeId: "wt_web_idle",
+          branch: "fix-nav-mobile",
+          terminalProvider: "tmux",
+        },
+        policy: { focusCreatedSession: true, dismissDashboard: false },
+      },
+    });
+  });
+
+  it.each([
+    ["missing", undefined],
+    [
+      "provider-mismatched",
+      {
+        type: "session.create" as const,
+        projectId: "web",
+        worktreeId: "wt_web_idle",
+        sessionId: "ses_wt_web_idle",
+        requestedPlacement: "detached" as const,
+        resolvedPlacement: {
+          provider: "native",
+          targetId: "native:wt_web_idle",
+          generation: "1",
+          presentation: "detached" as const,
+        },
+      },
+    ],
+  ])("returns a non-retryable notice for a %s durable result", async (_case, result) => {
+    const snapshot = createCommandSnapshot("idle");
+    const project = snapshot.projects[0];
+    if (project === undefined) throw new Error("project fixture missing");
+    const { service, capability } = createCapability(snapshot);
+    service.nextCompletion = {
+      status: "succeeded",
+      commandId: "cmd_tui_1",
+      ...(result === undefined ? {} : { result }),
+    };
+
+    await expect(
+      capability.create({
+        project,
+        title: "Quick session",
+        hiddenBranch: "fix-nav-mobile",
+        harness: "codex",
+      }).completion,
+    ).resolves.toMatchObject({
+      kind: "success",
+      notice: { kind: "error" },
     });
   });
 });

--- a/packages/dashboard-core/test/unit/state/operations/sessionGroups.test.ts
+++ b/packages/dashboard-core/test/unit/state/operations/sessionGroups.test.ts
@@ -62,6 +62,9 @@ describe("Create Session Group operation", () => {
       rowId: "session:ses_wt_web_quick_group",
       cellId: "identity",
     });
+    expect(setup.capabilities.createdSessionCommands).toEqual([
+      createdSessionCommand(request?.hiddenBranch ?? ""),
+    ]);
     expect(request?.hiddenBranch).toBe(request?.title);
     await setup.scope.dispose();
   });
@@ -159,7 +162,16 @@ describe("Create Session Group operation", () => {
     const setup = createOperationSetup(true);
     setup.capabilities.quickCreateHandle = () => {
       setup.service.setSnapshot(withCreatedGroup(createGroupedDashboardSnapshot()));
-      return dashboardExecution({ kind: "success" }, { optimistic: "pending-create" });
+      return dashboardExecution(
+        {
+          kind: "success",
+          notice: {
+            kind: "error",
+            message: "The session was created, but its canonical identity did not converge.",
+          },
+        },
+        { optimistic: "pending-create" },
+      );
     };
 
     await setup.run();
@@ -171,7 +183,7 @@ describe("Create Session Group operation", () => {
     expect(setup.store.getState().localRows.pendingCreate).toEqual([]);
     expect(setup.store.getState().toasts.at(-1)?.toast).toMatchObject({
       kind: "error",
-      message: "The new session could not be identified uniquely.",
+      message: "The session was created, but its canonical identity did not converge.",
     });
     await setup.scope.dispose();
   });
@@ -251,6 +263,7 @@ describe("Create Session Group operation", () => {
       rowId: "session:ses_wt_web_quick_group",
       cellId: "identity",
     });
+    expect(setup.capabilities.createdSessionCommands).toEqual([]);
     expect(setup.store.getState().toasts.at(-1)?.toast).toMatchObject({
       message: "The new session did not converge into its Group.",
     });
@@ -398,6 +411,9 @@ describe("Quick Session in existing Group operation", () => {
       rowId: "session:ses_wt_web_quick_group",
       cellId: "identity",
     });
+    expect(setup.capabilities.createdSessionCommands).toEqual([
+      createdSessionCommand(setup.operation.hiddenBranch),
+    ]);
     await setup.scope.dispose();
   });
 
@@ -453,6 +469,36 @@ describe("Quick Session in existing Group operation", () => {
     });
     await setup.scope.dispose();
   });
+
+  it("preserves canonical membership when the deferred UI effect fails", async () => {
+    const setup = createExistingGroupQuickSetup();
+    setup.capabilities.createdSessionResult = () => ({
+      kind: "failure",
+      disposition: "remove-immediately",
+      error: {
+        tag: "TuiCreatedSessionError",
+        code: "CREATED_SESSION_FOCUS_FAILED",
+        message: "The created session could not be focused.",
+      },
+    });
+
+    await setup.run();
+
+    expect(
+      setup.store
+        .getState()
+        .snapshot?.sessionGroups.find((group) => group.id === setup.operation.groupId)?.sessionIds,
+    ).toContain("ses_wt_web_quick_group");
+    expect(setup.store.getState().dashboardFocus).toEqual({
+      rowId: "session:ses_wt_web_quick_group",
+      cellId: "identity",
+    });
+    expect(setup.store.getState().toasts.at(-1)?.toast).toMatchObject({
+      kind: "error",
+      message: "The created session could not be focused.",
+    });
+    await setup.scope.dispose();
+  });
 });
 
 function createOperationSetup(
@@ -476,7 +522,10 @@ function createOperationSetup(
 
   capabilities.quickCreateHandle = (request) => {
     service.setSnapshot(withLaunchedSession(created, request.hiddenBranch));
-    return dashboardExecution({ kind: "success" }, { optimistic: "pending-create" });
+    return dashboardExecution(
+      { kind: "success", createdSessionCommand: createdSessionCommand(request.hiddenBranch) },
+      { optimistic: "pending-create" },
+    );
   };
   service.waitForCommandCompletion = async (commandId) => {
     const command = service.dispatched.at(-1);
@@ -555,7 +604,13 @@ function createExistingGroupQuickSetup() {
   });
   capabilities.quickCreateHandle = () => {
     service.setSnapshot(withLaunchedSession(initial, operation.hiddenBranch));
-    return dashboardExecution({ kind: "success" }, { optimistic: "pending-create" });
+    return dashboardExecution(
+      {
+        kind: "success",
+        createdSessionCommand: createdSessionCommand(operation.hiddenBranch),
+      },
+      { optimistic: "pending-create" },
+    );
   };
   service.waitForCommandCompletion = async (commandId) => {
     const current = store.getState().snapshot;
@@ -592,6 +647,20 @@ function createExistingGroupQuickSetup() {
         clientLabel: "test",
         scope,
       }),
+  };
+}
+
+function createdSessionCommand(branch: string) {
+  return {
+    type: "createdSession.applyUiPolicy" as const,
+    target: {
+      sessionId: "ses_wt_web_quick_group",
+      projectId: "web",
+      worktreeId: "wt_web_quick_group",
+      branch,
+      terminalProvider: "tmux",
+    },
+    policy: { focusCreatedSession: true, dismissDashboard: true },
   };
 }
 

--- a/packages/dashboard-core/test/unit/state/runtime.test.ts
+++ b/packages/dashboard-core/test/unit/state/runtime.test.ts
@@ -13,6 +13,7 @@ import type {
   TuiFolderReadResult,
   TuiFolderService,
 } from "../../../src/services/folderService.js";
+import type { CreatedSessionUiCommand } from "../../../src/state/capabilities/createdSession.js";
 import { dashboardExecution } from "../../../src/state/capabilities/execution.js";
 import { createEmptyTuiLocalRows } from "../../../src/state/localRows.js";
 import { selectedAddProjectFolderRow } from "../../../src/state/selection/addProject.js";
@@ -263,6 +264,52 @@ describe("dashboard runtime", () => {
     completion.resolve({ kind: "success" });
     await waitFor(() => store.state.getState().screen.name === "dashboard");
     expect(store.state.getState().localRows.pendingCreate).toEqual([]);
+  });
+
+  it("settles deliberate New Session before applying its created-session UI command", async () => {
+    const snapshot = createDashboardSnapshot();
+    const capabilities = createFakeDashboardCapabilities();
+    capabilities.createHandle = () =>
+      dashboardExecution({
+        kind: "success",
+        createdSessionCommand: createdSessionCommand(),
+      });
+    let screenAtInvocation: DashboardStateView["screen"] | undefined;
+    const store = createTestDashboardRuntime({
+      service: new FakeTuiObserverService(snapshot),
+      initialSnapshot: snapshot,
+      capabilities,
+    });
+    capabilities.createdSessionResult = () => {
+      screenAtInvocation = store.state.getState().screen;
+      return { kind: "success" };
+    };
+
+    store.actions.handleKey({ input: "N" });
+    store.actions.handleKey({ input: "C" });
+
+    await waitFor(() => capabilities.createdSessionCommands.length === 1);
+    expect(screenAtInvocation).toEqual({ name: "dashboard" });
+  });
+
+  it("discards a created-session UI command after the dashboard scope closes", async () => {
+    const snapshot = createDashboardSnapshot();
+    const capabilities = createFakeDashboardCapabilities();
+    const completion = deferred<Awaited<ReturnType<typeof dashboardExecution>["completion"]>>();
+    capabilities.createHandle = () => dashboardExecution(completion.promise);
+    const store = createTestDashboardRuntime({
+      service: new FakeTuiObserverService(snapshot),
+      initialSnapshot: snapshot,
+      capabilities,
+    });
+
+    store.actions.handleKey({ input: "N" });
+    store.actions.handleKey({ input: "C" });
+    const disposal = store.dispose();
+    completion.resolve({ kind: "success", createdSessionCommand: createdSessionCommand() });
+    await disposal;
+
+    expect(capabilities.createdSessionCommands).toEqual([]);
   });
 
   it("closes deliberate New Session and surfaces a non-retryable success notice", async () => {
@@ -1539,6 +1586,20 @@ function snapshotWithProjectHarness(
         ? { ...project, defaults: { ...project.defaults, harness } }
         : project,
     ),
+  };
+}
+
+function createdSessionCommand(): CreatedSessionUiCommand {
+  return {
+    type: "createdSession.applyUiPolicy",
+    target: {
+      sessionId: "ses_wt_web_idle",
+      projectId: "web",
+      worktreeId: "wt_web_idle",
+      branch: "fix-nav-mobile",
+      terminalProvider: "tmux",
+    },
+    policy: { focusCreatedSession: true, dismissDashboard: true },
   };
 }
 

--- a/station/src/app/createStation.ts
+++ b/station/src/app/createStation.ts
@@ -78,6 +78,10 @@ export function createStation(options: CreateStationOptions): Station {
     paneEffects,
     registry,
     managedLaunch,
+    createdSessionPolicy: options.createdSessionPolicy ?? {
+      focusCreatedSession: true,
+      dismissDashboard: true,
+    },
   });
   const dashboardRuntime = createStationDashboardRuntime(
     stationClient,

--- a/station/src/app/dashboardCapabilities.test.ts
+++ b/station/src/app/dashboardCapabilities.test.ts
@@ -9,7 +9,9 @@ import { FakeStationSource } from "../station/test/support/fakeStationSource.js"
 import { FakeTuiObserverService } from "../station/test/support/fakeObserverService.js";
 import { createDashboardCapabilities } from "./dashboardCapabilities.js";
 
-function harness() {
+function harness(
+  createdSessionPolicy = { focusCreatedSession: true, dismissDashboard: true },
+) {
   const snapshot = manyProjectsSnapshot();
   const source = new FakeStationSource(snapshot);
   const service = new FakeTuiObserverService(snapshot);
@@ -50,6 +52,7 @@ function harness() {
     paneEffects,
     registry: {} as PtyRegistry,
     managedLaunch,
+    createdSessionPolicy,
   });
   return {
     capabilities,
@@ -88,6 +91,70 @@ const FAILURE = {
 };
 
 describe("native dashboard capabilities", () => {
+  it("applies all native post-create focus and dismissal policy combinations", async () => {
+    const command = {
+      type: "createdSession.applyUiPolicy" as const,
+      target: {
+        sessionId: "ses_wt_station_idle",
+        projectId: "station",
+        worktreeId: "wt_station_idle",
+        branch: "pty-buffer",
+        terminalProvider: "native",
+      },
+      policy: { focusCreatedSession: false, dismissDashboard: false },
+    };
+    const fixture = harness();
+    fixture.store.actions.openOverlay(STATION_OVERLAY_ID);
+
+    await fixture.capabilities.createdSession.applyUiPolicy(command);
+    expect(fixture.activateRequests).toEqual([]);
+    expect(fixture.store.getState().input.activeOverlay).toBe(STATION_OVERLAY_ID);
+
+    await fixture.capabilities.createdSession.applyUiPolicy({
+      ...command,
+      policy: { focusCreatedSession: false, dismissDashboard: true },
+    });
+    expect(fixture.store.getState().input.activeOverlay).toBeNull();
+
+    fixture.store.actions.openOverlay(STATION_OVERLAY_ID);
+    await fixture.capabilities.createdSession.applyUiPolicy({
+      ...command,
+      policy: { focusCreatedSession: true, dismissDashboard: false },
+    });
+    expect(fixture.activateRequests).toHaveLength(1);
+    expect(fixture.store.getState().input.activeOverlay).toBe(STATION_OVERLAY_ID);
+
+    await fixture.capabilities.createdSession.applyUiPolicy({
+      ...command,
+      policy: { focusCreatedSession: true, dismissDashboard: true },
+    });
+    expect(fixture.store.getState().input.activeOverlay).toBeNull();
+  });
+
+  it("retains the native dashboard when created-session focus does not land", async () => {
+    const fixture = harness();
+    fixture.store.actions.openOverlay(STATION_OVERLAY_ID);
+    fixture.setActivationResult({ kind: "success", landed: false });
+
+    await expect(
+      fixture.capabilities.createdSession.applyUiPolicy({
+        type: "createdSession.applyUiPolicy",
+        target: {
+          sessionId: "ses_wt_station_idle",
+          projectId: "station",
+          worktreeId: "wt_station_idle",
+          branch: "pty-buffer",
+          terminalProvider: "native",
+        },
+        policy: { focusCreatedSession: true, dismissDashboard: true },
+      }),
+    ).resolves.toMatchObject({
+      kind: "failure",
+      error: { code: "CREATED_SESSION_FOCUS_UNCONFIRMED" },
+    });
+    expect(fixture.store.getState().input.activeOverlay).toBe(STATION_OVERLAY_ID);
+  });
+
   it("dismisses the overlay only after a managed activation lands", async () => {
     const fixture = harness();
     fixture.store.actions.openOverlay(STATION_OVERLAY_ID);
@@ -360,7 +427,12 @@ describe("native dashboard capabilities", () => {
         },
       ],
     });
-    expect(await completion).toEqual({ kind: "success" });
+    expect(await completion).toMatchObject({
+      kind: "success",
+      createdSessionCommand: {
+        target: { sessionId: session.id, branch, terminalProvider: "native" },
+      },
+    });
   });
 
   it("matches deliberate inline-Group placement by canonical membership and name", async () => {
@@ -395,7 +467,12 @@ describe("native dashboard capabilities", () => {
         },
       ],
     });
-    expect(await completion).toEqual({ kind: "success" });
+    expect(await completion).toMatchObject({
+      kind: "success",
+      createdSessionCommand: {
+        target: { sessionId: session.id, branch, terminalProvider: "native" },
+      },
+    });
   });
 
   it("refreshes once after placement timeout and warns without enabling duplicate retry", async () => {
@@ -434,7 +511,12 @@ describe("native dashboard capabilities", () => {
       const refreshedCompletion = refreshed.capabilities.managedSessions.create(request).completion;
       await new Promise((resolve) => realSetTimeout(resolve, 0));
       longTimers.shift()?.();
-      expect(await refreshedCompletion).toEqual({ kind: "success" });
+      expect(await refreshedCompletion).toMatchObject({
+        kind: "success",
+        createdSessionCommand: {
+          target: { sessionId: session.id, branch: request.hiddenBranch },
+        },
+      });
       expect(refreshed.service.loadCount).toBe(1);
 
       const unconfirmed = harness();
@@ -509,6 +591,11 @@ describe("native dashboard capabilities", () => {
         row.id === session.worktreeId ? { ...row, branch } : row,
       ),
     });
-    expect(await completion).toEqual({ kind: "success" });
+    expect(await completion).toMatchObject({
+      kind: "success",
+      createdSessionCommand: {
+        target: { sessionId: session.id, branch, terminalProvider: "native" },
+      },
+    });
   });
 });

--- a/station/src/app/dashboardCapabilities.test.ts
+++ b/station/src/app/dashboardCapabilities.test.ts
@@ -12,7 +12,15 @@ import { createDashboardCapabilities } from "./dashboardCapabilities.js";
 function harness(
   createdSessionPolicy = { focusCreatedSession: true, dismissDashboard: true },
 ) {
-  const snapshot = manyProjectsSnapshot();
+  const baseSnapshot = manyProjectsSnapshot();
+  const snapshot = {
+    ...baseSnapshot,
+    sessions: baseSnapshot.sessions.map((session) =>
+      session.terminal === undefined
+        ? session
+        : { ...session, terminal: { ...session.terminal, provider: "native" as const } },
+    ),
+  };
   const source = new FakeStationSource(snapshot);
   const service = new FakeTuiObserverService(snapshot);
   const store = createStationStore();
@@ -153,6 +161,46 @@ describe("native dashboard capabilities", () => {
       error: { code: "CREATED_SESSION_FOCUS_UNCONFIRMED" },
     });
     expect(fixture.store.getState().input.activeOverlay).toBe(STATION_OVERLAY_ID);
+  });
+
+  it("rejects provider drift and non-focusable native post-create targets", async () => {
+    const command = {
+      type: "createdSession.applyUiPolicy" as const,
+      target: {
+        sessionId: "ses_wt_station_idle",
+        projectId: "station",
+        worktreeId: "wt_station_idle",
+        branch: "pty-buffer",
+        terminalProvider: "native",
+      },
+      policy: { focusCreatedSession: true, dismissDashboard: true },
+    };
+    const cases = [
+      { terminal: { provider: "tmux" as const, focusable: true }, code: "CREATED_SESSION_TARGET_MISMATCH" },
+      { terminal: { provider: "native" as const, focusable: false }, code: "CREATED_SESSION_NOT_FOCUSABLE" },
+    ];
+
+    for (const testCase of cases) {
+      const fixture = harness();
+      const snapshot = fixture.source.getState().snapshot;
+      if (snapshot === undefined) throw new Error("Native fixture snapshot is missing.");
+      fixture.source.setSnapshot({
+        ...snapshot,
+        sessions: snapshot.sessions.map((session) =>
+          session.id === command.target.sessionId && session.terminal !== undefined
+            ? { ...session, terminal: { ...session.terminal, ...testCase.terminal } }
+            : session,
+        ),
+      });
+      fixture.store.actions.openOverlay(STATION_OVERLAY_ID);
+
+      await expect(fixture.capabilities.createdSession.applyUiPolicy(command)).resolves.toMatchObject({
+        kind: "failure",
+        error: { code: testCase.code },
+      });
+      expect(fixture.activateRequests).toEqual([]);
+      expect(fixture.store.getState().input.activeOverlay).toBe(STATION_OVERLAY_ID);
+    }
   });
 
   it("dismisses the overlay only after a managed activation lands", async () => {

--- a/station/src/app/dashboardCapabilities.ts
+++ b/station/src/app/dashboardCapabilities.ts
@@ -5,7 +5,13 @@ import {
   createObserverWorktreeRemovalCapabilities,
   dashboardExecution,
 } from "@station/dashboard-core/runtime";
-import type { DashboardCapabilities, DashboardExecutionHandle, DashboardExecutionResult } from "@station/dashboard-core/runtime";
+import type {
+  CreatedSessionUiCommand,
+  CreatedSessionUiPolicy,
+  DashboardCapabilities,
+  DashboardExecutionHandle,
+  DashboardExecutionResult,
+} from "@station/dashboard-core/runtime";
 import {
   resolveDashboardShellTarget,
   STALE_DASHBOARD_TARGET_NOTICE,
@@ -16,7 +22,6 @@ import type { ManagedLaunch, ManagedLaunchResult } from "../input/runtime/manage
 import type { PaneEffects } from "../input/runtime/paneEffects.js";
 import {
   findSessionPlacementByBranch,
-  waitForSessionByBranch,
   waitForSessionPlacementByBranch,
 } from "../input/runtime/stationRows.js";
 import type { PtyRegistry } from "../terminal/registry/ptyRegistry.js";
@@ -39,6 +44,8 @@ export type CreateNativeDashboardCapabilitiesOptions = {
   paneEffects: PaneEffects;
   registry: PtyRegistry;
   managedLaunch: ManagedLaunch;
+  /** Fully resolved native policy; capability composition receives no raw config. */
+  createdSessionPolicy: CreatedSessionUiPolicy;
 };
 
 /**
@@ -72,48 +79,19 @@ export function createDashboardCapabilities(
       runManagedSessionCreate(request).then(async (result): Promise<DashboardExecutionResult> => {
         if (result.kind === "failure") return managedSessionResult(result);
         if (result.kind === "notice") return { kind: "success", notice: result.notice };
-
-        const session = await waitForSessionPlacementByBranch(
-          options.clientState,
-          request.project.id,
-          request.hiddenBranch,
-          request.group,
-        );
-        if (session !== undefined) return { kind: "success" };
-
-        try {
-          const refreshed = await options.observerService.loadSnapshot();
-          const placed = findSessionPlacementByBranch(
-            refreshed,
-            request.project.id,
-            request.hiddenBranch,
-            request.group,
-          );
-          if (placed !== undefined) {
-            return { kind: "success" };
-          }
-        } catch {
-          // Launch already succeeded, so refresh failure must not make Create retryable.
-        }
-        return { kind: "success", notice: SESSION_PLACEMENT_UNCONFIRMED_NOTICE };
+        return resolveNativeCreatedSessionCommand(options, request);
       }),
       { successDisposition: "wait-for-canonical" },
     );
   const quickCreateManagedSession: DashboardCapabilities["managedSessions"]["quickCreate"] = (
     request,
   ) =>
-    managedSessionExecution(
-      runManagedSessionCreate(request).then(async (result) => {
-        if (result.kind === "success") {
-          // Native preparation publishes its session through an asynchronous Observer reconcile.
-          await waitForSessionByBranch(
-            options.clientState,
-            request.project.id,
-            request.hiddenBranch,
-          );
-        }
-        return result;
+    dashboardExecution(
+      runManagedSessionCreate(request).then(async (result): Promise<DashboardExecutionResult> => {
+        if (result.kind !== "success") return managedSessionResult(result);
+        return resolveNativeCreatedSessionCommand(options, request);
       }),
+      { optimistic: "pending-create", successDisposition: "wait-for-canonical" },
     );
   const closeDashboard: DashboardCapabilities["dismissal"]["dismissDashboard"] = () => {
     options.store.actions.closeOverlay();
@@ -166,6 +144,9 @@ export function createDashboardCapabilities(
           },
         );
       },
+    },
+    createdSession: {
+      applyUiPolicy: (command) => applyNativeCreatedSessionPolicy(options, command),
     },
     managedSessions: {
       create: createManagedSession,
@@ -232,6 +213,143 @@ export function createDashboardCapabilities(
     dismissal: {
       dismissDashboard: closeDashboard,
       exitRenderer: closeDashboard,
+    },
+  };
+}
+
+async function resolveNativeCreatedSessionCommand(
+  options: CreateNativeDashboardCapabilitiesOptions,
+  request: Parameters<DashboardCapabilities["managedSessions"]["create"]>[0],
+): Promise<DashboardExecutionResult> {
+  const observed = await waitForSessionPlacementByBranch(
+    options.clientState,
+    request.project.id,
+    request.hiddenBranch,
+    request.group,
+  );
+  if (observed !== undefined) {
+    const command = nativeCreatedSessionCommand(
+      options.clientState.getState().snapshot,
+      request,
+      observed.id,
+      options.createdSessionPolicy,
+    );
+    if (command !== undefined) return { kind: "success", createdSessionCommand: command };
+  }
+
+  try {
+    const refreshed = await options.observerService.loadSnapshot();
+    const placed = findSessionPlacementByBranch(
+      refreshed,
+      request.project.id,
+      request.hiddenBranch,
+      request.group,
+    );
+    const command =
+      placed === undefined
+        ? undefined
+        : nativeCreatedSessionCommand(
+            refreshed,
+            request,
+            placed.id,
+            options.createdSessionPolicy,
+          );
+    if (command !== undefined) return { kind: "success", createdSessionCommand: command };
+  } catch {
+    // Launch already succeeded, so refresh failure must not make Create retryable.
+  }
+  return { kind: "success", notice: SESSION_PLACEMENT_UNCONFIRMED_NOTICE };
+}
+
+function nativeCreatedSessionCommand(
+  snapshot: ReturnType<StationClientStateSource["getState"]>["snapshot"],
+  request: Parameters<DashboardCapabilities["managedSessions"]["create"]>[0],
+  sessionId: string,
+  policy: CreatedSessionUiPolicy,
+): CreatedSessionUiCommand | undefined {
+  const session = snapshot?.sessions.find(
+    (candidate) =>
+      candidate.id === sessionId && candidate.projectId === request.project.id,
+  );
+  const row = snapshot?.rows.find(
+    (candidate) =>
+      candidate.id === session?.worktreeId &&
+      candidate.projectId === request.project.id &&
+      candidate.branch === request.hiddenBranch,
+  );
+  if (session === undefined || row === undefined) return undefined;
+  return {
+    type: "createdSession.applyUiPolicy",
+    target: {
+      sessionId: session.id,
+      projectId: session.projectId,
+      worktreeId: session.worktreeId,
+      branch: row.branch,
+      terminalProvider: "native",
+    },
+    policy,
+  };
+}
+
+async function applyNativeCreatedSessionPolicy(
+  options: CreateNativeDashboardCapabilitiesOptions,
+  command: CreatedSessionUiCommand,
+): Promise<DashboardExecutionResult> {
+  if (!command.policy.focusCreatedSession) {
+    if (command.policy.dismissDashboard) options.store.actions.closeOverlay();
+    return { kind: "success" };
+  }
+
+  const snapshot = options.clientState.getState().snapshot;
+  const session = snapshot?.sessions.find(
+    (candidate) =>
+      candidate.id === command.target.sessionId &&
+      candidate.projectId === command.target.projectId &&
+      candidate.worktreeId === command.target.worktreeId,
+  );
+  const row = snapshot?.rows.find(
+    (candidate) =>
+      candidate.id === command.target.worktreeId &&
+      candidate.projectId === command.target.projectId &&
+      candidate.branch === command.target.branch,
+  );
+  if (command.target.terminalProvider !== "native" || session === undefined || row === undefined) {
+    return createdSessionFailure(
+      "CREATED_SESSION_TARGET_MISMATCH",
+      "The created session no longer matches its canonical native pane.",
+    );
+  }
+
+  const result = await options.managedLaunch.activate(agentWorktreePaneId(row.id), {
+    projectId: row.projectId,
+    worktreeId: row.id,
+    cwd: row.path,
+  });
+  if (result.kind === "failure") {
+    return { kind: "failure", error: result.error, disposition: "remove-immediately" };
+  }
+  if (result.kind === "notice") {
+    return createdSessionFailure("CREATED_SESSION_FOCUS_FAILED", result.notice.message);
+  }
+  if (!result.landed) {
+    return createdSessionFailure(
+      "CREATED_SESSION_FOCUS_UNCONFIRMED",
+      "Station could not confirm that the created session was focused.",
+    );
+  }
+  if (command.policy.dismissDashboard) options.store.actions.closeOverlay();
+  return { kind: "success" };
+}
+
+function createdSessionFailure(code: string, message: string): DashboardExecutionResult {
+  return {
+    kind: "failure",
+    disposition: "remove-immediately",
+    error: {
+      tag: "TuiCreatedSessionError",
+      code,
+      message,
+      hint: "The session was created successfully and remains available in the dashboard.",
     },
   };
 }

--- a/station/src/app/dashboardCapabilities.ts
+++ b/station/src/app/dashboardCapabilities.ts
@@ -313,10 +313,21 @@ async function applyNativeCreatedSessionPolicy(
       candidate.projectId === command.target.projectId &&
       candidate.branch === command.target.branch,
   );
-  if (command.target.terminalProvider !== "native" || session === undefined || row === undefined) {
+  if (
+    command.target.terminalProvider !== "native" ||
+    session === undefined ||
+    session.terminal?.provider !== "native" ||
+    row === undefined
+  ) {
     return createdSessionFailure(
       "CREATED_SESSION_TARGET_MISMATCH",
       "The created session no longer matches its canonical native pane.",
+    );
+  }
+  if (session.terminal.focusable !== true) {
+    return createdSessionFailure(
+      "CREATED_SESSION_NOT_FOCUSABLE",
+      "The created session cannot be focused from the native dashboard.",
     );
   }
 

--- a/station/src/app/types.ts
+++ b/station/src/app/types.ts
@@ -1,5 +1,6 @@
 import type { StationClientStateSource } from "@station/client";
 import type {
+  CreatedSessionUiPolicy,
   DashboardActions,
   DashboardRuntime,
   DashboardStateSource,
@@ -71,6 +72,8 @@ export type CreateStationOptions = {
   openExternalUrl?: (url: string) => void;
   tuiConfig?: TuiConfig;
   tuiConfigPath?: string;
+  /** Resolved native post-create policy; raw config never reaches capabilities. */
+  createdSessionPolicy?: CreatedSessionUiPolicy;
   topRowWidgetDeps?: TopRowWidgetRuntimeDeps;
   /** Existing registry to reuse across Bun HMR without killing live PTYs. */
   registry?: PtyRegistry;

--- a/station/src/config/tuiConfig.test.ts
+++ b/station/src/config/tuiConfig.test.ts
@@ -14,7 +14,12 @@ import {
 import { createStation } from "../app/createStation.js";
 import { NO_OP_CLIPBOARD_EFFECTS } from "../copy/testing.js";
 import { createStationStore } from "../state/store.js";
-import { loadStationTuiConfig, startWidgetConfigWrites } from "./tuiConfig.js";
+import {
+  loadStationTuiConfig,
+  resolveSessionCreatePolicies,
+  sessionCreatePolicyForTerminal,
+  startWidgetConfigWrites,
+} from "./tuiConfig.js";
 
 describe("loadStationTuiConfig", () => {
   const dirs: string[] = [];
@@ -299,6 +304,36 @@ root = "${projectRoot}"
 
     expect(dismisses).toBe(1);
     expect(exits).toBe(0);
+  });
+});
+
+describe("session-create policy resolution", () => {
+  it("defaults globally and inherits partial terminal overrides", () => {
+    const defaults = resolveSessionCreatePolicies(undefined);
+    expect(sessionCreatePolicyForTerminal(defaults, "tmux")).toEqual({
+      focusCreatedSession: true,
+      dismissDashboard: true,
+    });
+
+    const resolved = resolveSessionCreatePolicies({
+      focusCreatedSession: false,
+      terminals: {
+        tmux: { dismissDashboard: false },
+        native: { focusCreatedSession: true },
+      },
+    });
+    expect(sessionCreatePolicyForTerminal(resolved, "tmux")).toEqual({
+      focusCreatedSession: false,
+      dismissDashboard: false,
+    });
+    expect(sessionCreatePolicyForTerminal(resolved, "native")).toEqual({
+      focusCreatedSession: true,
+      dismissDashboard: true,
+    });
+    expect(sessionCreatePolicyForTerminal(resolved, "future")).toEqual({
+      focusCreatedSession: false,
+      dismissDashboard: true,
+    });
   });
 });
 

--- a/station/src/config/tuiConfig.test.ts
+++ b/station/src/config/tuiConfig.test.ts
@@ -334,6 +334,10 @@ describe("session-create policy resolution", () => {
       focusCreatedSession: false,
       dismissDashboard: true,
     });
+    expect(sessionCreatePolicyForTerminal(resolved, "constructor")).toEqual({
+      focusCreatedSession: false,
+      dismissDashboard: true,
+    });
   });
 });
 

--- a/station/src/config/tuiConfig.ts
+++ b/station/src/config/tuiConfig.ts
@@ -51,7 +51,10 @@ export function sessionCreatePolicyForTerminal(
   policies: ResolvedSessionCreatePolicies,
   provider: string,
 ): CreatedSessionUiPolicy {
-  return policies.terminals[provider] ?? policies.global;
+  const terminalPolicy = Object.hasOwn(policies.terminals, provider)
+    ? policies.terminals[provider]
+    : undefined;
+  return terminalPolicy ?? policies.global;
 }
 
 function resolveSessionCreatePolicy(

--- a/station/src/config/tuiConfig.ts
+++ b/station/src/config/tuiConfig.ts
@@ -6,8 +6,13 @@ import {
   loadConfig,
   setTuiWidgetsInConfig,
   type TuiConfig,
+  type TuiSessionCreateConfig,
 } from "@station/config";
-import type { DashboardActions, DashboardStateSource } from "@station/dashboard-core/runtime";
+import type {
+  CreatedSessionUiPolicy,
+  DashboardActions,
+  DashboardStateSource,
+} from "@station/dashboard-core/runtime";
 import type { DashboardStateView } from "@station/dashboard-core/state";
 import { safeErrorFromUnknown } from "@station/runtime";
 
@@ -16,6 +21,51 @@ export type StationTuiConfigLoadResult = {
   configPath?: string;
   warning?: string;
 };
+
+/** Renderer-ready policy table with global defaults already inherited into every override. */
+export type ResolvedSessionCreatePolicies = {
+  global: CreatedSessionUiPolicy;
+  terminals: Readonly<Record<string, CreatedSessionUiPolicy>>;
+};
+
+const DEFAULT_CREATED_SESSION_UI_POLICY: CreatedSessionUiPolicy = {
+  focusCreatedSession: true,
+  dismissDashboard: true,
+};
+
+/** Resolve raw `[tui.session_create]` once, before dashboard capability composition. */
+export function resolveSessionCreatePolicies(
+  config: TuiSessionCreateConfig | undefined,
+): ResolvedSessionCreatePolicies {
+  const global = resolveSessionCreatePolicy(DEFAULT_CREATED_SESSION_UI_POLICY, config);
+  const terminals = Object.fromEntries(
+    Object.entries(config?.terminals ?? {}).map(([provider, override]) => [
+      provider,
+      resolveSessionCreatePolicy(global, override),
+    ]),
+  );
+  return { global, terminals };
+}
+
+export function sessionCreatePolicyForTerminal(
+  policies: ResolvedSessionCreatePolicies,
+  provider: string,
+): CreatedSessionUiPolicy {
+  return policies.terminals[provider] ?? policies.global;
+}
+
+function resolveSessionCreatePolicy(
+  fallback: CreatedSessionUiPolicy,
+  config: Pick<
+    TuiSessionCreateConfig,
+    "focusCreatedSession" | "dismissDashboard"
+  > | undefined,
+): CreatedSessionUiPolicy {
+  return {
+    focusCreatedSession: config?.focusCreatedSession ?? fallback.focusCreatedSession,
+    dismissDashboard: config?.dismissDashboard ?? fallback.dismissDashboard,
+  };
+}
 
 export async function loadStationTuiConfig(options?: {
   env?: Record<string, string | undefined>;

--- a/station/src/dashboardRenderer/dashboardCapabilities.test.ts
+++ b/station/src/dashboardRenderer/dashboardCapabilities.test.ts
@@ -26,6 +26,10 @@ describe("standalone dashboard capabilities", () => {
         exitOnFocusSuccess: true,
         dispose: () => {},
       },
+      sessionCreatePolicies: {
+        global: { focusCreatedSession: true, dismissDashboard: true },
+        terminals: {},
+      },
       exitRenderer: () => {
         dismissCount += 1;
       },
@@ -73,6 +77,10 @@ describe("standalone dashboard capabilities", () => {
         },
         dispose: () => {},
       },
+      sessionCreatePolicies: {
+        global: { focusCreatedSession: true, dismissDashboard: true },
+        terminals: {},
+      },
       exitRenderer: () => {},
     });
 
@@ -88,5 +96,65 @@ describe("standalone dashboard capabilities", () => {
       await capabilities.dismissal.exitRenderer({ exitCode: 0 }).completion,
     ).toEqual({ kind: "success" });
     expect(dismissCount).toBe(2);
+  });
+
+  it("selects the resolved policy from the durable create provider", async () => {
+    const snapshot = manyProjectsSnapshot();
+    const source = new FakeStationSource(snapshot);
+    const service = new FakeTuiObserverService(snapshot);
+    service.nextCompletion = {
+      status: "succeeded",
+      commandId: "cmd_tui_1",
+      result: {
+        type: "session.create",
+        projectId: "station",
+        worktreeId: "wt_station_idle",
+        sessionId: "ses_wt_station_idle",
+        requestedPlacement: "detached",
+        resolvedPlacement: {
+          provider: "tmux",
+          targetId: "tmux:station:pty-buffer",
+          generation: "1",
+          presentation: "detached",
+        },
+      },
+    };
+    const capabilities = createDashboardCapabilities({
+      clientState: source,
+      observerService: service,
+      popupRuntime: {
+        persistentPopup: false,
+        exitOnFocusSuccess: false,
+        dispose: () => {},
+      },
+      sessionCreatePolicies: {
+        global: { focusCreatedSession: true, dismissDashboard: true },
+        terminals: {
+          tmux: { focusCreatedSession: false, dismissDashboard: false },
+        },
+      },
+      exitRenderer: () => {},
+    });
+    const project = snapshot.projects.find((candidate) => candidate.id === "station");
+    if (project === undefined) throw new Error("station project fixture missing");
+
+    await expect(
+      capabilities.managedSessions.quickCreate({
+        project,
+        title: "Quick session",
+        hiddenBranch: "pty-buffer",
+        harness: "codex",
+      }).completion,
+    ).resolves.toMatchObject({
+      kind: "success",
+      createdSessionCommand: {
+        target: {
+          sessionId: "ses_wt_station_idle",
+          worktreeId: "wt_station_idle",
+          terminalProvider: "tmux",
+        },
+        policy: { focusCreatedSession: false, dismissDashboard: false },
+      },
+    });
   });
 });

--- a/station/src/dashboardRenderer/dashboardCapabilities.ts
+++ b/station/src/dashboardRenderer/dashboardCapabilities.ts
@@ -1,6 +1,7 @@
 import { toSafeError, type ObserverService, type StationClientStateSource } from "@station/client";
 import {
   createObserverActivationCapabilities,
+  createObserverCreatedSessionCapabilities,
   createObserverManagedSessionCapabilities,
   createObserverWorktreeRemovalCapabilities,
   dashboardExecution,
@@ -10,6 +11,10 @@ import {
   resolveDashboardShellTarget,
   STALE_DASHBOARD_TARGET_NOTICE,
 } from "../dashboardCapabilities/shellTarget.js";
+import {
+  sessionCreatePolicyForTerminal,
+  type ResolvedSessionCreatePolicies,
+} from "../config/tuiConfig.js";
 import type { PopupRuntime } from "./popupRuntime.js";
 
 /** Standalone composition inputs for semantic dashboard execution. */
@@ -17,6 +22,8 @@ export type CreateStandaloneDashboardCapabilitiesOptions = {
   clientState: StationClientStateSource;
   observerService: ObserverService;
   popupRuntime: PopupRuntime;
+  /** Renderer-resolved policy table; this boundary never receives raw `[tui]` config. */
+  sessionCreatePolicies: ResolvedSessionCreatePolicies;
   exitRenderer(exitCode: number): void;
 };
 
@@ -27,6 +34,13 @@ export type CreateStandaloneDashboardCapabilitiesOptions = {
 export function createDashboardCapabilities(
   options: CreateStandaloneDashboardCapabilitiesOptions,
 ): DashboardCapabilities {
+  const dismissCreatedSessionDashboard = async (): Promise<void> => {
+    if (options.popupRuntime.dismissDashboard !== undefined) {
+      await options.popupRuntime.dismissDashboard();
+      return;
+    }
+    options.exitRenderer(0);
+  };
   const onFocusSuccess = options.popupRuntime.exitOnFocusSuccess
     ? async (): Promise<void> => {
         options.exitRenderer(0);
@@ -51,17 +65,28 @@ export function createDashboardCapabilities(
 
   const managedOptions: Parameters<typeof createObserverManagedSessionCapabilities>[0] = {
     service: options.observerService,
+    source: options.clientState,
     clientLabel: "station",
+    policyForTerminalProvider: (provider) =>
+      sessionCreatePolicyForTerminal(options.sessionCreatePolicies, provider),
+  };
+
+  const createdSessionOptions: Parameters<typeof createObserverCreatedSessionCapabilities>[0] = {
+    source: options.clientState,
+    service: options.observerService,
+    clientLabel: "station",
+    dismissDashboard: dismissCreatedSessionDashboard,
   };
   if (options.popupRuntime.focusOrigin !== undefined) {
-    managedOptions.focusOrigin = options.popupRuntime.focusOrigin;
+    createdSessionOptions.focusOrigin = options.popupRuntime.focusOrigin;
   }
   if (options.popupRuntime.resolveFocusTarget !== undefined) {
-    managedOptions.resolveFocusTarget = options.popupRuntime.resolveFocusTarget;
+    createdSessionOptions.resolveFocusTarget = options.popupRuntime.resolveFocusTarget;
   }
 
   return {
     activation: createObserverActivationCapabilities(activationOptions),
+    createdSession: createObserverCreatedSessionCapabilities(createdSessionOptions),
     managedSessions: createObserverManagedSessionCapabilities(managedOptions),
     worktreeRemoval: createObserverWorktreeRemovalCapabilities({
       service: options.observerService,

--- a/station/src/dashboardRenderer/main.tsx
+++ b/station/src/dashboardRenderer/main.tsx
@@ -9,6 +9,7 @@ import { toSafeError } from "@station/client";
 import { createDashboardRuntime } from "@station/dashboard-core/runtime";
 import {
   loadStationTuiConfig,
+  resolveSessionCreatePolicies,
   startWidgetConfigWrites,
   type WidgetConfigWrites,
 } from "../config/tuiConfig.js";
@@ -114,6 +115,7 @@ export async function runDashboardMain(): Promise<void> {
     clientState: client.state,
     observerService: client.service,
     popupRuntime,
+    sessionCreatePolicies: resolveSessionCreatePolicies(tuiConfig.config?.sessionCreate),
     exitRenderer: exit,
   });
   const dashboardLayout = createDashboardScrollController();

--- a/station/src/input/stationInput.test.ts
+++ b/station/src/input/stationInput.test.ts
@@ -822,6 +822,7 @@ describe("createStationInputRuntime open-pane wiring", () => {
         paneEffects,
         registry,
         managedLaunch,
+        createdSessionPolicy: { focusCreatedSession: true, dismissDashboard: true },
       }),
     });
     const runtime = createStationInputRuntime({
@@ -998,6 +999,7 @@ describe("createStationInputRuntime open-pane wiring", () => {
         paneEffects,
         registry,
         managedLaunch,
+        createdSessionPolicy: { focusCreatedSession: true, dismissDashboard: true },
       }),
     });
     let lastPanes: readonly PaneRecord[] | undefined;

--- a/station/src/input/stationIntegration.test.ts
+++ b/station/src/input/stationIntegration.test.ts
@@ -48,6 +48,9 @@ function makeViewStore(
               return dashboardExecution({ kind: "success" });
             },
           },
+          createdSession: {
+            applyUiPolicy: async () => ({ kind: "success" }),
+          },
           managedSessions: {
             create: () => dashboardExecution({ kind: "success" }),
             quickCreate: () => dashboardExecution({ kind: "success" }),

--- a/station/src/main.tsx
+++ b/station/src/main.tsx
@@ -9,7 +9,11 @@ import { stationBuildInfo } from "@station/runtime";
 import { convergeStationHost } from "@station/terminal";
 import { Profiler } from "react";
 import { loadStationConfig } from "./config/stationConfig.js";
-import { loadStationTuiConfig } from "./config/tuiConfig.js";
+import {
+  loadStationTuiConfig,
+  resolveSessionCreatePolicies,
+  sessionCreatePolicyForTerminal,
+} from "./config/tuiConfig.js";
 import { createNodeFolderService } from "./folderNavigation/nodeFolderService.js";
 import { createOpenTuiSelectionCopyHandler } from "./copy/openTuiSelection.js";
 import { createRuntimeClipboardEffects } from "./copy/runtimeClipboard.js";
@@ -344,6 +348,10 @@ async function startStationMain(
     openExternalUrl,
     ...(tuiConfig.config === undefined ? {} : { tuiConfig: tuiConfig.config }),
     ...(tuiConfig.configPath === undefined ? {} : { tuiConfigPath: tuiConfig.configPath }),
+    createdSessionPolicy: sessionCreatePolicyForTerminal(
+      resolveSessionCreatePolicies(tuiConfig.config?.sessionCreate),
+      "native",
+    ),
     shellAutoCloseOverlay: readShellAutoCloseOverlay(env.STATION_SHELL_AUTOCLOSE),
     ...(auxShellPlacement === undefined ? {} : { resolveAuxShellPlacement: auxShellPlacement }),
     ...(managedTerminalAttacher === undefined ? {} : { managedTerminalAttacher }),

--- a/station/src/station/store/dashboardRuntime.test.ts
+++ b/station/src/station/store/dashboardRuntime.test.ts
@@ -136,7 +136,16 @@ function makeStore(folderService?: TuiFolderService): StationDashboardRuntime {
   const service = createStationStubObserverService(source, { dispatchDelayMs: 1 });
   const capabilities: DashboardCapabilities = {
     activation: createObserverActivationCapabilities({ source, service, clientLabel: "Station" }),
-    managedSessions: createObserverManagedSessionCapabilities({ service, clientLabel: "Station" }),
+    createdSession: { applyUiPolicy: async () => ({ kind: "success" }) },
+    managedSessions: createObserverManagedSessionCapabilities({
+      source,
+      service,
+      clientLabel: "Station",
+      policyForTerminalProvider: () => ({
+        focusCreatedSession: true,
+        dismissDashboard: true,
+      }),
+    }),
     worktreeRemoval: createObserverWorktreeRemovalCapabilities({ service, clientLabel: "Station" }),
     shell: { open: () => dashboardExecution({ kind: "success" }) },
     dismissal: {

--- a/station/src/station/store/stationCommandDispatch.test.ts
+++ b/station/src/station/store/stationCommandDispatch.test.ts
@@ -54,9 +54,15 @@ describe("station command dispatch through the shared client", () => {
         clientLabel: "Station test",
         waitForFocusCompletion: true,
       }),
+      createdSession: { applyUiPolicy: async () => ({ kind: "success" }) },
       managedSessions: createObserverManagedSessionCapabilities({
+        source: client.state,
         service: client.service,
         clientLabel: "Station test",
+        policyForTerminalProvider: () => ({
+          focusCreatedSession: true,
+          dismissDashboard: true,
+        }),
       }),
       worktreeRemoval: createObserverWorktreeRemovalCapabilities({
         service: client.service,

--- a/station/src/station/test/support/makeStationTestRuntime.ts
+++ b/station/src/station/test/support/makeStationTestRuntime.ts
@@ -122,15 +122,17 @@ function createStationTestCapabilities(options: {
   }
   if (options.onFocusSuccess !== undefined) activationOptions.onFocusSuccess = options.onFocusSuccess;
   const managedOptions: Parameters<typeof createObserverManagedSessionCapabilities>[0] = {
+    source: options.clientState,
     service: options.service,
     clientLabel: "Station test",
+    policyForTerminalProvider: () => ({
+      focusCreatedSession: true,
+      dismissDashboard: true,
+    }),
   };
-  if (options.focusOrigin !== undefined) managedOptions.focusOrigin = options.focusOrigin;
-  if (options.resolveFocusTarget !== undefined) {
-    managedOptions.resolveFocusTarget = options.resolveFocusTarget;
-  }
   return {
     activation: createObserverActivationCapabilities(activationOptions),
+    createdSession: { applyUiPolicy: async () => ({ kind: "success" }) },
     managedSessions: createObserverManagedSessionCapabilities(managedOptions),
     worktreeRemoval: createObserverWorktreeRemovalCapabilities({
       service: options.service,

--- a/station/src/station/view/dashboard.golden.test.tsx
+++ b/station/src/station/view/dashboard.golden.test.tsx
@@ -100,6 +100,7 @@ function pendingDashboardCapabilities(): DashboardCapabilities {
   };
   return {
     activation: { activate: () => execution },
+    createdSession: { applyUiPolicy: async () => ({ kind: "success" }) },
     managedSessions: {
       create: () => execution,
       fork: () => execution,

--- a/tests/e2e/real/real-session-create-navigation.test.ts
+++ b/tests/e2e/real/real-session-create-navigation.test.ts
@@ -1,0 +1,351 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { SessionView, StationSnapshot, WorktreeRow } from "@station/contracts";
+import { buildWorkbenchWindowName } from "@station/tmux";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { findRowByBranch } from "../../support/real-station/assertions";
+import { uniqueTmuxSession, writeRealStationConfig } from "../../support/real-station/config";
+import {
+  type RealE2eEnvironment,
+  realE2eEnabled,
+  requireRealE2eEnvironment,
+} from "../../support/real-station/env";
+import { CleanupStack, runStationJson } from "../../support/real-station/process";
+import {
+  createRealObserverClient,
+  waitForCommandRecord,
+  waitForSnapshot,
+} from "../../support/real-station/protocol";
+import { createRealTempRepo, uniqueBranch } from "../../support/real-station/repo";
+import {
+  activeTmuxPane,
+  captureTmuxPane,
+  closeRealTmuxEndpoint,
+  displayStationPopupAndSendKey,
+  inspectTmuxClient,
+  launchNativeStationInTmux,
+  startAttachedTmuxPtyClient,
+} from "../../support/real-station/tmux";
+import {
+  createRealWorktrunkWorktree,
+  removeRealWorktrunkWorktree,
+} from "../../support/real-station/worktrunk";
+
+const describeReal = realE2eEnabled() ? describe : describe.skip;
+
+describeReal("real dashboard session-create navigation", () => {
+  let env: RealE2eEnvironment;
+  let cleanup: CleanupStack;
+
+  beforeAll(async () => {
+    env = await requireRealE2eEnvironment({ worktrunk: true, tmux: true });
+  });
+
+  afterEach(async () => {
+    await cleanup?.run();
+  });
+
+  it("lands native New Session on the exact created native pane", async () => {
+    cleanup = new CleanupStack();
+    const repo = await createRealTempRepo(env);
+    cleanup.defer(repo.cleanup);
+    const config = await writeRealStationConfig({
+      env,
+      repo,
+      harnessProvider: "scripted",
+      scriptedCommand: process.execPath,
+      sessionCreatePolicy: {
+        focusCreatedSession: true,
+        dismissDashboard: true,
+        terminals: {
+          native: { focusCreatedSession: true, dismissDashboard: true },
+        },
+      },
+    });
+    cleanup.defer(() => closeRealTmuxEndpoint(config.tmuxEndpoint));
+    cleanup.defer(() =>
+      runStationJson(env, {
+        configPath: config.configPath,
+        args: ["observer", "stop"],
+      }),
+    );
+    await runStationJson(env, {
+      configPath: config.configPath,
+      args: ["reconcile", "--reason", "real-native-create-navigation"],
+      timeoutMs: 60_000,
+    });
+    const observer = createRealObserverClient(config, 30_000);
+    const baseline = await observer.getSnapshot({ includeDebug: true });
+    const nativeSession = uniqueTmuxSession("station-real-native-create");
+    const launched = await launchNativeStationInTmux({
+      env,
+      endpoint: config.tmuxEndpoint,
+      configPath: config.configPath,
+      observerSocketPath: config.socketPath,
+      stateDir: config.stateDir,
+      sessionName: nativeSession,
+      cwd: repo.repoPath,
+    });
+    const terminal = await startAttachedTmuxPtyClient({
+      endpoint: config.tmuxEndpoint,
+      sessionName: nativeSession,
+    });
+    cleanup.defer(terminal.close);
+
+    await waitForPaneText(config.tmuxEndpoint, launched.target, "station real E2E");
+    await terminal.write(Buffer.from("N", "utf8"));
+    await waitForPaneText(config.tmuxEndpoint, launched.target, "New Session");
+    await terminal.write(Buffer.from("C", "utf8"));
+
+    const created = await waitForSnapshot(
+      observer,
+      (snapshot) => exactNewSession(snapshot, baseline)?.terminal?.provider === "native",
+      "Native New Session did not expose one exact new native session.",
+      90_000,
+    );
+    const session = exactNewSession(created, baseline);
+    if (session === undefined) throw new Error("Native created-session identity was ambiguous.");
+    const row = created.rows.find((candidate) => candidate.id === session.worktreeId);
+    if (row === undefined) throw new Error("Native created worktree row was missing.");
+    cleanup.defer(() => removeRealWorktrunkWorktree({ env, config, repo, branch: row.branch }));
+
+    await waitForPaneText(config.tmuxEndpoint, launched.target, row.branch);
+    expect(
+      await captureTmuxPane({ endpoint: config.tmuxEndpoint, target: launched.target }),
+    ).not.toContain("New Session");
+  }, 180_000);
+
+  it.each([
+    [false, false],
+    [true, true],
+  ] as const)(
+    "applies tmux Quick Group focus=%s dismiss=%s to the exact durable target",
+    async (focusCreatedSession, dismissDashboard) => {
+      cleanup = new CleanupStack();
+      const fixture = await createTmuxPopupFixture({
+        env,
+        cleanup,
+        focusCreatedSession,
+        dismissDashboard,
+      });
+      const markerPath = join(
+        fixture.repo.root,
+        `session-create-${focusCreatedSession}-${dismissDashboard}.marker`,
+      );
+      const popup = await displayStationPopupAndSendKey({
+        env,
+        endpoint: fixture.config.tmuxEndpoint,
+        client: fixture.terminal,
+        configPath: fixture.config.configPath,
+        target: fixture.initialTarget,
+        expectedWindowName: fixture.initialWindowName,
+        expectedPaneId: fixture.initialPaneId,
+        key: "G",
+        markerPath,
+      });
+      cleanup.defer(() => popup.release(false));
+
+      const created = await waitForSnapshot(
+        fixture.observer,
+        (snapshot) => createdQuickGroupTarget(snapshot, fixture.baseline) !== undefined,
+        "Quick Group did not converge through create, session launch, and membership.",
+        90_000,
+      );
+      const target = createdQuickGroupTarget(created, fixture.baseline);
+      if (target === undefined)
+        throw new Error("Quick Group target was not exact after convergence.");
+      cleanup.defer(() =>
+        removeRealWorktrunkWorktree({
+          env,
+          config: fixture.config,
+          repo: fixture.repo,
+          branch: target.row.branch,
+        }),
+      );
+      const finalWindowName = workbenchWindowName(target.row);
+      const finalTarget = `${fixture.config.tmuxSession}:${finalWindowName}.0`;
+      const finalPaneId = await activeTmuxPane(fixture.config.tmuxEndpoint, finalTarget);
+
+      if (!focusCreatedSession) {
+        expect(
+          await inspectTmuxClient(fixture.config.tmuxEndpoint, fixture.terminal.clientName),
+        ).toBe(
+          `${fixture.terminal.clientName}\t${fixture.terminal.clientPid}\t${fixture.config.tmuxSession}\t${fixture.initialWindowName}\t${fixture.initialPaneId}`,
+        );
+        expect(await readFile(markerPath, "utf8")).not.toContain("child-exit");
+        await popup.release(false);
+        return;
+      }
+
+      const expectedView = `${fixture.terminal.clientName}\t${fixture.terminal.clientPid}\t${fixture.config.tmuxSession}\t${finalWindowName}\t${finalPaneId}`;
+      await waitForTmuxClientView(
+        fixture.config.tmuxEndpoint,
+        fixture.terminal.clientName,
+        expectedView,
+      );
+      await popup.release(true, { windowName: finalWindowName, paneId: finalPaneId });
+      expect(target.group.sessionIds).toContain(target.session.id);
+    },
+    180_000,
+  );
+});
+
+async function createTmuxPopupFixture(input: {
+  env: RealE2eEnvironment;
+  cleanup: CleanupStack;
+  focusCreatedSession: boolean;
+  dismissDashboard: boolean;
+}) {
+  const repo = await createRealTempRepo(input.env);
+  input.cleanup.defer(repo.cleanup);
+  const config = await writeRealStationConfig({
+    env: input.env,
+    repo,
+    harnessProvider: "scripted",
+    scriptedCommand: process.execPath,
+    sessionCreatePolicy: {
+      focusCreatedSession: input.focusCreatedSession,
+      dismissDashboard: input.dismissDashboard,
+      terminals: {
+        tmux: {
+          focusCreatedSession: input.focusCreatedSession,
+          dismissDashboard: input.dismissDashboard,
+        },
+      },
+    },
+  });
+  input.cleanup.defer(() => closeRealTmuxEndpoint(config.tmuxEndpoint));
+  input.cleanup.defer(() =>
+    runStationJson(input.env, {
+      configPath: config.configPath,
+      args: ["observer", "stop"],
+    }),
+  );
+  const branch = uniqueBranch("create-nav-base");
+  input.cleanup.defer(() => removeRealWorktrunkWorktree({ env: input.env, config, repo, branch }));
+  await createRealWorktrunkWorktree({ env: input.env, config, repo, branch });
+  await runStationJson(input.env, {
+    configPath: config.configPath,
+    args: ["reconcile", "--reason", "real-session-create-navigation-baseline"],
+    timeoutMs: 60_000,
+  });
+  const observer = createRealObserverClient(config, 30_000);
+  const discovered = await waitForSnapshot(
+    observer,
+    (snapshot) => snapshot.rows.some((row) => row.branch === branch),
+    "Observer did not discover the popup baseline worktree.",
+    60_000,
+  );
+  const initialRow = findRowByBranch(discovered, branch);
+  const receipt = await observer.dispatch({
+    type: "session.startAgent",
+    payload: {
+      projectId: config.projectId,
+      worktreeId: initialRow.id,
+      harness: { provider: "scripted", mode: "interactive" },
+      terminal: { provider: "tmux", focus: false },
+    },
+  });
+  await expect(
+    waitForCommandRecord(observer, receipt.commandId, { timeoutMs: 60_000 }),
+  ).resolves.toMatchObject({
+    status: "succeeded",
+  });
+  const baseline = await waitForSnapshot(
+    observer,
+    (snapshot) =>
+      snapshot.sessions.some(
+        (session) => session.worktreeId === initialRow.id && session.terminal?.provider === "tmux",
+      ),
+    "Popup baseline session did not expose its tmux target.",
+    60_000,
+  );
+  const initialWindowName = workbenchWindowName(initialRow);
+  const initialTarget = `${config.tmuxSession}:${initialWindowName}.0`;
+  const initialPaneId = await activeTmuxPane(config.tmuxEndpoint, initialTarget);
+  const terminal = await startAttachedTmuxPtyClient({
+    endpoint: config.tmuxEndpoint,
+    sessionName: config.tmuxSession,
+  });
+  input.cleanup.defer(terminal.close);
+  return {
+    repo,
+    config,
+    observer,
+    baseline,
+    terminal,
+    initialTarget,
+    initialWindowName,
+    initialPaneId,
+  };
+}
+
+function exactNewSession(
+  snapshot: StationSnapshot,
+  baseline: StationSnapshot,
+): SessionView | undefined {
+  const baselineIds = new Set(baseline.sessions.map((session) => session.id));
+  const created = snapshot.sessions.filter((session) => !baselineIds.has(session.id));
+  return created.length === 1 ? created[0] : undefined;
+}
+
+function createdQuickGroupTarget(snapshot: StationSnapshot, baseline: StationSnapshot) {
+  const baselineGroupIds = new Set(baseline.sessionGroups.map((group) => group.id));
+  const baselineSessionIds = new Set(baseline.sessions.map((session) => session.id));
+  const groups = snapshot.sessionGroups.filter((group) => !baselineGroupIds.has(group.id));
+  if (groups.length !== 1) return undefined;
+  const group = groups[0];
+  if (group === undefined) return undefined;
+  const sessions = snapshot.sessions.filter(
+    (session) => !baselineSessionIds.has(session.id) && group.sessionIds.includes(session.id),
+  );
+  const session = sessions.length === 1 ? sessions[0] : undefined;
+  if (session?.terminal?.provider !== "tmux") return undefined;
+  const row = snapshot.rows.find(
+    (candidate) => candidate.id === session.worktreeId && candidate.projectId === session.projectId,
+  );
+  return row === undefined ? undefined : { group, session, row };
+}
+
+function workbenchWindowName(row: WorktreeRow): string {
+  return buildWorkbenchWindowName({
+    projectId: row.projectId,
+    branch: row.branch,
+    worktreeId: row.id,
+    path: row.path,
+  });
+}
+
+async function waitForPaneText(
+  endpoint: Parameters<typeof captureTmuxPane>[0]["endpoint"],
+  target: string,
+  expected: string,
+): Promise<void> {
+  const deadline = Date.now() + 30_000;
+  let frame = "";
+  while (Date.now() <= deadline) {
+    frame = await captureTmuxPane({ endpoint, target });
+    if (frame.includes(expected)) return;
+    await delay(250);
+  }
+  throw new Error(`Station pane did not render ${expected}.\nLast frame:\n${frame}`);
+}
+
+async function waitForTmuxClientView(
+  endpoint: Parameters<typeof inspectTmuxClient>[0],
+  clientName: string,
+  expected: string,
+): Promise<void> {
+  const deadline = Date.now() + 30_000;
+  let view = "";
+  while (Date.now() <= deadline) {
+    view = await inspectTmuxClient(endpoint, clientName);
+    if (view === expected) return;
+    await delay(250);
+  }
+  throw new Error(`tmux client did not reach ${expected}; last view was ${view}.`);
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/tests/support/real-station/config.ts
+++ b/tests/support/real-station/config.ts
@@ -33,6 +33,13 @@ export type WriteRealStationConfigOptions = {
   recovery?: boolean;
   stationPersistentAgents?: boolean;
   tmuxSession?: string;
+  sessionCreatePolicy?: {
+    focusCreatedSession: boolean;
+    dismissDashboard: boolean;
+    terminals?: Readonly<
+      Record<string, { focusCreatedSession?: boolean; dismissDashboard?: boolean }>
+    >;
+  };
   eventHook?: {
     command: string;
     args?: string[];
@@ -81,6 +88,7 @@ export async function writeRealStationConfig(
     `workbench_socket_path = ${tomlString(tmuxEndpoint.socketPath)}`,
     `workbench_session = ${tomlString(tmuxSession)}`,
     "",
+    ...sessionCreateConfigLines(options),
     ...harnessLines,
     ...eventHookConfigLines(options),
     ...featureFlagConfigLines(options),
@@ -123,6 +131,28 @@ export async function writeRealStationConfig(
     tmuxSession,
     projectId,
   };
+}
+
+function sessionCreateConfigLines(options: WriteRealStationConfigOptions): string[] {
+  const policy = options.sessionCreatePolicy;
+  if (policy === undefined) return [];
+  const lines = [
+    "[tui.session_create]",
+    `focus_created_session = ${policy.focusCreatedSession}`,
+    `dismiss_dashboard = ${policy.dismissDashboard}`,
+    "",
+  ];
+  for (const [provider, override] of Object.entries(policy.terminals ?? {})) {
+    lines.push(`[tui.session_create.terminals.${tomlKey(provider)}]`);
+    if (override.focusCreatedSession !== undefined) {
+      lines.push(`focus_created_session = ${override.focusCreatedSession}`);
+    }
+    if (override.dismissDashboard !== undefined) {
+      lines.push(`dismiss_dashboard = ${override.dismissDashboard}`);
+    }
+    lines.push("");
+  }
+  return lines;
 }
 
 function featureFlagConfigLines(options: WriteRealStationConfigOptions): string[] {
@@ -223,4 +253,8 @@ export function uniqueTmuxSession(prefix = "station-real"): string {
 
 function tomlString(value: string): string {
   return JSON.stringify(value);
+}
+
+function tomlKey(value: string): string {
+  return /^[A-Za-z0-9_-]+$/u.test(value) ? value : tomlString(value);
 }

--- a/tests/support/real-station/tmux.ts
+++ b/tests/support/real-station/tmux.ts
@@ -301,6 +301,11 @@ export async function startStationTuiInTmux(input: {
   await runTmuxCommand(input.endpoint, ["new-session", "-d", "-s", input.sessionName, command]);
 }
 
+/**
+ * Own one real popup invocation through start, input, renderer exit, and explicit
+ * release. Failed proofs close only that exact client popup; successful
+ * focus proofs may provide the exact post-focus tmux view expected before cleanup.
+ */
 export async function displayStationPopupAndSendKey(input: {
   env: RealE2eEnvironment;
   endpoint: RealTmuxEndpoint;
@@ -312,7 +317,12 @@ export async function displayStationPopupAndSendKey(input: {
   key: string;
   markerPath: string;
   delaySeconds?: number;
-}): Promise<{ release(causalSuccess: boolean): Promise<void> }> {
+}): Promise<{
+  release(
+    causalSuccess: boolean,
+    finalView?: { windowName: string; paneId: string },
+  ): Promise<void>;
+}> {
   const { client, endpoint } = input;
   const invocationNonce = randomUUID();
   const releasePath = `${input.markerPath}.${invocationNonce}.release`;
@@ -321,12 +331,15 @@ export async function displayStationPopupAndSendKey(input: {
       `popup client ${client.clientName}/${client.clientPid}/${client.sessionName} is not in target ${input.target} on ${endpoint.socketPath}${client.outputTail()}`,
     );
   }
-  const expectedView = `${client.clientName}\t${client.clientPid}\t${client.sessionName}\t${input.expectedWindowName}\t${input.expectedPaneId}`;
-  const checkView = async (phase: string): Promise<void> => {
+  const checkView = async (
+    phase: string,
+    view = { windowName: input.expectedWindowName, paneId: input.expectedPaneId },
+  ): Promise<void> => {
     const actual = await inspectTmuxClient(endpoint, client.clientName);
-    if (actual !== expectedView) {
+    const expected = `${client.clientName}\t${client.clientPid}\t${client.sessionName}\t${view.windowName}\t${view.paneId}`;
+    if (actual !== expected) {
       throw new Error(
-        `popup client changed ${phase} endpoint=${endpoint.socketPath} expected=${JSON.stringify(expectedView)} actual=${JSON.stringify(actual)}${client.outputTail()}`,
+        `popup client changed ${phase} endpoint=${endpoint.socketPath} expected=${JSON.stringify(expected)} actual=${JSON.stringify(actual)}${client.outputTail()}`,
       );
     }
   };
@@ -378,7 +391,10 @@ export async function displayStationPopupAndSendKey(input: {
   let markerEvidence = "<unread>";
   let releaseEvidence = "release=not-attempted";
   let releasePromise: Promise<void> | undefined;
-  const release = (causalSuccess: boolean): Promise<void> => {
+  const release = (
+    causalSuccess: boolean,
+    finalView?: { windowName: string; paneId: string },
+  ): Promise<void> => {
     releasePromise ??= (async () => {
       const failures: unknown[] = [];
       let closeState = "not-attempted";
@@ -415,7 +431,7 @@ export async function displayStationPopupAndSendKey(input: {
       }
       let viewExact = false;
       try {
-        await checkView("after release");
+        await checkView("after release", finalView);
         viewExact = true;
       } catch (error) {
         failures.push(error);


### PR DESCRIPTION
## What this fixes

Dashboard-driven session creation always followed one hard-coded focus-and-dismiss behavior, so native, fullscreen, and tmux workflows could not preserve the dashboard or opt out of terminal focus. Compound Group creation also needed to apply post-create UI effects only after the created session's canonical membership was durable.

Closes #816.

## What changed

- adds strict `[tui.session_create]` global policy and per-terminal-provider overrides, resolved once per renderer with `true`/`true` defaults and inheritance
- carries one dashboard-local, non-wire command bound to the exact canonical session, worktree, project, branch, and resolved terminal provider
- centralizes focus-before-dismiss handling for native and standalone renderers without changing Observer, protocol, durable command results, CLI creation, or fork behavior
- revalidates native provider and focusability at effect time and safely inherits policy for future provider IDs that overlap object prototype names
- defers Quick Session in Group, Quick Group, and New Group with Quick Session effects until version-checked membership and local row settlement complete
- preserves successful creation and membership when focus or dismissal fails, reporting one non-retryable dashboard error instead
- documents configuration and lifecycle semantics and adds unit, integration, Station, CLI-boundary, and opt-in real PTY coverage

## Testing

- `bun run build`
- `bun run typecheck`
- `bun run lint`
- `bun run test:unit -- --testTimeout=30000 --maxWorkers=4` (3,471 passed)
- `bun run test:contracts` (199 passed)
- `bun run test:integration` (918 passed)
- `bun run test:diagnostics` (192 passed)
- `bun run test:agent:scripted` (5 passed)
- `bun run test:e2e:setup` (30 passed)
- `bun run test:e2e:observer` (27 passed)
- `bun run smoke:install`
- `bun run test:ci:station`
- `bun run test:e2e:real -- tests/e2e/real/real-session-create-navigation.test.ts` (collected; 3 skipped because `STATION_REAL_E2E` was not enabled)
