### PR TITLE
perf(hooks): shorten Codex event-to-frame latency

### DIFF
--- a/apps/cli/src/ingress/command.ts
+++ b/apps/cli/src/ingress/command.ts
@@ -28,6 +28,8 @@ export type ProviderIngressCommandOptions = {
   env?: NodeJS.ProcessEnv;
   observerCommand?: ExecutableArgv;
   observerEntryPath?: string;
+  /** Reuses an ID minted by an attempted fast delivery so fallback remains deduplicated. */
+  hookId?: string;
 };
 
 export type ProviderIngressMainResult = {
@@ -145,7 +147,10 @@ export async function runProviderIngressMain(
   options: ProviderIngressCommandOptions = {},
 ): Promise<ProviderIngressMainResult> {
   try {
-    const receipt = await runProviderIngressCommand(argv, options, {});
+    const deps: ProviderHookSenderDeps = {};
+    const hookId = options.hookId;
+    if (hookId !== undefined) deps.hookId = () => hookId;
+    const receipt = await runProviderIngressCommand(argv, options, deps);
     if (receipt.status === "rejected") {
       return {
         code: 1,
@@ -222,6 +227,7 @@ async function parseArgs(argv: string[]): Promise<ParsedOptions> {
       autoStart = false;
       continue;
     }
+    if (arg === "--fast") continue;
     if (arg !== undefined) {
       providerArgs.push(arg);
     }

--- a/apps/cli/src/ingressMain.ts
+++ b/apps/cli/src/ingressMain.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { runProviderIngressMain } from "./ingress/command.js";
+import type { ProviderIngressMainResult } from "./ingress/command.js";
 import { readStdinIfAvailable } from "./stdin.js";
 
 /** Owns one raw-stdin read, renders the ingress result, and applies its exit code. */
@@ -7,11 +7,14 @@ export async function runCliIngressMain(
   argv: readonly string[] = process.argv.slice(2),
 ): Promise<void> {
   const stdin = (await readStdinIfAvailable()) ?? "";
+  const fallbackHookId = process.env.STATION_INTERNAL_PROVIDER_HOOK_ID;
+  const { runProviderIngressMain } = await import("./ingress/command.js");
   const options: Parameters<typeof runProviderIngressMain>[1] = {
     env: process.env,
     stdin,
   };
-  const result = await runProviderIngressMain([...argv], options);
+  if (fallbackHookId !== undefined) options.hookId = fallbackHookId;
+  const result: ProviderIngressMainResult = await runProviderIngressMain([...argv], options);
   if (result.stdout.length > 0) {
     process.stdout.write(result.stdout);
   }

--- a/apps/cli/src/update/installerInstallation.ts
+++ b/apps/cli/src/update/installerInstallation.ts
@@ -13,7 +13,7 @@ import { updateErrorFromUnknown } from "./updateError.js";
 
 const receiptName = ".station-install-receipt";
 const receiptContent = "station-installer-binary-v1\n";
-const expectedInstallationFormat = "station-installer-expected-v1";
+const expectedInstallationFormat = "station-installer-expected-v2";
 
 const InstallationFileIdentitySchema = z
   .object({
@@ -29,7 +29,7 @@ export const InstallerInstallationSchema = z
     installDir: z.string().startsWith("/"),
     executablePath: z.string().startsWith("/"),
     binaryIdentity: InstallationBinaryIdentitySchema,
-    ingressIdentity: InstallationFileIdentitySchema,
+    ingressIdentity: InstallationBinaryIdentitySchema,
     popupIdentity: InstallationFileIdentitySchema,
     receiptIdentity: InstallationFileIdentitySchema,
   })
@@ -59,7 +59,7 @@ export async function inspectInstallerInstallation(
     const popupPath = join(installDir, "stn-tmux-popup");
     const receiptPath = join(installDir, receiptName);
     const [ingress, popup] = await Promise.all([
-      launcherIdentity(ingressPath),
+      binaryIdentity(ingressPath),
       launcherIdentity(popupPath),
     ]);
     if (ingress === undefined || popup === undefined) return undefined;
@@ -89,7 +89,10 @@ export async function inspectInstallerInstallation(
         inode: String(executable.ino),
         sha256: await sha256File(executablePath),
       },
-      ingressIdentity: statIdentity(ingress),
+      ingressIdentity: {
+        ...statIdentity(ingress),
+        sha256: await sha256File(ingressPath),
+      },
       popupIdentity: statIdentity(popup),
       receiptIdentity: statIdentity(receipt),
     };
@@ -170,7 +173,8 @@ function isInstallerReplacement(
     current.installDir === previous.installDir &&
     !sameFileIdentity(current.binaryIdentity, previous.binaryIdentity) &&
     current.binaryIdentity.sha256 !== previous.binaryIdentity.sha256 &&
-    sameFileIdentity(current.ingressIdentity, previous.ingressIdentity) &&
+    !sameFileIdentity(current.ingressIdentity, previous.ingressIdentity) &&
+    current.ingressIdentity.sha256 !== previous.ingressIdentity.sha256 &&
     sameFileIdentity(current.popupIdentity, previous.popupIdentity) &&
     sameFileIdentity(current.receiptIdentity, previous.receiptIdentity)
   );
@@ -184,6 +188,7 @@ export function installerExpectationText(installation: InstallerInstallation): s
     `binary_inode=${installation.binaryIdentity.inode}`,
     `ingress_device=${installation.ingressIdentity.device}`,
     `ingress_inode=${installation.ingressIdentity.inode}`,
+    `ingress_sha256=${installation.ingressIdentity.sha256}`,
     `popup_device=${installation.popupIdentity.device}`,
     `popup_inode=${installation.popupIdentity.inode}`,
     `receipt_device=${installation.receiptIdentity.device}`,
@@ -202,6 +207,18 @@ async function launcherIdentity(path: string) {
   }
 }
 
+async function binaryIdentity(path: string) {
+  try {
+    const binary = await lstat(path, { bigint: true });
+    if (!binary.isFile() || binary.isSymbolicLink() || (binary.mode & 0o111n) === 0n) {
+      return undefined;
+    }
+    return binary;
+  } catch {
+    return undefined;
+  }
+}
+
 function sameInstallationIdentity(
   left: InstallerInstallation,
   right: InstallerInstallation,
@@ -210,6 +227,7 @@ function sameInstallationIdentity(
     sameFileIdentity(left.binaryIdentity, right.binaryIdentity) &&
     left.binaryIdentity.sha256 === right.binaryIdentity.sha256 &&
     sameFileIdentity(left.ingressIdentity, right.ingressIdentity) &&
+    left.ingressIdentity.sha256 === right.ingressIdentity.sha256 &&
     sameFileIdentity(left.popupIdentity, right.popupIdentity) &&
     sameFileIdentity(left.receiptIdentity, right.receiptIdentity)
   );

--- a/apps/cli/test/integration/installer-binary-update.test.ts
+++ b/apps/cli/test/integration/installer-binary-update.test.ts
@@ -33,7 +33,7 @@ afterEach(async () => {
 });
 
 describe("installer-binary channel with the real installer", () => {
-  it("replaces the binary through install.sh while preserving launchers and receipt", async () => {
+  it("replaces both binaries through install.sh while preserving popup and receipt", async () => {
     const fixture = await realInstallerFixture();
     const beforeReceipt = await lstat(fixture.receiptPath, { bigint: true });
     const beforeIngress = await lstat(join(fixture.installDir, "stn-ingress"), { bigint: true });
@@ -52,13 +52,18 @@ describe("installer-binary channel with the real installer", () => {
       warnings: [],
     });
     expect(await executableVersion(fixture.executablePath)).toBe(TARGET_TAG.slice(1));
-    expect(await readlink(join(fixture.installDir, "stn-ingress"))).toBe("stn");
+    expect(await executableVersion(join(fixture.installDir, "stn-ingress"))).toBe(
+      TARGET_TAG.slice(1),
+    );
     expect(await readlink(join(fixture.installDir, "stn-tmux-popup"))).toBe("stn");
     expect(await readFile(fixture.receiptPath, "utf8")).toBe(RECEIPT);
     const afterReceipt = await lstat(fixture.receiptPath, { bigint: true });
     const afterIngress = await lstat(join(fixture.installDir, "stn-ingress"), { bigint: true });
     expect([afterReceipt.dev, afterReceipt.ino]).toEqual([beforeReceipt.dev, beforeReceipt.ino]);
-    expect([afterIngress.dev, afterIngress.ino]).toEqual([beforeIngress.dev, beforeIngress.ino]);
+    expect([afterIngress.dev, afterIngress.ino]).not.toEqual([
+      beforeIngress.dev,
+      beforeIngress.ino,
+    ]);
   });
 
   it("refuses an installation replaced at the invocation boundary", async () => {
@@ -93,16 +98,16 @@ async function realInstallerFixture(options: { replaceIngressBeforeInstaller?: b
   const executablePath = join(installDir, "stn");
   const receiptPath = join(installDir, ".station-install-receipt");
   await writeExecutable(executablePath, versionScript(CURRENT_TAG.slice(1)));
+  await writeExecutable(join(installDir, "stn-ingress"), versionScript(CURRENT_TAG.slice(1)));
   await Promise.all([
-    symlink("stn", join(installDir, "stn-ingress")),
     symlink("stn", join(installDir, "stn-tmux-popup")),
     writeFile(receiptPath, RECEIPT, { mode: 0o600 }),
     writeFile(join(dataHome, "station", "LICENSE"), "old license\n", { mode: 0o644 }),
   ]);
 
   await writeExecutable(join(archiveSource, "stn"), versionScript(TARGET_TAG.slice(1)));
+  await writeExecutable(join(archiveSource, "stn-ingress"), versionScript(TARGET_TAG.slice(1)));
   await Promise.all([
-    symlink("stn", join(archiveSource, "stn-ingress")),
     symlink("stn", join(archiveSource, "stn-tmux-popup")),
     writeFile(join(archiveSource, "LICENSE"), "target license\n", { mode: 0o644 }),
   ]);

--- a/apps/cli/test/unit/ingress-command.test.ts
+++ b/apps/cli/test/unit/ingress-command.test.ts
@@ -353,6 +353,7 @@ describe("provider hook ingress command", () => {
         fixture.stateDir,
         "--config",
         configPath,
+        "--fast",
         "codex",
       ],
       {
@@ -889,6 +890,48 @@ describe("provider hook ingress command", () => {
     expect(result.code).toBe(1);
     expect(result.stdout).toBe("");
     expect(result.stderr).toContain("HOOK_PAYLOAD_INVALID");
+  });
+
+  it("reuses a native transport hook ID on canonical fallback", async () => {
+    const fixture = await createTempState();
+    const result = await runProviderIngressMain(
+      [
+        "--socket",
+        fixture.socketPath,
+        "--state-dir",
+        fixture.stateDir,
+        "--spool-dir",
+        fixture.hookSpoolDir,
+        "--no-auto-start",
+        "--fast",
+        "codex",
+        "Stop",
+      ],
+      {
+        stdin: JSON.stringify({
+          session_id: "codex_session_1",
+          transcript_path: null,
+          cwd: "/tmp/station/web/task",
+          hook_event_name: "Stop",
+          model: "gpt-5.4-codex",
+          permission_mode: "default",
+          turn_id: "turn_1",
+          stop_hook_active: false,
+          last_assistant_message: null,
+        }),
+        env: stationEnv(),
+        hookId: "hook_native_fallback",
+      },
+    );
+
+    expect(result.code).toBe(0);
+    const files = await listHookSpoolFiles(fixture.hookSpoolDir);
+    expect(files).toHaveLength(1);
+    await expect(
+      readHookSpoolRecord(fixture.hookSpoolDir, files[0] as string),
+    ).resolves.toMatchObject({
+      event: { hookId: "hook_native_fallback", event: "Stop" },
+    });
   });
 
   it("rejects malformed provider payloads before delivery or spool writes", async () => {

--- a/apps/cli/test/unit/installer-binary-update.test.ts
+++ b/apps/cli/test/unit/installer-binary-update.test.ts
@@ -5,7 +5,6 @@ import {
   mkdtemp,
   readdir,
   readFile,
-  readlink,
   realpath,
   rename,
   rm,
@@ -197,7 +196,11 @@ describe("installer-binary detection and planning", () => {
         inode: expect.any(String),
         sha256: createHash("sha256").update("current-binary").digest("hex"),
       },
-      ingressIdentity: { device: expect.any(String), inode: expect.any(String) },
+      ingressIdentity: {
+        device: expect.any(String),
+        inode: expect.any(String),
+        sha256: createHash("sha256").update("current-ingress").digest("hex"),
+      },
       popupIdentity: { device: expect.any(String), inode: expect.any(String) },
       receiptIdentity: { device: expect.any(String), inode: expect.any(String) },
     });
@@ -321,7 +324,7 @@ describe("installer-binary apply", () => {
         ],
       }),
     );
-    expect(await readlink(join(fixture.installDir, "stn-ingress"))).toBe("stn");
+    expect(await readFile(join(fixture.installDir, "stn-ingress"), "utf8")).toBe("target-ingress");
     expect(await readFile(fixture.receiptPath, "utf8")).toBe(RECEIPT);
     expect(await readdir(fixture.tempRoot)).toEqual([]);
   });
@@ -549,11 +552,9 @@ async function installedFixture() {
   const executablePath = join(installDir, "stn");
   const receiptPath = join(installDir, ".station-install-receipt");
   await writeFile(executablePath, "current-binary", { mode: 0o755 });
+  await writeFile(join(installDir, "stn-ingress"), "current-ingress", { mode: 0o755 });
   await writeFile(receiptPath, RECEIPT, { mode: 0o600 });
-  await Promise.all([
-    symlink("stn", join(installDir, "stn-ingress")),
-    symlink("stn", join(installDir, "stn-tmux-popup")),
-  ]);
+  await symlink("stn", join(installDir, "stn-tmux-popup"));
   return {
     root,
     installDir: await realpath(installDir),
@@ -658,6 +659,7 @@ function installingRunner(
         "binary_inode",
         "ingress_device",
         "ingress_inode",
+        "ingress_sha256",
         "popup_device",
         "popup_inode",
         "receipt_device",
@@ -665,6 +667,7 @@ function installingRunner(
       ]);
       if (options.installFailsBeforeMutation === true) throw installerError();
       await replaceExecutable(fixture.executablePath, "target-binary");
+      await replaceExecutable(join(fixture.installDir, "stn-ingress"), "target-ingress");
       installedVersion = TARGET_VERSION;
       if (options.installFailsAfterMutation === true) throw installerError();
       return commandResult(input);

--- a/apps/observer/src/hooks/ingestion.ts
+++ b/apps/observer/src/hooks/ingestion.ts
@@ -202,12 +202,13 @@ type IngestViaHookAdapterInput = {
 async function ingestViaHookAdapter(
   input: IngestViaHookAdapterInput,
 ): Promise<ProviderHookReceipt> {
+  const correlatedEvent = withTransportIdentityPayload(input.event, input.adapter);
   const event =
     input.adapter.normalizeEventName === undefined
-      ? input.event
+      ? correlatedEvent
       : ProviderHookEventSchema.parse({
-          ...input.event,
-          event: input.adapter.normalizeEventName(input.event.event),
+          ...correlatedEvent,
+          event: input.adapter.normalizeEventName(correlatedEvent.event),
         });
 
   const scope = input.adapter.decideScope?.(event);
@@ -240,7 +241,16 @@ async function ingestViaHookAdapter(
     // event resolve to the same report id and dedupe instead of duplicating.
     fallbackReportId: () => event.hookId ?? `hook_${randomUUID()}`,
   });
-  if (result === undefined || !result.ok) {
+  const eventMismatch = result?.ok === true && result.report.eventType !== event.event;
+  if (result === undefined || !result.ok || eventMismatch) {
+    const mismatchError: SafeError | undefined = eventMismatch
+      ? {
+          tag: "HookPayloadError",
+          code: "HOOK_EVENT_MISMATCH",
+          message: "Provider hook payload event did not match its transport event.",
+          provider: event.provider,
+        }
+      : undefined;
     return ProviderHookReceiptSchema.parse({
       schemaVersion: STATION_SCHEMA_VERSION,
       hookId: event.hookId,
@@ -248,12 +258,15 @@ async function ingestViaHookAdapter(
       event: event.event,
       status: "rejected",
       receivedAt: event.receivedAt,
-      error: safeErrorFromUnknown(result === undefined ? undefined : result.error, {
-        tag: "HookPayloadError",
-        code: "HOOK_REPORT_INVALID",
-        message: "Provider hook payload could not be normalized to a harness event report.",
-        provider: event.provider,
-      }),
+      error: safeErrorFromUnknown(
+        mismatchError ?? (result === undefined || result.ok ? undefined : result.error),
+        {
+          tag: "HookPayloadError",
+          code: "HOOK_REPORT_INVALID",
+          message: "Provider hook payload could not be normalized to a harness event report.",
+          provider: event.provider,
+        },
+      ),
     });
   }
 
@@ -270,6 +283,34 @@ async function ingestViaHookAdapter(
     hookReceipt.error = receipt.error;
   }
   return ProviderHookReceiptSchema.parse(hookReceipt);
+}
+
+// Native ingress cannot safely rewrite raw provider JSON, so the adapter performs
+// the ordinary environment-to-payload translation at the strict Observer boundary.
+function withTransportIdentityPayload(
+  event: ProviderHookEvent,
+  adapter: ProviderHookAdapter,
+): ProviderHookEvent {
+  const enrichPayload = adapter.enrichPayload;
+  if (enrichPayload === undefined) return event;
+  const env: Record<string, string | undefined> = {};
+  if (event.projectId !== undefined) env.STATION_PROJECT_ID = event.projectId;
+  if (event.worktreeId !== undefined) env.STATION_WORKTREE_ID = event.worktreeId;
+  if (event.worktreePath !== undefined) env.STATION_WORKTREE_PATH = event.worktreePath;
+  if (event.worktreeManagedRoot !== undefined) {
+    env.STATION_WORKTREE_MANAGED_ROOT = event.worktreeManagedRoot;
+  }
+  if (event.sessionId !== undefined) env.STATION_SESSION_ID = event.sessionId;
+  if (event.terminalProvider !== undefined) {
+    env.STATION_TERMINAL_PROVIDER = event.terminalProvider;
+  }
+  if (event.terminalTargetId !== undefined) {
+    env.STATION_TERMINAL_TARGET_ID = event.terminalTargetId;
+  }
+  return ProviderHookEventSchema.parse({
+    ...event,
+    payload: enrichPayload({ payload: event.payload, env }),
+  });
 }
 
 /**

--- a/apps/observer/src/runtime/reconcileScheduler.ts
+++ b/apps/observer/src/runtime/reconcileScheduler.ts
@@ -38,7 +38,9 @@ export type ReconcileSchedulerFlushProfile = {
 const defaultDebounceMs = 100;
 const defaultBacklogDebounceMs = 1000;
 const defaultInteractiveDebounceMs = 25;
-const defaultQuietDebounceMs = 250;
+// The quiet window must outlast a typical provider scan so projected events do
+// not queue behind the convergence work that their own delivery requested.
+const defaultQuietDebounceMs = 750;
 
 type QueuedReconcileRequest = {
   reason: string;

--- a/apps/observer/test/integration/hook-ingestion.test.ts
+++ b/apps/observer/test/integration/hook-ingestion.test.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 import type { HarnessEventReportReceipt, ProviderHookAdapter } from "@station/contracts";
-import { STATION_SCHEMA_VERSION } from "@station/contracts";
+import { enrichStationHookIdentityPayload, STATION_SCHEMA_VERSION } from "@station/contracts";
 import { FakeHarnessProvider, FakeTerminalProvider, FakeWorktreeProvider } from "@station/testing";
 import { describe, expect, it } from "vitest";
 import {
@@ -233,6 +233,113 @@ describe("observer provider hook ingress", () => {
     expect(ignored).toMatchObject({ status: "ignored" });
 
     await reports.return?.();
+    sqlite.close();
+  });
+
+  it("enriches native transport identity before provider scope and normalization", async () => {
+    const clock = { now: () => new Date(now) };
+    let enrichedSessionId: string | undefined;
+    const adapter: ProviderHookAdapter = {
+      provider: "fake-harness",
+      kind: "harness",
+      enrichPayload: enrichStationHookIdentityPayload,
+      decideScope: (event) =>
+        (event.payload as { station_session_id?: string }).station_session_id === "session-fast"
+          ? { action: "accept", reason: "station-env" }
+          : { action: "ignore", reason: "missing-station-env" },
+      toHarnessEventReport: (input) => {
+        enrichedSessionId = (input.event.payload as { station_session_id?: string })
+          .station_session_id;
+        return {
+          ok: true,
+          report: {
+            schemaVersion: STATION_SCHEMA_VERSION,
+            reportId: `fake:${input.event.hookId}`,
+            provider: "fake-harness",
+            kind: "harness",
+            eventType: input.event.event,
+            observedAt: input.event.receivedAt,
+            correlation: { sessionId: enrichedSessionId as string },
+          },
+        };
+      },
+    };
+    const providers = new ProviderRegistry({
+      worktree: new FakeWorktreeProvider({ now }),
+      terminal: new FakeTerminalProvider({ now }),
+      harnesses: [new FakeHarnessProvider({ now })],
+      hookAdapters: [adapter],
+    });
+    const { sqlite, eventBus, api } = createTestObserver({ config, providers, clock });
+    const reports = eventBus.subscribe({ type: "harness.eventReported" })[Symbol.asyncIterator]();
+
+    const receipt = await api.ingestProviderHookEvent({
+      schemaVersion: STATION_SCHEMA_VERSION,
+      hookId: "hook_native_identity",
+      provider: "fake-harness",
+      kind: "harness",
+      event: "Stop",
+      receivedAt: now,
+      sessionId: "session-fast",
+      worktreeId: "wt_web_task",
+      worktreePath: "/tmp/station/web/task",
+      terminalProvider: "tmux",
+      terminalTargetId: "tmux:server:$1:@2:%3",
+      payload: {},
+    });
+
+    expect(receipt).toMatchObject({ status: "accepted" });
+    await expect(reports.next()).resolves.toMatchObject({
+      value: {
+        type: "harness.eventReported",
+        reportId: "fake:hook_native_identity",
+      },
+    });
+    expect(enrichedSessionId).toBe("session-fast");
+    await reports.return?.();
+    sqlite.close();
+  });
+
+  it("rejects a declared transport event that disagrees with provider normalization", async () => {
+    const clock = { now: () => new Date(now) };
+    const adapter: ProviderHookAdapter = {
+      provider: "fake-harness",
+      kind: "harness",
+      toHarnessEventReport: (input) => ({
+        ok: true,
+        report: {
+          schemaVersion: STATION_SCHEMA_VERSION,
+          reportId: `fake:${input.event.hookId}`,
+          provider: "fake-harness",
+          kind: "harness",
+          eventType: "Stop",
+          observedAt: input.event.receivedAt,
+        },
+      }),
+    };
+    const providers = new ProviderRegistry({
+      worktree: new FakeWorktreeProvider({ now }),
+      terminal: new FakeTerminalProvider({ now }),
+      harnesses: [new FakeHarnessProvider({ now })],
+      hookAdapters: [adapter],
+    });
+    const { sqlite, persistence, api } = createTestObserver({ config, providers, clock });
+
+    await expect(
+      api.ingestProviderHookEvent({
+        schemaVersion: STATION_SCHEMA_VERSION,
+        hookId: "hook_event_mismatch",
+        provider: "fake-harness",
+        kind: "harness",
+        event: "PreToolUse",
+        receivedAt: now,
+        payload: {},
+      }),
+    ).resolves.toMatchObject({
+      status: "rejected",
+      error: { code: "HOOK_EVENT_MISMATCH" },
+    });
+    await expect(persistence.listProviderObservations()).resolves.toEqual([]);
     sqlite.close();
   });
 

--- a/apps/observer/test/unit/reconcileScheduler.test.ts
+++ b/apps/observer/test/unit/reconcileScheduler.test.ts
@@ -264,6 +264,24 @@ describe("reconcile scheduler", () => {
     expect(reasons).toEqual(["scheduled:batch(2)"]);
   });
 
+  it("keeps the default quiet window longer than a normal provider scan", async () => {
+    vi.useFakeTimers();
+    const reasons: string[] = [];
+    const scheduler = createReconcileScheduler({
+      reconcile: async (reason) => {
+        reasons.push(reason);
+      },
+    });
+
+    scheduler.requestAfterQuiet("harness-report:codex:PreToolUse");
+    await vi.advanceTimersByTimeAsync(749);
+    expect(reasons).toEqual([]);
+    await vi.advanceTimersByTimeAsync(1);
+    await drainMicrotasks();
+
+    expect(reasons).toEqual(["harness-report:codex:PreToolUse"]);
+  });
+
   it("does not let quiet work postpone an ordinary reconcile", async () => {
     vi.useFakeTimers();
     const reasons: string[] = [];

--- a/docs/harness-ingress.md
+++ b/docs/harness-ingress.md
@@ -47,6 +47,18 @@ bypasses that adapter. There is no secondary `HarnessProvider` raw-ingestion
 path: an accepted hook without a report-producing adapter is durable evidence
 to schedule reconcile, not a source of synthesized harness observations.
 
+Compiled Codex hook entries pass an explicit `--fast` marker and declared event
+to the generated script, except `PermissionRequest`, whose review semantics stay
+on canonical ingress. With Station session and worktree identity and an explicit
+Observer socket, the native launcher stamps one hook ID and sends the raw payload
+with an exact-build guard. The Observer rejects a build mismatch before mutation,
+enriches the provider payload from provider-neutral transport identity, and
+rejects disagreement between the declared event and the strictly parsed provider
+event. A byte-exact accepted receipt from that matching build completes in the
+native launcher and remains visible in the Observer report-processing log. Any
+other response or transport failure executes `stn __ingress` with the same hook
+ID for canonical validation, logging, spooling, startup, and error behavior.
+
 Station-generated Codex, Claude, and Cursor scripts, the OpenCode plugin, and
 Worktrunk lifecycle commands carry a strict artifact-owner marker. The canonical
 launcher path is the durable owner key; runtime kind, display version, and build
@@ -60,7 +72,7 @@ never adds `--takeover` automatically.
 
 ## Pre-Delivery Ordering And Evidence
 
-After required JSON parsing, `stn-ingress` resolves the provider event and applies
+On canonical ingress, after required JSON parsing, `stn-ingress` resolves the provider event and applies
 Claude, Codex, and OpenCode admission before correlation. An unlisted event
 returns an `ignored` receipt without hook logging, Observer health or startup
 work, delivery, or spooling. This silent zero-work path is intentional for noisy
@@ -84,6 +96,11 @@ a logging failure cannot change the receipt or trigger fallback work.
 Only an admitted, correlated event proceeds to shared event validation, Observer
 readiness and optional startup, delivery, compatibility handling, ordinary
 transport-failure spooling, and the existing final-receipt log.
+
+The explicit compiled Codex fast transport moves delivery ahead of canonical
+parsing only for event types selected by the Codex integration. Provider rules
+and the Observer-side adapter remain authoritative; no provider-specific payload
+logic is implemented in the native transport.
 
 ## Rollout
 

--- a/docs/harness-signals.md
+++ b/docs/harness-signals.md
@@ -72,6 +72,9 @@ Normalized events are `HarnessEventReport` / `HarnessEventObservation`
    use the raw `stn-ingress` path. `HarnessProvider` has no fallback raw-event
    ingestion operation; cwd-only and other unresolved report evidence is
    correlated against current graph truth only during Observer projection.
+   Compiled fast ingress may carry Station identity in provider-neutral envelope
+   fields; the Observer adapter translates those fields into the provider payload
+   before this one normalization pass.
 2. **No provider vocabulary in core.** Observer core and the TUI must not
    match on provider prose (`reason` strings), provider event names, or
    provider keys in `providerData`. If core needs to branch on it, it becomes
@@ -177,7 +180,7 @@ fold over signals shared by live projection and reconcile.
 - Live path: `projectHarnessEventReportOntoSnapshot`
   (`apps/observer/src/reconcile/statusProjection.ts`) applies a report to the
   current snapshot. After successful immediate projection, canonical reconcile is
-  coalesced until 250 ms of report quiet so clients can expose the projected state
+  coalesced until 750 ms of report quiet so clients can expose the projected state
   before provider scanning. Ordinary or interactive reconcile work may
   advance that pass.
 - Reconcile path: `applyHarnessEventStatusOverlays`

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -8,8 +8,11 @@ Observer process ownership remains defined by
 
 ## Responsibility
 
-The compiled `stn` executable contains the CLI, Observer, provider-hook ingress,
-native TUI, popup dashboard, and Station Host. It can start the native UI and a
+The compiled `stn` executable contains the CLI, Observer, canonical provider-hook
+ingress, native TUI, popup dashboard, and Station Host. A small native
+`stn-ingress` launcher handles the latency-sensitive first delivery before
+falling back to canonical ingress when delivery is not conclusively accepted.
+The installation can start the native UI and a
 healthy Observer without Node.js, a source checkout, or `node_modules`.
 
 External workflow tools remain separate. Git, Worktrunk, tmux, Hunk, and agent
@@ -37,7 +40,7 @@ Each release archive is named
 `stn-v{version}-{platform}-{architecture}.tar.gz` and contains exactly:
 
 - `stn`, the compiled executable;
-- `stn-ingress`, a symlink to `stn`;
+- `stn-ingress`, a native provider-hook transport launcher;
 - `stn-tmux-popup`, a symlink to `stn`; and
 - `LICENSE`.
 
@@ -59,14 +62,13 @@ bun run build:binary -- --version 0.0.0-local
 `scripts/build-binary.mjs` first performs the whole-repository source build and
 verifies its published build identity. It then links the Station workspace,
 builds the native controlling-terminal helper and provider assets, and writes
-the executable and aliases under `station/dist/bin/`.
+the executables and popup alias under `station/dist/bin/`.
 
 The compiled entrypoint dispatches raw arguments before CLI option parsing or
 stdin reads:
 
 ```text
 stn
-├── argv0 stn-ingress  -> provider-hook ingress
 ├── argv0 stn-tmux-popup -> popup command
 ├── __observer         -> Observer process
 ├── __ingress          -> provider-hook ingress
@@ -75,6 +77,10 @@ stn
 ├── __station-host     -> persistent PTY host
 ├── __tmux-popup       -> popup command
 └── all other argv     -> normal CLI
+
+stn-ingress
+├── explicit compatible --fast hook -> exact-build Observer delivery and exit
+└── every inconclusive result       -> stn __ingress with the same hook ID
 ```
 
 Internal tokens are process boundaries, not public CLI commands. Compiled
@@ -85,6 +91,16 @@ The installed executable directory is the ownership root for popup registration,
 setup-generated launchers, and the absolute `stn-ingress` path stored in provider
 hooks. A virtual compiled module path and filesystem root `/` are never accepted
 as ownership roots.
+
+The native ingress launcher does not own provider parsing or lifecycle policy.
+Only provider integrations opt configured events into `--fast`; the Observer
+performs strict normalization, and canonical ingress retains validation,
+auto-start, spooling, and error behavior for every non-accepted result. The
+native launcher recognizes only the exact validated accepted receipt emitted by
+the matching build; all other responses re-enter canonical ingress. Accepted
+fast delivery remains visible in the Observer's report-processing log. The
+initial socket request names the exact Observer build and is rejected before
+mutation on mismatch.
 
 ## Runtime boundaries
 
@@ -170,6 +186,11 @@ receipt contains exactly `station-installer-binary-v1`; installations without
 that receipt continue to run but require a later exact-tag install before the
 installer-binary update adapter can own them.
 
+The installer replaces the version-guarded ingress binary immediately before
+`stn`. Either mixed-version window falls back through canonical ingress because
+the native request cannot mutate an Observer with a different build. Update
+expectations use the v2 shape and bind both executable hashes and identities.
+
 Installer locking, interrupted-upgrade recovery, PATH guidance, and manual
 operator steps are documented in [Install Station](install.md). Those behaviors
 belong to the installer contract rather than the compiled executable.
@@ -182,8 +203,8 @@ Run the focused local binary proof with a development version:
 bun run smoke:binary -- --expected-version 0.0.0-local
 ```
 
-The smoke builds the binary and exercises version/help output, raw dispatch,
-both aliases, setup readiness, packaged assets, provider-hook ingress, Observer
+The smoke builds the binaries and exercises version/help output, raw dispatch,
+the native ingress transport, the popup alias, setup readiness, packaged assets, provider-hook ingress, Observer
 startup and handoff, hostile-directory isolation, popup reuse, inaccessible
 socket preservation, and the compiled PTY helper.
 

--- a/integrations/harness/codex/src/hooks.ts
+++ b/integrations/harness/codex/src/hooks.ts
@@ -15,7 +15,6 @@ import {
   commandLine,
   createHookSetupFileOps,
   expectedProviderHookScript,
-  hookCommandsForEvents,
   installConfigScriptHook,
   normalizeCancellationError,
   ProviderHookArtifactOwnershipError,
@@ -700,14 +699,28 @@ async function doctorCodexHooksWithinBoundary(
   return result;
 }
 
+/** Selects fast transport only for Codex events without permission-review semantics. */
 function expectedCodexHookCommands(input: {
   hookScriptPath: string;
 }): Record<CodexForwardedEventType, string> {
-  return hookCommandsForEvents(CODEX_HOOK_EVENT_NAMES, input.hookScriptPath);
+  return Object.fromEntries(
+    CODEX_HOOK_EVENT_NAMES.map((event) => [
+      event,
+      commandLine([
+        input.hookScriptPath,
+        ...(event === "PermissionRequest" ? [] : ["--fast"]),
+        event,
+      ]),
+    ]),
+  ) as Record<CodexForwardedEventType, string>;
 }
 
 function expectedCodexHookScript(input: CodexHookScriptOptions): string {
-  return expectedProviderHookScript({ provider: "codex", options: input });
+  return expectedProviderHookScript({
+    provider: "codex",
+    options: input,
+    forwardScriptArgs: true,
+  });
 }
 
 function installResultFromPlan(plan: CodexHookPlan, installed: boolean): CodexHookInstallResult {

--- a/integrations/harness/codex/src/hooks/hookConfigEditor.ts
+++ b/integrations/harness/codex/src/hooks/hookConfigEditor.ts
@@ -295,13 +295,28 @@ function generatedStationHookCommand(hook: unknown): string | undefined {
   ) {
     return undefined;
   }
-  return hookRecord.command;
+  return generatedHookScriptPath(hookRecord.command);
 }
 
 function commandLooksLikeGeneratedHookScript(command: string): boolean {
-  return (
-    command === GENERATED_HOOK_SCRIPT_NAME || command.endsWith(`/${GENERATED_HOOK_SCRIPT_NAME}`)
-  );
+  return generatedHookScriptPath(command) !== undefined;
+}
+
+function generatedHookScriptPath(command: string): string | undefined {
+  if (isGeneratedHookScriptPath(command)) return command;
+  let token: string;
+  if (command.startsWith("'")) {
+    const match = /'(?: |$)/u.exec(command);
+    if (match?.index === undefined) return undefined;
+    token = command.slice(1, match.index).replaceAll("'\\''", "'");
+  } else {
+    token = command.slice(0, command.indexOf(" ") < 0 ? undefined : command.indexOf(" "));
+  }
+  return isGeneratedHookScriptPath(token) ? token : undefined;
+}
+
+function isGeneratedHookScriptPath(path: string): boolean {
+  return path === GENERATED_HOOK_SCRIPT_NAME || path.endsWith(`/${GENERATED_HOOK_SCRIPT_NAME}`);
 }
 
 function withoutGeneratedHooksFromEntry(

--- a/integrations/harness/codex/test/unit/hooks.test.ts
+++ b/integrations/harness/codex/test/unit/hooks.test.ts
@@ -86,7 +86,8 @@ describe("Codex hook setup", () => {
       "SubagentStart",
       "Stop",
     ]);
-    expect(plan.commands.PreToolUse).toBe(hookScriptPath);
+    expect(plan.commands.PreToolUse).toBe(`${hookScriptPath} --fast PreToolUse`);
+    expect(plan.commands.PermissionRequest).toBe(`${hookScriptPath} PermissionRequest`);
     expect(plan.after).toContain("[[hooks.PreToolUse]]");
     expect(plan.after).not.toContain("[[hooks.SubagentStop]]");
     await expect(readFile(configPath, "utf8")).rejects.toThrow();
@@ -196,7 +197,7 @@ describe("Codex hook setup", () => {
     // and leave scope decisions to the provider adapter.
     expect(script).not.toContain("STATION_SESSION_ID");
     expect(script).not.toContain("payload_file=");
-    expect(script).toContain("codex > /dev/null");
+    expect(script).toContain('codex "$@" > /dev/null');
     expect(scriptMode).toBe(0o700);
   });
 
@@ -296,7 +297,7 @@ describe("Codex hook setup", () => {
     expect(verification.message).toContain("/tmp/station/config.toml");
     expect(verification.message).toContain("Correct invalid configuration or ownership");
     await expect(readFile(configPath, "utf8")).resolves.toBe("not = [valid");
-    await expect(readFile(hookScriptPath, "utf8")).resolves.toContain("codex > /dev/null");
+    await expect(readFile(hookScriptPath, "utf8")).resolves.toContain('codex "$@" > /dev/null');
   });
 
   it("rethrows cancellation and deadline from no-op verification without normalization", async () => {
@@ -383,11 +384,14 @@ describe("Codex hook setup", () => {
     });
 
     const payload = JSON.stringify({ hook_event_name: "PreToolUse" });
-    const result = await runHookScript(hookScriptPath, payload, { TMPDIR: root });
+    const result = await runHookScript(hookScriptPath, payload, { TMPDIR: root }, [
+      "--fast",
+      "PreToolUse",
+    ]);
 
     expect(result).toEqual({ code: 0, stdout: "", stderr: "" });
     await expect(readFile(argsLog, "utf8")).resolves.toBe(
-      "--config /tmp/station/config.toml codex\n",
+      "--config /tmp/station/config.toml codex --fast PreToolUse\n",
     );
   });
 
@@ -420,15 +424,20 @@ describe("Codex hook setup", () => {
     });
 
     const payload = JSON.stringify({ hook_event_name: "PreToolUse" });
-    const result = await runHookScript(hookScriptPath, payload, {
-      TMPDIR: root,
-      STATION_SESSION_ID: "ses_web_task",
-      STATION_WORKTREE_ID: "wt_web_task",
-    });
+    const result = await runHookScript(
+      hookScriptPath,
+      payload,
+      {
+        TMPDIR: root,
+        STATION_SESSION_ID: "ses_web_task",
+        STATION_WORKTREE_ID: "wt_web_task",
+      },
+      ["--fast", "PreToolUse"],
+    );
 
     expect(result).toEqual({ code: 0, stdout: "", stderr: "" });
     await expect(readFile(argsLog, "utf8")).resolves.toBe(
-      "--config /tmp/station/config.toml codex\n",
+      "--config /tmp/station/config.toml codex --fast PreToolUse\n",
     );
     await expect(readFile(stdinLog, "utf8")).resolves.toBe(payload);
   });
@@ -1229,6 +1238,7 @@ async function runHookScript(
   scriptPath: string,
   stdin: string,
   env: NodeJS.ProcessEnv,
+  args: readonly string[] = [],
 ): Promise<{ code: number | null; stdout: string; stderr: string }> {
   const childEnv: NodeJS.ProcessEnv = {};
   if (process.env.PATH !== undefined) {
@@ -1240,7 +1250,7 @@ async function runHookScript(
     }
   }
 
-  const child = spawn(scriptPath, [], {
+  const child = spawn(scriptPath, args, {
     env: childEnv,
     stdio: ["pipe", "pipe", "pipe"],
   });

--- a/packages/contracts/src/hooks.ts
+++ b/packages/contracts/src/hooks.ts
@@ -36,7 +36,12 @@ export const ProviderHookEventSchema = z
     receivedAt: TimestampSchema,
     projectId: ProjectIdSchema.optional(),
     worktreeId: WorktreeIdSchema.optional(),
+    /** Provider-neutral launch identity carried outside an unparsed provider payload. */
+    worktreePath: nonEmptyStringSchema.optional(),
+    worktreeManagedRoot: nonEmptyStringSchema.optional(),
     sessionId: SessionIdSchema.optional(),
+    terminalProvider: ProviderIdSchema.optional(),
+    terminalTargetId: TerminalTargetIdSchema.optional(),
     payload: optionalProviderDataSchema,
   })
   .strict();

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -141,6 +141,8 @@ export const ReconcileParamsSchema = z
 export const ProviderHookIngestParamsSchema = z
   .object({
     event: ProviderHookEventSchema,
+    /** Rejects a transport shortcut before mutation when the socket owner is another build. */
+    expectedBuildVersion: z.string().min(1).optional(),
   })
   .strict();
 

--- a/packages/protocol/src/server.ts
+++ b/packages/protocol/src/server.ts
@@ -205,6 +205,16 @@ async function routeSingleResponseRequest(
       }
       case "observer.ingestProviderHookEvent": {
         const params = ProviderHookIngestParamsSchema.parse(request.params);
+        if (params.expectedBuildVersion !== undefined) {
+          const health = await api.health();
+          if (health.version !== params.expectedBuildVersion) {
+            throw protocolSafeError({
+              code: "OBSERVER_BUILD_MISMATCH",
+              message: `Observer build mismatch: this ingress expects "${params.expectedBuildVersion}", but the socket owner reports "${health.version ?? "missing"}".`,
+              hint: "Retry through canonical ingress so Station can hand off to the current Observer.",
+            });
+          }
+        }
         return await api.ingestProviderHookEvent(params.event);
       }
       case "observer.harnessEvent.report": {

--- a/packages/protocol/test/integration/client-server.test.ts
+++ b/packages/protocol/test/integration/client-server.test.ts
@@ -1800,6 +1800,62 @@ describe("protocol client/server", () => {
       await server.close();
     }
   });
+
+  it("rejects a fast ingress build mismatch before mutating Observer state", async () => {
+    const { socketPath } = await createTempSocketPath();
+    const ingestProviderHookEvent = vi.fn(createFakeObserverApi().ingestProviderHookEvent);
+    const server = await startProtocolServer({
+      socketPath,
+      api: createFakeObserverApi({
+        health: async () => ({
+          schemaVersion: STATION_SCHEMA_VERSION,
+          status: "healthy",
+          pid: 1234,
+          startedAt: protocolTestNow,
+          version: "0.0.0+station.exact",
+        }),
+        ingestProviderHookEvent,
+      }),
+    });
+    const event: ProviderHookEvent = {
+      schemaVersion: STATION_SCHEMA_VERSION,
+      hookId: "hook_build_guard",
+      provider: "codex",
+      kind: "harness",
+      event: "Stop",
+      receivedAt: protocolTestNow,
+      payload: { hook_event_name: "Stop" },
+    };
+
+    try {
+      await expect(
+        sendRawRequest(socketPath, {
+          schemaVersion: STATION_SCHEMA_VERSION,
+          jsonrpc: "2.0",
+          id: "mismatch",
+          method: "observer.ingestProviderHookEvent",
+          params: { event, expectedBuildVersion: "0.0.0+station.other" },
+        }),
+      ).resolves.toMatchObject({
+        id: "mismatch",
+        error: { code: "OBSERVER_BUILD_MISMATCH" },
+      });
+      expect(ingestProviderHookEvent).not.toHaveBeenCalled();
+
+      await expect(
+        sendRawRequest(socketPath, {
+          schemaVersion: STATION_SCHEMA_VERSION,
+          jsonrpc: "2.0",
+          id: "exact",
+          method: "observer.ingestProviderHookEvent",
+          params: { event, expectedBuildVersion: "0.0.0+station.exact" },
+        }),
+      ).resolves.toMatchObject({ id: "exact", result: { status: "accepted" } });
+      expect(ingestProviderHookEvent).toHaveBeenCalledOnce();
+    } finally {
+      await server.close();
+    }
+  });
 });
 
 async function sendRawRequest(socketPath: string, request: unknown): Promise<unknown> {

--- a/packages/runtime/src/hookSetup.ts
+++ b/packages/runtime/src/hookSetup.ts
@@ -245,6 +245,7 @@ export type ConfigScriptHookUninstallPlan<Document, EventName extends string> = 
 function providerHookCommandLineFromScriptArgs(
   provider: string,
   options: ProviderHookScriptOptions,
+  forwardScriptArgs: boolean,
 ): string {
   return [
     shellQuote(options.hookBin ?? "stn-ingress"),
@@ -254,6 +255,7 @@ function providerHookCommandLineFromScriptArgs(
     guardedArrayExpansion("CONFIG_ARG"),
     ...(options.autoStartFromHooks === false ? ["--no-auto-start"] : []),
     shellQuote(provider),
+    ...(forwardScriptArgs ? ['"$@"'] : []),
   ].join(" ");
 }
 
@@ -506,6 +508,8 @@ export function expectedProviderHookScript(input: {
   options?: ProviderHookScriptOptions;
   ignoreFailure?: boolean;
   redirectStderr?: boolean;
+  /** Forwards provider-configured positional context to the ingress executable. */
+  forwardScriptArgs?: boolean;
 }): string {
   const suffix = input.ignoreFailure === true ? " || true" : "";
   const redirect = input.redirectStderr === true ? " > /dev/null 2>&1" : " > /dev/null";
@@ -514,7 +518,7 @@ export function expectedProviderHookScript(input: {
   // `codex` in any terminal) still deliver, and the provider adapter decides
   // scope — the observer correlates env-less events by their payload cwd.
   return [
-    "#!/usr/bin/env bash",
+    "#!/bin/bash",
     ...(options.artifactOwner === undefined
       ? []
       : [`# ${providerHookOwnerMarker(options.artifactOwner)}`]),
@@ -536,7 +540,11 @@ export function expectedProviderHookScript(input: {
       options.hookSpoolDir,
       { skipFallbackWhenEnvPresent: "STATION_CONFIG_PATH" },
     ),
-    `${providerHookCommandLineFromScriptArgs(input.provider, options)}${redirect}${suffix}`,
+    `${input.ignoreFailure === true ? "" : "exec "}${providerHookCommandLineFromScriptArgs(
+      input.provider,
+      options,
+      input.forwardScriptArgs === true,
+    )}${redirect}${suffix}`,
     "",
   ].join("\n");
 }
@@ -547,7 +555,8 @@ export function providerHookScriptRoutesByStationEnv(script: string, provider: s
     script.includes("STATION_CONFIG_PATH") &&
     script.includes("STATION_STATE_DIR") &&
     script.includes("STATION_HOOK_SPOOL_DIR") &&
-    script.includes(`${shellQuote(provider)} > /dev/null`)
+    script.includes(shellQuote(provider)) &&
+    script.includes(" > /dev/null")
   );
 }
 

--- a/packages/runtime/test/unit/hookSetup.test.ts
+++ b/packages/runtime/test/unit/hookSetup.test.ts
@@ -114,9 +114,17 @@ describe("runtime hookSetup", () => {
 
     it("reproduces each provider's exact redirect/suffix shape", () => {
       const plain = expectedProviderHookScript({ provider: "codex" });
+      expect(plain.startsWith("#!/bin/bash\n")).toBe(true);
       expect(plain).toContain(`stn-ingress \${SOCKET_ARG[@]+"\${SOCKET_ARG[@]}"}`);
+      expect(plain).toContain("exec stn-ingress");
       expect(plain).toContain("codex > /dev/null\n");
       expect(plain).not.toContain("|| true");
+
+      const forwarding = expectedProviderHookScript({
+        provider: "codex",
+        forwardScriptArgs: true,
+      });
+      expect(forwarding).toContain('codex "$@" > /dev/null\n');
 
       const ignoreAndRedirect = expectedProviderHookScript({
         provider: "claude",

--- a/scripts/build-binary.mjs
+++ b/scripts/build-binary.mjs
@@ -2,6 +2,7 @@
 import { cp, mkdir, readFile, rm, symlink } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { STATION_SCHEMA_VERSION } from "../packages/contracts/src/ids.ts";
 import { readBuildIdentity, verifyBuildIdentity } from "./build-identity.mjs";
 import {
   assertBunVersion,
@@ -112,6 +113,7 @@ async function main() {
   const { version } = parseArgs(process.argv.slice(2));
   const outputDir = join(stationRoot, "dist", "bin");
   const outputPath = join(outputDir, "stn");
+  const ingressOutputPath = join(outputDir, "stn-ingress");
   const piBundlePath = join(stationRoot, "dist", "piExtension.mjs");
   let bunRuntime;
   try {
@@ -121,7 +123,7 @@ async function main() {
   }
 
   const buildIdentity = await removeBinaryOutputAfterSourceAdmission(outputPath, async () => {
-    await runWithBunExecutable(bunRuntime, ["run", "build"], repoRoot);
+    await run(bunRuntime.executable, ["run", "--shell=system", "build"], repoRoot);
     let identity;
     try {
       identity = await readBuildIdentity(repoRoot);
@@ -169,18 +171,38 @@ async function main() {
         STATION_BUILD_COMPILED: "true",
         STATION_BUILD_IDENTITY: JSON.stringify(buildIdentity),
         STATION_BUILD_OPENCODE_PLUGIN_BODY: JSON.stringify(openCodePluginBody),
+        STATION_PROTOCOL_SCHEMA_VERSION: JSON.stringify(STATION_SCHEMA_VERSION),
       },
     },
     "Station binary compile",
   );
+  await rm(ingressOutputPath, { force: true });
+  const observerVersionSeparator = version.includes("+") ? "." : "+";
+  const observerVersion = `${version}${observerVersionSeparator}station.${buildIdentity}`;
+  await run(
+    "cc",
+    [
+      "-std=c11",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-O2",
+      `-DSTATION_PROTOCOL_SCHEMA_VERSION=${JSON.stringify(STATION_SCHEMA_VERSION)}`,
+      `-DSTATION_OBSERVER_VERSION=${JSON.stringify(observerVersion)}`,
+      "-o",
+      ingressOutputPath,
+      join(stationRoot, "src", "ingress", "station-ingress-fast.c"),
+    ],
+    repoRoot,
+  );
   if (!(await verifyBuildIdentity(buildIdentity, repoRoot))) {
     await rm(outputPath, { force: true });
+    await rm(ingressOutputPath, { force: true });
     fail(
       "Station build inputs or published identity changed during binary compilation; rebuild from a stable checkout.",
     );
   }
 
-  await replaceSymlink(join(outputDir, "stn-ingress"), "stn");
   await replaceSymlink(join(outputDir, "stn-tmux-popup"), "stn");
   await cp(join(repoRoot, "LICENSE"), join(outputDir, "LICENSE"));
   process.stdout.write(`Built ${outputPath} (${nativeTarget()}, ${version}).\n`);

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,10 +42,14 @@ activation_ambiguity_reported=0
 activation_failed_precommit=0
 activation_ambiguous=0
 rollback_failed=0
-created_ingress=0
 created_popup=0
-created_ingress_inode=""
 created_popup_inode=""
+ingress_backup=""
+ingress_displaced=0
+ingress_installed=0
+previous_ingress_inode=""
+installed_ingress_inode=""
+installed_ingress_sha256=""
 preserve_install_stage=0
 receipt_path=""
 receipt_stage=""
@@ -57,6 +61,7 @@ expected_binary_device=""
 expected_binary_inode=""
 expected_ingress_device=""
 expected_ingress_inode=""
+expected_ingress_sha256=""
 expected_popup_device=""
 expected_popup_inode=""
 expected_receipt_device=""
@@ -258,6 +263,37 @@ cleanup() {
   fi
 
   if [ "$runtime_committed" -eq 0 ]; then
+    if [ "$ingress_installed" -eq 1 ]; then
+      if [ ! -f "$install_dir/stn-ingress" ] || [ -L "$install_dir/stn-ingress" ] ||
+        [ ! -x "$install_dir/stn-ingress" ] ||
+        ! alias_inode "$install_dir/stn-ingress" ||
+        [ "$alias_inode_result" != "$installed_ingress_inode" ] ||
+        ! file_sha256 "$install_dir/stn-ingress" ||
+        [ "$hash_result" != "$installed_ingress_sha256" ]; then
+        rollback_failed=1
+        if [ "$ingress_displaced" -eq 1 ]; then preserve_install_stage=1; fi
+        warn "installed ingress binary changed during cleanup; inspect '$install_dir/stn-ingress' and '$ingress_backup' manually."
+      elif [ "$ingress_displaced" -eq 1 ]; then
+        if ! mv -f "$ingress_backup" "$install_dir/stn-ingress" 2>/dev/null; then
+          rollback_failed=1
+          preserve_install_stage=1
+          warn "could not restore the previous ingress launcher from '$ingress_backup'."
+        fi
+      elif ! rm -f "$install_dir/stn-ingress" 2>/dev/null; then
+        rollback_failed=1
+        warn "could not remove the new ingress binary '$install_dir/stn-ingress'."
+      fi
+    elif [ "$ingress_displaced" -eq 1 ]; then
+      if alias_inode "$install_dir/stn-ingress" &&
+        [ "$alias_inode_result" = "$previous_ingress_inode" ]; then
+        :
+      elif { [ -e "$install_dir/stn-ingress" ] || [ -L "$install_dir/stn-ingress" ]; } ||
+        ! mv "$ingress_backup" "$install_dir/stn-ingress" 2>/dev/null; then
+        rollback_failed=1
+        preserve_install_stage=1
+        warn "could not restore the previous ingress launcher from '$ingress_backup'."
+      fi
+    fi
     if [ "$license_displaced" -eq 1 ]; then
       if ! mv -f "$license_backup" "$license_path" 2>/dev/null; then
         rollback_failed=1
@@ -270,7 +306,6 @@ cleanup() {
         warn "could not remove the new license '$license_path'."
       fi
     fi
-    remove_created_alias "$install_dir/stn-ingress" "$created_ingress" "$created_ingress_inode" "$install_stage/stn-ingress.rollback"
     remove_created_alias "$install_dir/stn-tmux-popup" "$created_popup" "$created_popup_inode" "$install_stage/stn-tmux-popup.rollback"
     if [ "$activation_failed_precommit" -eq 1 ] && [ "$rollback_failed" -eq 0 ]; then
       printf 'The existing Station installation was unchanged.\n' >&2
@@ -490,6 +525,7 @@ parse_expected_installation() {
   seen_binary_inode=0
   seen_ingress_device=0
   seen_ingress_inode=0
+  seen_ingress_sha256=0
   seen_popup_device=0
   seen_popup_inode=0
   seen_receipt_device=0
@@ -526,6 +562,11 @@ parse_expected_installation() {
         seen_ingress_inode=1
         expected_ingress_inode=$expected_value
         ;;
+      ingress_sha256)
+        [ "$seen_ingress_sha256" -eq 0 ] || fail "expected installation file contains duplicate key 'ingress_sha256'."
+        seen_ingress_sha256=1
+        expected_ingress_sha256=$expected_value
+        ;;
       popup_device)
         [ "$seen_popup_device" -eq 0 ] || fail "expected installation file contains duplicate key 'popup_device'."
         seen_popup_device=1
@@ -552,8 +593,17 @@ parse_expected_installation() {
 
   [ "$seen_format$seen_binary_sha256$seen_binary_device$seen_binary_inode$seen_ingress_device$seen_ingress_inode$seen_popup_device$seen_popup_inode$seen_receipt_device$seen_receipt_inode" = 1111111111 ] ||
     fail "expected installation file is missing one or more required keys."
-  [ "$expected_format" = station-installer-expected-v1 ] ||
-    fail "expected installation file has an unsupported format."
+  case "$expected_format" in
+    station-installer-expected-v1)
+      [ "$seen_ingress_sha256" -eq 0 ] || fail "legacy expected installation file cannot contain ingress_sha256."
+      ;;
+    station-installer-expected-v2)
+      [ "$seen_ingress_sha256" -eq 1 ] || fail "expected installation file is missing ingress_sha256."
+      printf '%s\n' "$expected_ingress_sha256" | grep -Eq '^[0-9a-f]{64}$' ||
+        fail "expected installation file contains an invalid ingress SHA-256."
+      ;;
+    *) fail "expected installation file has an unsupported format." ;;
+  esac
   printf '%s\n' "$expected_binary_sha256" | grep -Eq '^[0-9a-f]{64}$' ||
     fail "expected installation file contains an invalid binary SHA-256."
   require_decimal "$expected_binary_device" "expected installation file contains an invalid binary device."
@@ -725,9 +775,9 @@ file_mode() {
 file_sha256() {
   hash_path=$1
   if command -v sha256sum >/dev/null 2>&1; then
-    hash_raw=$(sha256sum "$hash_path" 2>/dev/null) || return 1
+    hash_raw=$(sha256sum < "$hash_path" 2>/dev/null) || return 1
   elif command -v shasum >/dev/null 2>&1; then
-    hash_raw=$(shasum -a 256 "$hash_path" 2>/dev/null) || return 1
+    hash_raw=$(shasum -a 256 < "$hash_path" 2>/dev/null) || return 1
   else
     return 1
   fi
@@ -771,9 +821,18 @@ validate_expected_installation() {
   if [ ! -f "$binary_path" ] || [ -L "$binary_path" ]; then
     fail "expected Station binary '$binary_path' changed before installer commit."
   fi
-  if [ ! -L "$ingress_path" ] || ! readlink_target "$ingress_path" 2>/dev/null || [ "$link_target" != stn ]; then
-    fail "expected Station ingress launcher '$ingress_path' changed before installer commit."
-  fi
+  case "$expected_format" in
+    station-installer-expected-v1)
+      if [ ! -L "$ingress_path" ] || ! readlink_target "$ingress_path" 2>/dev/null || [ "$link_target" != stn ]; then
+        fail "expected Station ingress launcher '$ingress_path' changed before installer commit."
+      fi
+      ;;
+    station-installer-expected-v2)
+      if [ ! -f "$ingress_path" ] || [ -L "$ingress_path" ] || [ ! -x "$ingress_path" ]; then
+        fail "expected Station ingress binary '$ingress_path' changed before installer commit."
+      fi
+      ;;
+  esac
   if [ ! -L "$popup_path" ] || ! readlink_target "$popup_path" 2>/dev/null || [ "$link_target" != stn ]; then
     fail "expected Station popup launcher '$popup_path' changed before installer commit."
   fi
@@ -785,6 +844,10 @@ validate_expected_installation() {
   if ! file_sha256 "$binary_path" || [ "$hash_result" != "$expected_binary_sha256" ]; then
     fail "expected Station binary contents changed before installer commit."
   fi
+  if [ "$expected_format" = station-installer-expected-v2 ] &&
+    { ! file_sha256 "$ingress_path" || [ "$hash_result" != "$expected_ingress_sha256" ]; }; then
+    fail "expected Station ingress binary contents changed before installer commit."
+  fi
 }
 
 if [ -e "$binary_path" ] || [ -L "$binary_path" ]; then
@@ -792,13 +855,21 @@ if [ -e "$binary_path" ] || [ -L "$binary_path" ]; then
     fail "existing Station binary '$binary_path' must be a regular non-symlink file."
   fi
 fi
-for launcher_path in "$ingress_path" "$popup_path"; do
-  if [ -e "$launcher_path" ] || [ -L "$launcher_path" ]; then
-    if [ ! -L "$launcher_path" ] || ! readlink_target "$launcher_path" 2>/dev/null || [ "$link_target" != stn ]; then
-      fail "existing launcher '$launcher_path' must be absent or a symlink to 'stn'; it was not changed."
+if [ -e "$ingress_path" ] || [ -L "$ingress_path" ]; then
+  if [ -L "$ingress_path" ]; then
+    if ! readlink_target "$ingress_path" 2>/dev/null || [ "$link_target" != stn ]; then
+      fail "existing Station ingress launcher '$ingress_path' must target 'stn'; it was not changed."
     fi
+  elif [ ! -f "$ingress_path" ] || [ ! -x "$ingress_path" ] ||
+    { { [ ! -f "$receipt_path" ] || [ -L "$receipt_path" ]; } && { [ ! -f "$binary_path" ] || [ -L "$binary_path" ]; }; }; then
+    fail "existing Station ingress binary '$ingress_path' is not owned by an installed Station release; it was not changed."
   fi
-done
+fi
+if [ -e "$popup_path" ] || [ -L "$popup_path" ]; then
+  if [ ! -L "$popup_path" ] || ! readlink_target "$popup_path" 2>/dev/null || [ "$link_target" != stn ]; then
+    fail "existing launcher '$popup_path' must be absent or a symlink to 'stn'; it was not changed."
+  fi
+fi
 if [ -e "$license_path" ] || [ -L "$license_path" ]; then
   if [ ! -f "$license_path" ] || [ -L "$license_path" ]; then
     fail "existing Station license '$license_path' must be a regular non-symlink file."
@@ -929,7 +1000,7 @@ if ! tar -tvzf "$archive_path" > "$verbose_manifest_path"; then
 fi
 awk '{ print substr($1, 1, 1) }' "$verbose_manifest_path" > "$manifest_types_path"
 actual_typed_manifest=$(LC_ALL=C paste "$manifest_path" "$manifest_types_path" | LC_ALL=C sort)
-expected_typed_manifest=$(printf 'LICENSE\t-\nstn\t-\nstn-ingress\tl\nstn-tmux-popup\tl\n' | LC_ALL=C sort)
+expected_typed_manifest=$(printf 'LICENSE\t-\nstn\t-\nstn-ingress\t-\nstn-tmux-popup\tl\n' | LC_ALL=C sort)
 if [ "$actual_typed_manifest" != "$expected_typed_manifest" ]; then
   fail "$archive_name does not contain the required Station member types; nothing was installed."
 fi
@@ -943,14 +1014,15 @@ fi
 if [ ! -f "$extracted_dir/stn" ] || [ -L "$extracted_dir/stn" ]; then
   fail "the Station release manifest must contain a regular 'stn' binary."
 fi
+if [ ! -f "$extracted_dir/stn-ingress" ] || [ -L "$extracted_dir/stn-ingress" ] || [ ! -x "$extracted_dir/stn-ingress" ]; then
+  fail "the Station release manifest must contain a regular executable 'stn-ingress' binary."
+fi
 if [ ! -f "$extracted_dir/LICENSE" ] || [ -L "$extracted_dir/LICENSE" ]; then
   fail "the Station release manifest must contain a regular 'LICENSE' file."
 fi
-for launcher in stn-ingress stn-tmux-popup; do
-  if [ ! -L "$extracted_dir/$launcher" ] || ! readlink_target "$extracted_dir/$launcher" || [ "$link_target" != stn ]; then
-    fail "the Station release manifest must contain '$launcher' as a symlink to 'stn'."
-  fi
-done
+if [ ! -L "$extracted_dir/stn-tmux-popup" ] || ! readlink_target "$extracted_dir/stn-tmux-popup" || [ "$link_target" != stn ]; then
+  fail "the Station release manifest must contain 'stn-tmux-popup' as a symlink to 'stn'."
+fi
 
 # Stage on each destination filesystem so every final rename is atomic.
 install_stage=$(mktemp -d "$install_dir/.station-install.XXXXXX") || fail "cannot stage files in $install_dir."
@@ -966,8 +1038,17 @@ if ! cp "$extracted_dir/stn" "$install_stage/stn"; then
   fail "could not stage the Station binary in $install_dir."
 fi
 chmod 0755 "$install_stage/stn" || fail "could not set executable permissions on the staged Station binary."
+if ! cp "$extracted_dir/stn-ingress" "$install_stage/stn-ingress.new"; then
+  fail "could not stage the Station ingress binary in $install_dir."
+fi
+chmod 0755 "$install_stage/stn-ingress.new" || fail "could not set executable permissions on the staged Station ingress binary."
+if ! file_sha256 "$install_stage/stn-ingress.new"; then
+  fail "could not record the staged Station ingress binary contents."
+fi
+installed_ingress_sha256=$hash_result
 if { [ "$target" = darwin-arm64 ] || [ "$target" = darwin-x64 ]; } && command -v xattr >/dev/null 2>&1; then
   xattr -d com.apple.quarantine "$install_stage/stn" 2>/dev/null || true
+  xattr -d com.apple.quarantine "$install_stage/stn-ingress.new" 2>/dev/null || true
 fi
 
 probe_output=$temp_dir/probe.stdout
@@ -1136,10 +1217,6 @@ create_alias() {
         ;;
     esac
     case "$alias_kind" in
-      ingress)
-        created_ingress=1
-        created_ingress_inode=$file_value
-        ;;
       popup)
         created_popup=1
         created_popup_inode=$file_value
@@ -1154,9 +1231,6 @@ create_alias() {
   fail "could not create Station launcher '$alias_path'."
 }
 
-if [ ! -L "$ingress_path" ]; then
-  create_alias "$ingress_path" ingress
-fi
 if [ ! -L "$popup_path" ]; then
   create_alias "$popup_path" popup
 fi
@@ -1167,11 +1241,19 @@ revalidate_managed_paths() {
       fail "Station binary destination '$binary_path' changed during installation; it must remain absent or a regular non-symlink file."
     fi
   fi
-  for managed_launcher in "$ingress_path" "$popup_path"; do
-    if [ ! -L "$managed_launcher" ] || ! readlink_target "$managed_launcher" 2>/dev/null || [ "$link_target" != stn ]; then
-      fail "Station launcher '$managed_launcher' changed during installation; it must remain a symlink exactly targeting 'stn'."
+  if [ -e "$ingress_path" ] || [ -L "$ingress_path" ]; then
+    if [ -L "$ingress_path" ]; then
+      if ! readlink_target "$ingress_path" 2>/dev/null || [ "$link_target" != stn ]; then
+        fail "Station ingress launcher '$ingress_path' changed during installation."
+      fi
+    elif [ ! -f "$ingress_path" ] || [ ! -x "$ingress_path" ] ||
+      { { [ ! -f "$receipt_path" ] || [ -L "$receipt_path" ]; } && { [ ! -f "$binary_path" ] || [ -L "$binary_path" ]; }; }; then
+      fail "Station ingress binary '$ingress_path' changed during installation."
     fi
-  done
+  fi
+  if [ ! -L "$popup_path" ] || ! readlink_target "$popup_path" 2>/dev/null || [ "$link_target" != stn ]; then
+    fail "Station launcher '$popup_path' changed during installation; it must remain a symlink exactly targeting 'stn'."
+  fi
   if [ -e "$license_path" ] || [ -L "$license_path" ]; then
     if [ ! -f "$license_path" ] || [ -L "$license_path" ]; then
       fail "Station license destination '$license_path' changed during installation; it must remain absent or a regular non-symlink file."
@@ -1201,9 +1283,32 @@ if ! mv "$new_license" "$license_path"; then
   fail "could not install the Station license '$license_path'."
 fi
 
-# Renaming the verified binary is the sole runtime commit point; aliases already resolve through stn.
+# The ingress transport rejects a mismatched Observer build, so replacing it
+# immediately before the main binary keeps either mixed-version window safe.
 revalidate_managed_paths
 validate_expected_installation
+if [ -e "$ingress_path" ] || [ -L "$ingress_path" ]; then
+  ingress_backup=$install_stage/stn-ingress.previous
+  if ! alias_inode "$ingress_path"; then
+    fail "could not record the existing Station ingress launcher identity."
+  fi
+  previous_ingress_inode=$alias_inode_result
+  if ! ln -P "$ingress_path" "$ingress_backup"; then
+    fail "could not back up the existing Station ingress launcher '$ingress_path'."
+  fi
+  ingress_displaced=1
+fi
+if ! mv -f "$install_stage/stn-ingress.new" "$ingress_path"; then
+  fail "could not activate the verified Station ingress binary; restoring the previous installation."
+fi
+ingress_installed=1
+if ! alias_inode "$ingress_path"; then
+  fail "could not record the activated Station ingress binary identity."
+fi
+installed_ingress_inode=$alias_inode_result
+if ! file_sha256 "$ingress_path" || [ "$hash_result" != "$installed_ingress_sha256" ]; then
+  fail "the activated Station ingress binary changed before runtime commit."
+fi
 commit_started=1
 if mv -f "$install_stage/stn" "$binary_path"; then
   runtime_committed=1

--- a/scripts/release/package-archive.sh
+++ b/scripts/release/package-archive.sh
@@ -34,8 +34,8 @@ archive=$repo_root/stn-v$version-$target.tar.gz
   printf 'Expected an executable Station binary at %s/stn.\n' "$bin_dir" >&2
   exit 1
 }
-[ "$(readlink "$bin_dir/stn-ingress" 2>/dev/null || true)" = stn ] || {
-  printf 'Expected stn-ingress to be a symlink to stn.\n' >&2
+[ -x "$bin_dir/stn-ingress" ] && [ ! -L "$bin_dir/stn-ingress" ] || {
+  printf 'Expected an executable Station ingress binary at %s/stn-ingress.\n' "$bin_dir" >&2
   exit 1
 }
 [ "$(readlink "$bin_dir/stn-tmux-popup" 2>/dev/null || true)" = stn ] || {

--- a/scripts/test-runners/run-binary-smoke.mjs
+++ b/scripts/test-runners/run-binary-smoke.mjs
@@ -4,6 +4,7 @@ import { constants, readFileSync } from "node:fs";
 import {
   access,
   chmod,
+  copyFile,
   lstat,
   mkdir,
   mkdtemp,
@@ -15,6 +16,7 @@ import {
   rm,
   writeFile,
 } from "node:fs/promises";
+import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join, parse, relative, resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -27,6 +29,7 @@ import {
   ObserverHealthSchema,
   ObserverProcessIdentitySchema,
   SafeErrorSchema,
+  STATION_SCHEMA_VERSION,
 } from "../../packages/contracts/dist/index.js";
 import {
   createObserverClient,
@@ -208,7 +211,7 @@ async function runBinarySmoke() {
     if (installedRoot === parse(installedRoot).root) {
       fail("compiled popup ownership unexpectedly resolved to filesystem root");
     }
-    await assertExactBinaryAlias(installedRoot, "stn-ingress");
+    await assertExactIngressBinary(installedRoot);
     await assertExactBinaryAlias(installedRoot, "stn-tmux-popup");
     await Promise.all([
       mkdir(homeDir, { recursive: true, mode: 0o700 }),
@@ -222,6 +225,11 @@ async function runBinarySmoke() {
     await writeSmokeConfig(configPath, stateDir, socketPath);
     await writeSmokeConfig(popupConfigPath, stateDir, socketPath, "tmux");
     await writeHostileConfig(hostileDir, markerPath);
+    await verifyNativeIngressTransport({
+      ingressPath: join(installedRoot, "stn-ingress"),
+      root,
+      observerVersion: compiledObserverVersion,
+    });
 
     if (!ptyOnly) {
       await requireCommittedCleanCheckout(repoRoot);
@@ -3237,6 +3245,141 @@ async function assertExactBinaryAlias(installedRoot, name) {
   assertEqual(stat.isSymbolicLink(), true, `${name} exact symlink`);
   assertEqual(await readlink(path), "stn", `${name} exact symlink target`);
   assertEqual(await realpath(path), join(installedRoot, "stn"), `${name} binary identity`);
+}
+
+async function assertExactIngressBinary(installedRoot) {
+  const path = join(installedRoot, "stn-ingress");
+  const stat = await lstat(path);
+  assertEqual(stat.isFile(), true, "stn-ingress regular binary");
+  assertEqual(stat.isSymbolicLink(), false, "stn-ingress is not a symlink");
+  assertEqual((stat.mode & 0o111) !== 0, true, "stn-ingress executable mode");
+}
+
+async function verifyNativeIngressTransport(input) {
+  const directory = join(input.root, "native-ingress-smoke");
+  const ingressPath = join(directory, "stn-ingress");
+  const runtimePath = join(directory, "stn");
+  const argsPath = join(directory, "runtime.args");
+  const stdinPath = join(directory, "runtime.stdin");
+  const hookIdPath = join(directory, "runtime.hook-id");
+  const socketPath = join(input.root, "native-ingress.sock");
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  await copyFile(input.ingressPath, ingressPath);
+  await chmod(ingressPath, 0o755);
+  await writeFile(
+    runtimePath,
+    `#!/bin/sh\nprintf '%s\\n' "$@" > ${quoteShellWord(argsPath)}\nprintf '%s' "\${STATION_INTERNAL_PROVIDER_HOOK_ID:-}" > ${quoteShellWord(hookIdPath)}\ncat > ${quoteShellWord(stdinPath)}\n`,
+    { mode: 0o755 },
+  );
+
+  const requests = [];
+  const requestWaiters = [];
+  const nextRequest = () => {
+    const request = requests.shift();
+    return request === undefined
+      ? new Promise((resolve) => requestWaiters.push(resolve))
+      : Promise.resolve(request);
+  };
+  let requestCount = 0;
+  const server = createServer((socket) => {
+    let buffer = "";
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk) => {
+      buffer += chunk;
+      const newline = buffer.indexOf("\n");
+      if (newline < 0) return;
+      const value = JSON.parse(buffer.slice(0, newline));
+      const waiter = requestWaiters.shift();
+      if (waiter === undefined) requests.push(value);
+      else waiter(value);
+      const response =
+        requestCount === 0
+          ? {
+              schemaVersion: STATION_SCHEMA_VERSION,
+              jsonrpc: "2.0",
+              id: value.id,
+              result: {
+                schemaVersion: STATION_SCHEMA_VERSION,
+                hookId: value.params.event.hookId,
+                provider: value.params.event.provider,
+                event: value.params.event.event,
+                status: "accepted",
+                receivedAt: value.params.event.receivedAt,
+              },
+            }
+          : {
+              schemaVersion: STATION_SCHEMA_VERSION,
+              jsonrpc: "2.0",
+              id: value.id,
+              error: {
+                tag: "ProtocolError",
+                code: "OBSERVER_BUILD_MISMATCH",
+                message: "Synthetic fallback response.",
+              },
+            };
+      requestCount += 1;
+      socket.end(`${JSON.stringify(response)}\n`);
+    });
+  });
+  await new Promise((resolvePromise, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, resolvePromise);
+  });
+  const payload = {
+    session_id: "codex-native-ingress",
+    transcript_path: null,
+    cwd: input.root,
+    model: "codex-smoke",
+    turn_id: "turn-native-ingress",
+    hook_event_name: "Stop",
+    stop_hook_active: false,
+    last_assistant_message: null,
+  };
+  try {
+    const result = await run(ingressPath, ["--fast", "--socket", socketPath, "codex", "Stop"], {
+      env: {
+        PATH: "/usr/bin:/bin",
+        STATION_SESSION_ID: "session-native-ingress",
+        STATION_WORKTREE_ID: "worktree-native-ingress",
+      },
+      input: JSON.stringify(payload),
+    });
+    assertEqual(result.code, 0, "native ingress accepted completion");
+    const delivered = await nextRequest();
+    assertEqual(
+      delivered.params?.expectedBuildVersion,
+      input.observerVersion,
+      "native ingress exact Observer guard",
+    );
+    assertEqual(delivered.params?.event?.event, "Stop", "native ingress declared event");
+    assertEqual(
+      delivered.params?.event?.sessionId,
+      "session-native-ingress",
+      "native ingress session identity",
+    );
+    assertDeepEqual(delivered.params?.event?.payload, payload, "native ingress raw payload");
+    assertEqual(await pathExists(argsPath), false, "native accepted path skips canonical runtime");
+
+    const fallback = await run(ingressPath, ["--fast", "--socket", socketPath, "codex", "Stop"], {
+      env: {
+        PATH: "/usr/bin:/bin",
+        STATION_SESSION_ID: "session-native-ingress",
+        STATION_WORKTREE_ID: "worktree-native-ingress",
+      },
+      input: JSON.stringify(payload),
+    });
+    assertEqual(fallback.code, 0, "native ingress canonical fallback");
+    await nextRequest();
+    assertDeepEqual(
+      (await readFile(argsPath, "utf8")).trim().split("\n"),
+      ["__ingress", "--fast", "--socket", socketPath, "codex", "Stop"],
+      "native ingress canonical completion args",
+    );
+    assertEqual(await readFile(stdinPath, "utf8"), JSON.stringify(payload), "native stdin replay");
+    assertIncludes(await readFile(hookIdPath, "utf8"), "hook_", "native ingress hook ID handoff");
+  } finally {
+    await new Promise((resolvePromise) => server.close(resolvePromise));
+  }
 }
 
 function requiredSetupAction(plan, id) {

--- a/scripts/test-runners/run-install-smoke.mjs
+++ b/scripts/test-runners/run-install-smoke.mjs
@@ -159,19 +159,19 @@ function prepareFixtures() {
   createManualRelease("v1.2.14", "linux-x64", [
     tarFile("../stn", "untrusted traversal payload\n", 0o755),
     tarFile("LICENSE", "Station fixture license v1.2.14\n", 0o644),
-    tarSymlink("stn-ingress", "stn"),
+    tarFile("stn-ingress", releaseBinarySource("v1.2.14", "linux-x64"), 0o755),
     tarSymlink("stn-tmux-popup", "stn"),
   ]);
   createManualRelease("v1.2.15", "linux-x64", [
     tarSymlink("stn", "missing-runtime"),
     tarFile("LICENSE", "Station fixture license v1.2.15\n", 0o644),
-    tarSymlink("stn-ingress", "stn"),
+    tarFile("stn-ingress", releaseBinarySource("v1.2.15", "linux-x64"), 0o755),
     tarSymlink("stn-tmux-popup", "stn"),
   ]);
   createManualRelease("v1.2.16", "linux-x64", [
     tarFile("stn", releaseBinarySource("v1.2.16", "linux-x64"), 0o755),
     tarSymlink("LICENSE", "stn"),
-    tarSymlink("stn-ingress", "stn"),
+    tarFile("stn-ingress", releaseBinarySource("v1.2.16", "linux-x64"), 0o755),
     tarSymlink("stn-tmux-popup", "stn"),
   ]);
   createRelease("v1.2.17", ["linux-x64"], { ingressTarget: "../stn" });
@@ -184,20 +184,20 @@ function prepareFixtures() {
   createManualRelease("v1.2.24", "linux-x64", [
     tarFile("stn", releaseBinarySource("v1.2.24", "linux-x64"), 0o755),
     tarFile("LICENSE", "Station fixture license v1.2.24\n", 0o644),
-    tarFile("stn-ingress", "not a symlink\n", 0o755),
+    tarFile("stn-ingress", "not executable\n", 0o644),
     tarSymlink("stn-tmux-popup", "stn"),
   ]);
   createRelease("v1.2.25", ["linux-x64"], { probeMode: "stdout-flood" });
   createManualRelease("v1.2.26", "linux-x64", [
     tarFile("LICENSE", "Station fixture license v1.2.26\n", 0o644),
     tarHardlink("stn", "LICENSE"),
-    tarSymlink("stn-ingress", "stn"),
+    tarFile("stn-ingress", releaseBinarySource("v1.2.26", "linux-x64"), 0o755),
     tarSymlink("stn-tmux-popup", "stn"),
   ]);
   createManualRelease("v1.2.27", "linux-x64", [
     tarFile("stn", releaseBinarySource("v1.2.27", "linux-x64"), 0o755),
     tarHardlink("LICENSE", "stn"),
-    tarSymlink("stn-ingress", "stn"),
+    tarFile("stn-ingress", releaseBinarySource("v1.2.27", "linux-x64"), 0o755),
     tarSymlink("stn-tmux-popup", "stn"),
   ]);
   createRelease("v1.2.28", ["linux-x64"], { probeMode: "secret-check" });
@@ -820,9 +820,9 @@ function scenarioArtifactValidation() {
     ["v1.2.14", "exact Station release manifest", "traversal-like archive member"],
     ["v1.2.15", "required Station member types", "wrong binary archive type"],
     ["v1.2.16", "required Station member types", "wrong license archive type"],
-    ["v1.2.17", "symlink to 'stn'", "wrong launcher archive target"],
+    ["v1.2.17", "required Station member types", "wrong ingress archive type"],
     ["v1.2.23", "symlink to 'stn'", "wrong popup launcher archive target"],
-    ["v1.2.24", "required Station member types", "regular-file launcher archive type"],
+    ["v1.2.24", "regular executable 'stn-ingress'", "non-executable ingress archive"],
     ["v1.2.26", "required Station member types", "hardlinked binary archive type"],
     ["v1.2.27", "required Station member types", "hardlinked license archive type"],
     ["v1.2.9", "reports an unexpected version", "wrong embedded version"],
@@ -1009,7 +1009,7 @@ function scenarioPathResolutionAndFilesystemFailures() {
     platform: linuxX64(),
     dataHome: newlineLinkData,
   });
-  assertFailure(newlineLink, "existing launcher", "newline launcher target");
+  assertFailure(newlineLink, "existing Station ingress launcher", "newline launcher target");
   assertNoGhApiCalls(newlineLink, "newline launcher target");
   assertEqual(
     readlinkSync(join(newlineLinkDir, "stn-ingress")),
@@ -1477,7 +1477,7 @@ exec /bin/rm "$@"
 
 function scenarioCommitFailures() {
   const cases = [
-    { command: "ln", destination: "stn-ingress", label: "ingress alias commit" },
+    { command: "mv", destination: "stn-ingress", label: "ingress binary commit" },
     { command: "ln", destination: "stn-tmux-popup", label: "popup alias commit" },
     { command: "mv", destination: "LICENSE", label: "license commit" },
     { command: "mv", destination: "stn", label: "runtime commit" },
@@ -1563,7 +1563,7 @@ function scenarioAmbiguousRuntimeCommit() {
   const installDir = join(root, "ambiguous-runtime-bin");
   const dataHome = join(root, "ambiguous-runtime-data");
   seedInstallation({ installDir, dataHome, tag: "v0.9.0" });
-  const shim = makeMoveThenFailShim(join(installDir, "stn"));
+  const shim = makeMoveThenFailShim(join(installDir, "stn"), "runtime");
   const ambiguous = runInstaller({
     installDir,
     platform: linuxX64(),
@@ -1579,29 +1579,28 @@ function scenarioAmbiguousRuntimeCommit() {
   assertNotIncludes(ambiguous.stderr, "was unchanged", "ambiguous activation truthfulness");
   assertNoInstallerResidue(installDir, dataHome);
 
-  const aliasInstallDir = join(root, "ambiguous-alias-bin");
-  const aliasDataHome = join(root, "ambiguous-alias-data");
-  const aliasShim = makeLinkThenFailShim(join(aliasInstallDir, "stn-ingress"));
-  const aliasFailure = runInstaller({
-    installDir: aliasInstallDir,
+  const ingressInstallDir = join(root, "ambiguous-ingress-bin");
+  const ingressDataHome = join(root, "ambiguous-ingress-data");
+  const ingressShim = makeMoveThenFailShim(join(ingressInstallDir, "stn-ingress"), "ingress");
+  const ingressFailure = runInstaller({
+    installDir: ingressInstallDir,
     platform: linuxX64(),
     version: releaseTag,
-    dataHome: aliasDataHome,
-    commandBinDirs: [aliasShim.directory],
-    environment: aliasShim.environment,
+    dataHome: ingressDataHome,
+    commandBinDirs: [ingressShim.directory],
+    environment: ingressShim.environment,
   });
-  assertNonzero(aliasFailure, "link-performed-then-error");
-  assertEqual(
-    readlinkSync(join(aliasInstallDir, "stn-ingress")),
-    "stn",
-    "unconfirmed alias is not removed",
-  );
-  assert(!existsSync(join(aliasInstallDir, "stn")), "link ambiguity leaves runtime absent");
+  assertNonzero(ingressFailure, "ingress-move-performed-then-error");
   assert(
-    !existsSync(join(aliasDataHome, "station", "LICENSE")),
-    "link ambiguity leaves license absent",
+    !isSymlink(join(ingressInstallDir, "stn-ingress")),
+    "unconfirmed ingress binary is not removed",
   );
-  assertNoInstallerResidue(aliasInstallDir, aliasDataHome);
+  assert(!existsSync(join(ingressInstallDir, "stn")), "ingress ambiguity leaves runtime absent");
+  assert(
+    !existsSync(join(ingressDataHome, "station", "LICENSE")),
+    "ingress ambiguity leaves license absent",
+  );
+  assertNoInstallerResidue(ingressInstallDir, ingressDataHome);
 
   const warningInstallDir = join(root, "cleanup-warning-bin");
   const warningDataHome = join(root, "cleanup-warning-data");
@@ -1720,10 +1719,9 @@ async function scenarioManagedPathReplacement() {
         "popup replacement runtime preservation",
         { aliases: false, assertAliasesAbsent: false },
       );
-      assertEqual(
-        readlinkSync(join(replacementInstallDir, "stn-ingress")),
-        "stn",
-        "popup replacement leaves ingress",
+      assert(
+        existsSync(join(replacementInstallDir, "stn-ingress")),
+        "popup replacement leaves ingress launcher",
       );
       assertLicense(replacementDataHome, "v0.9.0", "popup replacement license preservation");
     } else if (resource === "binary") {
@@ -1938,7 +1936,7 @@ async function scenarioAliasCreationSignal() {
   const dataHome = join(root, "alias-signal-data");
   const marker = join(root, "alias-signal.ready");
   const releaseFile = join(root, "alias-signal.release");
-  const shim = makeLinkThenBlockShim(join(installDir, "stn-ingress"), marker, releaseFile);
+  const shim = makeLinkThenBlockShim(join(installDir, "stn-tmux-popup"), marker, releaseFile);
   const running = runInstaller({
     installDir,
     platform: linuxX64(),
@@ -1967,7 +1965,7 @@ async function scenarioAliasCreationSignal() {
   const replacedDataHome = join(root, "alias-signal-replaced-data");
   const replacedMarker = join(root, "alias-signal-replaced.ready");
   const replacedRelease = join(root, "alias-signal-replaced.release");
-  const replacedPath = join(replacedInstallDir, "stn-ingress");
+  const replacedPath = join(replacedInstallDir, "stn-tmux-popup");
   const replacedShim = makeLinkThenBlockShim(replacedPath, replacedMarker, replacedRelease);
   const replacedRunning = runInstaller({
     installDir: replacedInstallDir,
@@ -2325,7 +2323,16 @@ function createRelease(tag, targets, options = {}) {
       mode: options.probeMode,
       reportedVersion: options.reportedVersion,
     });
-    symlinkSync(options.ingressTarget ?? "stn", join(payloadDir, "stn-ingress"));
+    if (options.ingressTarget === undefined) {
+      writeReleaseBinary(join(payloadDir, "stn-ingress"), {
+        tag,
+        target,
+        mode: options.probeMode,
+        reportedVersion: options.reportedVersion,
+      });
+    } else {
+      symlinkSync(options.ingressTarget, join(payloadDir, "stn-ingress"));
+    }
     symlinkSync(options.popupTarget ?? "stn", join(payloadDir, "stn-tmux-popup"));
     writeText(join(payloadDir, "LICENSE"), `Station fixture license ${tag}\n`, 0o644);
 
@@ -2906,9 +2913,9 @@ exec "$FAKE_REAL_COMMAND" "$@"
   };
 }
 
-function makeMoveThenFailShim(destination) {
-  const shimDir = join(root, "move-then-fail-shim");
-  const state = join(root, "move-then-fail.state");
+function makeMoveThenFailShim(destination, slug) {
+  const shimDir = join(root, `${slug}-move-then-fail-shim`);
+  const state = join(root, `${slug}-move-then-fail.state`);
   makeDirectory(shimDir);
   writeExecutable(
     join(shimDir, "mv"),
@@ -2929,37 +2936,6 @@ exec "$FAKE_REAL_COMMAND" "$@"
     environment: {
       FAKE_FAIL_DESTINATION: destination,
       FAKE_REAL_COMMAND: resolveCommand("mv"),
-      FAKE_SHIM_STATE: state,
-    },
-  };
-}
-
-function makeLinkThenFailShim(destination) {
-  const shimDir = join(root, "link-then-fail-shim");
-  const state = join(root, "link-then-fail.state");
-  makeDirectory(shimDir);
-  writeExecutable(
-    join(shimDir, "ln"),
-    `#!/bin/sh
-last=''
-source=''
-for argument do source=$last; last=$argument; done
-destination=$last
-if [ -d "$last" ]; then destination=$last/\${source##*/}; fi
-if [ "$destination" = "$FAKE_FAIL_DESTINATION" ] && [ ! -e "$FAKE_SHIM_STATE" ]; then
-  "$FAKE_REAL_COMMAND" "$@" || exit
-  : > "$FAKE_SHIM_STATE"
-  chmod 600 "$FAKE_SHIM_STATE"
-  exit 71
-fi
-exec "$FAKE_REAL_COMMAND" "$@"
-`,
-  );
-  return {
-    directory: shimDir,
-    environment: {
-      FAKE_FAIL_DESTINATION: destination,
-      FAKE_REAL_COMMAND: resolveCommand("ln"),
       FAKE_SHIM_STATE: state,
     },
   };
@@ -3212,7 +3188,11 @@ if [ "\${1:-}" = --version ]; then printf '%s\\n' '${version}'; else printf '%s\
 `,
   );
   if (withAliases) {
-    symlinkSync("stn", join(installDir, "stn-ingress"));
+    if (withReceipt) {
+      writeExecutable(join(installDir, "stn-ingress"), `#!/bin/sh\nprintf '%s\\n' '${version}'\n`);
+    } else {
+      symlinkSync("stn", join(installDir, "stn-ingress"));
+    }
     symlinkSync("stn", join(installDir, "stn-tmux-popup"));
   }
   if (withReceipt) {
@@ -3236,12 +3216,13 @@ function writeExpectedInstallation(path, installDir) {
   writeText(
     path,
     [
-      "format=station-installer-expected-v1",
+      "format=station-installer-expected-v2",
       `binary_sha256=${binaryHash}`,
       `binary_device=${binaryStat.dev}`,
       `binary_inode=${binaryStat.ino}`,
       `ingress_device=${ingressStat.dev}`,
       `ingress_inode=${ingressStat.ino}`,
+      `ingress_sha256=${createHash("sha256").update(readFileSync(ingress)).digest("hex")}`,
       `popup_device=${popupStat.dev}`,
       `popup_inode=${popupStat.ino}`,
       `receipt_device=${receiptStat.dev}`,
@@ -3260,6 +3241,8 @@ function assertInstalled({ installDir, dataHome = dataDir, tag, target, receipt 
   assertRuntimeVersion(installDir, tag, `${target} installed entrypoints`);
   assertLicense(dataHome, tag, `${target} installed license`);
   assertMode(binary, 0o755, `${target} executable mode`);
+  assert(!isSymlink(join(installDir, "stn-ingress")), `${target} installed ingress binary`);
+  assertMode(join(installDir, "stn-ingress"), 0o755, `${target} ingress executable mode`);
   if (receipt) assertInstallerReceipt(installDir, `${target} installer receipt`);
 }
 
@@ -3285,7 +3268,7 @@ function assertRuntimeVersion(
     assertEqual(result.stdout, `${tag.slice(1)}\n`, `${label} ${entrypoint} version`);
   }
   if (aliases) {
-    assertEqual(readlinkSync(join(installDir, "stn-ingress")), "stn", `${label} ingress link`);
+    assert(existsSync(join(installDir, "stn-ingress")), `${label} ingress exists`);
     assertEqual(readlinkSync(join(installDir, "stn-tmux-popup")), "stn", `${label} popup link`);
   } else if (assertAliasesAbsent) {
     assert(!existsSync(join(installDir, "stn-ingress")), `${label} leaves ingress absent`);

--- a/scripts/test-runners/run-update-smoke.mjs
+++ b/scripts/test-runners/run-update-smoke.mjs
@@ -1481,7 +1481,8 @@ async function installIncumbent(source, installDir, dataHome) {
   const binary = join(installDir, "stn");
   await copyFile(source, binary);
   await chmod(binary, 0o755);
-  await symlink("stn", join(installDir, "stn-ingress"));
+  await copyFile(join(dirname(source), "stn-ingress"), join(installDir, "stn-ingress"));
+  await chmod(join(installDir, "stn-ingress"), 0o755);
   await symlink("stn", join(installDir, "stn-tmux-popup"));
   await writeFile(join(installDir, ".station-install-receipt"), receiptContent, {
     mode: 0o600,
@@ -1490,7 +1491,11 @@ async function installIncumbent(source, installDir, dataHome) {
   await mkdir(licenseDir, { recursive: true, mode: 0o700 });
   await copyFile(join(repoRoot, "LICENSE"), join(licenseDir, "LICENSE"));
   await chmod(join(licenseDir, "LICENSE"), 0o644);
-  assertEqual(await readlink(join(installDir, "stn-ingress")), "stn", "incumbent ingress alias");
+  assertEqual(
+    (await lstat(join(installDir, "stn-ingress"))).isFile(),
+    true,
+    "incumbent ingress binary",
+  );
   assertEqual(
     (await lstat(join(installDir, ".station-install-receipt"))).mode & 0o777,
     0o600,

--- a/station/src/ingress/station-ingress-fast.c
+++ b/station/src/ingress/station-ingress-fast.c
@@ -1,0 +1,491 @@
+#if defined(__APPLE__)
+#define _DARWIN_C_SOURCE
+#endif
+#define _POSIX_C_SOURCE 200809L
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/un.h>
+#include <time.h>
+#include <unistd.h>
+
+#if defined(__APPLE__)
+#include <mach-o/dyld.h>
+#endif
+
+#ifndef STATION_PROTOCOL_SCHEMA_VERSION
+#error "STATION_PROTOCOL_SCHEMA_VERSION must be defined"
+#endif
+#ifndef STATION_OBSERVER_VERSION
+#error "STATION_OBSERVER_VERSION must be defined"
+#endif
+
+#define MAX_STDIN_BYTES (8U * 1024U * 1024U)
+#define MAX_RESPONSE_BYTES (1024U * 1024U)
+
+struct byte_buffer {
+  char *data;
+  size_t length;
+  size_t capacity;
+};
+
+static int buffer_reserve(struct byte_buffer *buffer, size_t additional) {
+  if (additional > SIZE_MAX - buffer->length - 1U) return -1;
+  const size_t required = buffer->length + additional + 1U;
+  if (required <= buffer->capacity) return 0;
+  size_t capacity = buffer->capacity == 0U ? 4096U : buffer->capacity;
+  while (capacity < required) {
+    if (capacity > SIZE_MAX / 2U) {
+      capacity = required;
+      break;
+    }
+    capacity *= 2U;
+  }
+  char *next = realloc(buffer->data, capacity);
+  if (next == NULL) return -1;
+  buffer->data = next;
+  buffer->capacity = capacity;
+  return 0;
+}
+
+static int buffer_append_bytes(struct byte_buffer *buffer, const char *value, size_t length) {
+  if (buffer_reserve(buffer, length) != 0) return -1;
+  memcpy(buffer->data + buffer->length, value, length);
+  buffer->length += length;
+  buffer->data[buffer->length] = '\0';
+  return 0;
+}
+
+static int buffer_append(struct byte_buffer *buffer, const char *value) {
+  return buffer_append_bytes(buffer, value, strlen(value));
+}
+
+static int buffer_append_json_string(struct byte_buffer *buffer, const char *value) {
+  static const char hex[] = "0123456789abcdef";
+  if (buffer_append(buffer, "\"") != 0) return -1;
+  for (const unsigned char *cursor = (const unsigned char *)value; *cursor != '\0'; cursor += 1) {
+    const unsigned char character = *cursor;
+    if (character == '\"' || character == '\\') {
+      const char escaped[2] = {'\\', (char)character};
+      if (buffer_append_bytes(buffer, escaped, sizeof(escaped)) != 0) return -1;
+    } else if (character < 0x20U) {
+      const char escaped[6] = {'\\', 'u', '0', '0', hex[character >> 4U], hex[character & 0x0fU]};
+      if (buffer_append_bytes(buffer, escaped, sizeof(escaped)) != 0) return -1;
+    } else if (buffer_append_bytes(buffer, (const char *)cursor, 1U) != 0) {
+      return -1;
+    }
+  }
+  return buffer_append(buffer, "\"");
+}
+
+static int buffer_append_field(
+    struct byte_buffer *buffer,
+    const char *name,
+    const char *value) {
+  if (value == NULL || value[0] == '\0') return 0;
+  return buffer_append(buffer, ",\"") != 0 ||
+                 buffer_append(buffer, name) != 0 ||
+                 buffer_append(buffer, "\":") != 0 ||
+                 buffer_append_json_string(buffer, value) != 0
+             ? -1
+             : 0;
+}
+
+static int read_stdin(struct byte_buffer *payload) {
+  char chunk[8192];
+  for (;;) {
+    const ssize_t count = read(STDIN_FILENO, chunk, sizeof(chunk));
+    if (count == 0) return 0;
+    if (count < 0) {
+      if (errno == EINTR) continue;
+      return -1;
+    }
+    if ((size_t)count > MAX_STDIN_BYTES - payload->length) {
+      errno = EFBIG;
+      return -1;
+    }
+    if (buffer_append_bytes(payload, chunk, (size_t)count) != 0) return -1;
+  }
+}
+
+static int write_socket_all(int descriptor, const char *data, size_t length) {
+  size_t offset = 0U;
+  while (offset < length) {
+#if defined(MSG_NOSIGNAL)
+    const ssize_t count = send(descriptor, data + offset, length - offset, MSG_NOSIGNAL);
+#else
+    const ssize_t count = send(descriptor, data + offset, length - offset, 0);
+#endif
+    if (count < 0) {
+      if (errno == EINTR) continue;
+      return -1;
+    }
+    offset += (size_t)count;
+  }
+  return 0;
+}
+
+static int read_response(int descriptor, struct byte_buffer *response) {
+  char chunk[1024];
+  while (response->length < MAX_RESPONSE_BYTES) {
+    const ssize_t count = read(descriptor, chunk, sizeof(chunk));
+    if (count < 0) {
+      if (errno == EINTR) continue;
+      return -1;
+    }
+    if (count == 0) return -1;
+    const char *newline = memchr(chunk, '\n', (size_t)count);
+    const size_t accepted = newline == NULL ? (size_t)count : (size_t)(newline - chunk) + 1U;
+    if (buffer_append_bytes(response, chunk, accepted) != 0) return -1;
+    if (newline != NULL) return 0;
+  }
+  errno = EMSGSIZE;
+  return -1;
+}
+
+static const char *nonempty_env(const char *name) {
+  const char *value = getenv(name);
+  return value != NULL && value[0] != '\0' ? value : NULL;
+}
+
+static int event_timestamp(char *output, size_t output_size, struct timespec *now) {
+  if (clock_gettime(CLOCK_REALTIME, now) != 0) return -1;
+  struct tm utc;
+  if (gmtime_r(&now->tv_sec, &utc) == NULL) return -1;
+  const int count = snprintf(
+      output,
+      output_size,
+      "%04d-%02d-%02dT%02d:%02d:%02d.%03ldZ",
+      utc.tm_year + 1900,
+      utc.tm_mon + 1,
+      utc.tm_mday,
+      utc.tm_hour,
+      utc.tm_min,
+      utc.tm_sec,
+      now->tv_nsec / 1000000L);
+  return count > 0 && (size_t)count < output_size ? 0 : -1;
+}
+
+static int build_request(
+    struct byte_buffer *request,
+    const struct byte_buffer *payload,
+    const char *provider,
+    const char *event,
+    const char *hook_id,
+    const char *received_at) {
+  if (buffer_append(request, "{\"schemaVersion\":\"") != 0 ||
+      buffer_append(request, STATION_PROTOCOL_SCHEMA_VERSION) != 0 ||
+      buffer_append(request, "\",\"jsonrpc\":\"2.0\",\"id\":") != 0 ||
+      buffer_append_json_string(request, hook_id) != 0 ||
+      buffer_append(
+          request,
+          ",\"method\":\"observer.ingestProviderHookEvent\",\"params\":{\"event\":{\"schemaVersion\":\"") != 0 ||
+      buffer_append(request, STATION_PROTOCOL_SCHEMA_VERSION) != 0 ||
+      buffer_append(request, "\",\"hookId\":") != 0 ||
+      buffer_append_json_string(request, hook_id) != 0 ||
+      buffer_append(request, ",\"provider\":") != 0 ||
+      buffer_append_json_string(request, provider) != 0 ||
+      buffer_append(request, ",\"kind\":\"harness\",\"event\":") != 0 ||
+      buffer_append_json_string(request, event) != 0 ||
+      buffer_append(request, ",\"receivedAt\":") != 0 ||
+      buffer_append_json_string(request, received_at) != 0 ||
+      buffer_append_field(request, "projectId", nonempty_env("STATION_PROJECT_ID")) != 0 ||
+      buffer_append_field(request, "worktreeId", nonempty_env("STATION_WORKTREE_ID")) != 0 ||
+      buffer_append_field(request, "worktreePath", nonempty_env("STATION_WORKTREE_PATH")) != 0 ||
+      buffer_append_field(
+          request,
+          "worktreeManagedRoot",
+          nonempty_env("STATION_WORKTREE_MANAGED_ROOT")) != 0 ||
+      buffer_append_field(request, "sessionId", nonempty_env("STATION_SESSION_ID")) != 0 ||
+      buffer_append_field(
+          request,
+          "terminalProvider",
+          nonempty_env("STATION_TERMINAL_PROVIDER")) != 0 ||
+      buffer_append_field(
+          request,
+          "terminalTargetId",
+          nonempty_env("STATION_TERMINAL_TARGET_ID")) != 0 ||
+      buffer_append(request, ",\"payload\":") != 0 ||
+      buffer_append_bytes(request, payload->data, payload->length) != 0 ||
+      buffer_append(request, "},\"expectedBuildVersion\":\"") != 0 ||
+      buffer_append(request, STATION_OBSERVER_VERSION) != 0 ||
+      buffer_append(request, "\"}}\n") != 0) {
+    return -1;
+  }
+  return 0;
+}
+
+static int build_accepted_response(
+    struct byte_buffer *expected,
+    const char *provider,
+    const char *event,
+    const char *hook_id,
+    const char *received_at) {
+  if (buffer_append(expected, "{\"schemaVersion\":\"") != 0 ||
+      buffer_append(expected, STATION_PROTOCOL_SCHEMA_VERSION) != 0 ||
+      buffer_append(expected, "\",\"jsonrpc\":\"2.0\",\"id\":") != 0 ||
+      buffer_append_json_string(expected, hook_id) != 0 ||
+      buffer_append(expected, ",\"result\":{\"schemaVersion\":\"") != 0 ||
+      buffer_append(expected, STATION_PROTOCOL_SCHEMA_VERSION) != 0 ||
+      buffer_append(expected, "\",\"hookId\":") != 0 ||
+      buffer_append_json_string(expected, hook_id) != 0 ||
+      buffer_append(expected, ",\"provider\":") != 0 ||
+      buffer_append_json_string(expected, provider) != 0 ||
+      buffer_append(expected, ",\"event\":") != 0 ||
+      buffer_append_json_string(expected, event) != 0 ||
+      buffer_append(expected, ",\"status\":\"accepted\",\"receivedAt\":") != 0 ||
+      buffer_append_json_string(expected, received_at) != 0 ||
+      buffer_append(expected, "}}\n") != 0) {
+    return -1;
+  }
+  return 0;
+}
+
+static int send_request(
+    const char *socket_path,
+    const struct byte_buffer *request,
+    struct byte_buffer *response,
+    int timeout_ms) {
+  if (strlen(socket_path) >= sizeof(((struct sockaddr_un *)0)->sun_path)) {
+    errno = ENAMETOOLONG;
+    return -1;
+  }
+  const int descriptor = socket(AF_UNIX, SOCK_STREAM, 0);
+  if (descriptor < 0) return -1;
+#if defined(__APPLE__)
+  const int no_sigpipe = 1;
+  if (setsockopt(descriptor, SOL_SOCKET, SO_NOSIGPIPE, &no_sigpipe, sizeof(no_sigpipe)) != 0) {
+    close(descriptor);
+    return -1;
+  }
+#endif
+  struct timeval timeout = {
+      .tv_sec = timeout_ms / 1000,
+      .tv_usec = (timeout_ms % 1000) * 1000,
+  };
+  if (setsockopt(descriptor, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0 ||
+      setsockopt(descriptor, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)) != 0) {
+    close(descriptor);
+    return -1;
+  }
+  struct sockaddr_un address;
+  memset(&address, 0, sizeof(address));
+  address.sun_family = AF_UNIX;
+  memcpy(address.sun_path, socket_path, strlen(socket_path) + 1U);
+  const int result = connect(descriptor, (struct sockaddr *)&address, sizeof(address)) == 0 &&
+                             write_socket_all(descriptor, request->data, request->length) == 0 &&
+                             read_response(descriptor, response) == 0
+                         ? 0
+                         : -1;
+  const int saved_errno = errno;
+  close(descriptor);
+  errno = saved_errno;
+  return result;
+}
+
+static int current_executable_path(const char *argv0, char *output, size_t output_size) {
+  (void)argv0;
+  char unresolved[PATH_MAX];
+#if defined(__APPLE__)
+  uint32_t unresolved_size = (uint32_t)sizeof(unresolved);
+  if (_NSGetExecutablePath(unresolved, &unresolved_size) != 0) {
+    errno = ENAMETOOLONG;
+    return -1;
+  }
+#elif defined(__linux__)
+  const ssize_t count = readlink("/proc/self/exe", unresolved, sizeof(unresolved) - 1U);
+  if (count < 0 || (size_t)count >= sizeof(unresolved) - 1U) return -1;
+  unresolved[count] = '\0';
+#else
+  if (strlen(argv0) >= sizeof(unresolved)) {
+    errno = ENAMETOOLONG;
+    return -1;
+  }
+  memcpy(unresolved, argv0, strlen(argv0) + 1U);
+#endif
+  return realpath(unresolved, output) == NULL || strlen(output) >= output_size ? -1 : 0;
+}
+
+struct runtime_plan {
+  char executable[PATH_MAX];
+  char **argv;
+};
+
+static int prepare_runtime(
+    struct runtime_plan *plan,
+    int argc,
+    char **argv) {
+  char resolved[PATH_MAX];
+  if (current_executable_path(argv[0], resolved, sizeof(resolved)) != 0) return -1;
+  char *separator = strrchr(resolved, '/');
+  if (separator == NULL) {
+    errno = EINVAL;
+    return -1;
+  }
+  *separator = '\0';
+  const int count = snprintf(plan->executable, sizeof(plan->executable), "%s/stn", resolved);
+  if (count <= 0 || (size_t)count >= sizeof(plan->executable)) {
+    errno = ENAMETOOLONG;
+    return -1;
+  }
+  plan->argv = calloc((size_t)argc + 2U, sizeof(char *));
+  if (plan->argv == NULL) return -1;
+  plan->argv[0] = plan->executable;
+  plan->argv[1] = "__ingress";
+  for (int index = 1; index < argc; index += 1) plan->argv[index + 1] = argv[index];
+
+  return 0;
+}
+
+static int prepare_replay(const struct byte_buffer *payload) {
+  FILE *replay = tmpfile();
+  if (replay == NULL || (payload->length > 0U &&
+                         fwrite(payload->data, 1U, payload->length, replay) != payload->length) ||
+      fflush(replay) != 0 ||
+      fseek(replay, 0L, SEEK_SET) != 0 ||
+      dup2(fileno(replay), STDIN_FILENO) < 0) {
+    const int saved_errno = errno;
+    if (replay != NULL) fclose(replay);
+    errno = saved_errno;
+    return -1;
+  }
+  fclose(replay);
+  return 0;
+}
+
+static void exec_runtime(const struct runtime_plan *plan) {
+  execv(plan->executable, plan->argv);
+  const int saved_errno = errno;
+  perror("stn-ingress: exec runtime");
+  exit(saved_errno == ENOENT ? 127 : 126);
+}
+
+static int parse_positive_timeout(const char *value, int *output) {
+  errno = 0;
+  char *end = NULL;
+  const long parsed = strtol(value, &end, 10);
+  if (errno != 0 || end == value || *end != '\0' || parsed <= 0L || parsed > INT_MAX) return -1;
+  *output = (int)parsed;
+  return 0;
+}
+
+int main(int argc, char **argv) {
+  struct runtime_plan runtime = {0};
+  if (prepare_runtime(&runtime, argc, argv) != 0) {
+    perror("stn-ingress: canonical runtime setup");
+    return 126;
+  }
+
+  int fast_requested = 0;
+  for (int index = 1; index < argc; index += 1) {
+    if (strcmp(argv[index], "--fast") == 0) {
+      fast_requested = 1;
+      break;
+    }
+  }
+  if (fast_requested == 0) exec_runtime(&runtime);
+
+  struct byte_buffer payload = {0};
+  if (read_stdin(&payload) != 0) {
+    perror("stn-ingress: stdin");
+    free(payload.data);
+    free(runtime.argv);
+    return 1;
+  }
+  if (prepare_replay(&payload) != 0) {
+    perror("stn-ingress: canonical replay setup");
+    free(payload.data);
+    free(runtime.argv);
+    return 126;
+  }
+
+  int fast = 0;
+  int fast_options_valid = 1;
+  int delivery_timeout_ms = 2000;
+  const char *socket_path = NULL;
+  const char *provider = NULL;
+  const char *event = NULL;
+  int positional = 0;
+  for (int index = 1; index < argc; index += 1) {
+    const char *argument = argv[index];
+    if (strcmp(argument, "--fast") == 0) {
+      fast = 1;
+      continue;
+    }
+    if (strcmp(argument, "--no-auto-start") == 0) continue;
+    if (strcmp(argument, "--socket") == 0 || strcmp(argument, "--state-dir") == 0 ||
+        strcmp(argument, "--spool-dir") == 0 || strcmp(argument, "--config") == 0 ||
+        strcmp(argument, "--observer-entry") == 0 ||
+        strcmp(argument, "--delivery-timeout-ms") == 0 ||
+        strcmp(argument, "--startup-timeout-ms") == 0 ||
+        strcmp(argument, "--rate-limit-ms") == 0) {
+      if (index + 1 >= argc) break;
+      if (strcmp(argument, "--socket") == 0) socket_path = argv[index + 1];
+      if (strcmp(argument, "--delivery-timeout-ms") == 0 &&
+          parse_positive_timeout(argv[index + 1], &delivery_timeout_ms) != 0) {
+        fast_options_valid = 0;
+      }
+      index += 1;
+      continue;
+    }
+    if (positional == 0) provider = argument;
+    if (positional == 1) event = argument;
+    positional += 1;
+  }
+
+  if (fast == 0 || fast_options_valid == 0 || socket_path == NULL || provider == NULL ||
+      event == NULL || positional != 2 ||
+      nonempty_env("STATION_SESSION_ID") == NULL ||
+      nonempty_env("STATION_WORKTREE_ID") == NULL || payload.length == 0U) {
+    exec_runtime(&runtime);
+  }
+
+  struct timespec now;
+  char received_at[32];
+  char hook_id[96];
+  if (event_timestamp(received_at, sizeof(received_at), &now) != 0 ||
+      snprintf(
+          hook_id,
+          sizeof(hook_id),
+          "hook_%lld_%09ld_%ld",
+          (long long)now.tv_sec,
+          now.tv_nsec,
+          (long)getpid()) <= 0) {
+    exec_runtime(&runtime);
+  }
+  if (setenv("STATION_INTERNAL_PROVIDER_HOOK_ID", hook_id, 1) != 0) {
+    perror("stn-ingress: hook id");
+    return 126;
+  }
+
+  struct byte_buffer request = {0};
+  struct byte_buffer response = {0};
+  if (build_request(&request, &payload, provider, event, hook_id, received_at) == 0 &&
+      send_request(socket_path, &request, &response, delivery_timeout_ms) == 0) {
+    struct byte_buffer expected = {0};
+    // Only the exact validated success shape may bypass canonical ingress;
+    // protocol evolution or any ambiguous response must replay through it.
+    const int accepted =
+        build_accepted_response(&expected, provider, event, hook_id, received_at) == 0 &&
+        response.length == expected.length &&
+        memcmp(response.data, expected.data, response.length) == 0;
+    free(expected.data);
+    if (accepted) {
+      free(request.data);
+      free(response.data);
+      free(payload.data);
+      free(runtime.argv);
+      return 0;
+    }
+  }
+  free(request.data);
+  free(response.data);
+  exec_runtime(&runtime);
+  return 126;
+}

--- a/station/src/main.tsx
+++ b/station/src/main.tsx
@@ -432,7 +432,7 @@ async function startStationMain(
   installLiveHostTtyDimensions();
   const renderer = await createCliRenderer({
     exitOnCtrlC: false,
-    maxFps: 120,
+    maxFps: 1_500,
     exitSignals: [
       "SIGINT",
       "SIGTERM",

--- a/tests/contract-fixtures/hooks/provider-hook-events.json
+++ b/tests/contract-fixtures/hooks/provider-hook-events.json
@@ -21,7 +21,11 @@
     "receivedAt": "2026-05-20T12:03:00.000Z",
     "projectId": "web",
     "worktreeId": "wt_web_feature_auth",
+    "worktreePath": "/workspace/web/feature-auth",
+    "worktreeManagedRoot": "/workspace/web/.worktrees",
     "sessionId": "ses_web_feature_auth",
+    "terminalProvider": "tmux",
+    "terminalTargetId": "tmux:server:$1:@2:%3",
     "payload": {
       "state": "idle"
     }


### PR DESCRIPTION
## What this fixes

Station's Codex hook path started the compiled CLI before the Observer could project an event, leaving the TUI visibly behind active agent work. The fast path also needs to remain safe across upgrades, failed delivery, and provider-specific normalization.

## What changed

- Ship a small native `stn-ingress` transport for eligible Codex hooks while keeping permission-review events on canonical ingress.
- Require an exact Observer-build acknowledgement and replay the original stdin, arguments, and hook ID through `stn __ingress` on any inconclusive result.
- Carry provider-neutral launch identity through the strict protocol boundary, then perform Codex parsing, scope, and event validation in the integration adapter.
- Keep projected event streams ahead of their quiet reconciliation pass and reduce dirty-frame scheduling delay without adding idle rendering.
- Package, install, update, verify, and roll back `stn` and `stn-ingress` together with atomic reader-visible replacement.

## Testing

- `bun run typecheck`
- `bun run lint`
- `bun run test:unit` (3,513 tests)
- `bun run test:contracts` (201 tests)
- `bun run test:integration` (929 tests)
- `bun run smoke:install`
- `bun run build:binary -- --version 0.0.0-local`
- `bun run smoke:binary -- --expected-version 0.0.0-local`