### PR TITLE
fix(tui): integrate Group frame chrome with headers

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -249,6 +249,12 @@ settings, Help, menus, and filter conditions follow the same rule: semantic
 content stays mounted while one renderer-owned body scrolls inside a bounded
 surface.
 
+An expanded Group shares its top edge with the semantic header row and fills
+otherwise-empty cells between the header labels and corner chrome. Its full
+bottom edge remains a dedicated footer row. The frame uses the quiet hairline
+color by default, bright working color for header focus, and dim working color
+while a direct member has focus.
+
 Use `@station/dashboard-core/text` for grapheme-safe terminal-cell measurement,
 clipping, and truncation. JavaScript string length and indices are not terminal
 geometry. Optional headers and indicators should be absent when empty rather

--- a/station/src/dashboardRenderer/FullscreenDashboard.test.tsx
+++ b/station/src/dashboardRenderer/FullscreenDashboard.test.tsx
@@ -345,8 +345,8 @@ describe("FullscreenDashboard mouse composition", () => {
       return { row, line: lines[row] ?? "" };
     };
 
-    expect(setup.captureCharFrame()).toContain("│ ▼ Design refresh 2 sessions");
-    expect(setup.captureCharFrame()).toContain("│ [1]");
+    expect(setup.captureCharFrame()).toContain("╭─ ▼ Design refresh 2 sessions");
+    expect(setup.captureCharFrame()).toContain("│  [1]");
     const member = cellFor(setup.captureCharFrame(), "group-contracts");
     await actOn(async () => {
       await setup.mockMouse.click(member.col, member.row, MouseButtons.LEFT);

--- a/station/src/station/StationOverlay.test.tsx
+++ b/station/src/station/StationOverlay.test.tsx
@@ -152,7 +152,7 @@ describe("StationOverlay", () => {
     const groupId = dashboardRowIds.group("group_design_refresh");
     const header = cellFor(setup.captureCharFrame(), "Design refresh");
 
-    expect(setup.captureCharFrame()).toContain("│ ▼ Design refresh 2 sessions");
+    expect(setup.captureCharFrame()).toContain("╭─ ▼ Design refresh 2 sessions");
     await setup.mockMouse.click(header.col, header.row, MouseButtons.LEFT);
 
     expect(calls.at(-1)).toEqual({

--- a/station/src/station/view/GroupFrameView.test.tsx
+++ b/station/src/station/view/GroupFrameView.test.tsx
@@ -34,25 +34,23 @@ describe("GroupFrameView", () => {
     const child = setup.renderer.root.findDescendantById("mixed-child");
     const first = frame.findIndex((line) => line.includes("first semantic cell"));
     expect(child?.height).toBe(2);
-    expect(frame[first]?.startsWith("│")).toBe(true);
-    expect(frame[first]?.trimEnd().endsWith("│")).toBe(true);
+    expect(frame[first]).toMatch(/^╭─.*─╮$/u);
     expect(frame[first + 1]?.startsWith("│")).toBe(true);
     expect(frame[first + 1]?.trimEnd().endsWith("│")).toBe(true);
-    expect(frame[first - 1]?.trim()).toMatch(/^╭─+╮$/u);
-    expect(frame[first + 2]?.trim()).toMatch(/^╰─+╯$/u);
+    expect(frame[first + 2]?.trimEnd()).toMatch(/^╰─+╯$/u);
     expect(hitBottomCellId(setup, "last-semantic-cell")).toBe("last-semantic-cell");
 
-    await act(async () => setup.renderer.resize(14, 6));
+    await act(async () => setup.renderer.resize(14, 8));
     await setup.renderOnce();
     const resized = setup.captureCharFrame().split("\n");
     const resizedFirst = resized.findIndex((line) => line.includes("first"));
-    expect(child?.height).toBe(4);
-    for (const line of resized.slice(resizedFirst, resizedFirst + 4)) {
+    expect(child?.height).toBe(6);
+    expect(resized[resizedFirst]).toMatch(/^╭─.*─╮$/u);
+    for (const line of resized.slice(resizedFirst + 1, resizedFirst + 6)) {
       expect(line.startsWith("│")).toBe(true);
       expect(line.trimEnd().endsWith("│")).toBe(true);
     }
-    expect(resized[resizedFirst - 1]?.trim()).toMatch(/^╭─+╮$/u);
-    expect(resized[resizedFirst + 4]?.trim()).toMatch(/^╰─+╯$/u);
+    expect(resized[resizedFirst + 6]?.trimEnd()).toMatch(/^╰─+╯$/u);
     expect(hitBottomCellId(setup, "last-semantic-cell")).toBe("last-semantic-cell");
   });
 });

--- a/station/src/station/view/GroupFrameView.tsx
+++ b/station/src/station/view/GroupFrameView.tsx
@@ -1,10 +1,26 @@
 import type { ReactNode } from "react";
 import { toOpenTuiColor, useStationTheme } from "../../theme/index.js";
+import { alphaColor, stationColorSnapshot } from "../../theme/types.js";
+
+const MEMBER_FOCUS_BORDER_OPACITY = 0.55;
 
 export type GroupFrameFocus = {
   focusedHeader: boolean;
   containsFocusedRow: boolean;
 };
+
+export function GroupFrameHeaderRule({ focus }: { focus: GroupFrameFocus }) {
+  const borderColor = useGroupFrameBorderColor(focus);
+  return (
+    <box
+      minWidth={0}
+      height={1}
+      flexGrow={1}
+      border={["top"]}
+      borderColor={borderColor}
+    />
+  );
+}
 
 export function GroupFrameView({
   renderableId,
@@ -15,27 +31,46 @@ export function GroupFrameView({
   focus: GroupFrameFocus;
   children: ReactNode;
 }) {
-  const theme = useStationTheme();
-  const emphasized = focus.focusedHeader || focus.containsFocusedRow;
+  const borderColor = useGroupFrameBorderColor(focus);
   return (
     // Keep the border unclipped: OpenTUI's bordered scissor drops the final content row from hit-testing.
     <box
       {...(renderableId === undefined ? {} : { id: renderableId })}
       width="100%"
       flexDirection="column"
-      border
+      border={["left", "right", "bottom"]}
       borderStyle="rounded"
-      borderColor={toOpenTuiColor(
-        emphasized ? theme.status.working : theme.interaction.hairline,
-      )}
+      borderColor={borderColor}
+      paddingLeft={1}
+      paddingRight={1}
       overflow="visible"
     >
       {children}
+      {/* Overlay the top corners so the frame starts on the header's semantic row. */}
+      <text position="absolute" top={0} left={-1} fg={borderColor}>
+        ╭─
+      </text>
+      <text position="absolute" top={0} right={-1} fg={borderColor}>
+        ─╮
+      </text>
     </box>
   );
 }
 
-/** Renderer-boundary width available inside the frame's two vertical border cells. */
+/** Renderer-boundary width available between the frame's two-cell header markers. */
 export function groupFrameContentColumns(columns: number): number {
-  return Math.max(1, Math.floor(columns) - 2);
+  return Math.max(1, Math.floor(columns) - 4);
+}
+
+function useGroupFrameBorderColor(focus: GroupFrameFocus) {
+  const theme = useStationTheme();
+  const borderColor = focus.focusedHeader
+    ? theme.status.working
+    : focus.containsFocusedRow
+      ? alphaColor(
+          stationColorSnapshot(theme.status.working),
+          MEMBER_FOCUS_BORDER_OPACITY,
+        )
+      : theme.interaction.hairline;
+  return toOpenTuiColor(borderColor);
 }

--- a/station/src/station/view/GroupHeaderView.tsx
+++ b/station/src/station/view/GroupHeaderView.tsx
@@ -18,6 +18,10 @@ import {
   useStationMouse,
 } from "./stationMouseContext.js";
 import { dashboardQuickSessionActionLabel } from "./dashboardHeaderActionLabels.js";
+import {
+  GroupFrameHeaderRule,
+  type GroupFrameFocus,
+} from "./GroupFrameView.js";
 
 const MENU_LABEL = "[▾]";
 
@@ -40,6 +44,7 @@ export function GroupHeaderView({
   payload,
   cells,
   focusedCellId,
+  frameFocus,
 }: {
   renderableId?: string;
   columns: number;
@@ -47,6 +52,7 @@ export function GroupHeaderView({
   payload: DashboardGroupHeaderPayload;
   cells: readonly DashboardCellId[];
   focusedCellId?: DashboardCellId | undefined;
+  frameFocus?: GroupFrameFocus;
 }) {
   const actions = groupHeaderActions(cells, Math.max(1, Math.floor(columns)));
   const dimmed = payload.persistentFilterMatch?.matched === false;
@@ -66,7 +72,11 @@ export function GroupHeaderView({
           dimmed={dimmed}
           persistentFilterMatch={payload.persistentFilterMatch}
         />
-        <box flexGrow={1} />
+        {frameFocus === undefined ? (
+          <box flexGrow={1} />
+        ) : (
+          <GroupFrameHeaderRule focus={frameFocus} />
+        )}
       </box>
       {actions.map((action) => (
         <Fragment key={action.cellId}>

--- a/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
@@ -114,24 +114,24 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 1
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                       AGENT     STATUS                 DIFF · PR 
  ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾]▲
-╭─────────────────────────────────────────────────────────────────────────────╮▐
-│ ▼ Design refresh 2 sessions                                         [qs] [▾]│▐
-│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│▐
-│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│▐
+╭─ ▼ Design refresh 2 sessions────────────────────────────────────── [qs] [▾]─╮▐
+│  [1] ⠋ group-contracts           codex     working           +84 -20 #481 … │▐
+│  [2] ○ group-keyboard            codex     idle               +16 -4 #482 ✓ │▐
 ╰─────────────────────────────────────────────────────────────────────────────╯▐
-╭─────────────────────────────────────────────────────────────────────────────╮▐
-│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│▐
-│ [3] ○ input-routing               codex     idle                      +27 -6│▐
+╭─ ▼ Input parity and minimum-width interaction verification 1 sessi [qs] [▾]─╮▐
+│  [3] ○ input-routing             codex     idle                      +27 -6 │▐
 ╰─────────────────────────────────────────────────────────────────────────────╯▐
-╭─────────────────────────────────────────────────────────────────────────────╮▕
-│ ▼ Observer hardening 3 sessions                                     [qs] [▾]│▕
-│ [4] ○ diagnostic-index            codex     idle                      +38 -7│▕
-│ [5] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│▕
-│ [6] ⠋ trace-readiness             codex     working           +91 -22 #478 …│▕
+╭─ ▼ Observer hardening 3 sessions────────────────────────────────── [qs] [▾]─╮▐
+│  [4] ○ diagnostic-index          codex     idle                      +38 -7 │▐
+│  [5] ! handoff-refusal           codex     Agent needs app… +53 -11 #476 x1 │▐
+│  [6] ⠋ trace-readiness           codex     working           +91 -22 #478 … │▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
+╭─ ▼ Post-launch 0 sessions───────────────────────────────────────── [qs] [▾]─╮▕
 ╰─────────────────────────────────────────────────────────────────────────────╯▕
-╭─────────────────────────────────────────────────────────────────────────────╮▕
-│ ▼ Post-launch 0 sessions                                            [qs] [▾]│▼
-── ▼ 6 below · showing 6 of 12 ──────────────────────────────────────────────── 
+╭─ ▼ Release train 3 sessions─────────────────────────────────────── [qs] [▾]─╮▕
+│  [7] x asset-proof               codex     exited                    +19 -2 │▕
+│  [8] ⠋ installer-replay          codex     working                  +64 -12 │▼
+── ▼ 4 below · showing 8 of 12 ──────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
 "
 `;
@@ -142,36 +142,36 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle        
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
        SESSION                                   AGENT     STATUS                                             DIFF · PR 
  ▼ station  12 sessions · 6 Groups · 11 agents                                              [shell] [quick session] [▾] 
-╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Design refresh 2 sessions                                                                      [quick session] [▾]│ 
-│ [1] ⠋ group-contracts                           codex     working                                     +84 -20 #481 …│ 
-│ [2] ○ group-keyboard                            codex     idle                                         +16 -4 #482 ✓│ 
+╭─ ▼ Design refresh 2 sessions─────────────────────────────────────────────────────────────────── [quick session] [▾]─╮ 
+│  [1] ⠋ group-contracts                           codex     working                                   +84 -20 #481 … │ 
+│  [2] ○ group-keyboard                            codex     idle                                       +16 -4 #482 ✓ │ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Input parity and minimum-width interaction verification 1 session                              [quick session] [▾]│ 
-│ [3] ○ input-routing                             codex     idle                                                +27 -6│ 
+╭─ ▼ Input parity and minimum-width interaction verification 1 session─────────────────────────── [quick session] [▾]─╮ 
+│  [3] ○ input-routing                             codex     idle                                              +27 -6 │ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Observer hardening 3 sessions                                                                  [quick session] [▾]│ 
-│ [4] ○ diagnostic-index                          codex     idle                                                +38 -7│ 
-│ [5] ! handoff-refusal                           codex     Agent needs approval.                      +53 -11 #476 x1│ 
-│ [6] ⠋ trace-readiness                           codex     working                                     +91 -22 #478 …│ 
+╭─ ▼ Observer hardening 3 sessions─────────────────────────────────────────────────────────────── [quick session] [▾]─╮ 
+│  [4] ○ diagnostic-index                          codex     idle                                              +38 -7 │ 
+│  [5] ! handoff-refusal                           codex     Agent needs approval.                    +53 -11 #476 x1 │ 
+│  [6] ⠋ trace-readiness                           codex     working                                   +91 -22 #478 … │ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Post-launch 0 sessions                                                                         [quick session] [▾]│ 
+╭─ ▼ Post-launch 0 sessions────────────────────────────────────────────────────────────────────── [quick session] [▾]─╮ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Release train 3 sessions                                                                       [quick session] [▾]│ 
-│ [7] x asset-proof                               codex     exited                                              +19 -2│ 
-│ [8] ⠋ installer-replay                          codex     working                                            +64 -12│ 
-│ [9] ○ rc-manifest                               codex     idle                                         +31 -3 #471 ✓│ 
+╭─ ▼ Release train 3 sessions──────────────────────────────────────────────────────────────────── [quick session] [▾]─╮ 
+│  [7] x asset-proof                               codex     exited                                            +19 -2 │ 
+│  [8] ⠋ installer-replay                          codex     working                                          +64 -12 │ 
+│  [9] ○ rc-manifest                               codex     idle                                       +31 -3 #471 ✓ │ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Runtime cleanup 1 session                                                                      [quick session] [▾]│ 
-│ [a] ○ runtime-cleanup                           codex     idle                                                 +9 -2│ 
+╭─ ▼ Runtime cleanup 1 session─────────────────────────────────────────────────────────────────── [quick session] [▾]─╮ 
+│  [a] ○ runtime-cleanup                           codex     idle                                               +9 -2 │ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
  [b] ○ docs-refresh                              codex     idle                                            +8 -2 #479 ✓ 
  [c] - main                                      codex     no agent                                                     
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -186,16 +186,16 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited
 ─────────────────────────────────────────────────────────── 
        SESSION           AGENT     STATUS                PR 
  ▼ station  12 sessions · 6 Groups · 11 agent [sh] [qs] [▾]▲
-╭─────────────────────────────────────────────────────────╮▐
-│ ▼ Design refresh 2 sessions                     [qs] [▾]│▐
-│ [1] ⠋ group-contracts         codex     working         │▐
-│ [2] ○ group-keyboard          codex     idle            │▕
+╭─ ▼ Design refresh 2 sessions────────────────── [qs] [▾]─╮▐
+│  [1] ⠋ group-contracts       codex     working          │▐
+│  [2] ○ group-keyboard        codex     idle             │▐
 ╰─────────────────────────────────────────────────────────╯▕
-╭─────────────────────────────────────────────────────────╮▕
-│ ▼ Input parity and minimum-width interaction ve [qs] [▾]│▕
-│ [3] ○ input-routing           codex     idle            │▕
-╰─────────────────────────────────────────────────────────╯▼
-── ▼ 9 below · showing 3 of 12 ──────────────────────────── 
+╭─ ▼ Input parity and minimum-width interaction  [qs] [▾]─╮▕
+│  [3] ○ input-routing         codex     idle             │▕
+╰─────────────────────────────────────────────────────────╯▕
+╭─ ▼ Observer hardening 3 sessions────────────── [qs] [▾]─╮▕
+│  [4] ○ diagnostic-index      codex     idle             │▼
+── ▼ 8 below · showing 4 of 12 ──────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/e… 
 "
 `;
@@ -206,11 +206,11 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1
 ─────────────────────────────────────── 
        SESSION                          
  ▼ station  12 sessions · [sh] [qs] [▾]▲
-╭─────────────────────────────────────╮▐
-│ ▼ Design refresh 2 sessions [qs] [▾]│▕
-│ [1] ⠋ group-contracts               │▕
-│ [2] ○ group-keyboard                │▕
-╰─────────────────────────────────────╯▼
+╭─ ▼ Design refresh 2 sessio [qs] [▾]─╮▐
+│  [1] ⠋ group-contracts              │▕
+│  [2] ○ group-keyboard               │▕
+╰─────────────────────────────────────╯▕
+╭─ ▼ Input parity and minimu [qs] [▾]─╮▼
 ── ▼ 10 below · showing 2 of 12 ─────── 
 ↵ activate  N new  ⇥ next  / filter  X… 
 "
@@ -438,33 +438,33 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle        
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
        SESSION                                   AGENT     STATUS                                             DIFF · PR 
  ▼ station  12 sessions · 6 Groups · 11 agents                                              [shell] [quick session] [▾] 
-╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Design refresh 2 sessions                                                                      [quick session] [▾]│ 
-│ [1] ⠋ group-contracts                           codex     working                                     +84 -20 #481 …│ 
-│ [2] ○ group-keyboard                            codex     idle                                         +16 -4 #482 ✓│ 
+╭─ ▼ Design refresh 2 sessions─────────────────────────────────────────────────────────────────── [quick session] [▾]─╮ 
+│  [1] ⠋ group-contracts                           codex     working                                   +84 -20 #481 … │ 
+│  [2] ○ group-keyboard                            codex     idle                                       +16 -4 #482 ✓ │ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Input parity and minimum-width interaction verification 1 session                              [quick session] [▾]│ 
-│ [3] ○ input-routing                             codex     idle                                                +27 -6│ 
+╭─ ▼ Input parity and minimum-width interaction verification 1 session─────────────────────────── [quick session] [▾]─╮ 
+│  [3] ○ input-routing                             codex     idle                                              +27 -6 │ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Observer hardening 3 sessions                                                                  [quick session] [▾]│ 
-│ [4] ○ diagnostic-index                          codex     idle                                                +38 -7│ 
-│ [5] ! handoff-refusal                           codex     Agent needs approval.                      +53 -11 #476 x1│ 
-│ [6] ⠋ trace-readiness                           codex     working                                     +91 -22 #478 …│ 
+╭─ ▼ Observer hardening 3 sessions─────────────────────────────────────────────────────────────── [quick session] [▾]─╮ 
+│  [4] ○ diagnostic-index                          codex     idle                                              +38 -7 │ 
+│  [5] ! handoff-refusal                           codex     Agent needs approval.                    +53 -11 #476 x1 │ 
+│  [6] ⠋ trace-readiness                           codex     working                                   +91 -22 #478 … │ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Post-launch 0 sessions                                                                         [quick session] [▾]│ 
+╭─ ▼ Post-launch 0 sessions────────────────────────────────────────────────────────────────────── [quick session] [▾]─╮ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Release train 3 sessions                                                                       [quick session] [▾]│ 
-│ [7] x asset-proof                               codex     exited                                              +19 -2│ 
-│ [8] ⠋ installer-replay                          codex     working                                            +64 -12│ 
-│ [9] ○ rc-manifest                               codex     idle                                         +31 -3 #471 ✓│ 
+╭─ ▼ Release train 3 sessions──────────────────────────────────────────────────────────────────── [quick session] [▾]─╮ 
+│  [7] x asset-proof                               codex     exited                                            +19 -2 │ 
+│  [8] ⠋ installer-replay                          codex     working                                          +64 -12 │ 
+│  [9] ○ rc-manifest                               codex     idle                                       +31 -3 #471 ✓ │ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
   ▶ Runtime cleanup 1 session                                                                       [quick session] [▾] 
  [a] ○ docs-refresh                              codex     idle                                            +8 -2 #479 ✓ 
  [b] - main                                      codex     no agent                                                     
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -482,36 +482,36 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle        
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
        SESSION                                   AGENT     STATUS                                             DIFF · PR 
  ▼ station  12 sessions · 6 Groups · 11 agents                                              [shell] [quick session] [▾] 
-╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Design refresh 2 sessions                                                                      [quick session] [▾]│ 
-│ [1] ⠋ group-contracts                           codex     working                                     +84 -20 #481 …│ 
-│ [2] ○ group-keyboard                            codex     idle                                         +16 -4 #482 ✓│ 
+╭─ ▼ Design refresh 2 sessions─────────────────────────────────────────────────────────────────── [quick session] [▾]─╮ 
+│  [1] ⠋ group-contracts                           codex     working                                   +84 -20 #481 … │ 
+│  [2] ○ group-keyboard                            codex     idle                                       +16 -4 #482 ✓ │ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
  [3] ○ docs-refresh                              codex     idle                                            +8 -2 #479 ✓ 
-╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Input parity and minimum-width interaction verification 1 session                              [quick session] [▾]│ 
-│ [4] ○ input-routing                             codex     idle                                                +27 -6│ 
+╭─ ▼ Input parity and minimum-width interaction verification 1 session─────────────────────────── [quick session] [▾]─╮ 
+│  [4] ○ input-routing                             codex     idle                                              +27 -6 │ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
  [5] - main                                      codex     no agent                                                     
-╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Observer hardening 3 sessions                                                                  [quick session] [▾]│ 
-│ [6] ○ diagnostic-index                          codex     idle                                                +38 -7│ 
-│ [7] ! handoff-refusal                           codex     Agent needs approval.                      +53 -11 #476 x1│ 
-│ [8] ⠋ trace-readiness                           codex     working                                     +91 -22 #478 …│ 
+╭─ ▼ Observer hardening 3 sessions─────────────────────────────────────────────────────────────── [quick session] [▾]─╮ 
+│  [6] ○ diagnostic-index                          codex     idle                                              +38 -7 │ 
+│  [7] ! handoff-refusal                           codex     Agent needs approval.                    +53 -11 #476 x1 │ 
+│  [8] ⠋ trace-readiness                           codex     working                                   +91 -22 #478 … │ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Post-launch 0 sessions                                                                         [quick session] [▾]│ 
+╭─ ▼ Post-launch 0 sessions────────────────────────────────────────────────────────────────────── [quick session] [▾]─╮ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Release train 3 sessions                                                                       [quick session] [▾]│ 
-│ [9] x asset-proof                               codex     exited                                              +19 -2│ 
-│ [a] ⠋ installer-replay                          codex     working                                            +64 -12│ 
-│ [b] ○ rc-manifest                               codex     idle                                         +31 -3 #471 ✓│ 
+╭─ ▼ Release train 3 sessions──────────────────────────────────────────────────────────────────── [quick session] [▾]─╮ 
+│  [9] x asset-proof                               codex     exited                                            +19 -2 │ 
+│  [a] ⠋ installer-replay                          codex     working                                          +64 -12 │ 
+│  [b] ○ rc-manifest                               codex     idle                                       +31 -3 #471 ✓ │ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Runtime cleanup 1 session                                                                      [quick session] [▾]│ 
-│ [c] ○ runtime-cleanup                           codex     idle                                                 +9 -2│ 
+╭─ ▼ Runtime cleanup 1 session─────────────────────────────────────────────────────────────────── [quick session] [▾]─╮ 
+│  [c] ○ runtime-cleanup                           codex     idle                                               +9 -2 │ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -526,24 +526,24 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 1
 ─────────────────────────────────────────────────────────────────────────────── 
 FILTER no-such-session                                             0/12 matches 
  ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾] 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Design refresh 0 visible                                          [qs] [▾]│ 
+╭─ ▼ Design refresh 0 visible─────────────────────────────────────── [qs] [▾]─╮ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Input parity and minimum-width interaction verification 0 visible [qs] [▾]│ 
+╭─ ▼ Input parity and minimum-width interaction verification 0 visib [qs] [▾]─╮ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Observer hardening 0 visible                                      [qs] [▾]│ 
+╭─ ▼ Observer hardening 0 visible─────────────────────────────────── [qs] [▾]─╮ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Post-launch 0 sessions                                            [qs] [▾]│ 
+╭─ ▼ Post-launch 0 sessions───────────────────────────────────────── [qs] [▾]─╮ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Release train 0 visible                                           [qs] [▾]│ 
+╭─ ▼ Release train 0 visible──────────────────────────────────────── [qs] [▾]─╮ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
-╭─────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Runtime cleanup 0 visible                                         [qs] [▾]│ 
+╭─ ▼ Runtime cleanup 0 visible────────────────────────────────────── [qs] [▾]─╮ 
 ╰─────────────────────────────────────────────────────────────────────────────╯ 
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
                                                                                 
                                                                                 
                                                                                 
@@ -568,18 +568,18 @@ exports[`dashboard golden frames renders filtered Group counts and clips structu
 "                                                                                
 FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 12 · 11 
 ─────────────────────────────────────────────────────────────────────────────── 
-▲ 2 sessions above                                                              
-│ [1] ○ input-routing               codex     idle                      +27 -6│▲
-╰─────────────────────────────────────────────────────────────────────────────╯▕
-╭─────────────────────────────────────────────────────────────────────────────╮▕
-│ ▼ Observer hardening 3 sessions                                     [qs] [▾]│▐
-│ [2] ○ diagnostic-index            codex     idle                      +38 -7│▐
-│ [3] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│▐
-│ [4] ⠋ trace-readiness             codex     working           +91 -22 #478 …│▕
-╰─────────────────────────────────────────────────────────────────────────────╯▕
-╭─────────────────────────────────────────────────────────────────────────────╮▕
-│ ▼ Post-launch 0 sessions                                            [qs] [▾]│▼
-── ▼ 6 below · showing 4 of 12 ──────────────────────────────────────────────── 
+▲ 3 sessions above                                                              
+╭─ ▼ Observer hardening 3 sessions────────────────────────────────── [qs] [▾]─╮▲
+│  [1] ○ diagnostic-index          codex     idle                      +38 -7 │▕
+│  [2] ! handoff-refusal           codex     Agent needs app… +53 -11 #476 x1 │▕
+│  [3] ⠋ trace-readiness           codex     working           +91 -22 #478 … │▕
+╰─────────────────────────────────────────────────────────────────────────────╯▐
+╭─ ▼ Post-launch 0 sessions───────────────────────────────────────── [qs] [▾]─╮▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
+╭─ ▼ Release train 3 sessions─────────────────────────────────────── [qs] [▾]─╮▕
+│  [4] x asset-proof               codex     exited                    +19 -2 │▕
+│  [5] ⠋ installer-replay          codex     working                  +64 -12 │▼
+── ▼ 4 below · showing 5 of 12 ──────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
 "
 `;

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -178,24 +178,24 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 1
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                       AGENT     STATUS                 DIFF · PR 
  ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾]▲
-╭─────────────────────────────────────────────────────────────────────────────╮▐
-│ ▼ Design refresh 2 sessions                                         [qs]▸[▾]│▐
-│ [1] ⠋ group-contracts             codex     workin┌─Design refresh───────────┐
-│ [2] ○ group-keyboard              codex     idle  │▸Quick session           Q│
+╭─ ▼ Design refresh 2 sessions────────────────────────────────────── [qs]▸[▾]─╮▐
+│  [1] ⠋ group-contracts           codex     working┌─Design refresh───────────┐
+│  [2] ○ group-keyboard            codex     idle   │▸Quick session           Q│
 ╰───────────────────────────────────────────────────│ New session…            N│
-╭───────────────────────────────────────────────────│──────────────────────────│
-│ ▼ Input parity and minimum-width interaction verif│ Group settings…         S│
-│ [3] ○ input-routing               codex     idle  │──────────────────────────│
-╰───────────────────────────────────────────────────│ Remove Group…           R│
-╭───────────────────────────────────────────────────└──────────────────────────┘
-│ ▼ Observer hardening 3 sessions                                     [qs] [▾]│▕
-│ [4] ○ diagnostic-index            codex     idle                      +38 -7│▕
-│ [5] ! handoff-refusal             codex     Agent needs app… +53 -11 #476 x1│▕
-│ [6] ⠋ trace-readiness             codex     working           +91 -22 #478 …│▕
+╭─ ▼ Input parity and minimum-width interaction veri│──────────────────────────│
+│  [3] ○ input-routing             codex     idle   │ Group settings…         S│
+╰───────────────────────────────────────────────────│──────────────────────────│
+╭─ ▼ Observer hardening 3 sessions──────────────────│ Remove Group…           R│
+│  [4] ○ diagnostic-index          codex     idle   └──────────────────────────┘
+│  [5] ! handoff-refusal           codex     Agent needs app… +53 -11 #476 x1 │▐
+│  [6] ⠋ trace-readiness           codex     working           +91 -22 #478 … │▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
+╭─ ▼ Post-launch 0 sessions───────────────────────────────────────── [qs] [▾]─╮▕
 ╰─────────────────────────────────────────────────────────────────────────────╯▕
-╭─────────────────────────────────────────────────────────────────────────────╮▕
-│ ▼ Post-launch 0 sessions                                            [qs] [▾]│▼
-── ▼ 6 below · showing 6 of 12 ──────────────────────────────────────────────── 
+╭─ ▼ Release train 3 sessions─────────────────────────────────────── [qs] [▾]─╮▕
+│  [7] x asset-proof               codex     exited                    +19 -2 │▕
+│  [8] ⠋ installer-replay          codex     working                  +64 -12 │▼
+── ▼ 4 below · showing 8 of 12 ──────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
 "
 `;
@@ -204,9 +204,9 @@ exports[`modal flow golden frames renders the Group menu above a short viewport 
 "  ┌─Design refresh───────────┐
 FL│──────────────────────────│
 ──│ Group settings…         S│
-▲ │──────────────────────────│
-╭─│▸Remove Group…           R│
-│ └──────────────────────────┘
+  │──────────────────────────│
+ ▼│▸Remove Group…           R│
+╭─└──────────────────────────┘
 ───────────────────────────── 
 ↵ activate  N new  ⇥ next  /… 
 "
@@ -302,13 +302,13 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 1
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                       AGENT     STATUS                 DIFF · PR 
  ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾]▲
-╭─────────────────────────────────────────────────────────────────────────────╮▐
-│ ▼ Design refresh 2 sessions                                         [qs] [▾]│▐
-│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│▐
-│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│▐
+╭─ ▼ Design refresh 2 sessions────────────────────────────────────── [qs] [▾]─╮▐
+│  [1] ⠋ group-contracts           codex     working           +84 -20 #481 … │▐
+│  [2] ○ group-keyboard            codex     idle               +16 -4 #482 ✓ │▐
 ╰─────────────────────────────────────────────────────────────────────────────╯▐
-╭─────────────────────────────────────────────────────────────────────────────╮▐
-│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│▐
+╭─ ▼ Input parity and minimum-width interaction verification 1 sessi [qs] [▾]─╮▐
+│  [3] ○ input-routing             codex     idle                      +27 -6 │▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Move to Group                                                                │
 │ Session    group-contracts                                                   │
@@ -330,13 +330,13 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 1
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                       AGENT     STATUS                 DIFF · PR 
  ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾]▲
-╭─────────────────────────────────────────────────────────────────────────────╮▐
-│ ▼ Design refresh 2 sessions                                         [qs] [▾]│▐
-│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│▐
-│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│▐
+╭─ ▼ Design refresh 2 sessions────────────────────────────────────── [qs] [▾]─╮▐
+│  [1] ⠋ group-contracts           codex     working           +84 -20 #481 … │▐
+│  [2] ○ group-keyboard            codex     idle               +16 -4 #482 ✓ │▐
 ╰─────────────────────────────────────────────────────────────────────────────╯▐
-╭─────────────────────────────────────────────────────────────────────────────╮▐
-│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│▐
+╭─ ▼ Input parity and minimum-width interaction verification 1 sessi [qs] [▾]─╮▐
+│  [3] ○ input-routing             codex     idle                      +27 -6 │▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Move to Group                                                                │
 │  U Ungrouped                                                                 │
@@ -358,13 +358,13 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 1
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                       AGENT     STATUS                 DIFF · PR 
  ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾]▲
-╭─────────────────────────────────────────────────────────────────────────────╮▐
-│ ▼ Design refresh 2 sessions                                         [qs] [▾]│▐
-│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│▐
-│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│▐
+╭─ ▼ Design refresh 2 sessions────────────────────────────────────── [qs] [▾]─╮▐
+│  [1] ⠋ group-contracts           codex     working           +84 -20 #481 … │▐
+│  [2] ○ group-keyboard            codex     idle               +16 -4 #482 ✓ │▐
 ╰─────────────────────────────────────────────────────────────────────────────╯▐
-╭─────────────────────────────────────────────────────────────────────────────╮▐
-│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│▐
+╭─ ▼ Input parity and minimum-width interaction verification 1 sessi [qs] [▾]─╮▐
+│  [3] ○ input-routing             codex     idle                      +27 -6 │▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Create Group                                                                 │
 │ Session    group-contracts                                                   │
@@ -646,24 +646,24 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 1
 ───┌────────────────────────────────────────────────────────────────────────┐── 
    │ Group settings · Design refresh                                        │PR 
  ▼ │ Design refresh           │ General                                     │▾]▲
-╭──│▸ General                 │  Name Design refresh                        │─╮▐
-│ ▼│  Sessions                │ Save renames; sessions stay attached.       │]│▐
-│ [│  Remove Group            │                                             │…│▐
-│ [│                          │ Project station (read-only)                 │✓│▐
-╰──│                          │ /Users/example/Developer/station            │─╯▐
-╭──│                          │                                             │─╮▐
-│ ▼│                          │                                             │]│▐
-│ [│                          │                                             │6│▐
+╭─ │▸ General                 │  Name Design refresh                        │─╮▐
+│  │  Sessions                │ Save renames; sessions stay attached.       │ │▐
+│  │  Remove Group            │                                             │ │▐
+╰──│                          │ Project station (read-only)                 │─╯▐
+╭─ │                          │ /Users/example/Developer/station            │─╮▐
+│  │                          │                                             │ │▐
 ╰──│                          │                                             │─╯▐
-╭──│                          │                                             │─╮▕
-│ ▼│                          │                                             │]│▕
-│ [│                          │                                             │7│▕
-│ [│                          │                                             │1│▕
-│ [│                          │                                             │…│▕
-╰──│                          │  Save (Enter)    Cancel (Esc)               │─╯▕
-╭──│ ↑↓ or G/S/R select · →/enter edit · esc back                           │─╮▕
-│ ▼└────────────────────────────────────────────────────────────────────────┘]│▼
-── ▼ 6 below · showing 6 of 12 ──────────────────────────────────────────────── 
+╭─ │                          │                                             │─╮▐
+│  │                          │                                             │ │▐
+│  │                          │                                             │ │▐
+│  │                          │                                             │ │▐
+╰──│                          │                                             │─╯▐
+╭─ │                          │                                             │─╮▕
+╰──│                          │                                             │─╯▕
+╭─ │                          │  Save (Enter)    Cancel (Esc)               │─╮▕
+│  │ ↑↓ or G/S/R select · →/enter edit · esc back                           │ │▕
+│  └────────────────────────────────────────────────────────────────────────┘ │▼
+── ▼ 4 below · showing 8 of 12 ──────────────────────────────────────────────── 
 ↵ activate  N new  ⇥ next  / filter  X delete  ? help  Q/esc:close              
 "
 `;
@@ -674,36 +674,36 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle        
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
        SESSION                                   AGENT     STATUS                                             DIFF · PR 
  ▼ station  12 sessions · 6 Groups · 11 agents                                              [shell] [quick session] [▾] 
-╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ 
-│ ▼ Design refresh 2 sessions                                                                      [quick session]▸[▾]│ 
-│ [1] ⠋ group-contracts                           codex     working                                     +84 -20 #481 …│ 
-│ [2] ○ group-keyboard                            codex     idle                                         +16 -4 #482 ✓│ 
+╭─ ▼ Design refresh 2 sessions─────────────────────────────────────────────────────────────────── [quick session]▸[▾]─╮ 
+│  [1] ⠋ group-contracts                           codex     working                                   +84 -20 #481 … │ 
+│  [2] ○ group-keyboard                            codex     idle                                       +16 -4 #482 ✓ │ 
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
-╭───────────────┌──────────────────────────────────────────────────────────────────────────────────────┐──────────────╮ 
-│ ▼ Input parity│ Group settings · Design refresh                                                      │k session] [▾]│ 
-│ [3] ○ input-ro│ Design refresh           │ General                                                   │        +27 -6│ 
-╰───────────────│▸ General                 │  Name Design refresh                                      │──────────────╯ 
-╭───────────────│  Sessions                │ Save renames; sessions stay attached.                     │──────────────╮ 
-│ ▼ Observer har│  Remove Group            │                                                           │k session] [▾]│ 
-│ [4] ○ diagnost│                          │ Project station (read-only)                               │        +38 -7│ 
-│ [5] ! handoff-│                          │ /Users/example/Developer/station                          │53 -11 #476 x1│ 
-│ [6] ⠋ trace-re│                          │                                                           │+91 -22 #478 …│ 
+╭─ ▼ Input parity and minimum-width interaction verification 1 session─────────────────────────── [quick session] [▾]─╮ 
+│  [3] ○ input-r┌──────────────────────────────────────────────────────────────────────────────────────┐       +27 -6 │ 
+╰───────────────│ Group settings · Design refresh                                                      │──────────────╯ 
+╭─ ▼ Observer ha│ Design refresh           │ General                                                   │ session] [▾]─╮ 
+│  [4] ○ diagnos│▸ General                 │  Name Design refresh                                      │       +38 -7 │ 
+│  [5] ! handoff│  Sessions                │ Save renames; sessions stay attached.                     │3 -11 #476 x1 │ 
+│  [6] ⠋ trace-r│  Remove Group            │                                                           │91 -22 #478 … │ 
+╰───────────────│                          │ Project station (read-only)                               │──────────────╯ 
+╭─ ▼ Post-launch│                          │ /Users/example/Developer/station                          │ session] [▾]─╮ 
 ╰───────────────│                          │                                                           │──────────────╯ 
-╭───────────────│                          │                                                           │──────────────╮ 
-│ ▼ Post-launch │                          │                                                           │k session] [▾]│ 
+╭─ ▼ Release tra│                          │                                                           │ session] [▾]─╮ 
+│  [7] x asset-p│                          │                                                           │       +19 -2 │ 
+│  [8] ⠋ install│                          │                                                           │      +64 -12 │ 
+│  [9] ○ rc-mani│                          │                                                           │+31 -3 #471 ✓ │ 
 ╰───────────────│                          │                                                           │──────────────╯ 
-╭───────────────│                          │                                                           │──────────────╮ 
-│ ▼ Release trai│                          │                                                           │k session] [▾]│ 
-│ [7] x asset-pr│                          │                                                           │        +19 -2│ 
-│ [8] ⠋ installe│                          │                                                           │       +64 -12│ 
-│ [9] ○ rc-manif│                          │  Save (Enter)    Cancel (Esc)                             │ +31 -3 #471 ✓│ 
-╰───────────────│ ↑↓ or G/S/R select · →/enter edit · esc back                                         │──────────────╯ 
-╭───────────────└──────────────────────────────────────────────────────────────────────────────────────┘──────────────╮ 
-│ ▼ Runtime cleanup 1 session                                                                      [quick session] [▾]│ 
-│ [a] ○ runtime-cleanup                           codex     idle                                                 +9 -2│ 
-╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
- [b] ○ docs-refresh                              codex     idle                                            +8 -2 #479 ✓ 
- [c] - main                                      codex     no agent                                                     
+╭─ ▼ Runtime cle│                          │                                                           │ session] [▾]─╮ 
+│  [a] ○ runtime│                          │                                                           │        +9 -2 │ 
+╰───────────────│                          │                                                           │──────────────╯ 
+ [b] ○ docs-refr│                          │  Save (Enter)    Cancel (Esc)                             │   +8 -2 #479 ✓ 
+ [c] - main     │ ↑↓ or G/S/R select · →/enter edit · esc back                                         │                
+                └──────────────────────────────────────────────────────────────────────────────────────┘                
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -1206,23 +1206,23 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 1
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                       AGENT     STATUS                 DIFF · PR 
  ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾]▲
-╭─────────────────────────────────────────────────────────────────────────────╮▐
-│ ▼ Design refresh 2 sessions                                         [qs] [▾]│▐
-│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│▐
-│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│▐
+╭─ ▼ Design refresh 2 sessions────────────────────────────────────── [qs] [▾]─╮▐
+│  [1] ⠋ group-contracts           codex     working           +84 -20 #481 … │▐
+│  [2] ○ group-keyboard            codex     idle               +16 -4 #482 ✓ │▐
 ╰─────────────────────────────────────────────────────────────────────────────╯▐
-╭─────────────────────────────────────────────────────────────────────────────╮▐
-│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│▐
-┌────────────────────────────────────────────┐idle                      +27 -6│▐
-│ Fork Session                               │────────────────────────────────╯▐
-│ Source   station · group-contracts         │────────────────────────────────╮▕
-│  Name   group-contracts-fork               │                        [qs] [▾]│▕
-│▸ Group  [x] create in Design refresh       │idle                      +38 -7│▕
-│  Copy   [x] uncommitted changes            │Agent needs app… +53 -11 #476 x1│▕
-│ Source keeps running — copy is read-only.  │working           +91 -22 #478 …│▕
-│                                            │────────────────────────────────╯▕
-│                                            │────────────────────────────────╮▕
-│  Fork (enter)                              │                        [qs] [▾]│▼
+╭─ ▼ Input parity and minimum-width interaction verification 1 sessi [qs] [▾]─╮▐
+│  [3] ○ input-routing             codex     idle                      +27 -6 │▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
+┌────────────────────────────────────────────┐────────────────────── [qs] [▾]─╮▐
+│ Fork Session                               │dle                      +38 -7 │▐
+│ Source   station · group-contracts         │gent needs app… +53 -11 #476 x1 │▐
+│  Name   group-contracts-fork               │orking           +91 -22 #478 … │▐
+│▸ Group  [x] create in Design refresh       │────────────────────────────────╯▐
+│  Copy   [x] uncommitted changes            │────────────────────── [qs] [▾]─╮▕
+│ Source keeps running — copy is read-only.  │────────────────────────────────╯▕
+│                                            │────────────────────── [qs] [▾]─╮▕
+│                                            │xited                    +19 -2 │▕
+│  Fork (enter)                              │orking                  +64 -12 │▼
 │ Space/Enter toggle · ↑↓ focus · Esc back   │───────────────────────────────── 
 └────────────────────────────────────────────┘ ? help  Q/esc:close              
 "
@@ -1694,13 +1694,13 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 1
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                       AGENT     STATUS                 DIFF · PR 
  ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾]▲
-╭─────────────────────────────────────────────────────────────────────────────╮▐
-│ ▼ Design refresh 2 sessions                                         [qs] [▾]│▐
-│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│▐
-│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│▐
+╭─ ▼ Design refresh 2 sessions────────────────────────────────────── [qs] [▾]─╮▐
+│  [1] ⠋ group-contracts           codex     working           +84 -20 #481 … │▐
+│  [2] ○ group-keyboard            codex     idle               +16 -4 #482 ✓ │▐
 ╰─────────────────────────────────────────────────────────────────────────────╯▐
-╭─────────────────────────────────────────────────────────────────────────────╮▐
-│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│▐
+╭─ ▼ Input parity and minimum-width interaction verification 1 sessi [qs] [▾]─╮▐
+│  [3] ○ input-routing             codex     idle                      +27 -6 │▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Group                                                                 │
 │                                                                              │
@@ -1722,13 +1722,13 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 1
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                       AGENT     STATUS                 DIFF · PR 
  ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾]▲
-╭─────────────────────────────────────────────────────────────────────────────╮▐
-│ ▼ Design refresh 2 sessions                                         [qs] [▾]│▐
-│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│▐
-│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│▐
+╭─ ▼ Design refresh 2 sessions────────────────────────────────────── [qs] [▾]─╮▐
+│  [1] ⠋ group-contracts           codex     working           +84 -20 #481 … │▐
+│  [2] ○ group-keyboard            codex     idle               +16 -4 #482 ✓ │▐
 ╰─────────────────────────────────────────────────────────────────────────────╯▐
-╭─────────────────────────────────────────────────────────────────────────────╮▐
-│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│▐
+╭─ ▼ Input parity and minimum-width interaction verification 1 sessi [qs] [▾]─╮▐
+│  [3] ○ input-routing             codex     idle                      +27 -6 │▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Group                                                                 │
 │ ✓U Ungrouped                                                                 │
@@ -1750,13 +1750,13 @@ FLEET  ● 0 ready  ⠋ 3 working  ! 1 needs you  x 1 exited  ○ 6 idle  1 · 1
 ─────────────────────────────────────────────────────────────────────────────── 
        SESSION                       AGENT     STATUS                 DIFF · PR 
  ▼ station  12 sessions · 6 Groups · 11 agents                    [sh] [qs] [▾]▲
-╭─────────────────────────────────────────────────────────────────────────────╮▐
-│ ▼ Design refresh 2 sessions                                         [qs] [▾]│▐
-│ [1] ⠋ group-contracts             codex     working           +84 -20 #481 …│▐
-│ [2] ○ group-keyboard              codex     idle               +16 -4 #482 ✓│▐
+╭─ ▼ Design refresh 2 sessions────────────────────────────────────── [qs] [▾]─╮▐
+│  [1] ⠋ group-contracts           codex     working           +84 -20 #481 … │▐
+│  [2] ○ group-keyboard            codex     idle               +16 -4 #482 ✓ │▐
 ╰─────────────────────────────────────────────────────────────────────────────╯▐
-╭─────────────────────────────────────────────────────────────────────────────╮▐
-│ ▼ Input parity and minimum-width interaction verification 1 session [qs] [▾]│▐
+╭─ ▼ Input parity and minimum-width interaction verification 1 sessi [qs] [▾]─╮▐
+│  [3] ○ input-routing             codex     idle                      +27 -6 │▐
+╰─────────────────────────────────────────────────────────────────────────────╯▐
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Create Group                                                                 │
 │ Project      station                                                         │

--- a/station/src/station/view/dashboard.golden.test.tsx
+++ b/station/src/station/view/dashboard.golden.test.tsx
@@ -207,8 +207,14 @@ describe("dashboard golden frames", () => {
     expect(groupsFirstFrame).toContain("[a]");
     expect(groupsFirstFrame).toContain("[b]");
     expect(groupsFirstFrame).toContain("[c]");
+    const designHeader = groupsFirstLines.find((line) => line.includes("▼ Design refresh"));
+    expect(designHeader?.trimEnd()).toMatch(
+      /Design refresh 2 sessions─+ \[quick session\] \[▾\]─╮$/u,
+    );
     const emptyHeader = groupsFirstLines.findIndex((line) => line.includes("▼ Post-launch"));
-    expect(groupsFirstLines[emptyHeader + 1]?.trim()).toMatch(/^╰─+╯$/u);
+    expect(groupsFirstLines[emptyHeader]?.trimEnd()).toMatch(/^╭─.*─╮$/u);
+    expect(groupsFirstLines[emptyHeader + 1]?.trimEnd()).toMatch(/^╰─+╯$/u);
+    expect(groupsFirstLines[emptyHeader + 2]).toContain("▼ Release train");
 
     const collapsed = await renderDashboard({
       width: 120,
@@ -276,6 +282,7 @@ describe("dashboard golden frames", () => {
     expect(hasAncestor(group, "station-dashboard-project:project:station")).toBe(true);
     expect(lines[firstLine]?.startsWith("│")).toBe(true);
     expect(lines[firstLine]?.trimEnd().endsWith("│")).toBe(true);
+    expect(lines[firstLine + 1]?.trimEnd()).toMatch(/^╰─+╯$/u);
   });
 
   it("lays out mixed-height children and follows semantic focus through resize and reflow", async () => {
@@ -434,14 +441,14 @@ describe("dashboard golden frames", () => {
     });
     const lines = setup.captureCharFrame().split("\n");
     const project = lines.find((line) => line.includes("▼ 界e\u0301"));
-    const group = lines.find((line) => line.includes("▼ A 界e\u0301") && line.startsWith("│"));
+    const group = lines.find((line) => line.includes("▼ A 界e\u0301") && line.startsWith("╭─"));
 
     expect(project).toBeDefined();
     expect(group).toBeDefined();
     expect(project).not.toContain("�");
     expect(group).not.toContain("�");
     expect(project?.replace(/[▐▕▲▼]$/u, "").trimEnd().endsWith("[sh] [qs] [▾]")).toBe(true);
-    expect(group?.replace(/[▐▕▲▼]$/u, "").trimEnd().endsWith("[qs] [▾]│")).toBe(true);
+    expect(group?.replace(/[▐▕▲▼]$/u, "").trimEnd().endsWith("[qs] [▾]─╮")).toBe(true);
     expect(cellWidth(project ?? "")).toBe(40);
     expect(cellWidth(group ?? "")).toBe(40);
   });
@@ -519,10 +526,18 @@ describe("dashboard golden frames", () => {
     const memberColumn = memberLines[memberRow]?.indexOf("group-contracts") ?? -1;
     const spans = member.captureSpans();
     const ring = spanAtFrameCell(spans, headerRow, 0);
+    const headerRuleColumn = memberLines[headerRow]?.search(/─{2,}/u) ?? -1;
 
-    expect(spanHex(ring)).toBe(stationColorSnapshotValue(nativeStationTheme.status.working));
+    expect(spanHex(ring)).not.toBe(
+      stationColorSnapshotValue(nativeStationTheme.status.working),
+    );
+    expect(spanHex(ring)).not.toBe(
+      stationColorSnapshotValue(nativeStationTheme.interaction.hairline),
+    );
+    expect(headerRuleColumn).toBeGreaterThan(-1);
+    expect(spanHex(spanAtFrameCell(spans, headerRow, headerRuleColumn))).toBe(spanHex(ring));
     expect(((ring?.attributes ?? 0) & TextAttributes.DIM) !== 0).toBe(false);
-    expect(memberLines[memberRow]).toMatch(/^│▏/u);
+    expect(memberLines[memberRow]).toMatch(/^│ ▏/u);
     expect(memberLines[memberRow]?.match(/▏/gu)).toHaveLength(1);
     expect(spanBgHex(spanAtFrameCell(spans, memberRow, memberColumn))).toBe(
       stationColorSnapshotValue(nativeStationTheme.interaction.keyboardFocus),
@@ -535,25 +550,25 @@ describe("dashboard golden frames", () => {
         visibility: { quickSession: true, menu: true },
         quickSession: true,
         menu: true,
-        expandedSuffix: "[qs] [▾]│",
+        expandedSuffix: "[qs] [▾]─╮",
       },
       {
         visibility: { quickSession: true, menu: false },
         quickSession: true,
         menu: false,
-        expandedSuffix: "[qs]│",
+        expandedSuffix: "[qs]─╮",
       },
       {
         visibility: { quickSession: false, menu: true },
         quickSession: false,
         menu: true,
-        expandedSuffix: "[▾]│",
+        expandedSuffix: "[▾]─╮",
       },
       {
         visibility: { quickSession: false, menu: false },
         quickSession: false,
         menu: false,
-        expandedSuffix: "│",
+        expandedSuffix: "─╮",
       },
     ] as const;
 
@@ -580,13 +595,13 @@ describe("dashboard golden frames", () => {
           expect(line?.replace(/[▐▕]$/u, "").trimEnd().endsWith(testCase.expandedSuffix)).toBe(
             true,
           );
-          expect(line?.lastIndexOf("│")).toBe(78);
+          expect(line?.lastIndexOf("╮")).toBe(78);
         }
       }
     }
   });
 
-  it("keeps Group frame cells inert and restores target focus after hover", async () => {
+  it("keeps Group edge cells inert and restores target focus after hover", async () => {
     const targets: StationMouseTarget[] = [];
     const groupId = dashboardRowIds.group("group_design_refresh");
     const setup = await renderDashboard({

--- a/station/src/station/view/dashboard/DashboardTreeView.tsx
+++ b/station/src/station/view/dashboard/DashboardTreeView.tsx
@@ -123,6 +123,10 @@ function GroupBranchView({
   const row = branch.row;
   if (row.payload.type !== "groupHeader") return null;
   const renderableId = `station-dashboard-group:${row.id}`;
+  const frameFocus = {
+    focusedHeader: row.focusedCellId !== undefined,
+    containsFocusedRow: row.containsFocusedRow === true,
+  };
   const header = (
     <GroupHeaderView
       renderableId={semanticItemRenderableId(row.id)}
@@ -131,6 +135,7 @@ function GroupBranchView({
       payload={row.payload}
       cells={row.cells}
       focusedCellId={row.focusedCellId}
+      {...(row.payload.collapsed ? {} : { frameFocus })}
     />
   );
   if (row.payload.collapsed) {
@@ -141,13 +146,7 @@ function GroupBranchView({
     );
   }
   return (
-    <GroupFrameView
-      renderableId={renderableId}
-      focus={{
-        focusedHeader: row.focusedCellId !== undefined,
-        containsFocusedRow: row.containsFocusedRow === true,
-      }}
-    >
+    <GroupFrameView renderableId={renderableId} focus={frameFocus}>
       {header}
       {branch.children.map((child) => (
         <DashboardBranchView


### PR DESCRIPTION
## What this fixes

Expanded Group frames reserved a border-only row above the semantic header and used the same bright frame emphasis for both header and member focus. This made Group blocks taller and obscured which level actually owned focus.

## What changed

- Integrate the rounded top corners and horizontal rule into the Group header row.
- Fill unused header cells with frame chrome while preserving responsive labels and exact action targets.
- Keep direct members on ordinary side-railed rows and retain a dedicated full-width bottom footer.
- Use bright working color for exact header focus and muted working color when a direct member has focus.
- Preserve inert structural cells, final-member hit testing, narrow layout, and clipping behavior.
- Update the TUI contract and golden frames.

## Testing

- bun run lint
- bun run --cwd station typecheck
- bun run --cwd station test — 1,786 passed
- Focused renderer and golden suite — 186 passed, 115 snapshots
- PTY lanes — 106 node-pty and 70 Bun PTY tests passed
- Host upgrade and warm-reattach lane — 10 passed
- bun run test:all completed build, typecheck, and lint, then reached 3,493/3,494 unit tests before the unrelated protocol oversized-frame test exceeded its 10-second timeout under suite load. Its complete file passes 36/36 in isolation.

## User-visible behavior

Expanded Groups now render as a continuous top edge on the header row, normal member rows, and a full dedicated bottom border. Focusing a member mutes the complete frame, including the header rule; focusing the Group header keeps it bright.