### PR TITLE
test(release): prove update convergence across release boundaries

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       manual_acceptance:
-        description: Confirm macOS partial crossover preserved old Host output and the target native UI visibly refused it
+        description: Confirm documented native/tmux acceptance, current-target convergence, and preserved refusal
         required: true
         type: boolean
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -444,11 +444,10 @@ jobs:
           /bin/sh -n "$installer"
           grep -Fx "embedded_version=\"$TAG\"" "$installer"
           chmod 0700 "$installer"
-      - name: Fetch staged update assets and exact predecessor
+      - name: Fetch staged update assets
         if: runner.os == 'macOS'
         env:
           GH_TOKEN: ${{ github.token }}
-          PREVIOUS_TAG: ${{ needs.validate.outputs.previous_tag }}
           RELEASE_ID: ${{ needs['create-draft'].outputs.release_id }}
           TAG: ${{ needs.validate.outputs.tag }}
           TARGET: ${{ matrix.target }}
@@ -470,13 +469,17 @@ jobs:
             grep -E "  (install\\.sh|stn-v$target_version-$TARGET\\.tar\\.gz)$" SHA256SUMS |
               sha256sum -c -
           )
-
+      - name: Prepare exact predecessor
+        if: runner.os == 'macOS'
+        env:
+          PREVIOUS_TAG: ${{ needs.validate.outputs.previous_tag }}
+        run: |
+          unset GH_TOKEN GITHUB_TOKEN GH_ENTERPRISE_TOKEN GITHUB_ENTERPRISE_TOKEN
           predecessor_installer="$RUNNER_TEMP/previous-install.sh"
