### PR TITLE
perf(tui): surface projected harness state sooner

### DIFF
--- a/apps/observer/src/runtime/api.ts
+++ b/apps/observer/src/runtime/api.ts
@@ -228,6 +228,7 @@ export function createObserverApi(options: CreateObserverApiOptions): ObserverAp
     eventBus: options.eventBus,
     clock,
     requestReconcile: reconcileScheduler.request,
+    requestProjectedReconcile: reconcileScheduler.requestAfterQuiet,
     ...(options.logger === undefined ? {} : { logger: options.logger }),
   };
   if (providerHealthCache !== undefined) {

--- a/apps/observer/src/runtime/harnessReportProcessor.ts
+++ b/apps/observer/src/runtime/harnessReportProcessor.ts
@@ -15,7 +15,10 @@ export type HarnessReportProcessorDeps = {
   core: ObserverCore;
   eventBus: ObserverEventBus;
   clock: RuntimeClock;
+  /** Requests canonical convergence when immediate projection cannot establish visible state. */
   requestReconcile: (reason: string) => void;
+  /** Requests quiet-period convergence after immediate projection establishes visible state. */
+  requestProjectedReconcile: (reason: string) => void;
   refreshProviderHealth?: (providerId: string) => Promise<void>;
   logger?: StationLogger;
 };
@@ -123,6 +126,10 @@ export async function processHarnessIngressReport(
         .catch(() => undefined),
     );
   }
-  deps.requestReconcile(reconcileReason);
+  if (projection.value.projected) {
+    deps.requestProjectedReconcile(reconcileReason);
+  } else {
+    deps.requestReconcile(reconcileReason);
+  }
   return receipt;
 }

