### PR TITLE
fix(worktrunk): confirm removal after timeout

### DIFF
--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -595,7 +595,9 @@ export class WorktrunkProvider implements WorktreeProvider {
     // lands staged in the target, which is fine for a fork.
     const env = { GIT_INDEX_FILE: join(indexDir, "index") };
     try {
-      await this.#runSeedCommand("git", ["-C", srcPath, "read-tree", "HEAD"], { env });
+      await this.#runSeedCommand("git", ["-C", srcPath, "read-tree", "HEAD"], {
+        env,
+      });
       await this.#runSeedCommand("git", ["-C", srcPath, "add", "-A"], { env });
       const written = await this.#runSeedCommand("git", ["-C", srcPath, "write-tree"], { env });
       const tree = written.stdout.trim();
@@ -714,26 +716,54 @@ export class WorktrunkProvider implements WorktreeProvider {
     }
 
     // Worktrunk 0.64 needs selected-checkout context and cannot delete a branch shared elsewhere.
-    await this.#run(
-      this.#args([
-        "-C",
-        selected.path,
-        "remove",
-        ...this.#automationHookArgs(),
-        ...removalFlags,
-        "--foreground",
-        "--format=json",
-      ]),
-      undefined,
-      {
-        code: "WORKTRUNK_COMMAND_FAILED",
-        message: "Worktrunk failed to remove a worktree.",
-      },
-    );
+    try {
+      await this.#run(
+        this.#args([
+          "-C",
+          selected.path,
+          "remove",
+          ...this.#automationHookArgs(),
+          ...removalFlags,
+          "--foreground",
+          "--format=json",
+        ]),
+        undefined,
+        {
+          code: "WORKTRUNK_COMMAND_FAILED",
+          message: "Worktrunk failed to remove a worktree.",
+        },
+      );
+    } catch (cause) {
+      if (
+        !(cause instanceof WorktrunkProviderError) ||
+        cause.code !== "WORKTRUNK_TIMEOUT" ||
+        !(await this.#removalCompletedAfterTimeout(project, selected))
+      ) {
+        throw cause;
+      }
+    }
     return {
       worktreeId: request.worktreeId,
       removed: true,
     };
+  }
+
+  async #removalCompletedAfterTimeout(
+    project: ProviderProjectConfig,
+    selected: WorktreeObservation,
+  ): Promise<boolean> {
+    try {
+      if (!(await pathIsMissing(selected.path))) return false;
+      const currentWorktrees = await this.#readWorktrees(project, {
+        retries: 1,
+      });
+      return !currentWorktrees.some(
+        (worktree) =>
+          worktree.id === selected.id || samePath(worktree.path, selected.path, this.#platform),
+      );
+    } catch {
+      return false;
+    }
   }
 
   #args(args: string[]): string[] {
@@ -1267,6 +1297,18 @@ async function isExistingRegularFile(path: string): Promise<boolean> {
   } catch (cause) {
     if ((cause as NodeJS.ErrnoException).code === "ENOENT") {
       return false;
+    }
+    throw cause;
+  }
+}
+
+async function pathIsMissing(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return false;
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === "ENOENT") {
+      return true;
     }
     throw cause;
   }

--- a/integrations/worktree/worktrunk/test/unit/remove-timeout.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/remove-timeout.test.ts
@@ -1,0 +1,96 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ProviderProjectConfig } from "@station/contracts";
+import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
+import { WorktrunkProvider } from "@station/worktrunk";
+import { expect, it } from "vitest";
+
+const project: ProviderProjectConfig = {
+  id: "web",
+  label: "web",
+  root: "/tmp/station/web",
+  defaultBranch: "main",
+  defaults: { harness: "codex", terminal: "tmux", layout: "agent-shell" },
+  worktrunk: { enabled: true, base: "main" },
+};
+
+it.each([
+  {
+    title: "confirms removal when Worktrunk times out after deleting the checkout",
+    deleteCheckout: true,
+    succeeds: true,
+  },
+  {
+    title: "preserves the timeout when the checkout remains after registration disappears",
+    deleteCheckout: false,
+    succeeds: false,
+  },
+])("$title", async ({ deleteCheckout, succeeds }) => {
+  const root = await mkdtemp(join(tmpdir(), "station-wt-remove-timeout-"));
+  const worktreePath = join(root, "feature");
+  await mkdir(worktreePath);
+  let listed = true;
+  let listCalls = 0;
+  let aborted = false;
+  const provider = new WorktrunkProvider({
+    command: "wt",
+    timeoutMs: 5,
+    resolveRegistrationIdentity: async (path) => `git-registration:${path}`,
+    runner: async (input) => {
+      if (input.command === "wt" && input.args?.includes("remove")) {
+        listed = false;
+        if (deleteCheckout) await rm(worktreePath, { recursive: true });
+        return new Promise((_, reject) => {
+          input.signal?.addEventListener(
+            "abort",
+            () => {
+              aborted = true;
+              reject(
+                Object.assign(new Error("aborted"), { name: "AbortError", code: "ABORT_ERR" }),
+              );
+            },
+            { once: true },
+          );
+        });
+      }
+      listCalls += 1;
+      return result(
+        input,
+        JSON.stringify(listed ? [{ path: worktreePath, branch: "feature" }] : []),
+      );
+    },
+  });
+
+  try {
+    const [selected] = await provider.listWorktrees(project);
+    if (selected === undefined) throw new Error("Expected the worktree to be listed.");
+    const removal = provider.removeWorktree({
+      project,
+      worktreeId: selected.id,
+      expectedPath: selected.path,
+      expectedBranch: selected.branch,
+      expectedRegistrationIdentity: `git-registration:${selected.path}`,
+    });
+
+    if (succeeds) {
+      await expect(removal).resolves.toEqual({ worktreeId: selected.id, removed: true });
+    } else {
+      await expect(removal).rejects.toMatchObject({ code: "WORKTRUNK_TIMEOUT" });
+    }
+    expect(aborted).toBe(true);
+    expect(listCalls).toBe(succeeds ? 3 : 2);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+function result(input: ExternalCommandInput, stdout: string): ExternalCommandResult {
+  return {
+    command: input.command,
+    args: input.args ?? [],
+    stdout,
+    stderr: "",
+    exitCode: 0,
+  };
+}


### PR DESCRIPTION
## Summary

- verify checkout removal after a foreground Worktrunk command times out
- report success only when both the checkout path and fresh Git registration are absent
- preserve the original timeout when verification is incomplete or fails

## Tests

- `bun run test:unit -- integrations/worktree/worktrunk/test/unit/provider.test.ts integrations/worktree/worktrunk/test/unit/remove-timeout.test.ts`
- `bunx biome check integrations/worktree/worktrunk/src/provider.ts integrations/worktree/worktrunk/test/unit/remove-timeout.test.ts`
- `bun run --cwd integrations/worktree/worktrunk typecheck`
- `bun run test:all` reached unit tests; 3504 passed and 9 unrelated timing/socket tests failed under parallel load