### PR TITLE
fix(observer): bound live event subscribers

### DIFF
--- a/apps/observer/src/runtime/api.ts
+++ b/apps/observer/src/runtime/api.ts
@@ -628,6 +628,7 @@ async function buildHealth(
   if (options.socketPath !== undefined) health.socketPath = options.socketPath;
   if (options.stateDir !== undefined) health.stateDir = options.stateDir;
   if (spoolDepth !== undefined) health.hookSpoolDepth = spoolDepth;
+  health.eventBus = options.eventBus.health();
   health.harnessIngressQueue = harnessIngressQueue.health();
   health.sqlite = options.persistenceHealth.health();
   if (coreHealth.lastReconcile !== undefined) health.lastReconcile = coreHealth.lastReconcile;

--- a/apps/observer/src/runtime/eventBus.ts
+++ b/apps/observer/src/runtime/eventBus.ts
@@ -1,41 +1,99 @@
-import type { EventFilter, StationEvent } from "@station/contracts";
+import type { EventFilter, ObserverEventBusHealth, StationEvent } from "@station/contracts";
 import { StationEventSchema, stationEventMetadata } from "@station/contracts";
 import { Effect, Queue } from "@station/runtime";
 
+const observerEventBusSubscriberCapacity = 1_024;
+
+/** Future-only process-local delivery with bounded, independently disposable subscribers. */
 export type ObserverEventBus = {
   publish(event: StationEvent): void;
   subscribe(filter?: EventFilter): AsyncIterable<StationEvent>;
+  health(): ObserverEventBusHealth;
 };
 
 type Subscriber = {
   filter?: EventFilter;
   queue: Queue.Queue<StationEvent>;
+  queuedEvents: number;
   active: boolean;
 };
 
-export function createObserverEventBus(): ObserverEventBus {
+export function createObserverEventBus(
+  options: { subscriberCapacity?: number } = {},
+): ObserverEventBus {
+  const subscriberCapacity = options.subscriberCapacity ?? observerEventBusSubscriberCapacity;
   const subscribers = new Set<Subscriber>();
+  let queuedEvents = 0;
+  let highWaterQueuedEvents = 0;
+  let overflowCount = 0;
+  let disconnectCount = 0;
+  let resyncRequiredCount = 0;
+  let lastOverflowReason: ObserverEventBusHealth["lastOverflowReason"];
+
+  const health = (): ObserverEventBusHealth => {
+    const result: ObserverEventBusHealth = {
+      activeSubscribers: subscribers.size,
+      queuedEvents,
+      subscriberCapacity,
+      highWaterQueuedEvents,
+      overflowCount,
+      disconnectCount,
+      resyncRequiredCount,
+    };
+    if (lastOverflowReason !== undefined) result.lastOverflowReason = lastOverflowReason;
+    return result;
+  };
+  const updateDepth = (subscriber: Subscriber) => {
+    const nextDepth = Math.max(0, Effect.runSync(Queue.size(subscriber.queue)));
+    queuedEvents += nextDepth - subscriber.queuedEvents;
+    subscriber.queuedEvents = nextDepth;
+    highWaterQueuedEvents = Math.max(highWaterQueuedEvents, queuedEvents);
+  };
+  const release = (subscriber: Subscriber) => {
+    if (!subscriber.active) return;
+    subscriber.active = false;
+    subscribers.delete(subscriber);
+    queuedEvents -= subscriber.queuedEvents;
+    subscriber.queuedEvents = 0;
+    Effect.runSync(Queue.takeAll(subscriber.queue));
+    Effect.runSync(Queue.shutdown(subscriber.queue));
+  };
 
   return {
     publish: (event) => {
       const parsedEvent = StationEventSchema.parse(event);
       for (const subscriber of subscribers) {
         if (subscriber.active && eventMatchesFilter(parsedEvent, subscriber.filter)) {
-          Effect.runSync(Queue.offer(subscriber.queue, parsedEvent));
+          const accepted = Effect.runSync(Queue.offer(subscriber.queue, parsedEvent));
+          if (!accepted) {
+            overflowCount += 1;
+            disconnectCount += 1;
+            resyncRequiredCount += 1;
+            lastOverflowReason = "subscriber-capacity";
+            release(subscriber);
+            continue;
+          }
+          updateDepth(subscriber);
         }
       }
     },
-    subscribe: (filter) => effectQueueSubscription(subscribers, filter),
+    subscribe: (filter) =>
+      effectQueueSubscription(subscribers, subscriberCapacity, updateDepth, release, filter),
+    health,
   };
 }
 
 function effectQueueSubscription(
   subscribers: Set<Subscriber>,
+  subscriberCapacity: number,
+  updateDepth: (subscriber: Subscriber) => void,
+  release: (subscriber: Subscriber) => void,
   filter?: EventFilter,
 ): AsyncIterable<StationEvent> {
   const subscriber: Subscriber = {
     ...(filter === undefined ? {} : { filter }),
-    queue: Effect.runSync(Queue.unbounded<StationEvent>()),
+    queue: Effect.runSync(Queue.dropping<StationEvent>(subscriberCapacity)),
+    queuedEvents: 0,
     active: true,
   };
   subscribers.add(subscriber);
@@ -47,16 +105,15 @@ function effectQueueSubscription(
       }
       try {
         const event = await Effect.runPromise(Queue.take(subscriber.queue));
+        if (subscriber.active) updateDepth(subscriber);
         return subscriber.active ? { done: false, value: event } : { done: true, value: undefined };
       } catch {
         return { done: true, value: undefined };
       }
     },
     return: async () => {
-      // Remove the subscriber and shut down its queue so pending takes unblock.
-      subscriber.active = false;
-      subscribers.delete(subscriber);
-      await Effect.runPromise(Queue.shutdown(subscriber.queue));
+      // Drain before shutdown so a caller retaining the iterator cannot retain event payloads.
+      release(subscriber);
       return { done: true, value: undefined };
     },
   };

--- a/apps/observer/test/integration/in-memory-observer-api.test.ts
+++ b/apps/observer/test/integration/in-memory-observer-api.test.ts
@@ -240,6 +240,14 @@ describe("Observer API composition with in-memory persistence", () => {
     await expect(api.health()).resolves.toMatchObject({
       status: "healthy",
       sqlite: healthStub,
+      eventBus: {
+        activeSubscribers: 0,
+        queuedEvents: 0,
+        subscriberCapacity: 1_024,
+        overflowCount: 0,
+        disconnectCount: 0,
+        resyncRequiredCount: 0,
+      },
     });
     await expect(api.collectDiagnostics({ includeLogs: false })).resolves.toMatchObject({
       observerHealth: {

--- a/apps/observer/test/integration/protocol-server.test.ts
+++ b/apps/observer/test/integration/protocol-server.test.ts
@@ -104,6 +104,66 @@ describe("observer protocol server", () => {
     }
   });
 
+  it("disconnects an overflowed event subscriber and accepts a fresh subscription", async () => {
+    const { socketPath } = await createTempSocketPath();
+    const fixture = createObserverFixture(socketPath, 2);
+    const server = await startObserverServer({
+      socketPath,
+      api: fixture.api,
+      clock: fixture.clock,
+    });
+    const client = createObserverClient({ socketPath, requestId: ids("event-overflow") });
+    const stalled = client.subscribe()[Symbol.asyncIterator]();
+    const stalledNext = stalled.next();
+    const event = {
+      type: "observer.reconciled" as const,
+      at: now,
+      changed: 0,
+    };
+
+    try {
+      await vi.waitFor(() => {
+        expect(fixture.eventBus.health()).toMatchObject({ activeSubscribers: 1 });
+      });
+      fixture.eventBus.publish(event);
+      fixture.eventBus.publish(event);
+      fixture.eventBus.publish(event);
+      fixture.eventBus.publish(event);
+
+      await expect(stalledNext).rejects.toMatchObject({
+        code: "PROTOCOL_SUBSCRIPTION_CLOSED",
+      });
+      await expect(client.health()).resolves.toMatchObject({
+        eventBus: {
+          activeSubscribers: 0,
+          queuedEvents: 0,
+          subscriberCapacity: 2,
+          highWaterQueuedEvents: 2,
+          overflowCount: 1,
+          disconnectCount: 1,
+          resyncRequiredCount: 1,
+          lastOverflowReason: "subscriber-capacity",
+        },
+      });
+
+      const fresh = client.subscribe()[Symbol.asyncIterator]();
+      const freshNext = fresh.next();
+      await vi.waitFor(() => {
+        expect(fixture.eventBus.health()).toMatchObject({ activeSubscribers: 1 });
+      });
+      fixture.eventBus.publish(event);
+      await expect(freshNext).resolves.toEqual({ done: false, value: event });
+      await fresh.return?.();
+      await vi.waitFor(() => {
+        expect(fixture.eventBus.health()).toMatchObject({ activeSubscribers: 0, queuedEvents: 0 });
+      });
+    } finally {
+      await stalled.return?.();
+      await server.close();
+      fixture.sqlite.close();
+    }
+  });
+
   it("does not report generic attach ready when startup cancellation wins", async () => {
     const { dir, socketPath } = await createTempSocketPath();
     const fixture = createObserverFixture(socketPath);
@@ -847,7 +907,7 @@ describe("observer protocol server", () => {
   });
 });
 
-function createObserverFixture(socketPath: string) {
+function createObserverFixture(socketPath: string, subscriberCapacity?: number) {
   const clock = { now: () => new Date(now) };
   const sqlite = openObserverSqlite({ clock });
   const persistence = createSqliteObserverPersistence({
@@ -855,7 +915,9 @@ function createObserverFixture(socketPath: string) {
     clock,
     idFactory: observerIds(),
   });
-  const eventBus = createObserverEventBus();
+  const eventBus = createObserverEventBus(
+    subscriberCapacity === undefined ? {} : { subscriberCapacity },
+  );
   const queue = createCommandQueue({
     persistence,
     clock,
@@ -901,7 +963,7 @@ function createObserverFixture(socketPath: string) {
     eventBus,
     clock,
   });
-  return { api, queue, sqlite, clock };
+  return { api, queue, eventBus, sqlite, clock };
 }
 
 const config: StationConfig = {

--- a/apps/observer/test/unit/event-bus.test.ts
+++ b/apps/observer/test/unit/event-bus.test.ts
@@ -124,4 +124,81 @@ describe("observer event bus", () => {
     await expect(next).resolves.toEqual({ done: false, value: matchingEvent });
     await iterator.return?.();
   });
+
+  it("preserves order through the subscriber capacity and releases returned queues", async () => {
+    const bus = createObserverEventBus({ subscriberCapacity: 2 });
+    const iterator = bus.subscribe()[Symbol.asyncIterator]();
+    const first = failedEvent(1);
+    const second = failedEvent(2);
+
+    bus.publish(first);
+    bus.publish(second);
+
+    expect(bus.health()).toEqual({
+      activeSubscribers: 1,
+      queuedEvents: 2,
+      subscriberCapacity: 2,
+      highWaterQueuedEvents: 2,
+      overflowCount: 0,
+      disconnectCount: 0,
+      resyncRequiredCount: 0,
+    });
+    await expect(iterator.next()).resolves.toEqual({ done: false, value: first });
+    await expect(iterator.next()).resolves.toEqual({ done: false, value: second });
+    expect(bus.health()).toMatchObject({ queuedEvents: 0, highWaterQueuedEvents: 2 });
+
+    await iterator.return?.();
+    expect(bus.health()).toMatchObject({ activeSubscribers: 0, queuedEvents: 0 });
+  });
+
+  it("disconnects only a lagging subscriber while a healthy subscriber stays responsive", async () => {
+    const bus = createObserverEventBus({ subscriberCapacity: 2 });
+    const stalled = bus.subscribe()[Symbol.asyncIterator]();
+    const healthy = bus.subscribe()[Symbol.asyncIterator]();
+
+    for (const sequence of [1, 2, 3]) {
+      const next = healthy.next();
+      const event = failedEvent(sequence);
+      bus.publish(event);
+      await expect(next).resolves.toEqual({ done: false, value: event });
+    }
+
+    expect(bus.health()).toEqual({
+      activeSubscribers: 1,
+      queuedEvents: 0,
+      subscriberCapacity: 2,
+      highWaterQueuedEvents: 2,
+      overflowCount: 1,
+      disconnectCount: 1,
+      resyncRequiredCount: 1,
+      lastOverflowReason: "subscriber-capacity",
+    });
+    await expect(stalled.next()).resolves.toEqual({ done: true, value: undefined });
+
+    const next = healthy.next();
+    const event = failedEvent(4);
+    bus.publish(event);
+    await expect(next).resolves.toEqual({ done: false, value: event });
+    await healthy.return?.();
+
+    expect(bus.health()).toMatchObject({
+      activeSubscribers: 0,
+      queuedEvents: 0,
+      overflowCount: 1,
+      disconnectCount: 1,
+      resyncRequiredCount: 1,
+    });
+  });
 });
+
+function failedEvent(sequence: number): StationEvent {
+  return {
+    type: "command.failed",
+    commandId: `cmd_${sequence}`,
+    error: {
+      tag: "EventBusTestError",
+      code: "EVENT_BUS_TEST",
+      message: `Event bus test ${sequence}.`,
+    },
+  };
+}

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -11814,7 +11814,7 @@
           "specifier": "@station/contracts",
           "resolvedPath": "packages/contracts/src/index.ts",
           "edgeKind": "type-only",
-          "bindings": ["EventFilter", "StationEvent"]
+          "bindings": ["EventFilter", "ObserverEventBusHealth", "StationEvent"]
         },
         {
           "specifier": "@station/runtime",

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -341,11 +341,15 @@ The use case that produces an event owns whether it is persisted and whether
 persistence precedes publication. Callers must not infer a global
 persist-before-publish guarantee.
 
-The process-local event bus is currently unbounded and provides no replay or
-publisher backpressure. The Observer protocol adapter separately bounds each
-connection by frame count, bytes, and socket backpressure. Overflow closes only
-that connection and requires the client to resynchronize from a snapshot.
-Other transports do not inherit this policy automatically.
+The process-local event bus provides no replay or publisher backpressure. Each
+subscriber has a fixed event-count capacity; overflow releases that queue and
+ends only that subscription, requiring the client to resynchronize from a
+snapshot. Observer health reports the current queue depth, per-subscriber
+capacity, high-water depth, and content-free overflow, disconnect,
+resync-required counts and reason. The Observer protocol adapter separately
+bounds each connection by frame count,
+bytes, and socket backpressure. Other transports do not inherit the protocol
+policy automatically.
 
 Observer command records are the default evidence for accepted mutations.
 Process logs, exact-opt-in traces, and debug bundles are best-effort,

--- a/packages/contracts/src/observer.ts
+++ b/packages/contracts/src/observer.ts
@@ -210,6 +210,21 @@ export const HarnessIngressQueueHealthSchema = z
 
 export type HarnessIngressQueueHealth = z.infer<typeof HarnessIngressQueueHealthSchema>;
 
+export const ObserverEventBusHealthSchema = z
+  .object({
+    activeSubscribers: z.number().int().nonnegative(),
+    queuedEvents: z.number().int().nonnegative(),
+    subscriberCapacity: z.number().int().positive(),
+    highWaterQueuedEvents: z.number().int().nonnegative(),
+    overflowCount: z.number().int().nonnegative(),
+    disconnectCount: z.number().int().nonnegative(),
+    resyncRequiredCount: z.number().int().nonnegative(),
+    lastOverflowReason: z.literal("subscriber-capacity").optional(),
+  })
+  .strict();
+
+export type ObserverEventBusHealth = z.infer<typeof ObserverEventBusHealthSchema>;
+
 export const ObserverHealthSchema = z
   .object({
     schemaVersion: SchemaVersionSchema,
@@ -221,6 +236,7 @@ export const ObserverHealthSchema = z
     stateDir: nonEmptyStringSchema.optional(),
     uptimeMs: z.number().nonnegative().optional(),
     hookSpoolDepth: z.number().int().nonnegative().optional(),
+    eventBus: ObserverEventBusHealthSchema.optional(),
     harnessIngressQueue: HarnessIngressQueueHealthSchema.optional(),
     providerHealth: z.record(ProviderIdSchema, ProviderHealthSchema).optional(),
     sqlite: ObserverSqliteHealthSummarySchema.optional(),

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -2353,6 +2353,16 @@ describe("contract schemas", () => {
             finishedAt: "2026-05-20T12:00:02.000Z",
           },
         },
+        eventBus: {
+          activeSubscribers: 1,
+          queuedEvents: 12,
+          subscriberCapacity: 1_024,
+          highWaterQueuedEvents: 64,
+          overflowCount: 1,
+          disconnectCount: 1,
+          resyncRequiredCount: 1,
+          lastOverflowReason: "subscriber-capacity",
+        },
       },
       "observer health",
     );


### PR DESCRIPTION
## What this fixes

A stalled live-event consumer could retain every matching event inside the Observer process-local event bus before delivery reached the separately bounded protocol transport. In three direct 80,000-event runs, current `main` retained a median 507 MiB after cooldown, compared with 50-59 MiB for no-subscriber and draining controls.

Closes #750.

## What changed

- Bound each subscriber to 1,024 queued events without applying publisher backpressure.
- End and release only the lagging subscription when its queue is full; the failed offer cannot become silent event loss because that consumer must reconnect and load a fresh snapshot.
- Drain queued payloads before queue shutdown so retained iterators cannot keep event contents alive.
- Expose payload-free queue depth, capacity, high-water, overflow, disconnect, resync-required, and reason fields through Observer health.
- Document the event-bus overload and convergence contract.

## Testing

- Direct station-mini memory profile: 3 repeats each of no subscriber, draining subscriber, and stalled subscriber; 80,000 events with 4 KiB payloads; forced-GC checkpoints and a 15-second stalled cooldown.
- Fixed stalled median: 54 MiB after cooldown versus 507 MiB on `main` (89% reduction); every run stopped at a 1,024-event high-water mark, reported one overflow/disconnect/resync requirement, and retained zero queued events.
- `bun run test:all` passed on the committed patch before a conflict-free rebase over two unrelated TUI-only commits: build, full typecheck and lint, 3,496 unit tests, 199 contract tests, 922 integration tests, diagnostics, scripted-agent tests, 30 setup E2Es, 29 Observer/session E2Es, and install smoke.
- Final SHA `6d1dcf50`: build, full typecheck, focused event-bus unit tests, contract schema tests, Observer API integration tests, protocol disconnect/resubscribe integration tests, and the commit-time lint/architecture gate all passed.

## User-visible behavior

Healthy clients are unchanged. A client that falls more than 1,024 events behind briefly reconnects and reloads the canonical snapshot instead of growing Observer memory without bound. The diagnostic soak runner and raw evidence are intentionally outside this PR.
