### PR TITLE
fix(protocol): accept previous Observer health during updates

### DIFF
--- a/packages/protocol/src/client.ts
+++ b/packages/protocol/src/client.ts
@@ -15,8 +15,6 @@ import type {
 import {
   ObserverHealthSchema,
   ObserverStopReceiptSchema,
-  ProviderHealthSchema,
-  ProviderIdSchema,
   SessionRecoveryReadinessSchema,
   STATION_SCHEMA_VERSION,
   StationEventSchema,
@@ -127,35 +125,16 @@ const PreviousLifecycleErrorResponseSchema = z
     error: z.unknown(),
   })
   .strict();
-const PreviousProviderHealthSchema = ProviderHealthSchema.omit({ provider: true }).extend({
-  providerId: ProviderIdSchema,
-});
 const PreviousObserverHealthSchema = ObserverHealthSchema.omit({
   schemaVersion: true,
-  providerHealth: true,
 })
   .extend({
     schemaVersion: z.literal(PREVIOUS_LIFECYCLE_SCHEMA_VERSION),
-    providerHealth: z.record(ProviderIdSchema, PreviousProviderHealthSchema).optional(),
   })
-  .transform(({ schemaVersion: _schemaVersion, providerHealth, ...health }) => {
-    const normalizedProviderHealth =
-      providerHealth === undefined
-        ? undefined
-        : Object.fromEntries(
-            Object.entries(providerHealth).map(([providerId, entry]) => {
-              const { providerId: _legacyProviderId, ...provider } = entry;
-              return [providerId, { ...provider, provider: providerId }];
-            }),
-          );
-    return {
-      ...health,
-      schemaVersion: STATION_SCHEMA_VERSION,
-      ...(normalizedProviderHealth === undefined
-        ? {}
-        : { providerHealth: normalizedProviderHealth }),
-    };
-  });
+  .transform(({ schemaVersion: _schemaVersion, ...health }) => ({
+    ...health,
+    schemaVersion: STATION_SCHEMA_VERSION,
+  }));
 const PreviousObserverStopReceiptSchema = ObserverStopReceiptSchema.omit({
   schemaVersion: true,
 }).extend({ schemaVersion: z.literal(PREVIOUS_LIFECYCLE_SCHEMA_VERSION) });

--- a/packages/protocol/test/integration/client-server.test.ts
+++ b/packages/protocol/test/integration/client-server.test.ts
@@ -1079,7 +1079,7 @@ describe("protocol client/server", () => {
     }
   });
 
-  it("normalizes previous health provider IDs and readiness responses", async () => {
+  it("accepts previous health and readiness responses", async () => {
     const { socketPath } = await createTempSocketPath();
     const previousRequestSchema = z
       .object({
@@ -1089,7 +1089,7 @@ describe("protocol client/server", () => {
         method: z.enum(["observer.health", "session.recoveryReadiness", "observer.stop"]),
       })
       .strict();
-    const legacyHealth = {
+    const previousHealth = {
       schemaVersion: "0.12.0",
       status: "healthy",
       pid: 42,
@@ -1097,10 +1097,11 @@ describe("protocol client/server", () => {
       version: "0.0.0",
       providerHealth: {
         tmux: {
-          providerId: "tmux",
+          provider: "tmux",
           providerType: "terminal",
           status: "healthy",
           lastCheckedAt: protocolTestNow,
+          capabilities: { canFocusTarget: true },
         },
       },
     } as const;
@@ -1145,7 +1146,7 @@ describe("protocol client/server", () => {
           id: previousRequest.id,
           result:
             previousRequest.method === "observer.health"
-              ? legacyHealth
+              ? previousHealth
               : previousRequest.method === "observer.stop"
                 ? legacyStop
                 : readiness,
@@ -1162,16 +1163,8 @@ describe("protocol client/server", () => {
 
     try {
       await expect(client.health()).resolves.toEqual({
-        ...legacyHealth,
+        ...previousHealth,
         schemaVersion: STATION_SCHEMA_VERSION,
-        providerHealth: {
-          tmux: {
-            provider: "tmux",
-            providerType: "terminal",
-            status: "healthy",
-            lastCheckedAt: protocolTestNow,
-          },
-        },
       });
       await expect(client.getSessionRecoveryReadiness()).resolves.toEqual(readiness);
       await expect(client.stop()).resolves.toEqual({


### PR DESCRIPTION
## What this fixes

Station CLI supports the immediately previous Observer lifecycle schema during safe upgrades. The pre-alpha.14.2 release gate exposed that the 0.13 client decoded a real 0.12 health response using an older provider-health field shape, so it could not inspect or restart a healthy pre-alpha.14.1 Observer.

## What changed

- Reuse the current provider-health contract for the immediately previous lifecycle schema.
- Normalize only the top-level schema version after successful validation.
- Exercise the real pre-alpha.14.1 `provider` and capabilities shape in the client/server compatibility test.

## Testing

- `bun run build`
- protocol client/server integration: 46 passed
- source-target update smoke: 3 scenarios passed
- pre-commit and pre-push lint/architecture gates passed
- `bun run test:all` was attempted twice; each run passed 3,493/3,494 unit tests and hit an alternating 5-second timeout in the unrelated real Station config file, whose two tests pass together in 1.5 seconds when rerun alone