-          env -u GH_TOKEN -u GITHUB_TOKEN -u GH_ENTERPRISE_TOKEN -u GITHUB_ENTERPRISE_TOKEN \
-            curl --disable --fail --silent --show-error --location \
-              --proto '=https' --proto-redir '=https' --tlsv1.2 \
-              --output "$predecessor_installer" \
-              "https://github.com/$GITHUB_REPOSITORY/releases/download/$PREVIOUS_TAG/install.sh"
+          curl --disable --fail --silent --show-error --location \
+            --proto '=https' --proto-redir '=https' --tlsv1.2 \
+            --output "$predecessor_installer" \
+            "https://github.com/$GITHUB_REPOSITORY/releases/download/$PREVIOUS_TAG/install.sh"
           grep -Fx "embedded_version=\"$PREVIOUS_TAG\"" "$predecessor_installer"
           previous_home="$RUNNER_TEMP/update-incumbent-home"
           previous_bin="$RUNNER_TEMP/update-incumbent/bin"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -409,6 +409,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
           ref: ${{ needs.validate.outputs.commit }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -484,6 +485,19 @@ jobs:
             XDG_DATA_HOME="$previous_home/.local/share" \
             /bin/sh "$predecessor_installer" --install-dir "$previous_bin"
           test "$("$previous_bin/stn" --version)" = "${PREVIOUS_TAG#v}"
+
+          predecessor_source="$RUNNER_TEMP/update-predecessor-source"
+          predecessor_commit="$(git rev-parse "$PREVIOUS_TAG^{commit}")"
+          git worktree add --detach "$predecessor_source" "$predecessor_commit"
+          (
+            cd "$predecessor_source"
+            test "$(node -p 'require("./package.json").version')" = "${PREVIOUS_TAG#v}"
+            bun install --frozen-lockfile
+            bun run build
+            bun run --cwd station repair:node-pty
+            test -f station/node_modules/node-pty/package.json
+            test -s packages/runtime/dist/station-build-id
+          )
       - name: Seed existing installation
         run: |
           install_home="$RUNNER_TEMP/install-home"
@@ -572,7 +586,8 @@ jobs:
             --target-release-dir "$RUNNER_TEMP/update-release" \
             --target-tag "$TAG" \
             --target-build-identity "$target_build_identity" \
-            --scenarios full \
+            --predecessor-source-dir "$RUNNER_TEMP/update-predecessor-source" \
+            --scenarios release \
             --busy-host-outcome preserved-refusal
       - name: Verify lock refusal and same-version retry
         env:

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Station gives every agent an isolated Git worktree, keeps its terminal session a
 ## Install
 
 Station is experimental pre-alpha software. Install the current public version,
-`v0.0.0-pre-alpha.14.3`, with one command:
+`v0.0.0-pre-alpha.14.4`, with one command:
 
 ```sh
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.3/install.sh | sh
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.4/install.sh | sh
 ```
 
 Then complete and verify first-run setup:
@@ -125,11 +125,11 @@ Paste this prompt into a coding agent running on the machine where you want
 Station installed:
 
 ```text
-Install experimental Station v0.0.0-pre-alpha.14.3 and validate setup on this machine.
+Install experimental Station v0.0.0-pre-alpha.14.4 and validate setup on this machine.
 
 Safety and scope:
 - Do not clone the repository or build from source. Use only
-  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.3/install.sh`.
+  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.4/install.sh`.
 - Install to `~/.local/bin` unless I approve another location. Do not edit any
   shell startup file. If the installer reports a PATH mismatch, do not assume
   an export persists across agent tool calls or reaches my Terminal. Use the
@@ -208,7 +208,7 @@ or real-agent lanes.
 
 ## Release status
 
-Station `v0.0.0-pre-alpha.14.3` is an experimental pre-alpha. User-facing commands,
+Station `v0.0.0-pre-alpha.14.4` is an experimental pre-alpha. User-facing commands,
 configuration, state, and release packaging may change without compatibility.
 The old `v0.7.1-rc.*` releases were internal previews, not predecessors in the
 public version line. Report feedback and bugs through

--- a/apps/cli/src/commands/observer.ts
+++ b/apps/cli/src/commands/observer.ts
@@ -140,7 +140,7 @@ function takeTimeoutOption(
   };
 }
 
-export function observerCommandSummary(result: ObserverCommandResult): unknown {
+export function observerCommandSummary(result: ObserverCommandResult, action?: string): unknown {
   if ("plan" in result) {
     const { plan, applied } = result;
     return {
@@ -169,7 +169,9 @@ export function observerCommandSummary(result: ObserverCommandResult): unknown {
     const health =
       "restartResultSchema" in result && result.restartResultSchema === "0.12.0"
         ? previousObserverHealth(result.health)
-        : result.health;
+        : action === "restart"
+          ? updateCrossoverObserverHealth(result.health)
+          : result.health;
     return {
       status: result.status,
       socketPath: result.paths.socketPath,
@@ -181,6 +183,28 @@ export function observerCommandSummary(result: ObserverCommandResult): unknown {
     return result;
   }
   return result satisfies ObserverStopReceipt;
+}
+
+function updateCrossoverObserverHealth(health: ObserverHealth): Omit<ObserverHealth, "eventBus"> {
+  // Update callers strictly parse restart results, so additive health fields stay excluded.
+  const result: Omit<ObserverHealth, "eventBus"> = {
+    schemaVersion: health.schemaVersion,
+    status: health.status,
+  };
+  if (health.pid !== undefined) result.pid = health.pid;
+  if (health.startedAt !== undefined) result.startedAt = health.startedAt;
+  if (health.version !== undefined) result.version = health.version;
+  if (health.socketPath !== undefined) result.socketPath = health.socketPath;
+  if (health.stateDir !== undefined) result.stateDir = health.stateDir;
+  if (health.uptimeMs !== undefined) result.uptimeMs = health.uptimeMs;
+  if (health.hookSpoolDepth !== undefined) result.hookSpoolDepth = health.hookSpoolDepth;
+  if (health.harnessIngressQueue !== undefined) {
+    result.harnessIngressQueue = health.harnessIngressQueue;
+  }
+  if (health.providerHealth !== undefined) result.providerHealth = health.providerHealth;
+  if (health.sqlite !== undefined) result.sqlite = health.sqlite;
+  if (health.lastReconcile !== undefined) result.lastReconcile = health.lastReconcile;
+  return result;
 }
 
 type PreviousObserverHealth = Omit<ObserverHealth, "schemaVersion" | "providerHealth"> & {

--- a/apps/cli/src/commands/registry/host.ts
+++ b/apps/cli/src/commands/registry/host.ts
@@ -1,7 +1,31 @@
-import { safeErrorFromUnknown } from "@station/runtime";
+import { stationHostSocketPath } from "@station/config";
+import {
+  type HostHandoffFidelity,
+  projectStationHostUpdateCrossoverError,
+  type StationHostConvergenceCommand,
+  type StationHostTargetBuild,
+  type StationHostUpdateCrossoverResult,
+  StationHostUpdateCrossoverResultSchema,
+  stationHostEvidenceMatchesTargetBuild,
+  stationHostTerminalsAreHandoffEligible,
+} from "@station/contracts";
+import { stationHostSafeError } from "@station/host";
+import { safeErrorFromUnknown, stationBuildInfo } from "@station/runtime";
+import {
+  convergeStationHost,
+  inspectStationHost,
+  recoverExactStationHostOrphans,
+} from "@station/terminal";
+import { resolveObserverPaths } from "../../paths.js";
 import { loadedConfigCommandOptions } from "../cliCommand/helpers.js";
 import type { CliCommandNode, CliCommandRunContext } from "../cliCommand/types.js";
-import { hostCommandSummary, runHostCommand } from "../host/index.js";
+import { parseHostArgs } from "../host/args.js";
+import {
+  type HostCommandDeps,
+  hostCommandSummary,
+  resolveStationHostCommand,
+  runHostCommand,
+} from "../host/index.js";
 
 export const hostCliCommand: CliCommandNode = {
   name: "host",
@@ -48,7 +72,21 @@ export const hostCliCommand: CliCommandNode = {
 
 async function runHostCliCommand(context: CliCommandRunContext) {
   const options = loadedConfigCommandOptions(context);
+  const updateCrossover = context.args.includes("--update-crossover");
   try {
+    if (updateCrossover) {
+      const fidelity = parseUpdateCrossover(context.args);
+      await runUpdateHostCrossover(fidelity, options, context.options.hostDeps);
+      const result: StationHostUpdateCrossoverResult = {
+        schemaVersion: 1,
+        status: "completed",
+      };
+      return {
+        code: 0,
+        output: `${JSON.stringify(StationHostUpdateCrossoverResultSchema.parse(result))}\n`,
+        outputFormat: "text" as const,
+      };
+    }
     const result = await runHostCommand(context.args, options, context.options.hostDeps);
     const failed =
       (result.action === "handoff" &&
@@ -65,10 +103,109 @@ async function runHostCliCommand(context: CliCommandRunContext) {
       code: "HOST_COMMAND_FAILED",
       message: "Host command failed.",
     });
+    if (!updateCrossover) {
+      return {
+        code: 2,
+        output: `${normalized.message}\n`,
+        outputFormat: "text" as const,
+      };
+    }
+    const result: StationHostUpdateCrossoverResult = {
+      schemaVersion: 1,
+      status: "failed",
+      error: projectStationHostUpdateCrossoverError(normalized),
+    };
     return {
-      code: 2,
-      output: `${normalized.message}\n`,
+      code: 1,
+      output: `${JSON.stringify(StationHostUpdateCrossoverResultSchema.parse(result))}\n`,
       outputFormat: "text" as const,
     };
   }
+}
+
+function parseUpdateCrossover(args: readonly string[]): HostHandoffFidelity {
+  if (args.filter((arg) => arg === "--update-crossover").length !== 1) {
+    throw new Error("Host update crossover may be selected only once.");
+  }
+  const parsed = parseHostArgs(args.filter((arg) => arg !== "--update-crossover"));
+  if (parsed.action !== "handoff" || parsed.dryRun) {
+    throw new Error("Host update crossover requires a non-preview handoff.");
+  }
+  return parsed.fidelity;
+}
+
+async function runUpdateHostCrossover(
+  fidelity: HostHandoffFidelity,
+  options: ReturnType<typeof loadedConfigCommandOptions>,
+  deps: HostCommandDeps = {},
+): Promise<void> {
+  const targetBuild: StationHostTargetBuild =
+    deps.expectedBuildVersion !== undefined && deps.expectedBuildIdentity !== undefined
+      ? {
+          buildVersion: deps.expectedBuildVersion,
+          buildIdentity: deps.expectedBuildIdentity,
+        }
+      : (() => {
+          const build = stationBuildInfo();
+          return {
+            buildVersion: deps.expectedBuildVersion ?? build.version,
+            buildIdentity: deps.expectedBuildIdentity ?? build.buildIdentity,
+          };
+        })();
+  const socketPath = stationHostSocketPath(options.config);
+  const stateDir = resolveObserverPaths(options.config).stateDir;
+  const deadlineMs = (deps.now ?? Date.now)() + 12_000;
+  let selectedHostCommand: readonly [string, ...string[]] | undefined;
+  const hostCommand = () => {
+    selectedHostCommand ??= deps.resolveHostCommand?.() ?? resolveStationHostCommand();
+    return selectedHostCommand;
+  };
+  const inspection = await (deps.inspectHost ?? inspectStationHost)({
+    socketPath,
+    expectedBuildVersion: targetBuild.buildVersion,
+  });
+
+  if (inspection.status === "inaccessible" || inspection.status === "unknown") {
+    throw inspection.error;
+  }
+  if (
+    inspection.status === "exact" &&
+    !stationHostEvidenceMatchesTargetBuild(inspection.evidence, targetBuild)
+  ) {
+    if (
+      inspection.evidence.terminals.length > 0 &&
+      !stationHostTerminalsAreHandoffEligible(inspection.evidence.terminals)
+    ) {
+      throw stationHostSafeError(
+        "HOST_UPGRADE_BLOCKED",
+        "Host terminals are not all eligible for live handoff.",
+      );
+    }
+    const common = {
+      targetBuild,
+      socketPath,
+      expected: inspection.evidence,
+      deadlineMs,
+    };
+    const command: StationHostConvergenceCommand =
+      inspection.evidence.terminals.length === 0
+        ? { ...common, action: "replace-idle" }
+        : { ...common, action: "handoff", fidelity };
+    const convergence = await (deps.convergeHost ?? convergeStationHost)({
+      command,
+      targetBuild,
+      socketPath,
+      stateDir,
+      hostCommand: hostCommand(),
+    });
+    if (convergence.status === "failed") throw convergence.error;
+  }
+
+  await (deps.recoverHostOrphans ?? recoverExactStationHostOrphans)({
+    socketPath,
+    stateDir,
+    targetBuild,
+    hostCommand: hostCommand(),
+    deadlineMs,
+  });
 }

--- a/apps/cli/src/commands/registry/observer.ts
+++ b/apps/cli/src/commands/registry/observer.ts
@@ -88,5 +88,5 @@ async function runObserverCliCommand(context: CliCommandRunContext) {
     (action === "start" || action === "restart" || action === "ensure-exact-build") &&
     "status" in result &&
     result.status !== "running";
-  return { code: failedStart ? 1 : 0, output: observerCommandSummary(result) };
+  return { code: failedStart ? 1 : 0, output: observerCommandSummary(result, action) };
 }

--- a/apps/cli/test/integration/codex-hooks-command.test.ts
+++ b/apps/cli/test/integration/codex-hooks-command.test.ts
@@ -800,7 +800,7 @@ function artifactOwner(launcher: string, runtimeKind: "compiled" | "source", dig
     schemaVersion: 1 as const,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.3",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.4",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/integration/host-command.test.ts
+++ b/apps/cli/test/integration/host-command.test.ts
@@ -1,5 +1,6 @@
 import { runCli } from "@station/cli";
 import { stationHostSocketPath } from "@station/config";
+import { StationHostUpdateCrossoverResultSchema } from "@station/contracts";
 import { describe, expect, it, vi } from "vitest";
 import { createTempState, writeConfigToml } from "../../../../tests/support/temp-projects";
 
@@ -8,6 +9,33 @@ const targetIdentity = "b".repeat(64);
 const runningBuild = "0.9.0+incumbent";
 
 describe("registered stn host command", () => {
+  it("retains the strict update Host crossover process boundary", async () => {
+    const fixture = await createTempState();
+    const configPath = await writeConfigToml(fixture.root, fixture.config);
+    const recoverHostOrphans = vi.fn(async () => ({ recoveredPtyIds: [] }));
+    const result = await runCli(
+      ["--config", configPath, "host", "handoff", "--update-crossover", "--fidelity", "processes"],
+      {
+        hostDeps: {
+          expectedBuildVersion: targetBuild,
+          expectedBuildIdentity: targetIdentity,
+          inspectHost: async () => ({ status: "absent" }),
+          recoverHostOrphans,
+          resolveHostCommand: () => ["station-host"],
+        },
+      },
+    );
+
+    expect(result.code).toBe(0);
+    expect(StationHostUpdateCrossoverResultSchema.parse(JSON.parse(String(result.output)))).toEqual(
+      {
+        schemaVersion: 1,
+        status: "completed",
+      },
+    );
+    expect(recoverHostOrphans).toHaveBeenCalledOnce();
+  });
+
   it("preserves complete current status text and invokes no mutation dependency", async () => {
     const fixture = await createTempState();
     const configPath = await writeConfigToml(fixture.root, fixture.config);

--- a/apps/cli/test/integration/installer-binary-update.test.ts
+++ b/apps/cli/test/integration/installer-binary-update.test.ts
@@ -24,7 +24,7 @@ import type { NativeBinaryRelease } from "../../src/update/githubRelease.js";
 import { createInstallerBinaryUpdateChannel } from "../../src/update/installerBinaryUpdate.js";
 
 const CURRENT_TAG = "v0.7.1-rc.8";
-const TARGET_TAG = "v0.0.0-pre-alpha.14.3";
+const TARGET_TAG = "v0.0.0-pre-alpha.14.4";
 const RECEIPT = "station-installer-binary-v1\n";
 const tempRoots: string[] = [];
 

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -136,7 +136,7 @@ describe("CLI manual-smoke commands", () => {
       "--version",
     ]);
 
-    expect(direct).toEqual({ code: 0, output: "0.0.0-pre-alpha.14.3", outputFormat: "text" });
+    expect(direct).toEqual({ code: 0, output: "0.0.0-pre-alpha.14.4", outputFormat: "text" });
     expect(withMissingConfig).toEqual(direct);
   });
 

--- a/apps/cli/test/integration/observer-commands.test.ts
+++ b/apps/cli/test/integration/observer-commands.test.ts
@@ -1,7 +1,7 @@
 import { chmod, lstat } from "node:fs/promises";
 import { join } from "node:path";
 import { runCli } from "@station/cli";
-import { runObserverCommand } from "@station/cli/internal";
+import { observerCommandSummary, runObserverCommand } from "@station/cli/internal";
 import { listenUnixSocket } from "@station/protocol";
 import { describe, expect, it, vi } from "vitest";
 import { createTempState, writeConfigToml } from "../../../../tests/support/temp-projects";
@@ -12,6 +12,41 @@ const requestedBuildIdentity = "a".repeat(64);
 const requestedBuildVersion = `1.2.3+station.${requestedBuildIdentity}`;
 
 describe("CLI observer commands", () => {
+  it("omits additive health fields from the restart result parsed across update crossover", () => {
+    const health = {
+      schemaVersion: "0.13.0" as const,
+      status: "healthy" as const,
+      pid: 1234,
+      startedAt: now,
+      version: requestedBuildVersion,
+      eventBus: {
+        activeSubscribers: 0,
+        queuedEvents: 0,
+        subscriberCapacity: 1024,
+        highWaterQueuedEvents: 0,
+        overflowCount: 0,
+        disconnectCount: 0,
+        resyncRequiredCount: 0,
+      },
+    };
+    const result = { status: "running" as const, paths: fixturePaths(), health };
+
+    expect(observerCommandSummary(result, "restart")).toEqual({
+      status: "running",
+      socketPath: result.paths.socketPath,
+      health: {
+        schemaVersion: "0.13.0",
+        status: "healthy",
+        pid: 1234,
+        startedAt: now,
+        version: requestedBuildVersion,
+      },
+    });
+    expect(observerCommandSummary(result, "status")).toMatchObject({
+      health: { eventBus: health.eventBus },
+    });
+  });
+
   it("starts, reports status, stops, and restarts through injected process/protocol boundaries", async () => {
     const fixture = await createTempState();
     let running = false;
@@ -417,3 +452,14 @@ describe("CLI observer commands", () => {
     }
   });
 });
+
+function fixturePaths() {
+  return {
+    stateDir: "/state",
+    socketPath: "/runtime/observer.sock",
+    dbPath: "/state/observer.sqlite",
+    logDir: "/state/logs",
+    diagnosticsDir: "/state/diagnostics",
+    hookSpoolDir: "/state/spool/hooks",
+  };
+}

--- a/apps/cli/test/integration/popup-command.test.ts
+++ b/apps/cli/test/integration/popup-command.test.ts
@@ -15,7 +15,7 @@ import { createTempState, writeConfigToml } from "../../../../tests/support/temp
 const now = "2026-05-20T12:00:00.000Z";
 const buildIdentity = "a".repeat(64);
 const observerBuildVersion = `0.0.0-local+station.${buildIdentity}`;
-const higherObserverBuildVersion = `0.0.0-pre-alpha.14.3+station.${buildIdentity}`;
+const higherObserverBuildVersion = `0.0.0-pre-alpha.14.4+station.${buildIdentity}`;
 const tuiObserverBuildMismatchError = {
   tag: "TuiCommandError",
   code: "TUI_OBSERVER_BUILD_MISMATCH",

--- a/apps/cli/test/integration/provider-hook-ownership.test.ts
+++ b/apps/cli/test/integration/provider-hook-ownership.test.ts
@@ -241,7 +241,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.3",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.4",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -171,7 +171,7 @@ describe("CLI setup command", () => {
       schemaVersion: 1 as const,
       launcher: join(root, "source", "bin", "stn-ingress"),
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.14.3",
+      version: "0.0.0-pre-alpha.14.4",
       buildIdentity: "a".repeat(64),
     };
     const current = {

--- a/apps/cli/test/integration/tui-command.test.ts
+++ b/apps/cli/test/integration/tui-command.test.ts
@@ -19,7 +19,7 @@ import { resolveStationWorkspaceDir } from "../../src/stationWorkspace.js";
 const now = "2026-05-20T12:00:00.000Z";
 const buildIdentity = "a".repeat(64);
 const observerBuildVersion = `0.0.0-local+station.${buildIdentity}`;
-const higherObserverBuildVersion = `0.0.0-pre-alpha.14.3+station.${buildIdentity}`;
+const higherObserverBuildVersion = `0.0.0-pre-alpha.14.4+station.${buildIdentity}`;
 const nestedTuiDisabledError = {
   tag: "TuiCommandError",
   code: "NESTED_TUI_DISABLED",

--- a/apps/cli/test/integration/worktrunk-hooks-command.test.ts
+++ b/apps/cli/test/integration/worktrunk-hooks-command.test.ts
@@ -352,7 +352,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.3",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.4",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/unit/installer-binary-update.test.ts
+++ b/apps/cli/test/unit/installer-binary-update.test.ts
@@ -30,7 +30,7 @@ import {
 
 const CURRENT_TAG = "v0.7.1-rc.8";
 const CURRENT_VERSION = CURRENT_TAG.slice(1);
-const TARGET_TAG = "v0.0.0-pre-alpha.14.3";
+const TARGET_TAG = "v0.0.0-pre-alpha.14.4";
 const TARGET_VERSION = TARGET_TAG.slice(1);
 const TARGETS = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"] as const;
 const RECEIPT = "station-installer-binary-v1\n";

--- a/apps/cli/test/unit/observer-process/activation-surfacing.test.ts
+++ b/apps/cli/test/unit/observer-process/activation-surfacing.test.ts
@@ -17,7 +17,7 @@ import { createTempState } from "../../../../../tests/support/temp-projects";
 
 const now = "2026-05-20T12:00:00.000Z";
 const sourceBuildVersion = `0.0.0-pre-alpha.4+station.${"e".repeat(64)}`;
-const compiledBuildVersion = `0.0.0-pre-alpha.14.3+station.${"d".repeat(64)}`;
+const compiledBuildVersion = `0.0.0-pre-alpha.14.4+station.${"d".repeat(64)}`;
 
 const bootReason = "FATAL: socket owned by foreign build dbf7f368";
 

--- a/apps/cli/test/unit/observer-process/setup-observer-activation.test.ts
+++ b/apps/cli/test/unit/observer-process/setup-observer-activation.test.ts
@@ -15,7 +15,7 @@ vi.mock("../../../src/observerProcess.js", async (importActual) => {
 });
 
 const now = "2026-05-20T12:00:00.000Z";
-const compiledBuildVersion = `0.0.0-pre-alpha.14.3+station.${"d".repeat(64)}`;
+const compiledBuildVersion = `0.0.0-pre-alpha.14.4+station.${"d".repeat(64)}`;
 
 restartObserverSpy.mockImplementation(async () => ({
   status: "running",

--- a/apps/cli/test/unit/setup-json-presenter.test.ts
+++ b/apps/cli/test/unit/setup-json-presenter.test.ts
@@ -269,7 +269,7 @@ describe("setup plan projection", () => {
       schemaVersion: 1 as const,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.14.3",
+      version: "0.0.0-pre-alpha.14.4",
       buildIdentity: "a".repeat(64),
     };
     const current = {

--- a/apps/observer/test/unit/observerHandoff.test.ts
+++ b/apps/observer/test/unit/observerHandoff.test.ts
@@ -71,7 +71,7 @@ describe("classifyObserverBuildPrecedence", () => {
   });
 
   it("orders the public pre-alpha after the internal preview version line", () => {
-    const publicPreAlpha = observerBuildVersion("0.0.0-pre-alpha.14.3", higherBuildIdentity);
+    const publicPreAlpha = observerBuildVersion("0.0.0-pre-alpha.14.4", higherBuildIdentity);
     const internalPreview = observerBuildVersion("0.7.1-rc.8", lowerBuildIdentity);
 
     expect(precedenceFor(publicPreAlpha, internalPreview)).toEqual({
@@ -83,7 +83,7 @@ describe("classifyObserverBuildPrecedence", () => {
   });
 
   it("orders the next public pre-alpha epoch after the prior release", () => {
-    const nextEpoch = observerBuildVersion("0.0.0-pre-alpha.14.3", higherBuildIdentity);
+    const nextEpoch = observerBuildVersion("0.0.0-pre-alpha.14.4", higherBuildIdentity);
     const priorRelease = observerBuildVersion("0.0.0-pre-alpha.7", lowerBuildIdentity);
 
     expect(precedenceFor(nextEpoch, priorRelease)).toEqual({

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ can use it or help improve it.
 
 > [!IMPORTANT]
 > Station is experimental pre-alpha software. The current public version is
-> `v0.0.0-pre-alpha.14.3`. Native binaries support macOS 13+ and glibc 2.39+ Linux
+> `v0.0.0-pre-alpha.14.4`. Native binaries support macOS 13+ and glibc 2.39+ Linux
 > on arm64 and x64.
 
 ## Start Here
@@ -26,7 +26,7 @@ Choose the path that matches what you want to do:
 Install the current release:
 
 ```sh
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.3/install.sh | sh
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.4/install.sh | sh
 ```
 
 Then complete and verify setup:

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -10,7 +10,7 @@ only with explicit `stn update --drive-package-manager`; it does not install a
 tap, formula, or cask.
 
 The public installation path for experimental pre-alpha
-`v0.0.0-pre-alpha.14.3` is the exact-tag native installer documented in
+`v0.0.0-pre-alpha.14.4` is the exact-tag native installer documented in
 [Install Station](install.md). Do not use the historical tap for public
 onboarding, and do not update it as part of pre-alpha publication.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,7 +1,7 @@
 # Install Station
 
 Station is experimental pre-alpha software. The current public version is
-`v0.0.0-pre-alpha.14.3`.
+`v0.0.0-pre-alpha.14.4`.
 
 ## Binary Requirements
 
@@ -33,7 +33,7 @@ setup, update, and recovery reference.
 From any directory, run:
 
 ```bash
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.3/install.sh | sh
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.4/install.sh | sh
 ```
 
 The installer downloads only the stamped tag's matching native archive and
@@ -81,7 +81,7 @@ names in a new shell.
 Pass an absolute or home-relative path through the exact installer:
 
 ```bash
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.3/install.sh | \
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.4/install.sh | \
   sh -s -- --install-dir "$HOME/bin"
 ```
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,6 +1,6 @@
 # Limitations and Workarounds
 
-Station `v0.0.0-pre-alpha.14.3` is experimental pre-alpha software. This page
+Station `v0.0.0-pre-alpha.14.4` is experimental pre-alpha software. This page
 lists user-visible constraints and the available operational workaround for
 each one.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -20,12 +20,34 @@ The tag starts `.github/workflows/release.yml`. That workflow runs standard CI,
 builds the four native targets, creates a six-asset draft, exercises the stamped
 draft installer, binds the exact numeric asset IDs and shared target build
 identity, and records an immutable `accepted-release-candidate-*` artifact. The
-macOS candidate lane selects the newest complete immutable predecessor and
-runs the full scenario set: compiled predecessors must preserve and visibly
-refuse busy Hosts whose in-process PTYs cannot hand off, while the no-Host
-scenario must complete the version change. Post-promotion public update checks
-repeat the no-Host discovery, download, and installation proof. The tag
-workflow never publishes the draft automatically.
+macOS candidate lane selects the newest complete immutable predecessor and runs
+seven staged cases. The predecessor artifact runs external and tmux busy
+compiled-Host refusals plus one tmux no-Host update. The refusal cases preserve
+the old Host, PTY, and output, while the no-Host case completes the version
+change. Four more cases start the compiled predecessor runtime, install the
+exact candidate, and then run the candidate CLI against the current artifact:
+no Host, an idle compiled Host, a busy exact-tag source-bridge Host, and a busy
+compiled Bun Host. The compiled predecessor explicitly rejects its source-only
+bridge implementation. The workflow therefore checks out the exact predecessor
+tag, installs its frozen dependencies, builds it, and launches that source Host
+without identity overrides. The runner verifies the source Host and immutable
+compiled Observer against their independently derived build identities because
+the source and release builds can have different output identities. This case
+proves bridge handoff across the exact predecessor source revision, while the
+other cases retain compiled-artifact packaging proof. The first three converge
+the candidate runtime; the busy compiled Bun case returns
+`reap-required` without signaling or changing the installed candidate or old
+runtime.
+
+Every v5 preview and result uses correlated `public-*` aliases instead of local
+project, worktree, session, terminal-target, PTY, and PTY-instance identifiers.
+Successful results include a completed final inspection whose newly derived
+plan is `converged`. `bun run test:ci:binary` runs the same seven cases against
+deterministic same-source binaries; its source bridge uses the current checkout
+with an explicit test identity override. Only the tagged staged lane proves the
+immutable predecessor-to-candidate release boundary. Post-promotion public update
+checks continue to repeat the exact-tag no-Host discovery, download, and
+installation proof. The tag workflow never publishes the draft automatically.
 
 Do not begin manual acceptance until the workflow succeeds. Treat the workflow,
 not this prose, as the source of truth for artifact names, checksums, and target

--- a/integrations/harness/claude/test/unit/hooks.test.ts
+++ b/integrations/harness/claude/test/unit/hooks.test.ts
@@ -354,7 +354,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.3",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.4",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/cursor/test/unit/hooks.test.ts
+++ b/integrations/harness/cursor/test/unit/hooks.test.ts
@@ -419,7 +419,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.3",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.4",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/opencode/test/unit/pluginInstall.test.ts
+++ b/integrations/harness/opencode/test/unit/pluginInstall.test.ts
@@ -643,7 +643,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.3",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.4",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/opencode/test/unit/provider.test.ts
+++ b/integrations/harness/opencode/test/unit/provider.test.ts
@@ -301,7 +301,7 @@ describe("OpenCodeHarnessProvider", () => {
       schemaVersion: 1 as const,
       launcher: join(root, "requester", "bin", "stn-ingress"),
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.14.3",
+      version: "0.0.0-pre-alpha.14.4",
       buildIdentity: "a".repeat(64),
     };
 

--- a/integrations/worktree/worktrunk/test/unit/hooks.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/hooks.test.ts
@@ -266,7 +266,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.3",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.4",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "station",
-  "version": "0.0.0-pre-alpha.14.3",
+  "version": "0.0.0-pre-alpha.14.4",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",
@@ -108,7 +108,7 @@
     "test:env:docker": "node scripts/test-runners/run-setup-container.mjs",
     "test:ci:fast": "bun run build && bun run test:unit && bun run test:contracts && bun run test:diagnostics && bun run test:agent:scripted",
     "test:ci:station": "bun run --cwd station typecheck && bun run --cwd station test && bun run --cwd station test:pty && bun run --cwd station test:pty:bun && bun run test:e2e:host-upgrade",
-    "test:ci:binary": "bun run build:binary -- --version 0.0.0-local && bun run smoke:binary -- --expected-version 0.0.0-local && bun run smoke:update -- --incumbent-binary station/dist/bin/stn --incumbent-version 0.0.0-local --target-source-version 0.0.1-local --busy-host-outcome preserved-refusal",
+    "test:ci:binary": "bun run build:binary -- --version 0.0.0-local && bun run smoke:binary -- --expected-version 0.0.0-local && bun run smoke:update -- --incumbent-binary station/dist/bin/stn --incumbent-version 0.0.0-local --target-source-version 0.0.1-local --scenarios release --busy-host-outcome preserved-refusal",
     "test:all": "bun run build && bun run typecheck && bun run lint && bun run test:unit && bun run test:contracts && bun run test:integration && bun run test:diagnostics && bun run test:agent:scripted && bun run test:e2e:setup && bun run test:e2e:observer && bun run smoke:install",
     "test:pre-push": "bun run lint"
   },

--- a/packages/contracts/src/stationHostConvergence.ts
+++ b/packages/contracts/src/stationHostConvergence.ts
@@ -180,3 +180,40 @@ export const StationHostConvergenceResultSchema = z.union([
   failed,
 ]);
 export type StationHostConvergenceResult = z.infer<typeof StationHostConvergenceResultSchema>;
+
+const stationHostUpdateCrossoverErrorSchema = z
+  .object({
+    tag: z.string().min(1).max(128),
+    code: z.string().min(1).max(128),
+    message: z.string().min(1).max(4_096),
+    hint: z.string().min(1).max(4_096).optional(),
+  })
+  .strict();
+
+/** Strict private result returned to an update caller after Host crossover. */
+export const StationHostUpdateCrossoverResultSchema = z.discriminatedUnion("status", [
+  z.object({ schemaVersion: z.literal(1), status: z.literal("completed") }).strict(),
+  z
+    .object({
+      schemaVersion: z.literal(1),
+      status: z.literal("failed"),
+      error: stationHostUpdateCrossoverErrorSchema,
+    })
+    .strict(),
+]);
+export type StationHostUpdateCrossoverResult = z.infer<
+  typeof StationHostUpdateCrossoverResultSchema
+>;
+
+/** Bounds the SafeError subset accepted across the update crossover process boundary. */
+export function projectStationHostUpdateCrossoverError(
+  error: z.infer<typeof SafeErrorSchema>,
+): z.infer<typeof stationHostUpdateCrossoverErrorSchema> {
+  const projected: z.infer<typeof stationHostUpdateCrossoverErrorSchema> = {
+    tag: error.tag.slice(0, 128),
+    code: error.code.slice(0, 128),
+    message: error.message.slice(0, 4_096),
+  };
+  if (error.hint !== undefined) projected.hint = error.hint.slice(0, 4_096);
+  return projected;
+}

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -123,7 +123,7 @@ describe("contract schemas", () => {
       schemaVersion: 1,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source",
-      version: "0.0.0-pre-alpha.14.3",
+      version: "0.0.0-pre-alpha.14.4",
       buildIdentity: "a".repeat(64),
     } as const;
     const current = {

--- a/packages/contracts/test/schema/diagnostics-schema.test.ts
+++ b/packages/contracts/test/schema/diagnostics-schema.test.ts
@@ -238,7 +238,7 @@ describe("diagnostics schemas", () => {
         schemaVersion: 1,
         launcher: "/checkout/station/bin/stn-ingress",
         runtimeKind: "source",
-        version: "0.0.0-pre-alpha.14.3",
+        version: "0.0.0-pre-alpha.14.4",
         buildIdentity: "a".repeat(64),
       },
     };

--- a/packages/contracts/test/schema/station-host-convergence-schema.test.ts
+++ b/packages/contracts/test/schema/station-host-convergence-schema.test.ts
@@ -3,6 +3,7 @@ import {
   parseStationHostConvergenceCommand,
   StationHostConvergenceCommandSchema,
   StationHostConvergenceResultSchema,
+  StationHostUpdateCrossoverResultSchema,
   stationHostEvidenceMatchesTargetBuild,
   stationHostTerminalsAreHandoffEligible,
 } from "@station/contracts";
@@ -247,6 +248,27 @@ describe("Station Host convergence contracts", () => {
           source: "command-expectation",
           evidence: expected,
         },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("retains the bounded update crossover result", () => {
+    expect(
+      StationHostUpdateCrossoverResultSchema.parse({
+        schemaVersion: 1,
+        status: "failed",
+        error: {
+          tag: "TerminalProviderError",
+          code: "HOST_UPGRADE_BLOCKED",
+          message: "Host terminals cannot cross this release boundary.",
+        },
+      }),
+    ).toMatchObject({ schemaVersion: 1, status: "failed" });
+    expect(
+      StationHostUpdateCrossoverResultSchema.safeParse({
+        schemaVersion: 1,
+        status: "completed",
+        terminalIds: ["private-terminal-id"],
       }).success,
     ).toBe(false);
   });

--- a/packages/harness-shared/test/unit/provider.test.ts
+++ b/packages/harness-shared/test/unit/provider.test.ts
@@ -146,7 +146,7 @@ describe("createTerminalBoundHarnessProvider", () => {
       schemaVersion: 1 as const,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.14.3",
+      version: "0.0.0-pre-alpha.14.4",
       buildIdentity: "a".repeat(64),
     };
 

--- a/packages/runtime/src/buildInfo.ts
+++ b/packages/runtime/src/buildInfo.ts
@@ -28,7 +28,7 @@ export type StationBuildInfo = {
 export function stationBuildInfo(): StationBuildInfo {
   return {
     version:
-      typeof STATION_BUILD_VERSION === "undefined" ? "0.0.0-pre-alpha.14.3" : STATION_BUILD_VERSION,
+      typeof STATION_BUILD_VERSION === "undefined" ? "0.0.0-pre-alpha.14.4" : STATION_BUILD_VERSION,
     compiled: isCompiledBinary(),
     buildIdentity:
       typeof STATION_BUILD_IDENTITY === "undefined"

--- a/packages/runtime/test/unit/buildInfo.test.ts
+++ b/packages/runtime/test/unit/buildInfo.test.ts
@@ -34,14 +34,14 @@ describe("station build info", () => {
     expect(isCompiledBinary()).toBe(false);
     expect(verifyBuildIdentity).not.toHaveBeenCalled();
     expect(stationBuildInfo()).toEqual({
-      version: "0.0.0-pre-alpha.14.3",
+      version: "0.0.0-pre-alpha.14.4",
       compiled: false,
       buildIdentity,
     });
-    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.14.3+station.${buildIdentity}`);
-    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.14.3+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.14.4+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.14.4+station.${buildIdentity}`);
     expect(stationBuildInfo()).toEqual({
-      version: "0.0.0-pre-alpha.14.3",
+      version: "0.0.0-pre-alpha.14.4",
       compiled: false,
       buildIdentity,
     });

--- a/scripts/test-runners/composed-update-report.mjs
+++ b/scripts/test-runners/composed-update-report.mjs
@@ -1,10 +1,20 @@
 import { z } from "zod";
 import {
+  HostHandoffFidelitySchema,
+  ObserverStartupEvidenceSchema,
+  ProviderHookHealthSchema,
+  ProviderHookReconciliationResultSchema,
+  ProviderIdSchema,
   SafeErrorSchema,
   UpdateArtifactSchema,
   UpdateChannelIdSchema,
   UpdateCommandArgvSchema,
   UpdateCommandReportSchema,
+  UpdateCommandStepSchema,
+  UpdateConvergencePlanSchema,
+  UpdateReapHostEvidenceSchema,
+  UpdateReapObserverEvidenceSchema,
+  UpdateReapTerminalDispositionSchema,
 } from "../../packages/contracts/dist/index.js";
 
 const legacySafeTextSchema = z
@@ -35,19 +45,134 @@ const legacyV1UpdateCommandReportSchema = z
   })
   .strict();
 
-const composedUpdateReportSchema = z.union([
-  legacyV1UpdateCommandReportSchema,
-  UpdateCommandReportSchema,
+const predecessorV4PreflightSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    boundary: z
+      .object({
+        authorization: z.literal("none"),
+        actions: z.literal("not-included"),
+        digest: z.literal("not-included"),
+      })
+      .strict(),
+    installed: UpdateArtifactSchema,
+    target: UpdateArtifactSchema,
+    observer: UpdateReapObserverEvidenceSchema,
+    host: UpdateReapHostEvidenceSchema,
+    hookProviderIds: z.array(ProviderIdSchema),
+    hooks: z.array(ProviderHookHealthSchema),
+    terminalDispositions: z.array(UpdateReapTerminalDispositionSchema),
+    evidenceComplete: z.boolean(),
+  })
+  .strict();
+const predecessorV4ConvergencePlanSchema = UpdateConvergencePlanSchema.superRefine(
+  (plan, context) => {
+    if (plan.phases.hostConvergence.action === "recover-parked") {
+      context.addIssue({
+        code: "custom",
+        path: ["phases", "hostConvergence", "action"],
+        message: "The schema-v4 predecessor cannot report parked-bridge recovery.",
+      });
+    }
+  },
+);
+const predecessorV4FailureSummarySchema = z
+  .object({
+    status: z.literal("failed"),
+    action: z.enum(["replace-idle", "handoff"]),
+    phase: z.enum([
+      "admission",
+      "incumbent-validation",
+      "incumbent-release",
+      "target-start",
+      "target-validation",
+      "adoption",
+      "final-verification",
+    ]),
+    incumbentDisposition: z.enum(["none", "preserved", "released", "unknown"]),
+    terminalDisposition: z.enum(["none", "incumbent", "parked", "successor", "mixed", "unknown"]),
+    recoveryAuthority: z.literal("none"),
+    terminalCount: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+    terminalRecoveryCounts: z
+      .object({
+        incumbent: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+        parked: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+        successor: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+        unknown: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+      })
+      .strict(),
+    handoffReceipt: z
+      .object({
+        retained: z.boolean(),
+        terminalCount: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+        fidelity: HostHandoffFidelitySchema.optional(),
+      })
+      .strict(),
+    error: z
+      .object({
+        tag: z.string().min(1).max(128),
+        code: z.string().min(1).max(128),
+        message: z.string().min(1).max(4_096),
+        hint: z.string().min(1).max(4_096).optional(),
+      })
+      .strict(),
+  })
+  .strict();
+const predecessorV4Common = {
+  schemaVersion: z.literal(4),
+  channel: UpdateChannelIdSchema,
+  current: UpdateArtifactSchema,
+  target: UpdateArtifactSchema,
+};
+const predecessorV4PreviewSchema = z
+  .object({
+    ...predecessorV4Common,
+    kind: z.literal("preview"),
+    initial: predecessorV4PreflightSchema,
+    plan: predecessorV4ConvergencePlanSchema,
+  })
+  .strict();
+const predecessorV4ResultSchema = z
+  .object({
+    ...predecessorV4Common,
+    kind: z.literal("result"),
+    status: z.enum(["current", "updated", "deferred", "failed"]),
+    steps: z.array(UpdateCommandStepSchema),
+    warnings: z.array(SafeErrorSchema),
+    recoveryCommands: z.array(UpdateCommandArgvSchema),
+    hookReconciliation: ProviderHookReconciliationResultSchema.optional(),
+    error: SafeErrorSchema.optional(),
+    cause: SafeErrorSchema.optional(),
+    startupEvidence: ObserverStartupEvidenceSchema.optional(),
+    hostConvergenceFailure: predecessorV4FailureSummarySchema.optional(),
+  })
+  .strict();
+const predecessorV4UpdateCommandReportSchema = z.union([
+  predecessorV4PreviewSchema,
+  predecessorV4ResultSchema,
 ]);
 const legacyV1IncumbentVersion = "0.0.0-pre-alpha.5.16";
+const predecessorV4EmitterVersion = "0.0.0-pre-alpha.14.3";
 
 export function parseComposedUpdateReport(value, incumbentVersion) {
-  const report = composedUpdateReportSchema.parse(value);
-  const expectedSchemaVersion = incumbentVersion === legacyV1IncumbentVersion ? 1 : 5;
-  if (report.schemaVersion !== expectedSchemaVersion) {
+  if (incumbentVersion === legacyV1IncumbentVersion) {
+    return parseExpectedReport(legacyV1UpdateCommandReportSchema, value, incumbentVersion, 1);
+  }
+  if (incumbentVersion === predecessorV4EmitterVersion) {
+    return parseExpectedReport(predecessorV4UpdateCommandReportSchema, value, incumbentVersion, 4);
+  }
+  return parseExpectedReport(UpdateCommandReportSchema, value, incumbentVersion, 5);
+}
+
+function parseExpectedReport(schema, value, incumbentVersion, expectedSchemaVersion) {
+  const actualSchemaVersion = z
+    .object({ schemaVersion: z.number().int() })
+    .passthrough()
+    .parse(value).schemaVersion;
+  if (actualSchemaVersion !== expectedSchemaVersion) {
     throw new Error(
-      `Expected update report schema ${expectedSchemaVersion} from incumbent ${incumbentVersion}, received ${report.schemaVersion}.`,
+      `Expected update report schema ${expectedSchemaVersion} from incumbent ${incumbentVersion}, received ${actualSchemaVersion}.`,
     );
   }
-  return report;
+  return schema.parse(value);
 }

--- a/scripts/test-runners/composed-update-report.mjs
+++ b/scripts/test-runners/composed-update-report.mjs
@@ -154,14 +154,21 @@ const predecessorV4UpdateCommandReportSchema = z.union([
 const legacyV1IncumbentVersion = "0.0.0-pre-alpha.5.16";
 const predecessorV4EmitterVersion = "0.0.0-pre-alpha.14.3";
 
-export function parseComposedUpdateReport(value, incumbentVersion) {
-  if (incumbentVersion === legacyV1IncumbentVersion) {
-    return parseExpectedReport(legacyV1UpdateCommandReportSchema, value, incumbentVersion, 1);
-  }
-  if (incumbentVersion === predecessorV4EmitterVersion) {
-    return parseExpectedReport(predecessorV4UpdateCommandReportSchema, value, incumbentVersion, 4);
-  }
-  return parseExpectedReport(UpdateCommandReportSchema, value, incumbentVersion, 5);
+export function updateReportSchemaVersionForEmitter(version) {
+  if (version === legacyV1IncumbentVersion) return 1;
+  if (version === predecessorV4EmitterVersion) return 4;
+  return 5;
+}
+
+export function parseComposedUpdateReport(value, emitterVersion) {
+  const schemaVersion = updateReportSchemaVersionForEmitter(emitterVersion);
+  const schema =
+    schemaVersion === 1
+      ? legacyV1UpdateCommandReportSchema
+      : schemaVersion === 4
+        ? predecessorV4UpdateCommandReportSchema
+        : UpdateCommandReportSchema;
+  return parseExpectedReport(schema, value, emitterVersion, schemaVersion);
 }
 
 function parseExpectedReport(schema, value, incumbentVersion, expectedSchemaVersion) {

--- a/scripts/test-runners/run-update-smoke.mjs
+++ b/scripts/test-runners/run-update-smoke.mjs
@@ -40,7 +40,10 @@ import {
   releaseBinarySmokeEvidenceReservation,
   reserveBinarySmokeEvidenceDestination,
 } from "./binary-smoke-evidence.mjs";
-import { parseComposedUpdateReport } from "./composed-update-report.mjs";
+import {
+  parseComposedUpdateReport,
+  updateReportSchemaVersionForEmitter,
+} from "./composed-update-report.mjs";
 
 const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
 const runnerPath = fileURLToPath(import.meta.url);
@@ -715,35 +718,31 @@ async function runScenario(input) {
         stderr: updateResult.stderr,
       })})`,
     );