--- a/apps/observer/src/runtime/reconcileScheduler.ts
+++ b/apps/observer/src/runtime/reconcileScheduler.ts
@@ -2,6 +2,8 @@ import { Effect } from "@station/runtime";
 
 export type ReconcileScheduler = {
   request(reason: string): void;
+  /** Coalesces already-projected work until the configured quiet interval elapses. */
+  requestAfterQuiet(reason: string): void;
   requestInteractive(reason: string): void;
   requestWhenReady(reason: string, readiness: ReconcileReadiness): void;
   requestInteractiveWhenReady(reason: string, readiness: ReconcileReadiness): void;
@@ -18,6 +20,8 @@ export type CreateReconcileSchedulerOptions = {
   debounceMs?: number;
   backlogDebounceMs?: number;
   interactiveDebounceMs?: number;
+  /** Quiet interval for convergence work whose user-visible projection is already applied. */
+  quietDebounceMs?: number;
   onError?: (error: unknown) => Promise<void> | void;
   onFlushFinish?: (profile: ReconcileSchedulerFlushProfile) => Promise<void> | void;
 };
@@ -34,11 +38,13 @@ export type ReconcileSchedulerFlushProfile = {
 const defaultDebounceMs = 100;
 const defaultBacklogDebounceMs = 1000;
 const defaultInteractiveDebounceMs = 25;
+const defaultQuietDebounceMs = 250;
 
 type QueuedReconcileRequest = {
   reason: string;
   queuedAt: number;
   interactive: boolean;
+  quiet: boolean;
   readiness?: ReconcileReadiness;
 };
 
@@ -48,6 +54,7 @@ export function createReconcileScheduler(
   const debounceMs = options.debounceMs ?? defaultDebounceMs;
   const backlogDebounceMs = options.backlogDebounceMs ?? defaultBacklogDebounceMs;
   const interactiveDebounceMs = options.interactiveDebounceMs ?? defaultInteractiveDebounceMs;
+  const quietDebounceMs = options.quietDebounceMs ?? defaultQuietDebounceMs;
   let running = false;
   let timerScheduled = false;
   let stopped = false;
@@ -59,12 +66,16 @@ export function createReconcileScheduler(
   const queuedRequests: QueuedReconcileRequest[] = [];
 
   return {
-    request: (reason) => request({ reason, queuedAt: Date.now(), interactive: false }),
-    requestInteractive: (reason) => request({ reason, queuedAt: Date.now(), interactive: true }),
+    request: (reason) =>
+      request({ reason, queuedAt: Date.now(), interactive: false, quiet: false }),
+    requestAfterQuiet: (reason) =>
+      request({ reason, queuedAt: Date.now(), interactive: false, quiet: true }),
+    requestInteractive: (reason) =>
+      request({ reason, queuedAt: Date.now(), interactive: true, quiet: false }),
     requestWhenReady: (reason, readiness) =>
-      request({ reason, queuedAt: Date.now(), interactive: false, readiness }),
+      request({ reason, queuedAt: Date.now(), interactive: false, quiet: false, readiness }),
     requestInteractiveWhenReady: (reason, readiness) =>
-      request({ reason, queuedAt: Date.now(), interactive: true, readiness }),
+      request({ reason, queuedAt: Date.now(), interactive: true, quiet: false, readiness }),
     shutdown: async () => {
       stopped = true;
       queuedRequests.length = 0;
@@ -82,10 +93,18 @@ export function createReconcileScheduler(
       armReadinessWait();
       return;
     }
-    const delayMs = queued.interactive ? interactiveDebounceMs : debounceMs;
+    const delayMs = queued.interactive
+      ? interactiveDebounceMs
+      : queued.quiet
+        ? quietDebounceMs
+        : debounceMs;
     if (timerScheduled) {
       const requestedFor = queued.queuedAt + delayMs;
-      if (queued.interactive && (scheduledFor === undefined || requestedFor < scheduledFor)) {
+      if (!queued.quiet && (scheduledFor === undefined || requestedFor < scheduledFor)) {
+        scheduleFlush(delayMs);
+      } else if (queued.quiet && !hasReadyImmediateRequest()) {
+        // Already-projected event streams need one canonical pass after they
+        // become quiet, not a competing provider scan between visible states.
         scheduleFlush(delayMs);
       }
       return;
@@ -174,6 +193,12 @@ export function createReconcileScheduler(
     return queuedRequests.some(
       (queued) =>
         queued.interactive && (queued.readiness === undefined || queued.readiness.isReady()),
+    );
+  }
+
+  function hasReadyImmediateRequest(): boolean {
+    return queuedRequests.some(
+      (queued) => !queued.quiet && (queued.readiness === undefined || queued.readiness.isReady()),
     );
   }
 

--- a/apps/observer/test/unit/harnessReportProcessor.test.ts
+++ b/apps/observer/test/unit/harnessReportProcessor.test.ts
@@ -76,6 +76,7 @@ describe("harness report processor logging", () => {
       eventBus,
       clock: { now: () => new Date(now) },
       requestReconcile: () => undefined,
+      requestProjectedReconcile: () => undefined,
       logger,
     };
 
@@ -119,8 +120,8 @@ describe("harness report processor logging", () => {
 });
 
 describe("harness report provider health revalidation", () => {
-  it("requests canonical reconcile for an accepted non-deduplicated report", async () => {
-    const { deps, requestReconcile } = healthRevalidationDeps({
+  it("requests quiet-period reconcile for a successfully projected report", async () => {
+    const { deps, requestReconcile, requestProjectedReconcile } = healthRevalidationDeps({
       healthStatus: "healthy",
     });
 
@@ -133,8 +134,28 @@ describe("harness report provider health revalidation", () => {
       }),
     );
 
-    expect(requestReconcile).toHaveBeenCalledOnce();
+    expect(requestProjectedReconcile).toHaveBeenCalledOnce();
+    expect(requestProjectedReconcile).toHaveBeenCalledWith("harness-report:codex:PreToolUse");
+    expect(requestReconcile).not.toHaveBeenCalled();
+  });
+
+  it("does not delay canonical reconcile when immediate projection cannot apply", async () => {
+    const { deps, requestReconcile, requestProjectedReconcile } = healthRevalidationDeps({
+      healthStatus: "healthy",
+      projected: false,
+    });
+
+    await processHarnessIngressReport(
+      deps,
+      report({
+        reportId: "report_unprojected_reconcile",
+        nativeSessionId: "native_unprojected_reconcile",
+        cwd: "/tmp/station/web",
+      }),
+    );
+
     expect(requestReconcile).toHaveBeenCalledWith("harness-report:codex:PreToolUse");
+    expect(requestProjectedReconcile).not.toHaveBeenCalled();
   });
 
   it("re-probes unavailable health after an accepted starting report projects", async () => {
@@ -203,6 +224,7 @@ function healthRevalidationDeps(input: {
   const accepted = input.accepted ?? true;
   const refreshProviderHealth = vi.fn(async () => undefined);
   const requestReconcile = vi.fn();
+  const requestProjectedReconcile = vi.fn();
   const harnessEventReportIngestion: HarnessEventReportIngestion = {
     ingest: (ingestedReport): Promise<HarnessEventReportReceipt> =>
       Promise.resolve({
@@ -249,9 +271,10 @@ function healthRevalidationDeps(input: {
     eventBus,
     clock: { now: () => new Date(now) },
     requestReconcile,
+    requestProjectedReconcile,
     refreshProviderHealth,
   };
-  return { deps, refreshProviderHealth, requestReconcile };
+  return { deps, refreshProviderHealth, requestReconcile, requestProjectedReconcile };
 }
 
 function report(input: {

--- a/apps/observer/test/unit/reconcileScheduler.test.ts
+++ b/apps/observer/test/unit/reconcileScheduler.test.ts
@@ -243,6 +243,69 @@ describe("reconcile scheduler", () => {
     expect(reasons).toEqual(["scheduled:batch(2)"]);
   });
 
+  it("reconciles already-projected work after a quiet period", async () => {
+    vi.useFakeTimers();
+    const reasons: string[] = [];
+    const scheduler = createReconcileScheduler({
+      quietDebounceMs: 250,
+      reconcile: async (reason) => {
+        reasons.push(reason);
+      },
+    });
+
+    scheduler.requestAfterQuiet("harness-report:codex:PreToolUse");
+    await vi.advanceTimersByTimeAsync(200);
+    scheduler.requestAfterQuiet("harness-report:codex:PostToolUse");
+    await vi.advanceTimersByTimeAsync(249);
+    expect(reasons).toEqual([]);
+    await vi.advanceTimersByTimeAsync(1);
+    await drainMicrotasks();
+
+    expect(reasons).toEqual(["scheduled:batch(2)"]);
+  });
+
+  it("does not let quiet work postpone an ordinary reconcile", async () => {
+    vi.useFakeTimers();
+    const reasons: string[] = [];
+    const scheduler = createReconcileScheduler({
+      debounceMs: 100,
+      quietDebounceMs: 250,
+      reconcile: async (reason) => {
+        reasons.push(reason);
+      },
+    });
+
+    scheduler.request("metadata:change_summary");
+    await vi.advanceTimersByTimeAsync(50);
+    scheduler.requestAfterQuiet("harness-report:codex:PreToolUse");
+    await vi.advanceTimersByTimeAsync(50);
+    await drainMicrotasks();
+
+    expect(reasons).toEqual(["scheduled:batch(2)"]);
+  });
+
+  it("lets ordinary work advance a pending quiet reconcile", async () => {
+    vi.useFakeTimers();
+    const reasons: string[] = [];
+    const scheduler = createReconcileScheduler({
+      debounceMs: 100,
+      quietDebounceMs: 250,
+      reconcile: async (reason) => {
+        reasons.push(reason);
+      },
+    });
+
+    scheduler.requestAfterQuiet("harness-report:codex:PreToolUse");
+    await vi.advanceTimersByTimeAsync(50);
+    scheduler.request("metadata:change_summary");
+    await vi.advanceTimersByTimeAsync(99);
+    expect(reasons).toEqual([]);
+    await vi.advanceTimersByTimeAsync(1);
+    await drainMicrotasks();
+
+    expect(reasons).toEqual(["scheduled:batch(2)"]);
+  });
+
   it("uses the interactive delay for ready work queued behind a running reconcile", async () => {
     vi.useFakeTimers();
     const reasons: string[] = [];

--- a/docs/harness-signals.md
+++ b/docs/harness-signals.md
@@ -176,7 +176,10 @@ fold over signals shared by live projection and reconcile.
   observation; `status.updatedAt` timestamps the status evidence it carries.
 - Live path: `projectHarnessEventReportOntoSnapshot`
   (`apps/observer/src/reconcile/statusProjection.ts`) applies a report to the
-  current snapshot.
+  current snapshot. After successful immediate projection, canonical reconcile is
+  coalesced until 250 ms of report quiet so clients can expose the projected state
+  before provider scanning. Ordinary or interactive reconcile work may
+  advance that pass.
 - Reconcile path: `applyHarnessEventStatusOverlays`
   (`apps/observer/src/reconcile/harnessEventStatus.ts`) rebuilds from persisted
   observations; the latest correlated overlay wins over the discovered run

--- a/station/src/main.tsx
+++ b/station/src/main.tsx
@@ -432,6 +432,7 @@ async function startStationMain(
   installLiveHostTtyDimensions();
   const renderer = await createCliRenderer({
     exitOnCtrlC: false,
+    maxFps: 120,
     exitSignals: [
       "SIGINT",
       "SIGTERM",


### PR DESCRIPTION
## What this fixes

Observer immediately projects accepted harness status, but its follow-up canonical reconcile can compete for the serialized snapshot path before the TUI exposes that state. Immediate TUI updates are also limited to a 60 FPS render ceiling.

## What changed

- Coalesce reconciliation for successfully projected reports until 250 ms of quiet, while keeping ordinary and interactive requests able to advance it.
- Keep unprojected reports on the existing reconcile path.
- Raise the TUI's immediate-render ceiling to 120 FPS without changing continuous rendering.

## Testing

- `bun run lint`
- Root and Station TypeScript typechecks
- Observer scheduler and harness-report processor tests (27 passed)
- Codex hook-reconciliation end-to-end test
- Standard CI passed static, fast, Observer, Station, SQLite, guided-setup, and binary lanes.
- All 924 integration assertions passed, but the lane failed afterward when an existing Observer shutdown timer called `process.exit(0)`; a retry reproduced the runner failure.
- The unrelated setup-core bootstrap test repeatedly hit its existing 90-second timeout, including on an independent `origin/main` control run; this diff does not touch its setup or launcher path.