### PR TITLE
fix(observer): isolate shutdown exit timers

### DIFF
--- a/apps/observer/src/runtime/main.ts
+++ b/apps/observer/src/runtime/main.ts
@@ -140,6 +140,7 @@ export type RunObserverMainDeps = {
   /** Test/composition override for the child-side incumbent admission policy. */
   startupPolicy?: "generic" | "preserve-incumbent";
   startupReadinessSink?: ObserverStartupReadinessSink;
+  /** Process termination boundary for forced and delayed shutdown exits. */
   exit?: (code: number) => void;
 };
 
@@ -654,7 +655,7 @@ async function runClaimedObserverRuntime(input: {
       },
       STOP_BACKSTOP_MS,
       {
-        exit: () => process.exit(shutdownExitCode),
+        exit: () => (deps.exit ?? process.exit)(shutdownExitCode),
         setTimer: (fn, ms) => setTimeout(fn, ms),
         clearTimer: (timer) => clearTimeout(timer as NodeJS.Timeout),
       },
@@ -816,7 +817,7 @@ async function runClaimedObserverRuntime(input: {
     (deps.exit ?? process.exit)(shutdownExitCode);
   }
   // Stray unref-less timers must not keep a stopped observer alive.
-  setTimeout(() => process.exit(0), 2000).unref();
+  setTimeout(() => (deps.exit ?? process.exit)(0), 2000).unref();
   return 0;
 }
 

--- a/apps/observer/test/integration/protocol-server.test.ts
+++ b/apps/observer/test/integration/protocol-server.test.ts
@@ -449,6 +449,7 @@ describe("observer protocol server", () => {
               }),
             processEvidence,
             buildVersion: `0.0.1+station.${"b".repeat(64)}`,
+            exit: vi.fn(),
             incumbentLifecycle: {
               health: () => fixture.api.health(),
               stop,
@@ -521,6 +522,7 @@ describe("observer protocol server", () => {
             harnesses: [harness],
           }),
         buildVersion: observerBuildVersion,
+        exit: vi.fn(),
       },
     );
     const client = createObserverClient({ socketPath, requestId: ids("hook-reconcile") });
@@ -604,7 +606,7 @@ describe("observer protocol server", () => {
     );
     const runtime = runObserverMain(
       ["--socket", socketPath, "--state-dir", stateDir, "--startup-timeout-ms", "2000"],
-      { providerRegistryFactory, buildVersion: observerBuildVersion },
+      { providerRegistryFactory, buildVersion: observerBuildVersion, exit: vi.fn() },
     );
     const client = createObserverClient({ socketPath, requestId: ids("runtime-path") });
 
@@ -695,7 +697,7 @@ describe("observer protocol server", () => {
         terminal: new FakeTerminalProvider({ now }),
         harnesses: [new FakeHarnessProvider({ now })],
       });
-    const exit = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    const exit = vi.fn();
     const runtime = runObserverMain(
       [
         "--socket",
@@ -709,7 +711,12 @@ describe("observer protocol server", () => {
         "--process-token",
         processToken,
       ],
-      { providerRegistryFactory, buildVersion: observerBuildVersion, duplicateProcessEvidence },
+      {
+        providerRegistryFactory,
+        buildVersion: observerBuildVersion,
+        duplicateProcessEvidence,
+        exit,
+      },
     );
     const client = createObserverClient({ socketPath, requestId: ids("report-only") });
 
@@ -739,7 +746,8 @@ describe("observer protocol server", () => {
       await client.stop().catch(() => undefined);
       await runtime.catch(() => undefined);
       await new Promise((resolve) => setTimeout(resolve, 2100));
-      exit.mockRestore();
+      expect(exit).toHaveBeenCalledOnce();
+      expect(exit).toHaveBeenCalledWith(0);
       await rm(dir, { recursive: true, force: true });
     }
   }, 16_000);
@@ -767,6 +775,7 @@ describe("observer protocol server", () => {
           }),
         buildVersion: observerBuildVersion,
         startupReadinessSink,
+        exit: vi.fn(),
       },
     );
     const client = createObserverClient({ socketPath, requestId: ids("startup-context") });


### PR DESCRIPTION
## What this fixes

The Observer runtime owns a delayed process-exit safeguard after clean shutdown. In-process integration runtimes could not replace that exit boundary, so delayed callbacks escaped their test lifetime and Vitest reported `process.exit(0)` after all 924 integration tests passed.

## What changed

- Route both the bounded shutdown backstop and delayed clean-stop exit through the existing injected process termination boundary.
- Preserve `process.exit` as the production default and keep both shutdown safeguards intact.
- Give each successful in-process protocol runtime an isolated exit fake and assert the delayed clean-stop exit still fires once with code 0.

## Testing

- `bun run vitest run --config config/vitest/vitest.integration.config.ts apps/observer/test/integration/protocol-server.test.ts`
- `bun run build && bun run typecheck && bun run lint && bun run vitest run --config config/vitest/vitest.unit.config.ts apps/observer/test/unit/gracefulExit.test.ts`
- `bun run test:integration` — 68 files and 924 tests passed without unhandled errors.
- `bun run test:all` passed through build, typecheck, lint/architecture, unit, contracts, integration, diagnostics, and scripted-agent lanes; the unrelated setup E2E lane was stopped after `setup-core-flow.test.ts` remained in its existing bootstrap hang.

## Safety and scope

Production shutdown timing and explicit process-exit behavior are unchanged. This PR does not touch performance PR #848 or setup behavior.