### PR TITLE
fix(claude): preserve Shift+Enter soft newlines

### DIFF
--- a/integrations/harness/claude/src/provider.ts
+++ b/integrations/harness/claude/src/provider.ts
@@ -51,7 +51,7 @@ const baseCapabilities: HarnessCapabilities = {
   canStop: false,
   canRunNonInteractive: true,
   canExposeApprovalState: true,
-  supportsModifiedEnterSoftNewline: false,
+  supportsModifiedEnterSoftNewline: true,
 };
 
 export const claudeHarnessCommandDefinition = {

--- a/integrations/harness/claude/test/unit/provider.test.ts
+++ b/integrations/harness/claude/test/unit/provider.test.ts
@@ -22,7 +22,7 @@ describe("ClaudeHarnessProvider", () => {
       canStop: false,
       canRunNonInteractive: true,
       canExposeApprovalState: true,
-      supportsModifiedEnterSoftNewline: false,
+      supportsModifiedEnterSoftNewline: true,
     });
   });
 


### PR DESCRIPTION
## What this fixes

Station uses each harness provider's modified-Enter capability when a managed agent pane does not have current keyboard-negotiation evidence. Claude Code supports Shift+Enter for multiline prompts, but Station advertised that capability as unsupported. Station could therefore convert Shift+Enter to ordinary Enter and submit the prompt instead of inserting a newline, especially after attaching to an existing Claude pane.

## What changed

- Advertise Claude Code's modified-Enter soft-newline support through the existing provider-neutral capability.
- Update the Claude provider contract assertion.
- Keep plain shell panes and other harness providers on their existing input policy.

## Testing

- `bun run build`
- `bun run --cwd integrations/harness/claude typecheck`
- `bun run test:unit -- integrations/harness/claude/test/unit/provider.test.ts` (14 passed)
- `bun test station/src/input/stationInput.test.ts station/src/input/runtime/sequenceNormalize.test.ts station/src/terminal/input/kittyToLegacy.test.ts` (92 passed)
- Contracts, integration, diagnostics, scripted-agent, setup E2E, Observer E2E, and installer smoke phases passed.
- `bun run test:all` passed build, typecheck, and lint, then hit unrelated load-sensitive timeouts in the protocol transport and tmux popup unit tests. Those files passed independently (36/36 and 17/17).

## User-visible behavior

Shift+Enter inserts a newline in a managed Claude Code prompt after fresh launch or attachment. Plain Enter still submits the prompt.