-    if (preservedRefusal) {
-      if (updateResult.stdout.trim().length === 0) {
-        assertIncludes(
-          updateResult.stderr,
-          "UPDATE_HOST_HANDOFF_PREFLIGHT_FAILED",
-          `${input.name} refused update code`,
-        );
-        assertIncludes(
-          updateResult.stderr,
-          "Host terminals are not all eligible for live handoff.",
-          `${input.name} refused update reason`,
-        );
-        assertDeepEqual(
-          await captureDryRunState(dryRunStateInput),
-          beforeDryRun,
-          `${input.name} refused update persistent and runtime state`,
-        );
-      } else {
-        const reportJson = parseJson(updateResult.stdout, `${input.name} update report`);
-        const report = parseComposedUpdateReport(reportJson, reportEmitterVersion(input));
-        assertUpdateReport(report, reportJson, input, installedBinary, configPath, reportEvidence);
-        assertNoMismatch(updateResult.stderr, `${input.name} update stderr`);
-        completedInstallRefusal = report.status === "failed";
-      }
+    const emitterVersion = reportEmitterVersion(input);
+    const reportSchemaVersion = updateReportSchemaVersionForEmitter(emitterVersion);
+    const allowsStderrOnlyRefusal = reportSchemaVersion === 1 || reportSchemaVersion === 4;
+    if (preservedRefusal && updateResult.stdout.trim().length === 0 && allowsStderrOnlyRefusal) {
+      assertIncludes(
+        updateResult.stderr,
+        "UPDATE_HOST_HANDOFF_PREFLIGHT_FAILED",
+        `${input.name} refused update code`,
+      );
+      assertIncludes(
+        updateResult.stderr,
+        "Host terminals are not all eligible for live handoff.",
+        `${input.name} refused update reason`,
+      );
+      assertDeepEqual(
+        await captureDryRunState(dryRunStateInput),
+        beforeDryRun,
+        `${input.name} refused update persistent and runtime state`,
+      );
     } else {
       const reportJson = parseJson(updateResult.stdout, `${input.name} update report`);
-      const report = parseComposedUpdateReport(reportJson, reportEmitterVersion(input));
+      const report = parseComposedUpdateReport(reportJson, emitterVersion);
       assertUpdateReport(report, reportJson, input, installedBinary, configPath, reportEvidence);
       assertNoMismatch(updateResult.stderr, `${input.name} update stderr`);
+      completedInstallRefusal = preservedRefusal && report.status === "failed";
     }
     if (preservedRefusal) {
       assertDeepEqual(

--- a/scripts/test-runners/run-update-smoke.mjs
+++ b/scripts/test-runners/run-update-smoke.mjs
@@ -246,20 +246,77 @@ async function runUpdateSmoke(options) {
     options.incumbentBinary,
     options.incumbentVersion,
   );
+  let predecessorSource;
+  if (options.predecessorSourceDir !== undefined) {
+    predecessorSource = await snapshotTaggedPredecessorSource(
+      options.predecessorSourceDir,
+      options.incumbentVersion,
+    );
+  }
   const target = await prepareTarget(options, root);
   await assertTargetAssetsUnchanged(target);
+  const predecessorScenarios = [
+    {
+      name: "external-busy-host",
+      socketKey: "e",
+      invocation: "external",
+      artifactState: "predecessor",
+      hostState: "busy-compiled-non-bridge",
+    },
+    {
+      name: "tmux-busy-host",
+      socketKey: "b",
+      invocation: "tmux",
+      artifactState: "predecessor",
+      hostState:
+        options.busyHostOutcome === "full-handoff"
+          ? "busy-source-bridge"
+          : "busy-compiled-non-bridge",
+    },
+    {
+      name: "tmux-no-host",
+      socketKey: "n",
+      invocation: "tmux",
+      artifactState: "predecessor",
+      hostState: "absent",
+    },
+  ];
+  const currentArtifactScenarios = [
+    {
+      name: "current-no-host",
+      socketKey: "cn",
+      invocation: "external",
+      artifactState: "current",
+      hostState: "absent",
+    },
+    {
+      name: "current-idle-host",
+      socketKey: "ci",
+      invocation: "external",
+      artifactState: "current",
+      hostState: "idle-compiled",
+    },
+    {
+      name: "current-busy-source-bridge-host",
+      socketKey: "cb",
+      invocation: "external",
+      artifactState: "current",
+      hostState: "busy-source-bridge",
+    },
+    {
+      name: "current-busy-non-bridge-host",
+      socketKey: "cx",
+      invocation: "external",
+      artifactState: "current",
+      hostState: "busy-compiled-non-bridge",
+    },
+  ];
   const scenarios =
     options.scenarios === "no-host"
-      ? [{ name: "tmux-no-host", invocation: "tmux", busyHost: false }]
-      : [
-          {
-            name: "external-busy-host",
-            invocation: "external",
-            busyHost: true,
-          },
-          { name: "tmux-busy-host", invocation: "tmux", busyHost: true },
-          { name: "tmux-no-host", invocation: "tmux", busyHost: false },
-        ];
+      ? [predecessorScenarios[2]]
+      : options.scenarios === "release"
+        ? [...predecessorScenarios, ...currentArtifactScenarios]
+        : predecessorScenarios;
 
   try {
     for (const scenario of scenarios) {
@@ -269,12 +326,16 @@ async function runUpdateSmoke(options) {
         options,
         root,
         suppliedBinary,
+        predecessorSource,
         target,
         evidenceDir,
       });
     }
     await assertTargetAssetsUnchanged(target);
     await assertSuppliedBinaryUnchanged(suppliedBinary);
+    if (predecessorSource !== undefined) {
+      await assertTaggedPredecessorSourceUnchanged(predecessorSource);
+    }
     process.stdout.write(
       `update smoke passed (${scenarios.length} scenario${scenarios.length === 1 ? "" : "s"})\n`,
     );
@@ -300,18 +361,16 @@ async function runUpdateSmoke(options) {
 
 async function runScenario(input) {
   const scenarioRoot = join(input.root, "scenarios", input.name);
-  const scenarioKey =
-    input.name === "external-busy-host" ? "e" : input.name === "tmux-busy-host" ? "b" : "n";
   const homeDir = join(scenarioRoot, "home");
   const configHome = join(homeDir, ".config");
   const stateHome = join(scenarioRoot, "state-home");
   const dataHome = join(scenarioRoot, "data-home");
   const cacheHome = join(scenarioRoot, "cache-home");
   // Bridge control sockets inherit this path; keep it short enough for macOS sun_path.
-  const stateDir = join(input.root, "s", scenarioKey);
-  const runtimeDir = join(input.root, "r", scenarioKey);
+  const stateDir = join(input.root, "s", input.socketKey);
+  const runtimeDir = join(input.root, "r", input.socketKey);
   const tempDir = join(scenarioRoot, "tmp");
-  const tmuxTempDir = await mkdtemp(join("/tmp", `stn-tmux-${scenarioKey}-`));
+  const tmuxTempDir = await mkdtemp(join("/tmp", `stn-tmux-${input.socketKey}-`));
   const installDir = join(scenarioRoot, "bin");
   const configPath = join(configHome, "station", "config.toml");
   const socketPath = join(runtimeDir, "observer.sock");
@@ -325,6 +384,7 @@ async function runScenario(input) {
   const cleanupWarnings = [];
   let observerClient;
   let incumbentObserver;
+  let incumbentHostBuildIdentity;
   let incumbentHostProcess;
   let incumbentHostOutput;
   let tmuxServer;
@@ -348,17 +408,33 @@ async function runScenario(input) {
   );
   await installIncumbent(input.suppliedBinary.path, installDir, dataHome);
   await writeConfig(configPath, stateDir, socketPath);
-  const transportDir =
+  const updateTransportDir =
     input.target.mode === "public"
       ? undefined
       : await writeReleaseTransport({
           scenarioRoot,
-          currentTag: `v${input.options.incumbentVersion}`,
+          ledger: "update-transport",
+          currentTag:
+            input.artifactState === "current"
+              ? input.target.tag
+              : `v${input.options.incumbentVersion}`,
           target: input.target,
+          includeAssets: input.artifactState === "predecessor",
         });
+  const targetInstallTransportDir =
+    input.artifactState === "current"
+      ? await writeReleaseTransport({
+          scenarioRoot,
+          ledger: "target-install-transport",
+          currentTag: input.target.tag,
+          target: input.target,
+          includeMetadata: false,
+          includeInstaller: false,
+        })
+      : undefined;
   const tmuxPath = findExecutable("tmux", process.env.PATH);
   const tmuxAudit = await prepareTmuxAudit(scenarioRoot, tmuxPath);
-  const env = isolatedEnvironment({
+  const environmentInput = {
     homeDir,
     configHome,
     stateHome,
@@ -371,10 +447,20 @@ async function runScenario(input) {
     configPath,
     socketPath,
     hostSocketPath,
-    transportDir,
     tmuxPath,
     tmuxShadowDir: tmuxAudit.shadowDir,
+  };
+  const env = isolatedEnvironment({
+    ...environmentInput,
+    transportDir: updateTransportDir,
   });
+  const targetInstallEnv =
+    targetInstallTransportDir === undefined
+      ? undefined
+      : isolatedEnvironment({
+          ...environmentInput,
+          transportDir: targetInstallTransportDir,
+        });
   const installedBinary = await realpath(join(installDir, "stn"));
 
   try {
@@ -406,33 +492,44 @@ async function runScenario(input) {
       acceptPreviousLifecycleSchema: true,
     });
 
-    if (input.busyHost) {
-      const bridgeBackedHost =
-        input.invocation === "tmux" && input.options.busyHostOutcome === "full-handoff";
-      if (bridgeBackedHost && incumbentBuildIdentity === undefined) {
+    if (scenarioHasHost(input)) {
+      const sourceBridgeHost = input.hostState === "busy-source-bridge";
+      if (sourceBridgeHost && incumbentBuildIdentity === undefined) {
         throw new Error(`${input.name} incumbent Observer did not expose a build identity.`);
       }
-      const hostCommand = bridgeBackedHost
-        ? (process.env.STATION_BUN ?? findExecutable("bun", env.PATH))
-        : installedBinary;
-      const hostArgs = bridgeBackedHost
-        ? [
-            join(repoRoot, "station", "src", "host", "hostMain.ts"),
-            "--socket",
-            hostSocketPath,
-            "--state-dir",
-            stateDir,
+      const taggedPredecessorHost = sourceBridgeHost && input.predecessorSource !== undefined;
+      if (taggedPredecessorHost) {
+        incumbentHostBuildIdentity = input.predecessorSource.buildIdentity;
+      } else {
+        incumbentHostBuildIdentity = incumbentBuildIdentity;
+      }
+      let hostCommand = installedBinary;
+      let hostArgs = ["__station-host", "--socket", hostSocketPath, "--state-dir", stateDir];
+      let hostEnvironment = env;
+      let hostCwd = scenarioRoot;
+      if (sourceBridgeHost) {
+        hostCommand = process.env.STATION_BUN ?? findExecutable("bun", process.env.PATH);
+        hostCwd = input.predecessorSource?.path ?? repoRoot;
+        hostArgs = [
+          join(hostCwd, "station", "src", "host", "hostMain.ts"),
+          "--socket",
+          hostSocketPath,
+          "--state-dir",
+          stateDir,
+        ];
+        hostEnvironment = { ...env, STATION_PTY_IMPL: "bridge" };
+        if (!taggedPredecessorHost) {
+          hostArgs.push(
             "--build-version",
             input.options.incumbentVersion,
             "--build-identity",
             incumbentBuildIdentity,
-          ]
-        : ["__station-host", "--socket", hostSocketPath, "--state-dir", stateDir];
-      const hostEnvironment = bridgeBackedHost
-        ? { ...env, STATION_HOST_ALLOW_BUILD_VERSION_OVERRIDE: "1", STATION_PTY_IMPL: "bridge" }
-        : env;
+          );
+          hostEnvironment.STATION_HOST_ALLOW_BUILD_VERSION_OVERRIDE = "1";
+        }
+      }
       incumbentHostProcess = spawn(hostCommand, hostArgs, {
-        cwd: bridgeBackedHost ? repoRoot : scenarioRoot,
+        cwd: hostCwd,
         env: hostEnvironment,
         stdio: ["ignore", "pipe", "pipe"],
       });
@@ -444,45 +541,85 @@ async function runScenario(input) {
         timeoutMs: 2000,
         expectedBuildVersion: input.options.incumbentVersion,
       });
-      await waitForHost(incumbentHostClient, incumbentHostOutput);
+      const incumbentHostHealth = await waitForHost(incumbentHostClient, incumbentHostOutput);
+      assertEqual(
+        incumbentHostHealth.buildVersion,
+        input.options.incumbentVersion,
+        `${input.name} incumbent Host version`,
+      );
       assertDeepEqual(
         readUnixSocketHolderPids(hostSocketPath),
         [incumbentHostProcess.pid],
         `${input.name} incumbent Host holder`,
       );
-      ptyIdentity = {
-        kind: "agent",
-        terminalTargetId: `native:${input.name}`,
-        worktreeId: input.name,
-        projectId: "update-smoke",
-        sessionId: `ses_${input.name.replaceAll("-", "_")}`,
-        worktreePath: scenarioRoot,
-        harnessProvider: "scripted",
-      };
-      spawnedPty = await incumbentHostClient.spawn({
-        ...ptyIdentity,
-        command: "/bin/sh",
-        args: [
-          "-c",
-          'printf "UPDATE_SMOKE_PRE\\n"; while [ ! -f "$1" ]; do sleep 0.1; done; printf "UPDATE_SMOKE_POST\\n"; while [ ! -f "$2" ]; do sleep 0.1; done',
-          "update-smoke-child",
-          postSignal,
-          releaseSignal,
-        ],
-        cwd: scenarioRoot,
-        cols: 80,
-        rows: 24,
-      });
-      ptyChildPid = await waitForPtyChild(incumbentHostClient, spawnedPty);
-      await recordProcessIdentity(processIdentities, "pty-payload", ptyChildPid);
-      await waitForPtyOutput(
-        incumbentHostClient,
-        { ...ptyIdentity, ...spawnedPty },
-        "UPDATE_SMOKE_PRE",
-      );
+      if (scenarioHasBusyHost(input)) {
+        const rawIdentityCanary = randomUUID().replaceAll("-", "");
+        ptyIdentity = {
+          kind: "agent",
+          terminalTargetId: `native:raw-terminal-${rawIdentityCanary}`,
+          worktreeId: `raw-worktree-${rawIdentityCanary}`,
+          projectId: `raw-project-${rawIdentityCanary}`,
+          sessionId: `ses_raw_session_${rawIdentityCanary}`,
+          worktreePath: scenarioRoot,
+          harnessProvider: "scripted",
+        };
+        spawnedPty = await incumbentHostClient.spawn({
+          ...ptyIdentity,
+          command: "/bin/sh",
+          args: [
+            "-c",
+            'printf "UPDATE_SMOKE_PRE\\n"; while [ ! -f "$1" ]; do sleep 0.1; done; printf "UPDATE_SMOKE_POST\\n"; while [ ! -f "$2" ]; do sleep 0.1; done',
+            "update-smoke-child",
+            postSignal,
+            releaseSignal,
+          ],
+          cwd: scenarioRoot,
+          cols: 80,
+          rows: 24,
+        });
+        ptyChildPid = await waitForPtyChild(incumbentHostClient, spawnedPty);
+        await recordProcessIdentity(processIdentities, "pty-payload", ptyChildPid);
+        await waitForPtyOutput(
+          incumbentHostClient,
+          { ...ptyIdentity, ...spawnedPty },
+          "UPDATE_SMOKE_PRE",
+        );
+      }
       incumbentHostClient.dispose();
     } else {
       assertEqual(await pathExists(hostSocketPath), false, `${input.name} starts without Host`);
+    }
+
+    if (input.artifactState === "current") {
+      if (input.target.mode === "public" || targetInstallEnv === undefined) {
+        throw new Error("Current-artifact scenarios require snapshotted target assets.");
+      }
+      // The old runtime must start before the exact target artifact replaces the installed binary.
+      await run("/bin/sh", [input.target.installerPath, "--install-dir", installDir], {
+        cwd: scenarioRoot,
+        env: targetInstallEnv,
+        timeoutMs: childTimeoutMs,
+      });
+      const installedTargetVersion = await run(installedBinary, ["--version"], {
+        env,
+      });
+      assertEqual(
+        installedTargetVersion.stdout.trim(),
+        input.target.version,
+        `${input.name} preinstalled target version`,
+      );
+      assertEqual(
+        await processIdentityMatches(processIdentities.get("incumbent-observer")),
+        true,
+        `${input.name} target installation preserves incumbent Observer`,
+      );
+      if (scenarioHasHost(input)) {
+        assertEqual(
+          await processIdentityMatches(processIdentities.get("incumbent-host")),
+          true,
+          `${input.name} target installation preserves incumbent Host`,
+        );
+      }
     }
 
     if (input.invocation === "tmux") {
@@ -498,7 +635,7 @@ async function runScenario(input) {
       hostSocketPath,
       observerBuildVersion: incumbentObserver.version,
       hostBuildVersion: input.options.incumbentVersion,
-      busyHost: input.busyHost,
+      hasHost: scenarioHasHost(input),
     };
     const beforeDryRun = await captureDryRunState(dryRunStateInput);
     const dryRunResult =
@@ -514,11 +651,20 @@ async function runScenario(input) {
             [installedBinary, "update", "--dry-run", "--json"],
             scenarioRoot,
           );
-    const dryRunReport = parseComposedUpdateReport(
-      parseJson(dryRunResult.stdout, `${input.name} compiled dry-run report`),
-      input.options.incumbentVersion,
+    const dryRunJson = parseJson(dryRunResult.stdout, `${input.name} compiled dry-run report`);
+    const dryRunReport = parseComposedUpdateReport(dryRunJson, reportEmitterVersion(input));
+    const reportEvidence = {
+      incumbentBuildIdentity,
+      incumbentHostBuildIdentity,
+      ptyIdentity,
+      spawnedPty,
+    };
+    const expectedDryRunCode = assertDryUpdateReport(
+      dryRunReport,
+      dryRunJson,
+      input,
+      reportEvidence,
     );
-    const expectedDryRunCode = assertDryUpdateReport(dryRunReport, input);
     assertEqual(dryRunResult.code, expectedDryRunCode, `${input.name} dry-run outcome exit code`);
     assertDeepEqual(
       await captureDryRunState(dryRunStateInput),
@@ -530,12 +676,14 @@ async function runScenario(input) {
       true,
       `${input.name} dry run preserves incumbent Observer`,
     );
-    if (input.busyHost) {
+    if (scenarioHasHost(input)) {
       assertEqual(
         await processIdentityMatches(processIdentities.get("incumbent-host")),
         true,
         `${input.name} dry run preserves incumbent Host`,
       );
+    }
+    if (scenarioHasBusyHost(input)) {
       assertEqual(
         await processIdentityMatches(processIdentities.get("pty-payload")),
         true,
@@ -559,7 +707,14 @@ async function runScenario(input) {
             [installedBinary, "update", "--json"],
             scenarioRoot,
           );
-    assertEqual(updateResult.code, expectedUpdateCode, `${input.name} update exit code`);
+    assertEqual(
+      updateResult.code,
+      expectedUpdateCode,
+      `${input.name} update exit code (${JSON.stringify({
+        stdout: updateResult.stdout,
+        stderr: updateResult.stderr,
+      })})`,
+    );
     if (preservedRefusal) {
       if (updateResult.stdout.trim().length === 0) {
         assertIncludes(
@@ -578,24 +733,32 @@ async function runScenario(input) {
           `${input.name} refused update persistent and runtime state`,
         );
       } else {
-        const report = parseComposedUpdateReport(
-          parseJson(updateResult.stdout, `${input.name} update report`),
-          input.options.incumbentVersion,
-        );
-        assertUpdateReport(report, input, installedBinary, configPath);
+        const reportJson = parseJson(updateResult.stdout, `${input.name} update report`);
+        const report = parseComposedUpdateReport(reportJson, reportEmitterVersion(input));
+        assertUpdateReport(report, reportJson, input, installedBinary, configPath, reportEvidence);
         assertNoMismatch(updateResult.stderr, `${input.name} update stderr`);
         completedInstallRefusal = report.status === "failed";
       }
     } else {
-      const report = parseComposedUpdateReport(
-        parseJson(updateResult.stdout, `${input.name} update report`),
-        input.options.incumbentVersion,
-      );
-      assertUpdateReport(report, input, installedBinary, configPath);
+      const reportJson = parseJson(updateResult.stdout, `${input.name} update report`);
+      const report = parseComposedUpdateReport(reportJson, reportEmitterVersion(input));
+      assertUpdateReport(report, reportJson, input, installedBinary, configPath, reportEvidence);
       assertNoMismatch(updateResult.stderr, `${input.name} update stderr`);
     }
-    if (transportDir !== undefined) {
-      await assertExactTransportRequests(transportDir, input, completedInstallRefusal);
+    if (preservedRefusal) {
+      assertDeepEqual(
+        await captureDryRunState(dryRunStateInput),
+        beforeDryRun,
+        `${input.name} refused update persistent and runtime state`,
+      );
+    }
+    if (updateTransportDir !== undefined) {
+      await assertExactTransportRequests({
+        updateTransportDir,
+        targetInstallTransportDir,
+        input,
+        completedInstallRefusal,
+      });
     }
 
     if (preservedRefusal && !completedInstallRefusal) {
@@ -639,7 +802,7 @@ async function runScenario(input) {
       );
     }
 
-    if (input.busyHost && !preservedRefusal) {
+    if (scenarioHasHost(input) && !preservedRefusal) {
       assertEqual(
         await waitForExactProcessExit(processIdentities.get("incumbent-host"), 10_000),
         true,
@@ -657,27 +820,33 @@ async function runScenario(input) {
       });
       const hostHealth = await targetHostClient.health();
       assertEqual(hostHealth.buildVersion, input.target.version, `${input.name} target Host build`);
-      const live = (await targetHostClient.list()).find(
-        (entry) => entry.ptyId === spawnedPty.ptyId,
-      );
-      if (live === undefined) throw new Error(`${input.name} target Host lost the live PTY.`);
-      assertEqual(live.ptyId, spawnedPty.ptyId, `${input.name} PTY ID`);
-      assertEqual(live.ptyInstanceId, spawnedPty.ptyInstanceId, `${input.name} PTY instance`);
-      assertEqual(live.pid, ptyChildPid, `${input.name} PTY child PID`);
-      const attachment = await targetHostClient.attach({ ...ptyIdentity, ...spawnedPty }, "viewer");
-      const replay = replayText(attachment.ack);
-      assertIncludes(replay, "UPDATE_SMOKE_PRE", `${input.name} preserved replay`);
-      const iterator = attachment.frames[Symbol.asyncIterator]();
-      await writeFile(postSignal, "\n", { mode: 0o600 });
-      const post = await waitForFrame(iterator, "UPDATE_SMOKE_POST", 10_000);
-      assertIncludes(post, "UPDATE_SMOKE_POST", `${input.name} continued PTY output`);
-      await writeFile(releaseSignal, "\n", { mode: 0o600 });
-      await waitForExitFrame(iterator, 10_000);
-      await iterator.return?.();
-      await attachment.detach();
-      await targetHostClient.close(spawnedPty.ptyId).catch(() => undefined);
+      const targetInventory = await targetHostClient.list();
+      if (scenarioHasBusyHost(input)) {
+        const live = targetInventory.find((entry) => entry.ptyId === spawnedPty.ptyId);
+        if (live === undefined) throw new Error(`${input.name} target Host lost the live PTY.`);
+        assertEqual(live.ptyId, spawnedPty.ptyId, `${input.name} PTY ID`);
+        assertEqual(live.ptyInstanceId, spawnedPty.ptyInstanceId, `${input.name} PTY instance`);
+        assertEqual(live.pid, ptyChildPid, `${input.name} PTY child PID`);
+        const attachment = await targetHostClient.attach(
+          { ...ptyIdentity, ...spawnedPty },
+          "viewer",
+        );
+        const replay = replayText(attachment.ack);
+        assertIncludes(replay, "UPDATE_SMOKE_PRE", `${input.name} preserved replay`);
+        const iterator = attachment.frames[Symbol.asyncIterator]();
+        await writeFile(postSignal, "\n", { mode: 0o600 });
+        const post = await waitForFrame(iterator, "UPDATE_SMOKE_POST", 10_000);
+        assertIncludes(post, "UPDATE_SMOKE_POST", `${input.name} continued PTY output`);
+        await writeFile(releaseSignal, "\n", { mode: 0o600 });
+        await waitForExitFrame(iterator, 10_000);
+        await iterator.return?.();
+        await attachment.detach();
+        await targetHostClient.close(spawnedPty.ptyId).catch(() => undefined);
+      } else {
+        assertDeepEqual(targetInventory, [], `${input.name} target Host empty inventory`);
+      }
       targetHostClient.dispose();
-    } else if (input.busyHost) {
+    } else if (scenarioHasBusyHost(input)) {
       const incumbentHostIdentity = processIdentities.get("incumbent-host");
       assertEqual(
         await processIdentityMatches(incumbentHostIdentity),
@@ -732,10 +901,12 @@ async function runScenario(input) {
       tmuxTempDir,
       tmuxServer,
       name: input.name,
-      expectNativeRefusal: completedInstallRefusal,
+      expectNativeRefusal:
+        completedInstallRefusal || (input.artifactState === "current" && preservedRefusal),
+      expectTmuxRefusal: input.artifactState === "current" && preservedRefusal,
       processIdentities,
     });
-    if (input.busyHost) {
+    if (scenarioHasHost(input)) {
       const expectedHostVersion = preservedRefusal
         ? input.options.incumbentVersion
         : input.target.version;
@@ -767,7 +938,9 @@ async function runScenario(input) {
     await waitForMissing(socketPath, 10_000);
     assertEqual(
       await waitForExactProcessExit(
-        processIdentities.get(completedInstallRefusal ? "target-observer" : "incumbent-observer"),
+        processIdentities.get(
+          preservedRefusal && !completedInstallRefusal ? "incumbent-observer" : "target-observer",
+        ),
         10_000,
       ),
       true,
@@ -828,6 +1001,7 @@ async function runScenario(input) {
       const raw = createStationHostClient({
         socketPath: hostSocketPath,
         timeoutMs: 2000,
+        expectedBuildVersion: input.options.incumbentVersion,
       });
       const health = await raw.health();
       raw.dispose();
@@ -1059,7 +1233,7 @@ async function captureDryRunState(input) {
   };
   const recoveryReadiness = await observer.getSessionRecoveryReadiness();
   let host;
-  if (input.busyHost) {
+  if (input.hasHost) {
     const client = createStationHostClient({
       socketPath: input.hostSocketPath,
       timeoutMs: 3000,
@@ -1096,7 +1270,7 @@ async function captureDryRunState(input) {
     },
     host: {
       socket: await snapshotEntry(input.hostSocketPath),
-      holders: input.busyHost ? readUnixSocketHolderPids(input.hostSocketPath) : [],
+      holders: input.hasHost ? readUnixSocketHolderPids(input.hostSocketPath) : [],
       evidence: host,
     },
   };
@@ -1142,30 +1316,45 @@ async function snapshotEntry(path) {
 }
 
 async function writeReleaseTransport(input) {
-  const transportDir = join(input.scenarioRoot, "transport");
+  const transportDir = join(input.scenarioRoot, input.ledger);
   await mkdir(transportDir, { recursive: true, mode: 0o700 });
   const curlPath = join(transportDir, "curl");
   const current = releaseMetadata(input.currentTag, 1001, "2026-01-01T00:00:00Z");
   const target = releaseMetadata(input.target.tag, 1002, "2026-01-02T00:00:00Z");
   const routes = [
-    [releaseApiTagUrl(input.currentTag), { kind: "json", value: current }],
-    [releaseApiTagUrl(input.target.tag), { kind: "json", value: target }],
-    [
-      "https://api.github.com/repos/jeremy0dell/station/releases?per_page=100&page=1",
-      { kind: "json", value: [current, target] },
-    ],
-    [
-      releaseDownloadUrl(input.target.tag, "install.sh"),
-      { kind: "file", path: input.target.installerPath },
-    ],
-    [
-      releaseDownloadUrl(input.target.tag, "SHA256SUMS"),
-      { kind: "file", path: input.target.checksumsPath },
-    ],
-    [
-      releaseDownloadUrl(input.target.tag, basename(input.target.archivePath)),
-      { kind: "file", path: input.target.archivePath },
-    ],
+    ...(input.includeMetadata === false
+      ? []
+      : [
+          [releaseApiTagUrl(input.currentTag), { kind: "json", value: current }],
+          [releaseApiTagUrl(input.target.tag), { kind: "json", value: target }],
+          [
+            "https://api.github.com/repos/jeremy0dell/station/releases?per_page=100&page=1",
+            {
+              kind: "json",
+              value: input.currentTag === input.target.tag ? [target] : [current, target],
+            },
+          ],
+        ]),
+    ...(input.includeAssets === false
+      ? []
+      : [
+          ...(input.includeInstaller === false
+            ? []
+            : [
+                [
+                  releaseDownloadUrl(input.target.tag, "install.sh"),
+                  { kind: "file", path: input.target.installerPath },
+                ],
+              ]),
+          [
+            releaseDownloadUrl(input.target.tag, "SHA256SUMS"),
+            { kind: "file", path: input.target.checksumsPath },
+          ],
+          [
+            releaseDownloadUrl(input.target.tag, basename(input.target.archivePath)),
+            { kind: "file", path: input.target.archivePath },
+          ],
+        ]),
   ];
   const fileRoutes = Object.fromEntries(
     await Promise.all(
@@ -1205,21 +1394,29 @@ async function writeReleaseTransport(input) {
   return transportDir;
 }
 
-async function assertExactTransportRequests(transportDir, input, completedInstallRefusal) {
+async function assertExactTransportRequests({
+  updateTransportDir,
+  targetInstallTransportDir,
+  input,
+  completedInstallRefusal,
+}) {
   const archiveName = `stn-${input.target.tag}-${nativeTarget()}.tar.gz`;
-  const actual = (await readFile(join(transportDir, "curl.log"), "utf8"))
+  const actual = (await readFile(join(updateTransportDir, "curl.log"), "utf8"))
     .split(/\r?\n/u)
     .filter(Boolean)
     .sort();
+  const currentTag =
+    input.artifactState === "current" ? input.target.tag : `v${input.options.incumbentVersion}`;
   const detectionRequests = [
-    releaseApiTagUrl(`v${input.options.incumbentVersion}`),
-    releaseApiTagUrl(`v${input.options.incumbentVersion}`),
+    releaseApiTagUrl(currentTag),
+    releaseApiTagUrl(currentTag),
     "https://api.github.com/repos/jeremy0dell/station/releases?per_page=100&page=1",
     "https://api.github.com/repos/jeremy0dell/station/releases?per_page=100&page=1",
   ];
   const expected = [
     ...detectionRequests,
-    ...(updateRequiresPreservation(input) && !completedInstallRefusal
+    ...(input.artifactState === "current" ||
+    (updateRequiresPreservation(input) && !completedInstallRefusal)
       ? []
       : [
           releaseDownloadUrl(input.target.tag, "install.sh"),
@@ -1229,6 +1426,31 @@ async function assertExactTransportRequests(transportDir, input, completedInstal
         ]),
   ].sort();
   assertDeepEqual(actual, expected, `${input.name} exact update transport requests`);
+  if (input.artifactState === "current") {
+    if (targetInstallTransportDir === undefined) {
+      throw new Error(`${input.name} target installer transport ledger is missing.`);
+    }
+    const targetInstallRequests = (
+      await readFile(join(targetInstallTransportDir, "curl.log"), "utf8")
+    )
+      .split(/\r?\n/u)
+      .filter(Boolean)
+      .sort();
+    assertDeepEqual(
+      targetInstallRequests,
+      [
+        releaseDownloadUrl(input.target.tag, archiveName),
+        releaseDownloadUrl(input.target.tag, "SHA256SUMS"),
+      ].sort(),
+      `${input.name} exact target installer transport requests`,
+    );
+  } else {
+    assertEqual(
+      targetInstallTransportDir,
+      undefined,
+      `${input.name} omits target installer transport`,
+    );
+  }
 }
 
 function releaseMetadata(tag, id, publishedAt) {
@@ -1630,26 +1852,43 @@ async function verifyBareLaunches(input) {
       [input.installedBinary],
       input.scenarioRoot,
     );
-    assertEqual(tmuxResult.code, 0, `${input.name} tmux bare exit code`);
-    await waitForPath(tmuxCanary, 10_000);
-    assertNoMismatch(tmuxResult.stderr, `${input.name} tmux bare stn`);
+    assertEqual(
+      tmuxResult.code,
+      input.expectTmuxRefusal ? 1 : 0,
+      `${input.name} tmux bare exit code`,
+    );
+    if (input.expectTmuxRefusal) {
+      assertEqual(await pathExists(tmuxCanary), false, `${input.name} tmux refusal mutation`);
+      assertVisibleRefusal(tmuxResult, `${input.name} tmux bare stn`);
+    } else {
+      await waitForPath(tmuxCanary, 10_000);
+      assertNoMismatch(tmuxResult.stderr, `${input.name} tmux bare stn`);
+    }
   } finally {
     if (input.tmuxServer === undefined) await stopTmuxServer(server);
   }
 }
 
-function assertUpdateReport(report, input, installedBinary, configPath) {
+function assertUpdateReport(report, reportJson, input, installedBinary, configPath, evidence) {
   if (report.schemaVersion === 1) {
     assertLegacyUpdateReport(report, input, installedBinary, configPath);
+    return;
+  }
+  if (report.schemaVersion === 4) {
+    assertPredecessorV4UpdateReport(report, input, installedBinary, configPath);
     return;
   }
   assertEqual(report.schemaVersion, 5, `${input.name} update schema`);
   assertEqual(report.kind, "result", `${input.name} update result kind`);
   assertEqual(report.channel, "installer-binary", `${input.name} update channel`);
   const refusal = updateRequiresPreservation(input);
-  assertEqual(report.status, refusal ? "reap-required" : "updated", `${input.name} update status`);
-  assertEqual(report.current?.version, input.options.incumbentVersion, `${input.name} current`);
-  assertEqual(report.target?.version, input.target.version, `${input.name} target`);
+  const expectedStatus = refusal
+    ? "reap-required"
+    : input.artifactState === "current"
+      ? "current"
+      : "updated";
+  assertEqual(report.status, expectedStatus, `${input.name} update status`);
+  assertV5ReportEvidence(report, reportJson, input, evidence);
   assertDeepEqual(report.warnings, [], `${input.name} update warnings`);
   const expectedRecovery = refusal
     ? [[installedBinary, "--config", configPath, "update", "--handoff=processes"]]
@@ -1660,6 +1899,20 @@ function assertUpdateReport(report, input, installedBinary, configPath) {
     `${input.name} recovery commands (${JSON.stringify({ error: report.error, steps: report.steps })})`,
   );
   assertEqual(report.error?.code, undefined, `${input.name} update error`);
+  if (refusal) {
+    assertEqual(report.finalInspection, undefined, `${input.name} refusal final inspection`);
+  } else {
+    assertEqual(
+      report.finalInspection?.status,
+      "completed",
+      `${input.name} completed final inspection`,
+    );
+    assertEqual(
+      report.finalInspection?.plan.outcome,
+      "converged",
+      `${input.name} final convergence plan`,
+    );
+  }
   assertDeepEqual(
     report.hookReconciliations,
     refusal ? [] : expectedNoOpHookReconciliations(report.initial.hooks),
@@ -1671,12 +1924,10 @@ function assertUpdateReport(report, input, installedBinary, configPath) {
         "detect",
         "plan",
         "apply",
-        "detect",
-        "plan",
-        "apply",
+        ...(input.artifactState === "predecessor" ? ["detect", "plan", "apply"] : []),
         "hook-reconciliation",
         "observer-restart",
-        ...(input.busyHost ? ["host-handoff"] : []),
+        ...(scenarioHasHost(input) ? ["host-handoff"] : []),
         "persisted-state-reconcile",
         "final-verification",
       ];
@@ -1689,16 +1940,91 @@ function assertUpdateReport(report, input, installedBinary, configPath) {
     report.steps.map((step) => step.status),
     refusal
       ? ["completed", "completed", "skipped"]
-      : expectedIds.map((id, index) => (id === "apply" && index > 2 ? "skipped" : "completed")),
+      : expectedIds.map((id, index) =>
+          id === "apply" && (input.artifactState === "current" || index > 2)
+            ? "skipped"
+            : "completed",
+        ),
     `${input.name} exact update step outcomes`,
   );
 }
 
-function updateRequiresPreservation(input) {
-  return (
-    input.busyHost &&
-    (input.options.busyHostOutcome === "preserved-refusal" || input.invocation === "external")
+function assertPredecessorV4UpdateReport(report, input, installedBinary, configPath) {
+  assertEqual(report.kind, "result", `${input.name} predecessor update result kind`);
+  assertEqual(report.channel, "installer-binary", `${input.name} predecessor update channel`);
+  const refusal = updateRequiresPreservation(input);
+  assertEqual(
+    report.status,
+    refusal ? "failed" : "updated",
+    `${input.name} predecessor update status`,
   );
+  assertDeepEqual(
+    report.current,
+    { version: input.options.incumbentVersion },
+    `${input.name} predecessor current artifact`,
+  );
+  assertDeepEqual(
+    report.target,
+    { version: input.target.version },
+    `${input.name} predecessor target artifact`,
+  );
+  assertDeepEqual(report.warnings, [], `${input.name} predecessor update warnings`);
+  assertDeepEqual(
+    report.recoveryCommands,
+    refusal
+      ? [[installedBinary, "--config", configPath, "host", "handoff", "--fidelity", "processes"]]
+      : [],
+    `${input.name} predecessor recovery commands`,
+  );
+  assertEqual(
+    report.error?.code,
+    refusal ? "UPDATE_RUNTIME_CROSSOVER_FAILED" : undefined,
+    `${input.name} predecessor update error`,
+  );
+  assertDeepEqual(
+    report.hookReconciliation,
+    {
+      provider: "codex",
+      status: "configured-disabled",
+      changed: false,
+      verified: false,
+      followUp: { action: "enable-hooks" },
+    },
+    `${input.name} predecessor hook reconciliation`,
+  );
+  assertDeepEqual(
+    report.steps.map((step) => step.id),
+    ["detect", "plan", "apply", "hook-reconciliation", "observer-restart", "host-handoff"],
+    `${input.name} exact ordered predecessor update steps`,
+  );
+  assertDeepEqual(
+    report.steps.map((step) => step.status),
+    [
+      "completed",
+      "completed",
+      "completed",
+      "completed",
+      "completed",
+      refusal ? "failed" : "completed",
+    ],
+    `${input.name} exact predecessor update step outcomes`,
+  );
+}
+
+function updateRequiresPreservation(input) {
+  return input.hostState === "busy-compiled-non-bridge";
+}
+
+function scenarioHasHost(input) {
+  return input.hostState !== "absent";
+}
+
+function scenarioHasBusyHost(input) {
+  return input.hostState.startsWith("busy-");
+}
+
+function reportEmitterVersion(input) {
+  return input.artifactState === "current" ? input.target.version : input.options.incumbentVersion;
 }
 
 function expectedNoOpHookReconciliations(hooks) {
@@ -1713,9 +2039,19 @@ function expectedNoOpHookReconciliations(hooks) {
           followUp: hook.followUp,
         };
       case "unsupported":
-        return { provider: hook.provider, status: hook.status, changed: false, verified: false };
+        return {
+          provider: hook.provider,
+          status: hook.status,
+          changed: false,
+          verified: false,
+        };
       case "healthy":
-        return { provider: hook.provider, status: hook.status, changed: false, verified: true };
+        return {
+          provider: hook.provider,
+          status: hook.status,
+          changed: false,
+          verified: true,
+        };
       default:
         throw new Error(
           `Expected a successful no-op hook health result, received ${hook.status} for ${hook.provider}.`,
@@ -1727,7 +2063,7 @@ function expectedNoOpHookReconciliations(hooks) {
 function assertLegacyUpdateReport(report, input, installedBinary, configPath) {
   assertEqual(report.schemaVersion, 1, `${input.name} legacy update schema`);
   assertEqual(report.channel, "installer-binary", `${input.name} legacy update channel`);
-  const refusal = input.busyHost && input.options.busyHostOutcome === "preserved-refusal";
+  const refusal = updateRequiresPreservation(input);
   assertEqual(report.status, refusal ? "failed" : "updated", `${input.name} legacy update status`);
   assertEqual(
     report.current?.version,
@@ -1766,7 +2102,7 @@ function assertLegacyUpdateReport(report, input, installedBinary, configPath) {
       "completed",
       refusal
         ? "failed"
-        : !input.busyHost && input.target.mode === "public"
+        : !scenarioHasHost(input) && input.target.mode === "public"
           ? "skipped"
           : "completed",
     ],
@@ -1774,7 +2110,7 @@ function assertLegacyUpdateReport(report, input, installedBinary, configPath) {
   );
 }
 
-function assertDryUpdateReport(report, input) {
+function assertDryUpdateReport(report, reportJson, input, evidence) {
   if (report.schemaVersion === 1) {
     assertEqual(report.status, "planned", `${input.name} legacy dry-run status`);
     assertEqual(report.channel, "installer-binary", `${input.name} legacy dry-run channel`);
@@ -1794,20 +2130,250 @@ function assertDryUpdateReport(report, input) {
     );
     assertDeepEqual(
       report.steps.map((step) => step.status),
-      ["completed", "completed", "planned", "planned", input.busyHost ? "planned" : "skipped"],
+      [
+        "completed",
+        "completed",
+        "planned",
+        "planned",
+        scenarioHasHost(input) ? "planned" : "skipped",
+      ],
       `${input.name} exact legacy dry-run step outcomes`,
     );
     return 0;
   }
+  if (report.schemaVersion === 4) {
+    return assertPredecessorV4DryUpdateReport(report, reportJson, input, evidence);
+  }
   assertEqual(report.schemaVersion, 5, `${input.name} dry-run schema`);
   assertEqual(report.kind, "preview", `${input.name} dry-run kind`);
   assertEqual(report.channel, "installer-binary", `${input.name} dry-run channel`);
-  assertEqual(report.current?.version, input.options.incumbentVersion, `${input.name} dry current`);
-  assertEqual(report.target?.version, input.target.version, `${input.name} dry target`);
+  assertV5ReportEvidence(report, reportJson, input, evidence);
   assertEqual(report.initial?.boundary.authorization, "none", `${input.name} dry authorization`);
   assertEqual(report.plan?.authorization, "none", `${input.name} dry plan authorization`);
   assertEqual("recoveryPreflight" in report, false, `${input.name} dry omits nested preflight`);
+  assertEqual(
+    report.plan.outcome,
+    updateRequiresPreservation(input) ? "reap-required" : "actionable",
+    `${input.name} dry-run classification`,
+  );
   return ["blocked", "reap-required"].includes(report.plan.outcome) ? 1 : 0;
+}
+
+function assertPredecessorV4DryUpdateReport(report, reportJson, input, evidence) {
+  assertEqual(report.kind, "preview", `${input.name} predecessor dry-run kind`);
+  assertEqual(report.channel, "installer-binary", `${input.name} predecessor dry-run channel`);
+  assertDeepEqual(
+    report.current,
+    { version: input.options.incumbentVersion },
+    `${input.name} predecessor dry current artifact`,
+  );
+  assertDeepEqual(
+    report.target,
+    { version: input.target.version },
+    `${input.name} predecessor dry target artifact`,
+  );
+  assertDeepEqual(
+    report.plan.selectedTarget.artifact,
+    { version: input.target.version },
+    `${input.name} predecessor planned target artifact`,
+  );
+  assertDeepEqual(
+    Object.keys(report.plan.phases),
+    [
+      "artifactApplication",
+      "hookReconciliation",
+      "observerConvergence",
+      "terminalConvergence",
+      "hostConvergence",
+      "persistedStateReconcile",
+      "finalVerification",
+    ],
+    `${input.name} predecessor ordered convergence phases`,
+  );
+  assertAggregateRuntime(
+    report.initial,
+    input,
+    input.options.incumbentVersion,
+    evidence.incumbentBuildIdentity,
+    `${input.name} predecessor initial`,
+    evidence.incumbentHostBuildIdentity,
+  );
+  assertDeepEqual(
+    report.plan.selectedTarget.runtimeBuild,
+    { status: "not-yet-provable" },
+    `${input.name} predecessor target runtime`,
+  );
+  assertPublicIdentityAliases(reportJson, input, evidence);
+  assertEqual(
+    report.initial.boundary.authorization,
+    "none",
+    `${input.name} predecessor dry authorization`,
+  );
+  assertEqual(
+    report.plan.authorization,
+    "none",
+    `${input.name} predecessor dry plan authorization`,
+  );
+  assertEqual(
+    "recoveryPreflight" in report,
+    false,
+    `${input.name} predecessor dry omits nested preflight`,
+  );
+  return ["blocked", "reap-required"].includes(report.plan.outcome) ? 1 : 0;
+}
+
+function assertV5ReportEvidence(report, reportJson, input, evidence) {
+  const incumbentArtifact = { version: input.options.incumbentVersion };
+  const targetArtifact = { version: input.target.version };
+  assertDeepEqual(
+    report.current,
+    input.artifactState === "current" ? targetArtifact : incumbentArtifact,
+    `${input.name} exact current artifact`,
+  );
+  assertDeepEqual(report.target, targetArtifact, `${input.name} exact target artifact`);
+  assertDeepEqual(
+    report.plan.selectedTarget.artifact,
+    targetArtifact,
+    `${input.name} planned target artifact`,
+  );
+  assertDeepEqual(
+    Object.keys(report.plan.phases),
+    [
+      "artifactApplication",
+      "hookReconciliation",
+      "observerConvergence",
+      "terminalConvergence",
+      "hostConvergence",
+      "persistedStateReconcile",
+      "finalVerification",
+    ],
+    `${input.name} ordered convergence phases`,
+  );
+  assertAggregateRuntime(
+    report.initial,
+    input,
+    input.options.incumbentVersion,
+    evidence.incumbentBuildIdentity,
+    `${input.name} initial`,
+    evidence.incumbentHostBuildIdentity,
+  );
+  if (input.artifactState === "current") {
+    assertKnownTargetRuntime(
+      report.plan.selectedTarget.runtimeBuild,
+      input,
+      `${input.name} planned target runtime`,
+    );
+  } else {
+    assertDeepEqual(
+      report.plan.selectedTarget.runtimeBuild,
+      { status: "not-yet-provable" },
+      `${input.name} preinstallation target runtime`,
+    );
+  }
+  if (report.kind === "result" && report.finalInspection?.status === "completed") {
+    assertDeepEqual(
+      report.finalInspection.aggregate.installed,
+      targetArtifact,
+      `${input.name} final installed artifact`,
+    );
+    assertDeepEqual(
+      report.finalInspection.aggregate.target,
+      targetArtifact,
+      `${input.name} final selected artifact`,
+    );
+    assertAggregateRuntime(
+      report.finalInspection.aggregate,
+      input,
+      input.target.version,
+      input.target.buildIdentity,
+      `${input.name} final`,
+    );
+    assertKnownTargetRuntime(
+      report.finalInspection.plan.selectedTarget.runtimeBuild,
+      input,
+      `${input.name} final target runtime`,
+    );
+  }
+  assertPublicIdentityAliases(reportJson, input, evidence);
+}
+
+function assertAggregateRuntime(
+  aggregate,
+  input,
+  version,
+  observerBuildIdentity,
+  label,
+  hostBuildIdentity = observerBuildIdentity,
+) {
+  assertEqual(aggregate.observer.status, "exact", `${label} Observer status`);
+  assertDisplayVersion(aggregate.observer.buildVersion, version, `${label} Observer`);
+  assertObserverBuildIdentity(
+    aggregate.observer.buildVersion,
+    observerBuildIdentity,
+    `${label} Observer`,
+  );
+  if (scenarioHasHost(input)) {
+    assertEqual(aggregate.host.status, "inspected", `${label} Host status`);
+    assertEqual(aggregate.host.buildVersion, version, `${label} Host version`);
+    assertEqual(aggregate.host.buildIdentity, hostBuildIdentity, `${label} Host build identity`);
+  } else {
+    assertDeepEqual(aggregate.host, { status: "absent" }, `${label} Host absence`);
+  }
+}
+
+function assertKnownTargetRuntime(runtimeBuild, input, label) {
+  assertEqual(runtimeBuild.status, "known", `${label} status`);
+  assertEqual(runtimeBuild.buildIdentity, input.target.buildIdentity, `${label} build identity`);
+  assertDisplayVersion(runtimeBuild.observerSelector, input.target.version, label);
+  assertObserverBuildIdentity(runtimeBuild.observerSelector, input.target.buildIdentity, label);
+}
+
+function assertPublicIdentityAliases(report, input, evidence) {
+  const fields = {
+    projectId: "project",
+    worktreeId: "worktree",
+    sessionId: "session",
+    terminalTargetId: "terminal-target",
+    ptyId: "pty",
+    ptyInstanceId: "pty-instance",
+  };
+  const raw =
+    evidence.ptyIdentity === undefined || evidence.spawnedPty === undefined
+      ? {}
+      : {
+          projectId: evidence.ptyIdentity.projectId,
+          worktreeId: evidence.ptyIdentity.worktreeId,
+          sessionId: evidence.ptyIdentity.sessionId,
+          terminalTargetId: evidence.ptyIdentity.terminalTargetId,
+          ptyId: evidence.spawnedPty.ptyId,
+          ptyInstanceId: evidence.spawnedPty.ptyInstanceId,
+        };
+  const serialized = JSON.stringify(report);
+  for (const [field, label] of Object.entries(fields)) {
+    const values = collectStringFieldValues(report, field);
+    const expectedRaw = raw[field];
+    assertDeepEqual(
+      [...new Set(values)].sort(),
+      expectedRaw === undefined ? [] : [`public-${label}-00000001`],
+      `${input.name} stable public ${label} aliases`,
+    );
+    if (expectedRaw !== undefined) {
+      assertEqual(
+        serialized.includes(expectedRaw),
+        false,
+        `${input.name} omits raw ${label} identity`,
+      );
+    }
+  }
+}
+
+function collectStringFieldValues(value, field) {
+  if (value === null || typeof value !== "object") return [];
+  if (Array.isArray(value)) return value.flatMap((entry) => collectStringFieldValues(entry, field));
+  return Object.entries(value).flatMap(([key, entry]) => [
+    ...(key === field && typeof entry === "string" ? [entry] : []),
+    ...collectStringFieldValues(entry, field),
+  ]);
 }
 
 function assertVisibleRefusal(result, label) {
@@ -2023,6 +2589,44 @@ async function snapshotSuppliedBinary(path, version) {
   };
 }
 
+async function snapshotTaggedPredecessorSource(path, version) {
+  const resolvedPath = resolve(path);
+  const packageJson = parseJson(
+    await readFile(join(resolvedPath, "package.json"), "utf8"),
+    "tagged predecessor package.json",
+  );
+  assertEqual(packageJson.version, version, "tagged predecessor source version");
+  const expectedTag = `v${version}`;
+  const head = await runGit(resolvedPath, ["rev-parse", "HEAD"]);
+  const taggedCommit = await runGit(resolvedPath, ["rev-parse", `${expectedTag}^{commit}`]);
+  assertEqual(head, taggedCommit, "tagged predecessor source commit");
+  const sourceChanges = await runGit(resolvedPath, ["status", "--porcelain"]);
+  assertEqual(sourceChanges, "", "tagged predecessor source state");
+  const buildIdentity = (
+    await readFile(join(resolvedPath, "packages", "runtime", "dist", "station-build-id"), "utf8")
+  ).trim();
+  assertBuildIdentity(buildIdentity, "tagged predecessor source build identity");
+  await run(
+    process.execPath,
+    [join(resolvedPath, "scripts", "build-identity.mjs"), "--verify", buildIdentity],
+    { cwd: resolvedPath, env: buildEnvironment() },
+  );
+  return { path: resolvedPath, version, tag: expectedTag, commit: head, buildIdentity };
+}
+
+async function assertTaggedPredecessorSourceUnchanged(snapshot) {
+  const current = await snapshotTaggedPredecessorSource(snapshot.path, snapshot.version);
+  assertDeepEqual(current, snapshot, "tagged predecessor source identity");
+}
+
+async function runGit(cwd, args) {
+  const result = await run("/usr/bin/git", args, {
+    cwd,
+    env: buildEnvironment(),
+  });
+  return result.stdout.trim();
+}
+
 async function assertSuppliedBinaryUnchanged(snapshot) {
   const current = await snapshotSuppliedBinary(snapshot.path);
   assertDeepEqual(
@@ -2060,6 +2664,7 @@ function parseArgs(argv) {
         "--target-tag",
         "--target-build-identity",
         "--public-target-tag",
+        "--predecessor-source-dir",
         "--scenarios",
         "--busy-host-outcome",
       ].includes(key)
@@ -2074,6 +2679,7 @@ function parseArgs(argv) {
   const targetTag = values.get("--target-tag");
   const targetBuildIdentity = values.get("--target-build-identity");
   const publicTag = values.get("--public-target-tag");
+  const predecessorSourceDir = values.get("--predecessor-source-dir");
   const modes = [
     sourceVersion !== undefined,
     releaseDir !== undefined || targetTag !== undefined,
@@ -2113,8 +2719,8 @@ function parseArgs(argv) {
     throw new Error("Update smoke target must differ from the incumbent version.");
   }
   const scenarios = values.get("--scenarios") ?? "full";
-  if (scenarios !== "full" && scenarios !== "no-host") {
-    throw new Error("--scenarios must be full or no-host.");
+  if (scenarios !== "full" && scenarios !== "no-host" && scenarios !== "release") {
+    throw new Error("--scenarios must be full, no-host, or release.");
   }
   const busyHostOutcome = values.get("--busy-host-outcome") ?? "full-handoff";
   if (busyHostOutcome !== "full-handoff" && busyHostOutcome !== "preserved-refusal") {
@@ -2123,18 +2729,33 @@ function parseArgs(argv) {
   if (scenarios === "no-host" && busyHostOutcome === "preserved-refusal") {
     throw new Error("--busy-host-outcome preserved-refusal requires --scenarios full.");
   }
+  if (scenarios === "release" && busyHostOutcome !== "preserved-refusal") {
+    throw new Error("--scenarios release requires --busy-host-outcome preserved-refusal.");
+  }
+  if (scenarios === "release" && target.mode === "public") {
+    throw new Error("--scenarios release requires snapshotted source or staged target assets.");
+  }
+  if (predecessorSourceDir !== undefined && target.mode === "public") {
+    throw new Error("--predecessor-source-dir is not valid for public targets.");
+  }
+  if (scenarios === "release" && target.mode === "staged" && predecessorSourceDir === undefined) {
+    throw new Error("Staged release scenarios require --predecessor-source-dir.");
+  }
   return {
     incumbentBinary: resolve(incumbentBinary),
     incumbentVersion,
     target,
     scenarios,
     busyHostOutcome,
+    ...(predecessorSourceDir === undefined
+      ? {}
+      : { predecessorSourceDir: resolve(predecessorSourceDir) }),
     keepTemp,
   };
 }
 
 function updateSmokeUsage() {
-  return "Usage: run-update-smoke.mjs --incumbent-binary <path> --incumbent-version <version> (--target-source-version <version> | --target-release-dir <path> --target-tag <tag> --target-build-identity <64-hex> | --public-target-tag <tag> --target-build-identity <64-hex>) [--scenarios full|no-host] [--busy-host-outcome full-handoff|preserved-refusal] [--keep-temp]";
+  return "Usage: run-update-smoke.mjs --incumbent-binary <path> --incumbent-version <version> (--target-source-version <version> | --target-release-dir <path> --target-tag <tag> --target-build-identity <64-hex> | --public-target-tag <tag> --target-build-identity <64-hex>) [--predecessor-source-dir <path>] [--scenarios full|no-host|release] [--busy-host-outcome full-handoff|preserved-refusal] [--keep-temp]";
 }
 
 function assertBuildIdentity(value, label) {

--- a/tests/diagnostics/ci-workflow-policy.test.ts
+++ b/tests/diagnostics/ci-workflow-policy.test.ts
@@ -68,6 +68,14 @@ function workflowSteps(file: WorkflowFile): readonly WorkflowStep[] {
   });
 }
 
+function namedWorkflowStep(document: string, name: string): string {
+  const steps = workflowSteps({ path: "", document, lines: document.split("\n") }).filter(
+    (step) => step.text.split("\n")[0]?.trim() === `- name: ${name}`,
+  );
+  expect(steps, `workflow step named ${name}`).toHaveLength(1);
+  return steps[0]?.text ?? "";
+}
+
 function workflowJobNames(document: string): readonly string[] {
   const lines = document.slice(document.indexOf("jobs:")).split("\n");
   return lines.flatMap((line) => {
@@ -453,6 +461,7 @@ describe("hosted CI policy", () => {
     const promotion = read(".github/workflows/promote-release.yml");
     const updateSmoke = read("scripts/test-runners/run-update-smoke.mjs");
     const installDraft = workflowJob(release, "install-draft");
+    const preparePredecessor = namedWorkflowStep(installDraft, "Prepare exact predecessor");
     const createDraft = workflowJob(release, "create-draft");
     const accepted = workflowJob(release, "record-accepted-candidate");
     const promote = workflowJob(promotion, "promote");
@@ -467,7 +476,7 @@ describe("hosted CI policy", () => {
       createDraft.indexOf("release-candidate-input-"),
     );
     expect(createDraft).toContain("targetBuildIdentity: $targetBuildIdentity");
-    expect(installDraft).toContain("Fetch staged update assets and exact predecessor");
+    expect(installDraft).toContain("Fetch staged update assets");
     expect(installDraft).toContain("fetch-depth: 0");
     expect(installDraft).toContain("actions/download-artifact@");
     expect(installDraft).toContain('awk -F= -v name="$name"');
@@ -478,11 +487,31 @@ describe("hosted CI policy", () => {
     expect(installDraft).toContain('git worktree add --detach "$predecessor_source"');
     expect(installDraft).toContain("bun install --frozen-lockfile");
     expect(installDraft).toContain("bun run --cwd station repair:node-pty");
+    expect(preparePredecessor).toContain(
+      `env:\n          PREVIOUS_TAG: ${actionsExpression("needs.validate.outputs.previous_tag")}\n        run:`,
+    );
+    expect(preparePredecessor).not.toContain(actionsExpression("github.token"));
+    const credentialRemoval = preparePredecessor.indexOf(
+      "unset GH_TOKEN GITHUB_TOKEN GH_ENTERPRISE_TOKEN GITHUB_ENTERPRISE_TOKEN",
+    );
+    expect(credentialRemoval).toBeGreaterThanOrEqual(0);
+    for (const command of [
+      "curl --disable",
+      '/bin/sh "$predecessor_installer"',
+      "bun install --frozen-lockfile",
+      "bun run build",
+      "bun run --cwd station repair:node-pty",
+    ]) {
+      expect(credentialRemoval, command).toBeLessThan(preparePredecessor.indexOf(command));
+    }
     expect(installDraft).toContain(
       '--predecessor-source-dir "$RUNNER_TEMP/update-predecessor-source"',
     );
     expect(installDraft).toContain("--scenarios release");
     expect(installDraft).toContain("--busy-host-outcome preserved-refusal");
+    expect(updateSmoke).toMatch(
+      /options\.scenarios === "release"\s*\? \[\.\.\.predecessorScenarios, \.\.\.currentArtifactScenarios\]/u,
+    );
     for (const scenario of [
       "external-busy-host",
       "tmux-busy-host",

--- a/tests/diagnostics/ci-workflow-policy.test.ts
+++ b/tests/diagnostics/ci-workflow-policy.test.ts
@@ -37,7 +37,10 @@ interface WorkflowStep {
 
 function workflowFiles(): readonly WorkflowFile[] {
   return [".github/workflows", ".github/actions"].flatMap((directory) =>
-    readdirSync(new URL(directory, root), { recursive: true, withFileTypes: true })
+    readdirSync(new URL(directory, root), {
+      recursive: true,
+      withFileTypes: true,
+    })
       .filter((entry) => entry.isFile() && /\.ya?ml$/.test(entry.name))
       .map((entry) => {
         const path = `${directory}/${entry.parentPath.slice(
@@ -350,7 +353,10 @@ describe("hosted CI policy", () => {
       },
       {
         name: "contradictory documentation selectors",
-        environment: { ...documentationCiEnvironment, SHELL_MATRIX_SELECTED: "true" },
+        environment: {
+          ...documentationCiEnvironment,
+          SHELL_MATRIX_SELECTED: "true",
+        },
       },
     ]) {
       const result = runAggregatePolicy(testCase.environment);
@@ -407,7 +413,10 @@ describe("hosted CI policy", () => {
       { ...newer, published_at: "not-a-date" },
       { ...newer, tag_name: "v01.2.4" },
       { ...newer, id: 0 },
-      { ...newer, assets: newer.assets.map((asset, index) => ({ ...asset, id: index })) },
+      {
+        ...newer,
+        assets: newer.assets.map((asset, index) => ({ ...asset, id: index })),
+      },
       {
         ...newer,
         assets: newer.assets.map((asset, index) => ({
@@ -439,9 +448,10 @@ describe("hosted CI policy", () => {
     }
   });
 
-  it("binds staged and public update acceptance to one exact predecessor", () => {
+  it("keeps staged predecessor, current-target, and public update acceptance", () => {
     const release = read(".github/workflows/release.yml");
     const promotion = read(".github/workflows/promote-release.yml");
+    const updateSmoke = read("scripts/test-runners/run-update-smoke.mjs");
     const installDraft = workflowJob(release, "install-draft");
     const createDraft = workflowJob(release, "create-draft");
     const accepted = workflowJob(release, "record-accepted-candidate");
@@ -458,14 +468,55 @@ describe("hosted CI policy", () => {
     );
     expect(createDraft).toContain("targetBuildIdentity: $targetBuildIdentity");
     expect(installDraft).toContain("Fetch staged update assets and exact predecessor");
+    expect(installDraft).toContain("fetch-depth: 0");
     expect(installDraft).toContain("actions/download-artifact@");
     expect(installDraft).toContain('awk -F= -v name="$name"');
     expect(installDraft).toContain('cmp candidate/SHA256SUMS "$release_dir/SHA256SUMS"');
     expect(installDraft).not.toContain("select(.name == $name)");
     expect(installDraft).toContain('--target-release-dir "$RUNNER_TEMP/update-release"');
     expect(installDraft).toContain('--target-build-identity "$target_build_identity"');
-    expect(installDraft).toContain("--scenarios full");
+    expect(installDraft).toContain('git worktree add --detach "$predecessor_source"');
+    expect(installDraft).toContain("bun install --frozen-lockfile");
+    expect(installDraft).toContain("bun run --cwd station repair:node-pty");
+    expect(installDraft).toContain(
+      '--predecessor-source-dir "$RUNNER_TEMP/update-predecessor-source"',
+    );
+    expect(installDraft).toContain("--scenarios release");
     expect(installDraft).toContain("--busy-host-outcome preserved-refusal");
+    for (const scenario of [
+      "external-busy-host",
+      "tmux-busy-host",
+      "tmux-no-host",
+      "current-no-host",
+      "current-idle-host",
+      "current-busy-source-bridge-host",
+      "current-busy-non-bridge-host",
+    ]) {
+      expect(updateSmoke).toContain(`name: "${scenario}"`);
+    }
+    for (const [scenario, socketKey] of [
+      ["external-busy-host", "e"],
+      ["tmux-busy-host", "b"],
+      ["tmux-no-host", "n"],
+      ["current-no-host", "cn"],
+      ["current-idle-host", "ci"],
+      ["current-busy-source-bridge-host", "cb"],
+      ["current-busy-non-bridge-host", "cx"],
+    ]) {
+      expect(updateSmoke).toContain(`name: "${scenario}",\n      socketKey: "${socketKey}"`);
+    }
+    expect(updateSmoke).toContain('hostState: "busy-source-bridge"');
+    expect(updateSmoke).not.toContain('hostState: "busy-compiled-bridge"');
+    expect(updateSmoke).toContain(
+      '"--scenarios release requires --busy-host-outcome preserved-refusal."',
+    );
+    expect(updateSmoke).toContain(
+      '"--scenarios release requires snapshotted source or staged target assets."',
+    );
+    expect(updateSmoke).toContain('"--predecessor-source-dir is not valid for public targets."');
+    expect(updateSmoke).toContain('"Staged release scenarios require --predecessor-source-dir."');
+    expect(updateSmoke).toContain("serialized.includes(expectedRaw)");
+    expect(updateSmoke).not.toContain("serialized.includes(JSON.stringify(expectedRaw))");
     expect(accepted).toContain('test "$current_ids" = "$(cat candidate/asset-ids.txt)"');
     expect(accepted).not.toContain(": > candidate/asset-ids.txt");
 
@@ -482,13 +533,15 @@ describe("hosted CI policy", () => {
     expect(publicInstall).toContain('--target-build-identity "$TARGET_BUILD_IDENTITY"');
     expect(publicInstall).toContain("--scenarios no-host");
     expect(promotion).toContain(
-      "Confirm macOS partial crossover preserved old Host output and the target native UI visibly refused it",
+      "Confirm documented native/tmux acceptance, current-target convergence, and preserved refusal",
     );
   });
 
   it("keeps binary handoff stress manual, capped, and failure-artifact-only", () => {
     const stress = read(".github/workflows/binary-handoff-stress.yml");
-    const packageJson = JSON.parse(read("package.json")) as { scripts: Record<string, string> };
+    const packageJson = JSON.parse(read("package.json")) as {
+      scripts: Record<string, string>;
+    };
 
     expect(stress).toContain("workflow_dispatch:");
     expect(stress).not.toContain("schedule:");
@@ -546,6 +599,10 @@ describe("hosted CI policy", () => {
     );
     expect(packageJson.scripts["test:ci:binary"]).toContain(
       "bun run smoke:update -- --incumbent-binary station/dist/bin/stn",
+    );
+    expect(packageJson.scripts["test:ci:binary"]).toContain("--scenarios release");
+    expect(packageJson.scripts["test:ci:binary"]).toContain(
+      "--busy-host-outcome preserved-refusal",
     );
     expect(packageJson.scripts["test:ci:station"]).toContain("test:pty:bun");
     expect(lefthook).toContain(

--- a/tests/diagnostics/composed-update-report.test.ts
+++ b/tests/diagnostics/composed-update-report.test.ts
@@ -131,6 +131,16 @@ function predecessorV4Report() {
 }
 
 describe("composed update report parsing", () => {
+  it("maps each emitter generation to its exact report schema", async () => {
+    const { updateReportSchemaVersionForEmitter } = await loadReportModule();
+
+    expect(updateReportSchemaVersionForEmitter("0.0.0-pre-alpha.5.16")).toBe(1);
+    expect(updateReportSchemaVersionForEmitter("0.0.0-pre-alpha.14.3")).toBe(4);
+    expect(updateReportSchemaVersionForEmitter("0.0.0-pre-alpha.14.4")).toBe(5);
+    expect(updateReportSchemaVersionForEmitter("0.0.0-local")).toBe(5);
+    expect(updateReportSchemaVersionForEmitter("0.0.1-local")).toBe(5);
+  });
+
   it("accepts the strict published-predecessor report", async () => {
     const { parseComposedUpdateReport } = await loadReportModule();
     const report = legacyReport();

--- a/tests/diagnostics/composed-update-report.test.ts
+++ b/tests/diagnostics/composed-update-report.test.ts
@@ -79,6 +79,57 @@ function currentReport() {
   };
 }
 
+function predecessorV4Report() {
+  const current = { version: "0.0.0-pre-alpha.14.3" };
+  const target = { version: "0.0.0-pre-alpha.14.4" };
+  return {
+    schemaVersion: 4,
+    kind: "preview",
+    channel: "installer-binary",
+    current,
+    target,
+    initial: {
+      schemaVersion: 1,
+      boundary: { authorization: "none", actions: "not-included", digest: "not-included" },
+      installed: current,
+      target,
+      observer: { status: "absent" },
+      host: { status: "absent" },
+      hookProviderIds: [],
+      hooks: [],
+      terminalDispositions: [],
+      evidenceComplete: false,
+    },
+    plan: {
+      authorization: "none",
+      selectedTarget: { artifact: target, runtimeBuild: { status: "not-yet-provable" } },
+      outcome: "actionable",
+      phases: {
+        artifactApplication: {
+          action: "apply",
+          reason: "selected-artifact-different",
+          before: current,
+          owner: "installer-binary",
+          command: { kind: "none" },
+        },
+        hookReconciliation: { action: "no-op", reason: "healthy", providers: [] },
+        observerConvergence: { action: "reinspect", reason: "target-build-not-yet-provable" },
+        terminalConvergence: {
+          action: "reinspect",
+          reason: "target-build-not-yet-provable",
+          terminals: [],
+        },
+        hostConvergence: { action: "reinspect", reason: "target-build-not-yet-provable" },
+        persistedStateReconcile: {
+          action: "await-artifact",
+          reason: "target-build-not-yet-provable",
+        },
+        finalVerification: { action: "inspect", reason: "after-actions" },
+      },
+    },
+  };
+}
+
 describe("composed update report parsing", () => {
   it("accepts the strict published-predecessor report", async () => {
     const { parseComposedUpdateReport } = await loadReportModule();
@@ -109,6 +160,30 @@ describe("composed update report parsing", () => {
     ).toThrow();
   });
 
+  it("accepts the frozen schema-v4 predecessor contract", async () => {
+    const { parseComposedUpdateReport } = await loadReportModule();
+    const report = predecessorV4Report();
+
+    expect(parseComposedUpdateReport(report, "0.0.0-pre-alpha.14.3")).toEqual(report);
+    expect(() =>
+      parseComposedUpdateReport(
+        {
+          ...report,
+          initial: {
+            ...report.initial,
+            parkedBridges: {
+              status: "assessed",
+              totalParkedCount: 0,
+              unownedParkedCount: 0,
+              adoptionRequiredCount: 0,
+            },
+          },
+        },
+        "0.0.0-pre-alpha.14.3",
+      ),
+    ).toThrow();
+  });
+
   it.each([2, 3])("rejects unsupported report schema %i", async (schemaVersion) => {
     const { parseComposedUpdateReport } = await loadReportModule();
 
@@ -125,6 +200,12 @@ describe("composed update report parsing", () => {
     );
     expect(() => parseComposedUpdateReport(currentReport(), "0.0.0-pre-alpha.5.16")).toThrow(
       /Expected update report schema 1/u,
+    );
+    expect(() => parseComposedUpdateReport(predecessorV4Report(), "0.0.0-local")).toThrow(
+      /Expected update report schema 5/u,
+    );
+    expect(() => parseComposedUpdateReport(currentReport(), "0.0.0-pre-alpha.14.3")).toThrow(
+      /Expected update report schema 4/u,
     );
   });
 });

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -79,9 +79,9 @@ describe("release readiness docs", () => {
       "let your agent install and validate station",
     );
     expect(prompt).toContain(
-      "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.3/install.sh",
+      "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.4/install.sh",
     );
-    expect(prompt).toContain("v0.0.0-pre-alpha.14.3");
+    expect(prompt).toContain("v0.0.0-pre-alpha.14.4");
     expect(prompt).toContain("stn setup check --json");
     expect(prompt).toContain("stn doctor");
     expect(prompt).toContain("summary.requiredOk: true");
@@ -101,7 +101,7 @@ describe("release readiness docs", () => {
     expect(normalizedPrompt).toContain("verify all three launchers in a new shell");
     expect(normalizedPrompt).toContain("do not claim success");
     expect(install).toContain("../README.md#let-your-agent-install-and-validate-station");
-    expect(install).not.toContain("Install experimental Station v0.0.0-pre-alpha.14.3");
+    expect(install).not.toContain("Install experimental Station v0.0.0-pre-alpha.14.4");
   });
 
   it("keeps the Node.js 24.2+ development requirement consistent", async () => {
@@ -232,9 +232,10 @@ describe("release readiness docs", () => {
       ].map(read),
     );
     const packageJson = await readPackageManifest();
-    const exactVersion = "v0.0.0-pre-alpha.14.3";
+    const normalizedReleasing = releasing.replace(/\s+/g, " ");
+    const exactVersion = "v0.0.0-pre-alpha.14.4";
     const exactInstallerUrl =
-      "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.3/install.sh";
+      "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.4/install.sh";
 
     for (const [path, document] of [
       ["README.md", readme],
@@ -286,8 +287,28 @@ describe("release readiness docs", () => {
     expect(releasing).toContain("repository-wide publication lock");
     expect(releasing).toContain("`full-handoff`");
     expect(releasing).toContain("`preserved-refusal`");
-    expect(releasing).toContain("compiled predecessors must preserve and visibly");
-    expect(releasing).toContain("scenario must complete the version change");
+    for (const scenario of [
+      "external and tmux busy",
+      "tmux no-Host update",
+      "no Host",
+      "an idle compiled Host",
+      "a busy exact-tag source-bridge Host",
+      "a busy compiled Bun Host",
+    ]) {
+      expect(normalizedReleasing).toContain(scenario);
+    }
+    expect(releasing).toContain("seven staged cases");
+    expect(releasing).toContain("Every v5 preview and result");
+    expect(releasing).toContain("correlated `public-*` aliases");
+    expect(releasing).toContain("completed final inspection");
+    expect(releasing).toContain("plan is `converged`");
+    expect(normalizedReleasing).toContain("proves bridge handoff across");
+    expect(normalizedReleasing).toContain("without identity overrides");
+    expect(normalizedReleasing).toContain(
+      "source Host and immutable compiled Observer against their independently derived build identities",
+    );
+    expect(normalizedReleasing).toContain("Only the tagged staged lane proves");
+    expect(releasing).toContain("exact-tag no-Host");
     expect(releasing).not.toContain(exactVersion);
     expect(homebrew).toContain("Homebrew installation is not currently supported");
     expect(homebrew).toContain("This distribution policy is separate from first-run dependencies");
@@ -365,7 +386,7 @@ describe("release readiness docs", () => {
       expect(promote).toContain(target);
     }
 
-    expect(packageJson.version).toBe("0.0.0-pre-alpha.14.3");
+    expect(packageJson.version).toBe("0.0.0-pre-alpha.14.4");
     expect(packageJson.scripts["smoke:install"]).toBe(
       "node scripts/test-runners/run-install-smoke.mjs",
     );

--- a/tests/e2e/setup-core-flow.test.ts
+++ b/tests/e2e/setup-core-flow.test.ts
@@ -48,6 +48,19 @@ describe("setup core flow e2e", () => {
       await writeShim(bin, "npm", "echo 0.1.0\n");
       await writeShim(
         bin,
+        "npx",
+        [
+          'if [ "$1 $2" != "--yes bun@1.4.0" ]; then',
+          '  echo "unexpected npx $*" >&2',
+          "  exit 2",
+          "fi",
+          "shift 2",
+          `exec "${bunBin}" "$@"`,
+          "",
+        ].join("\n"),
+      );
+      await writeShim(
+        bin,
         "wt",
         'if [ "$1" = "--version" ]; then echo "worktrunk 1.2.3"; exit 0; fi\nexit 0\n',
       );


### PR DESCRIPTION
## What this fixes

Release acceptance previously proved only three predecessor cases and could not show that a candidate already installed over an older runtime converges safely. Exact .14.3 acceptance also exposed two target-side process-result incompatibilities: restart JSON included an additive health field rejected by the predecessor, and the target no longer accepted the bounded Host crossover command.

Refs #679. Parent release gate: #640. PR #843 completed the prerequisite work in #678.

## What changed

- Adds a seven-case release smoke set: three immutable-predecessor cases and four current-artifact runtime cases, with fixed short socket keys and separate installation and update transport ledgers.
- Verifies exact target and build identity, ordered v4 and v5 reports, final converged inspection, stable public aliases, native and tmux launches, PTY continuity, and no-signal reap-required preservation.
- Builds the exact predecessor tag with its frozen dependencies for the source-only bridge case, launches that Host without identity overrides, and verifies its independently derived build identity in every emitted report.
- Keeps Observer restart and Host crossover subprocess results strict and bounded for the immutable predecessor while leaving update planning, execution, and destructive reap authority unchanged.
- Runs staged macOS acceptance and deterministic test:ci:binary coverage against the release set while retaining public post-promotion no-Host verification.
- Advances the candidate documentation and runtime identity to 0.0.0-pre-alpha.14.4.

## Testing

- bunx vitest run --config config/vitest/vitest.diagnostics.config.ts tests/diagnostics/composed-update-report.test.ts tests/diagnostics/ci-workflow-policy.test.ts tests/diagnostics/release-readiness-docs.test.ts
- bun run build
- bun run typecheck
- bun run lint
- bun run test:ci:binary
- Immutable 0.0.0-pre-alpha.14.3 public binary and exact-tag source Host to locally built 0.0.0-pre-alpha.14.4 seven-case update suite
- bun run test:all
- Focused retry of packages/protocol/test/unit/transport.test.ts after one transient full-suite timeout
- bun run test:e2e:real:local tests/e2e/real/real-station-process.test.ts tests/e2e/real/real-native-tui-mouse.test.ts tests/e2e/real/real-session-lifecycle-codex.test.ts tests/e2e/real/real-popup-navigation.test.ts

## Safety and scope

- This PR does not change the update planner, update executor, Observer backend, connectors, migrations, destructive reap behavior, or signal authority.
- The immutable .14.3 compiled Host rejects bridge PTY selection by design. The bridge case uses a clean checkout of the exact .14.3 tag, its frozen lockfile, and its genuine independently verified source build identity. It does not relabel candidate source as the predecessor.
- The raw-identity proof uses opaque identifiers and rejects each raw substring anywhere in serialized JSON, including nested error and step strings.
- Issues #679 and #640 remain open until the exact merge commit is tagged, accepted, manually reviewed, promoted, and publicly verified.