### PR TITLE
feat(worktree): copy configured setup files into new worktrees

### DIFF
--- a/apps/observer/src/reconcile/core.ts
+++ b/apps/observer/src/reconcile/core.ts
@@ -570,6 +570,11 @@ export function providerProjectsFromConfig(config: StationConfig): ProviderProje
     if (project.worktrunk.includeExternal !== undefined) {
       providerProject.worktrunk.includeExternal = project.worktrunk.includeExternal;
     }
+    if (project.setup !== undefined) {
+      providerProject.setup = {
+        copyFromProjectRoot: [...project.setup.copyFromProjectRoot],
+      };
+    }
     if (project.recoveryBreadcrumbs !== undefined) {
       providerProject.recoveryBreadcrumbs = {
         location: project.recoveryBreadcrumbs.location,

--- a/apps/observer/test/integration/metadata-refresh.test.ts
+++ b/apps/observer/test/integration/metadata-refresh.test.ts
@@ -73,6 +73,23 @@ const config: StationConfig = {
 };
 
 describe("observer worktree metadata refresh use case", () => {
+  it("passes global project setup to provider project configuration", () => {
+    const project = config.projects[0];
+    expect(project).toBeDefined();
+    if (project === undefined) throw new Error("Expected the web project fixture.");
+    const [providerProject] = providerProjectsFromConfig({
+      ...config,
+      projects: [
+        {
+          ...project,
+          setup: { copyFromProjectRoot: [".env.local"] },
+        },
+      ],
+    });
+
+    expect(providerProject?.setup).toEqual({ copyFromProjectRoot: [".env.local"] });
+  });
+
   it("merges cached pull request and checks metadata into hot snapshots, including stale rows", async () => {
     const fixture = createFixture();
     await fixture.persistence.upsertWorktreeMetadataCurrent({

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -196,6 +196,7 @@ be unique, and each `root` must exist when the config loads.
 | `worktrunk.base` | string | Overrides the global Worktrunk base. |
 | `worktrunk.managed_root` | string | Relative paths resolve from `project.root`; omitted global roots get a unique project child. |
 | `worktrunk.include_main` / `worktrunk.include_external` | bool | Override the matching global listing policy. |
+| `setup.copy_from_project_root` | string[] | Required regular files copied to the same relative paths in each new worktree before launch. |
 | `recovery_breadcrumbs.location` | enum | Overrides the global breadcrumb location. |
 | `recovery_breadcrumbs.path` | string | Optional breadcrumb path. |
 | `local_config.enabled` | bool | Required in the table; only `true` reads the local file. |
@@ -208,6 +209,23 @@ config file.
 A checkout-style project root with local `core.bare=true` is rejected by
 `stn project add`; Station does not rewrite that Git setting. Use the
 project doctor and [Diagnostics](diagnostics.md) for repair guidance.
+
+Project setup can copy local files that Git does not place in a new worktree:
+
+```toml
+[projects.setup]
+copy_from_project_root = [".env.local", "config/private.json"]
+```
+
+Each entry uses forward-slash relative syntax. Absolute paths, dot path
+components, backslashes, duplicate entries, directories, and symbolic links
+are rejected. The source must resolve inside `project.root` and exist as a
+regular file before Worktrunk creates the worktree. Station copies the files in
+the configured order after fork seeding and before agent launch. Missing parent
+directories are created inside the worktree. An existing regular destination
+is preserved; any other destination type fails setup. A copy failure removes
+the exact newly created worktree. A failed removal reports the worktree identity
+and requires inspection before retrying.
 
 ### `[workspace]` — native Station UI behavior (optional, best-effort)
 
@@ -353,7 +371,7 @@ Only these overrides are accepted:
 | `[commands]` | any command labels | table<string,string> | Additive only; collisions keep the global value and emit `CONFIG_LOCAL_COMMAND_OVERRIDE`. |
 | `[display]` | `group`, `sort_order` | string / int | Shallow merge; local values win. |
 
-`env` cannot be set locally. A missing, unreadable, invalid, or schema-invalid
+`env` and `setup` cannot be set locally. A missing, unreadable, invalid, or schema-invalid
 enabled file leaves the global project block in effect and records a diagnostic;
 the core runtime config remains a hard-failure boundary.
 
@@ -442,6 +460,7 @@ are internal context, not user-facing relocation settings.
 | Change default harness/terminal/layout | `config.toml` | `[defaults]` |
 | Set a project harness or layout | Local config or `config.toml` | `[defaults]` / `[projects.defaults]` |
 | Add project commands | `config.toml` or local config | `[projects.commands]` / `[commands]` |
+| Copy required local files into new worktrees | `config.toml` | `[projects.setup]` |
 | Tune the Observer | `config.toml` | `[observer]` |
 | React to Observer events | `config.toml` | `[[hooks.event]]` |
 | Change native scroll, welcome, or automations | `config.toml` | `[workspace]` |

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -18795,7 +18795,7 @@
       "declaration": "WorktrunkProvider",
       "kind": "class",
       "role": "ADAPTER",
-      "purpose": "Translates Worktrunk lifecycle output and commands into Station worktree contracts. Hook diagnostics use an atomic requester runtime when supplied and retain the whole Observer composition expectation as a fallback. List results are returned without retaining inventory; only the Worktrunk project identifier needed to preserve managed-path precedence is memoized. Checkout roots are validated before Worktrunk runs. Concurrent creates share only an in-flight managed-path identity probe and retain their common-case mutation overlap. Reads and removals drain active creates; the exact nested Git sibling-registration race does the same before Worktrunk resumes its half-created branch. Removal freshly revalidates native Git identity, path, and branch before mutation.",
+      "purpose": "Translates Worktrunk lifecycle output and commands into Station worktree contracts. Hook diagnostics use an atomic requester runtime when supplied and retain the whole Observer composition expectation as a fallback. List results are returned without retaining inventory; only the Worktrunk project identifier needed to preserve managed-path precedence is memoized. Checkout roots are validated before Worktrunk runs. Concurrent creates share only an in-flight managed-path identity probe and retain their common-case mutation overlap. Reads and removals drain active creates; the exact nested Git sibling-registration race does the same before Worktrunk resumes its half-created branch. Removal freshly revalidates native Git identity, path, and branch before mutation. Create validates and copies configured project-root files after any working-tree seed. Copy failure removes the exact new worktree or reports cleanup uncertainty.",
       "dependencies": [
         {
           "path": "packages/contracts/src/observedPaths.ts",
@@ -18952,7 +18952,7 @@
       "declaration": "WorktreeProvider",
       "kind": "interface",
       "role": "DRIVEN PORT",
-      "purpose": "Supplies fresh worktree lifecycle evidence and mutations without exposing provider mechanics. Callers provide project context for mutations; removal adapters must revalidate opaque registration identity, path, and branch immediately before mutation.",
+      "purpose": "Supplies fresh worktree lifecycle evidence and mutations without exposing provider mechanics. Callers provide project context for mutations; removal adapters must revalidate opaque registration identity, path, and branch immediately before mutation. Create adapters complete configured project setup before returning success. A setup failure removes the exact newly created worktree or reports cleanup uncertainty.",
       "dependencies": []
     },
     {

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -18795,7 +18795,7 @@
       "declaration": "WorktrunkProvider",
       "kind": "class",
       "role": "ADAPTER",
-      "purpose": "Translates Worktrunk lifecycle output and commands into Station worktree contracts. Hook diagnostics use an atomic requester runtime when supplied and retain the whole Observer composition expectation as a fallback. List results are returned without retaining inventory; only the Worktrunk project identifier needed to preserve managed-path precedence is memoized. Checkout roots are validated before Worktrunk runs. Concurrent creates share only an in-flight managed-path identity probe and retain their common-case mutation overlap. Reads and removals drain active creates; the exact nested Git sibling-registration race does the same before Worktrunk resumes its half-created branch. Removal freshly revalidates native Git identity, path, and branch before mutation. Create validates and copies configured project-root files after any working-tree seed. Copy failure removes the exact new worktree or reports cleanup uncertainty.",
+      "purpose": "Translates Station worktree lifecycle requests into Worktrunk commands and Worktrunk output into provider-neutral observations.",
       "dependencies": [
         {
           "path": "packages/contracts/src/observedPaths.ts",

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -333,6 +333,13 @@ identity-checked snapshot projection; projection failure preserves the external
 success and falls back to reconciliation rather than publishing speculative
 state.
 
+A worktree provider completes configured project setup before it reports create
+success. The Worktrunk adapter validates project-root copy sources before
+creation, applies them after any fork seed, and returns only after copying
+finishes. A post-create setup failure removes the exact verified worktree or
+reports cleanup uncertainty with that worktree identity. Observer commands do
+not launch an agent from a partially configured worktree.
+
 Managed terminal attachments and release authority stay opaque. Cleanup may
 remove only the exact session and binding generation owned by the attempt; a
 delayed exit or failed rollback must not remove a replacement binding. An

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -138,6 +138,9 @@ aliases = ["app"]
 root = "~/projects/mobile"
 repo = "github.com/my-org/mobile"
 
+[projects.setup]
+copy_from_project_root = [".env.local"]
+
 [projects.defaults]
 harness = "opencode"
 

--- a/integrations/worktree/worktrunk/src/errors.ts
+++ b/integrations/worktree/worktrunk/src/errors.ts
@@ -1,4 +1,4 @@
-import type { DiagnosticDetail, SafeError } from "@station/contracts";
+import type { DiagnosticDetail, SafeError, WorktreeId } from "@station/contracts";
 
 export type WorktrunkProviderErrorCode =
   | "WORKTRUNK_BRANCH_EXISTS"
@@ -9,6 +9,9 @@ export type WorktrunkProviderErrorCode =
   | "WORKTRUNK_BASE_MISSING"
   | "WORKTRUNK_PROJECT_ROOT_BARE"
   | "WORKTRUNK_SEED_FAILED"
+  | "WORKTRUNK_SETUP_CLEANUP_FAILED"
+  | "WORKTRUNK_SETUP_COPY_FAILED"
+  | "WORKTRUNK_SETUP_SOURCE_INVALID"
   | "WORKTRUNK_TIMEOUT"
   | "WORKTRUNK_UNAVAILABLE"
   | "WORKTRUNK_UNSUPPORTED_FLAG"
@@ -22,6 +25,7 @@ export class WorktrunkProviderError extends Error implements SafeError {
   readonly code: WorktrunkProviderErrorCode;
   readonly hint?: string;
   readonly projectId?: string;
+  readonly worktreeId?: WorktreeId;
   readonly diagnosticDetails?: DiagnosticDetail[];
 
   constructor(
@@ -30,6 +34,7 @@ export class WorktrunkProviderError extends Error implements SafeError {
     options: {
       hint?: string;
       projectId?: string;
+      worktreeId?: WorktreeId;
       cause?: unknown;
       diagnosticDetails?: DiagnosticDetail[];
     } = {},
@@ -46,6 +51,9 @@ export class WorktrunkProviderError extends Error implements SafeError {
     }
     if (options.projectId !== undefined) {
       this.projectId = options.projectId;
+    }
+    if (options.worktreeId !== undefined) {
+      this.worktreeId = options.worktreeId;
     }
     if (options.diagnosticDetails !== undefined) {
       this.diagnosticDetails = options.diagnosticDetails;

--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -92,16 +92,8 @@ type ProjectSetupPlan = {
 /**
  * ADAPTER
  *
- * Translates Worktrunk lifecycle output and commands into Station worktree contracts.
- * Hook diagnostics use an atomic requester runtime when supplied and retain the whole Observer composition
- * expectation as a fallback. List results are returned without retaining inventory; only the Worktrunk
- * project identifier needed to preserve managed-path precedence is memoized. Checkout roots are validated
- * before Worktrunk runs. Concurrent creates share only an in-flight managed-path identity probe and retain
- * their common-case mutation overlap. Reads and removals drain active creates; the exact nested Git
- * sibling-registration race does the same before Worktrunk resumes its half-created branch. Removal freshly
- * revalidates native Git identity, path, and branch before mutation. Create validates and copies configured
- * project-root files after any working-tree seed. Copy failure removes the exact new worktree or reports
- * cleanup uncertainty.
+ * Translates Station worktree lifecycle requests into Worktrunk commands and
+ * Worktrunk output into provider-neutral observations.
  */
 export class WorktrunkProvider implements WorktreeProvider {
   readonly id: ProviderId = "worktrunk";

--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
-import { lstat, mkdtemp, readFile, rm } from "node:fs/promises";
+import { constants } from "node:fs";
+import { chmod, copyFile, lstat, mkdir, mkdtemp, readFile, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, normalize, resolve } from "node:path";
 import type {
@@ -83,6 +84,11 @@ type StaleRegistrationInspection =
   | { status: "completed"; check?: ProviderDoctorCheck }
   | { status: "failed"; check: ProviderDoctorCheck };
 
+type ProjectSetupPlan = {
+  projectRoot: string;
+  relativePaths: string[];
+};
+
 /**
  * ADAPTER
  *
@@ -93,7 +99,9 @@ type StaleRegistrationInspection =
  * before Worktrunk runs. Concurrent creates share only an in-flight managed-path identity probe and retain
  * their common-case mutation overlap. Reads and removals drain active creates; the exact nested Git
  * sibling-registration race does the same before Worktrunk resumes its half-created branch. Removal freshly
- * revalidates native Git identity, path, and branch before mutation.
+ * revalidates native Git identity, path, and branch before mutation. Create validates and copies configured
+ * project-root files after any working-tree seed. Copy failure removes the exact new worktree or reports
+ * cleanup uncertainty.
  */
 export class WorktrunkProvider implements WorktreeProvider {
   readonly id: ProviderId = "worktrunk";
@@ -326,6 +334,7 @@ export class WorktrunkProvider implements WorktreeProvider {
 
   async createWorktree(request: CreateWorktreeRequest): Promise<WorktreeObservation> {
     await this.#assertProjectRootUsable(request.project);
+    const setup = await this.#preflightProjectSetup(request.project);
     const base = request.base ?? request.project.worktrunk.base;
     const pathEnv = worktreePathEnv(request.project, request.branch, request.path);
     const managedPathArgs = await this.#managedWorktreePathArgs(request.project, pathEnv);
@@ -429,7 +438,40 @@ export class WorktrunkProvider implements WorktreeProvider {
         }).catch(() => {});
         throw seedError;
       }
-      // Re-list so the caller sees the post-seed dirty state.
+    }
+    if (setup !== undefined) {
+      try {
+        await this.#copyProjectSetup(request.project, setup, found.path);
+      } catch (copyError) {
+        try {
+          const cleanup = await this.removeWorktree({
+            project: request.project,
+            worktreeId: found.id,
+            expectedPath: found.path,
+            expectedBranch: found.branch,
+            expectedRegistrationIdentity: found.registrationIdentity,
+            force: true,
+          });
+          if (!cleanup.removed) {
+            throw new Error("Worktrunk did not confirm removal.");
+          }
+        } catch (cleanupError) {
+          throw new WorktrunkProviderError(
+            "WORKTRUNK_SETUP_CLEANUP_FAILED",
+            "Station could not confirm cleanup after project setup failed.",
+            {
+              projectId: request.project.id,
+              worktreeId: found.id,
+              hint: `Inspect ${found.path} before retrying worktree creation.`,
+              cause: cleanupError,
+            },
+          );
+        }
+        throw copyError;
+      }
+    }
+    if (request.seedFrom !== undefined || setup !== undefined) {
+      // Re-list so the caller sees the post-setup dirty state.
       const refreshed = (await this.listWorktrees(request.project)).find(
         (observation) => observation.id === found.id,
       );
@@ -438,6 +480,110 @@ export class WorktrunkProvider implements WorktreeProvider {
       }
     }
     return found;
+  }
+
+  async #preflightProjectSetup(
+    project: ProviderProjectConfig,
+  ): Promise<ProjectSetupPlan | undefined> {
+    if (project.setup === undefined) {
+      return undefined;
+    }
+    let projectRoot: string;
+    try {
+      projectRoot = await realpath(project.root);
+    } catch (cause) {
+      throw new WorktrunkProviderError(
+        "WORKTRUNK_SETUP_SOURCE_INVALID",
+        "Station could not resolve the project root for configured setup files.",
+        { projectId: project.id, cause },
+      );
+    }
+    for (const relativePath of project.setup.copyFromProjectRoot) {
+      await this.#validateSetupSource(project, projectRoot, relativePath);
+    }
+    return {
+      projectRoot,
+      relativePaths: [...project.setup.copyFromProjectRoot],
+    };
+  }
+
+  async #validateSetupSource(
+    project: ProviderProjectConfig,
+    projectRoot: string,
+    relativePath: string,
+  ): Promise<{ path: string; mode: number }> {
+    const sourcePath = resolve(projectRoot, relativePath);
+    try {
+      const [metadata, resolvedPath] = await Promise.all([lstat(sourcePath), realpath(sourcePath)]);
+      if (
+        metadata.isSymbolicLink() ||
+        !metadata.isFile() ||
+        !isPathInside(resolvedPath, projectRoot, this.#platform)
+      ) {
+        throw new Error("The setup source is not a regular file inside the project root.");
+      }
+      return { path: sourcePath, mode: metadata.mode };
+    } catch (cause) {
+      throw new WorktrunkProviderError(
+        "WORKTRUNK_SETUP_SOURCE_INVALID",
+        `Configured setup file is unavailable or unsafe: ${relativePath}.`,
+        { projectId: project.id, cause },
+      );
+    }
+  }
+
+  async #copyProjectSetup(
+    project: ProviderProjectConfig,
+    setup: ProjectSetupPlan,
+    worktreePath: string,
+  ): Promise<void> {
+    let worktreeRoot: string;
+    try {
+      worktreeRoot = await realpath(worktreePath);
+    } catch (cause) {
+      throw new WorktrunkProviderError(
+        "WORKTRUNK_SETUP_COPY_FAILED",
+        "Station could not resolve the created worktree for project setup.",
+        { projectId: project.id, cause },
+      );
+    }
+    for (const relativePath of setup.relativePaths) {
+      try {
+        const source = await this.#validateSetupSource(project, setup.projectRoot, relativePath);
+        const components = relativePath.split("/");
+        const fileName = components.pop();
+        if (fileName === undefined) {
+          throw new Error("The setup destination has no file name.");
+        }
+        let parentPath = worktreeRoot;
+        for (const component of components) {
+          parentPath = join(parentPath, component);
+          await ensureSetupDirectory(parentPath);
+        }
+        const resolvedParent = await realpath(parentPath);
+        if (!isPathInside(resolvedParent, worktreeRoot, this.#platform)) {
+          throw new Error("The setup destination resolves outside the worktree.");
+        }
+        const destinationPath = join(resolvedParent, fileName);
+        if (await isExistingRegularFile(destinationPath)) {
+          continue;
+        }
+        await copyFile(source.path, destinationPath, constants.COPYFILE_EXCL);
+        await chmod(destinationPath, source.mode & 0o777);
+      } catch (cause) {
+        if (
+          cause instanceof WorktrunkProviderError &&
+          cause.code === "WORKTRUNK_SETUP_SOURCE_INVALID"
+        ) {
+          throw cause;
+        }
+        throw new WorktrunkProviderError(
+          "WORKTRUNK_SETUP_COPY_FAILED",
+          `Station could not copy configured setup file: ${relativePath}.`,
+          { projectId: project.id, cause },
+        );
+      }
+    }
   }
 
   async #withRegistrationIdentity(observation: WorktreeObservation): Promise<WorktreeObservation> {
@@ -1092,6 +1238,46 @@ function resolveManagedRoot(project: ProviderProjectConfig): string | undefined 
     return undefined;
   }
   return normalize(isAbsolute(configured) ? configured : resolve(project.root, configured));
+}
+
+async function ensureSetupDirectory(path: string): Promise<void> {
+  try {
+    const metadata = await lstat(path);
+    if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+      throw new Error("A setup destination parent is not a directory.");
+    }
+    return;
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw cause;
+    }
+  }
+  try {
+    await mkdir(path);
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code !== "EEXIST") {
+      throw cause;
+    }
+  }
+  const metadata = await lstat(path);
+  if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+    throw new Error("A setup destination parent is not a directory.");
+  }
+}
+
+async function isExistingRegularFile(path: string): Promise<boolean> {
+  try {
+    const metadata = await lstat(path);
+    if (metadata.isSymbolicLink() || !metadata.isFile()) {
+      throw new Error("A setup destination exists but is not a regular file.");
+    }
+    return true;
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw cause;
+  }
 }
 
 function isPathInside(path: string, root: string, platform: NodeJS.Platform): boolean {

--- a/integrations/worktree/worktrunk/test/unit/provider.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/provider.test.ts
@@ -1,4 +1,14 @@
-import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ProviderProjectConfig } from "@station/contracts";
@@ -643,6 +653,167 @@ describe("WorktrunkProvider", () => {
         "--format=json",
       ],
     ]);
+  });
+
+  it("copies configured project-root files and preserves an existing regular destination", async () => {
+    const root = await mkdtemp(join(tmpdir(), "wt-setup-copy-"));
+    const projectRoot = join(root, "project");
+    const worktreePath = join(root, "feature");
+    await mkdir(join(projectRoot, "config"), { recursive: true });
+    await mkdir(join(projectRoot, "nested"), { recursive: true });
+    await writeFile(join(projectRoot, ".env.local"), "source-secret");
+    await chmod(join(projectRoot, ".env.local"), 0o640);
+    await writeFile(join(projectRoot, "config", "private.json"), "source-private");
+    await writeFile(join(projectRoot, "nested", "generated.json"), "nested-source");
+    const configuredProject: ProviderProjectConfig = {
+      ...project,
+      root: projectRoot,
+      setup: {
+        copyFromProjectRoot: [".env.local", "config/private.json", "nested/generated.json"],
+      },
+    };
+    const provider = testProvider({
+      command: "wt",
+      clock: { now: () => new Date(now) },
+      runner: async (input) => {
+        if (input.args?.[0] === "switch") {
+          await mkdir(join(worktreePath, "config"), { recursive: true });
+          await writeFile(join(worktreePath, "config", "private.json"), "existing-private");
+        }
+        return result(
+          input,
+          JSON.stringify([{ path: worktreePath, branch: "feature", dirty: true }]),
+        );
+      },
+    });
+
+    try {
+      await expect(
+        provider.createWorktree({ project: configuredProject, branch: "feature" }),
+      ).resolves.toMatchObject({ branch: "feature", dirty: true });
+      expect(await readFile(join(worktreePath, ".env.local"), "utf8")).toBe("source-secret");
+      expect((await lstat(join(worktreePath, ".env.local"))).mode & 0o777).toBe(0o640);
+      expect(await readFile(join(worktreePath, "config", "private.json"), "utf8")).toBe(
+        "existing-private",
+      );
+      expect(await readFile(join(worktreePath, "nested", "generated.json"), "utf8")).toBe(
+        "nested-source",
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects missing and symlinked setup sources before Worktrunk creates a worktree", async () => {
+    const root = await mkdtemp(join(tmpdir(), "wt-setup-source-"));
+    const projectRoot = join(root, "project");
+    const outsideRoot = join(root, "outside");
+    await mkdir(projectRoot, { recursive: true });
+    await mkdir(outsideRoot, { recursive: true });
+    const calls: ExternalCommandInput[] = [];
+    const provider = testProvider({
+      runner: async (input) => {
+        calls.push(input);
+        return result(input, "[]");
+      },
+    });
+    const configuredProject: ProviderProjectConfig = {
+      ...project,
+      root: projectRoot,
+      setup: { copyFromProjectRoot: [".env.local"] },
+    };
+
+    try {
+      await expect(
+        provider.createWorktree({ project: configuredProject, branch: "missing" }),
+      ).rejects.toMatchObject({ code: "WORKTRUNK_SETUP_SOURCE_INVALID" });
+      await writeFile(join(outsideRoot, ".env.local"), "outside-secret");
+      await symlink(join(outsideRoot, ".env.local"), join(projectRoot, ".env.local"));
+      await expect(
+        provider.createWorktree({ project: configuredProject, branch: "symlink" }),
+      ).rejects.toMatchObject({ code: "WORKTRUNK_SETUP_SOURCE_INVALID" });
+      expect(calls).toEqual([]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("removes the exact new worktree when a later setup destination is unsafe", async () => {
+    const root = await mkdtemp(join(tmpdir(), "wt-setup-rollback-"));
+    const projectRoot = join(root, "project");
+    const outsideRoot = join(root, "outside");
+    const worktreePath = join(root, "feature");
+    await mkdir(join(projectRoot, "nested"), { recursive: true });
+    await mkdir(outsideRoot, { recursive: true });
+    await writeFile(join(projectRoot, ".env.local"), "source-secret");
+    await writeFile(join(projectRoot, "nested", "private.json"), "source-private");
+    const configuredProject: ProviderProjectConfig = {
+      ...project,
+      root: projectRoot,
+      setup: { copyFromProjectRoot: [".env.local", "nested/private.json"] },
+    };
+    const calls: ExternalCommandInput[] = [];
+    const provider = testProvider({
+      runner: async (input) => {
+        calls.push(input);
+        if (input.args?.[0] === "switch") {
+          await mkdir(worktreePath, { recursive: true });
+          await symlink(outsideRoot, join(worktreePath, "nested"));
+        }
+        if (input.args?.includes("remove")) {
+          await rm(worktreePath, { recursive: true, force: true });
+          return result(input, "{}");
+        }
+        return result(input, JSON.stringify([{ path: worktreePath, branch: "feature" }]));
+      },
+    });
+
+    try {
+      await expect(
+        provider.createWorktree({ project: configuredProject, branch: "feature" }),
+      ).rejects.toMatchObject({ code: "WORKTRUNK_SETUP_COPY_FAILED" });
+      expect(calls.some((call) => call.args?.includes("remove"))).toBe(true);
+      await expect(lstat(worktreePath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("reports the worktree identity when setup rollback cannot be confirmed", async () => {
+    const root = await mkdtemp(join(tmpdir(), "wt-setup-cleanup-"));
+    const projectRoot = join(root, "project");
+    const worktreePath = join(root, "feature");
+    await mkdir(projectRoot, { recursive: true });
+    await writeFile(join(projectRoot, "blocked"), "source");
+    const configuredProject: ProviderProjectConfig = {
+      ...project,
+      root: projectRoot,
+      setup: { copyFromProjectRoot: ["blocked"] },
+    };
+    const provider = testProvider({
+      runner: async (input) => {
+        if (input.args?.[0] === "switch") {
+          await mkdir(join(worktreePath, "blocked"), { recursive: true });
+        }
+        if (input.args?.includes("remove")) {
+          throw Object.assign(new Error("remove failed"), { code: "EACCES" });
+        }
+        return result(input, JSON.stringify([{ path: worktreePath, branch: "feature" }]));
+      },
+    });
+
+    try {
+      await expect(
+        provider.createWorktree({ project: configuredProject, branch: "feature" }),
+      ).rejects.toMatchObject({
+        code: "WORKTRUNK_SETUP_CLEANUP_FAILED",
+        worktreeId: expect.stringMatching(/^wt_web_feature_/),
+        hint: expect.stringContaining(worktreePath),
+      });
+      await expect(lstat(worktreePath)).resolves.toBeDefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it("drains concurrent creates before resuming a branch left by Git registry initialization", async () => {

--- a/packages/config/src/load/normalize.ts
+++ b/packages/config/src/load/normalize.ts
@@ -296,6 +296,7 @@ function normalizeProjectConfig(value: unknown): unknown {
       worktrunk: normalizeProjectWorktrunkConfig,
       commands: preserveRecordKeys,
       env: preserveRecordKeys,
+      setup: normalizeProjectSetupConfig,
       display: normalizeDisplayConfig,
       localConfig: normalizeProjectLocalConfigRef,
       recoveryBreadcrumbs: normalizeProjectRecoveryBreadcrumbsConfig,
@@ -309,6 +310,12 @@ function normalizeProjectDefaults(value: unknown): unknown {
 
 function normalizeProjectWorktrunkConfig(value: unknown): unknown {
   return normalizeObject(value);
+}
+
+function normalizeProjectSetupConfig(value: unknown): unknown {
+  return normalizeObject(value, {
+    copy_from_project_root: "copyFromProjectRoot",
+  });
 }
 
 function normalizeDisplayConfig(value: unknown): unknown {

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -2,6 +2,7 @@ import {
   FeatureFlagConfigSchema,
   HarnessPermissionModeSchema,
   ObserverEventHookConfigSchema,
+  ProjectSetupConfigSchema,
   TuiConfigSchema,
 } from "@station/contracts";
 import { z } from "zod";
@@ -79,6 +80,7 @@ export const ProjectConfigSchema = z
     worktrunk: ProjectWorktrunkConfigSchema,
     commands: z.record(nonEmptyStringSchema, nonEmptyStringSchema).optional(),
     env: z.record(nonEmptyStringSchema, z.string()).optional(),
+    setup: ProjectSetupConfigSchema.optional(),
     display: ProjectDisplayConfigSchema.optional(),
     localConfig: ProjectLocalConfigRefSchema.optional(),
     recoveryBreadcrumbs: ProjectRecoveryBreadcrumbsSchema.optional(),

--- a/packages/config/test/fixtures/valid-config.json
+++ b/packages/config/test/fixtures/valid-config.json
@@ -109,6 +109,9 @@
       "env": {
         "NODE_ENV": "development"
       },
+      "setup": {
+        "copyFromProjectRoot": [".env.local"]
+      },
       "display": {
         "group": "work",
         "sortOrder": 10

--- a/packages/config/test/unit/config-schema.test.ts
+++ b/packages/config/test/unit/config-schema.test.ts
@@ -33,6 +33,9 @@ describe("config schemas", () => {
     expect(parsed.projects[0]?.recoveryBreadcrumbs).toEqual({
       location: "external",
     });
+    expect(parsed.projects[0]?.setup).toEqual({
+      copyFromProjectRoot: [".env.local"],
+    });
     expect(parsed.terminal?.tmux?.workbenchSocketPath).toBe("~/.local/state/station/tmux.sock");
   });
 
@@ -62,6 +65,12 @@ describe("config schemas", () => {
       ProjectLocalConfigSchema.safeParse({
         schemaVersion: 1,
         projects: [{ id: "web" }],
+      }).success,
+    ).toBe(false);
+    expect(
+      ProjectLocalConfigSchema.safeParse({
+        schemaVersion: 1,
+        setup: { copyFromProjectRoot: [".env.local"] },
       }).success,
     ).toBe(false);
   });

--- a/packages/config/test/unit/load-config.test.ts
+++ b/packages/config/test/unit/load-config.test.ts
@@ -48,6 +48,7 @@ function projectToml(
     defaults?: string;
     localConfig?: string;
     commands?: string;
+    setup?: string;
     recoveryBreadcrumbs?: string;
     label?: string;
     worktrunk?: string;
@@ -73,6 +74,7 @@ ${options.worktrunk ?? ""}
 
 ${options.defaults ?? ""}
 ${options.commands ?? ""}
+${options.setup ?? ""}
 ${options.localConfig ?? ""}
 ${options.recoveryBreadcrumbs ?? ""}
 `;
@@ -1154,6 +1156,55 @@ enabled = true
     });
   });
 
+  it("normalizes global project setup file copies", async () => {
+    const tempDir = await makeTempDir();
+    const root = await makeProjectRoot(tempDir, "web");
+    await writeProjectLocalConfig(root, 'schema_version = 1\n[defaults]\nharness = "opencode"\n');
+    const loaded = await loadConfigFromToml(
+      baseToml(
+        projectToml("web", root, {
+          setup: `
+[projects.setup]
+copy_from_project_root = [".env.local", "config/private.json"]
+`,
+          localConfig: `
+[projects.local_config]
+enabled = true
+path = ".station/config.toml"
+`,
+        }),
+      ),
+      { configPath: join(tempDir, "config.toml"), homeDir: tempDir },
+    );
+
+    expect(loaded.projects[0]?.setup).toEqual({
+      copyFromProjectRoot: [".env.local", "config/private.json"],
+    });
+    expect(loaded.projects[0]?.defaults.harness).toBe("opencode");
+  });
+
+  it("rejects unsafe global project setup file paths", async () => {
+    const tempDir = await makeTempDir();
+    const root = await makeProjectRoot(tempDir, "web");
+
+    await expect(
+      loadConfigFromToml(
+        baseToml(
+          projectToml("web", root, {
+            setup: `
+[projects.setup]
+copy_from_project_root = ["../.env.local"]
+`,
+          }),
+        ),
+        { configPath: join(tempDir, "config.toml"), homeDir: tempDir },
+      ),
+    ).rejects.toMatchObject({
+      tag: "ConfigError",
+      code: "CONFIG_VALIDATION_FAILED",
+    });
+  });
+
   it("ignores project-local config unless explicitly enabled", async () => {
     const tempDir = await makeTempDir();
     const root = await makeProjectRoot(tempDir, "web");
@@ -1264,6 +1315,9 @@ root = "/tmp/shadow"
 [harness.codex]
 permission_mode = "yolo"
 approval_policy = "never"
+
+[setup]
+copy_from_project_root = [".env.local"]
 `,
     );
 

--- a/packages/contracts/src/providers.ts
+++ b/packages/contracts/src/providers.ts
@@ -1,4 +1,4 @@
-import { isAbsolute } from "node:path";
+import { isAbsolute, win32 } from "node:path";
 import { z } from "zod";
 import type { TerminalFocusOrigin } from "./commands/terminal.js";
 import { SafeErrorSchema } from "./errors.js";
@@ -135,6 +135,46 @@ export const ProviderProjectRecoveryBreadcrumbsSchema = z
   })
   .strict();
 
+const projectSetupRelativeFileSchema = nonEmptyStringSchema
+  .refine((path) => path.trim() === path, "Setup file paths must not have surrounding whitespace.")
+  .refine((path) => !path.includes("\0"), "Setup file paths must not contain NUL bytes.")
+  .refine((path) => !path.includes("\\"), "Setup file paths must use forward slashes.")
+  .refine(
+    (path) => !isAbsolute(path) && !win32.isAbsolute(path),
+    "Setup file paths must be relative to the project root.",
+  )
+  .refine((path) => !/^[A-Za-z]:/.test(path), "Setup file paths must not use Windows drives.")
+  .refine(
+    (path) =>
+      path
+        .split("/")
+        .every((component) => component !== "" && component !== "." && component !== ".."),
+    "Setup file paths must not contain empty or dot path components.",
+  );
+
+export const ProjectSetupConfigSchema = z
+  .object({
+    copyFromProjectRoot: z
+      .array(projectSetupRelativeFileSchema)
+      .min(1)
+      .superRefine((paths, context) => {
+        const seen = new Set<string>();
+        paths.forEach((path, index) => {
+          if (seen.has(path)) {
+            context.addIssue({
+              code: "custom",
+              message: "Setup file paths must be unique.",
+              path: [index],
+            });
+          }
+          seen.add(path);
+        });
+      }),
+  })
+  .strict();
+
+export type ProjectSetupConfig = z.infer<typeof ProjectSetupConfigSchema>;
+
 export const ProviderProjectConfigSchema = z
   .object({
     id: ProjectIdSchema,
@@ -143,6 +183,7 @@ export const ProviderProjectConfigSchema = z
     defaultBranch: nonEmptyStringSchema.optional(),
     defaults: ProviderProjectDefaultsSchema,
     worktrunk: ProviderProjectWorktrunkConfigSchema,
+    setup: ProjectSetupConfigSchema.optional(),
     recoveryBreadcrumbs: ProviderProjectRecoveryBreadcrumbsSchema.optional(),
   })
   .strict();
@@ -438,7 +479,8 @@ export type RepositoryChecksRequest = z.infer<typeof RepositoryChecksRequestSche
  *
  * Supplies fresh worktree lifecycle evidence and mutations without exposing provider mechanics.
  * Callers provide project context for mutations; removal adapters must revalidate opaque registration identity,
- * path, and branch immediately before mutation.
+ * path, and branch immediately before mutation. Create adapters complete configured project setup before
+ * returning success. A setup failure removes the exact newly created worktree or reports cleanup uncertainty.
  */
 export interface WorktreeProvider {
   id: ProviderId;

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -39,6 +39,7 @@ import {
   ObserverStopReceiptSchema,
   type ProjectId,
   ProjectIdSchema,
+  ProjectSetupConfigSchema,
   ProviderHealthSchema,
   ProviderHookArtifactOwnershipSchema,
   ProviderHookEventSchema,
@@ -2851,12 +2852,45 @@ describe("contract schemas", () => {
           enabled: true,
           base: "main",
         },
+        setup: {
+          copyFromProjectRoot: [".env.local", "config/private.json"],
+        },
         recoveryBreadcrumbs: {
           location: "worktree",
           path: ".station/recovery-breadcrumb.json",
         },
       },
       "provider project config",
+    );
+    expectParses(
+      ProjectSetupConfigSchema,
+      { copyFromProjectRoot: [".env.local", "config/private.json"] },
+      "project setup config",
+    );
+    for (const copyFromProjectRoot of [
+      [],
+      [".env.local", ".env.local"],
+      ["/tmp/.env"],
+      ["C:\\private\\.env"],
+      ["C:private.env"],
+      ["../.env"],
+      ["config/../.env"],
+      ["config//.env"],
+      ["config/"],
+      [" config/.env"],
+      ["config\\.env"],
+      ["config/\0.env"],
+    ]) {
+      expectFails(
+        ProjectSetupConfigSchema,
+        { copyFromProjectRoot },
+        `unsafe project setup path list ${JSON.stringify(copyFromProjectRoot)}`,
+      );
+    }
+    expectFails(
+      ProjectSetupConfigSchema,
+      { copyFromProjectRoot: [".env.local"], command: "pnpm install" },
+      "project setup config with unsupported field",
     );
     expectParses(
       RecoveryBreadcrumbSchema,


### PR DESCRIPTION
## What this fixes

Station creates a worktree before launching its session command. Project-local files that Git intentionally ignores, such as `.env.local`, are therefore absent and can make the command fail immediately. Projects need a declarative way to copy required files without granting configuration an arbitrary command hook.

## What changed

- Add global `[projects.setup] copy_from_project_root` configuration for project-relative regular files. Project-local configuration cannot override setup.
- Pass the typed setup configuration through Observer reconciliation to the worktree provider.
- Preflight every source before Worktrunk creates the worktree, then copy configured files after optional fork seeding and before creation returns success.
- Reject absolute paths, traversal, backslashes, duplicate entries, symbolic links, directories, and paths that resolve outside either root.
- Preserve existing regular destination files and source permission bits.
- Remove the exact newly created worktree when copying fails. Report the worktree identity when cleanup cannot be confirmed.
- Document the configuration and update the generated Observer architecture manifest.

## Testing

- `bun run typecheck`
- `bun run lint`
- Focused contract tests: 31 passed
- Focused config and Worktrunk tests: 120 passed
- Focused Observer integration tests: 17 passed
- Full unit suite with four workers: 3,502 passed
- Contract, integration, diagnostics, scripted-agent, setup E2E, and Observer E2E gates passed
- `bun run smoke:install`

`bun run test:all` was also attempted. Under default unit concurrency, an unchanged protocol transport test timed out twice at its 10-second limit. The protocol file passed 36/36 in isolation, and the complete unit suite passed with `--maxWorkers=4`.

## Safety and scope

Setup accepts file copies only; it does not execute project-defined commands. Source contents are not included in errors or logs. Missing or unsafe sources fail before worktree creation, while post-creation failures trigger identity-checked cleanup.