### PR TITLE
perf(hooks): bypass Bun startup for Claude and Cursor events

### DIFF
--- a/apps/observer/test/integration/hook-ingestion.test.ts
+++ b/apps/observer/test/integration/hook-ingestion.test.ts
@@ -1,6 +1,8 @@
+import { claudeHookAdapter } from "@station/claude";
 import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 import type { HarnessEventReportReceipt, ProviderHookAdapter } from "@station/contracts";
 import { enrichStationHookIdentityPayload, STATION_SCHEMA_VERSION } from "@station/contracts";
+import { cursorHookAdapter } from "@station/cursor";
 import { FakeHarnessProvider, FakeTerminalProvider, FakeWorktreeProvider } from "@station/testing";
 import { describe, expect, it } from "vitest";
 import {
@@ -298,6 +300,86 @@ describe("observer provider hook ingress", () => {
     expect(enrichedSessionId).toBe("session-fast");
     await reports.return?.();
     sqlite.close();
+  });
+
+  it.each([
+    {
+      provider: "claude",
+      adapter: claudeHookAdapter,
+      event: "PreToolUse",
+      payload: {
+        session_id: "claude_native_fast",
+        cwd: "/tmp/station/web/task",
+        hook_event_name: "PreToolUse",
+        tool_name: "Bash",
+        tool_input: { command: "pnpm test" },
+        tool_use_id: "tool_claude_native_fast",
+      },
+    },
+    {
+      provider: "cursor",
+      adapter: cursorHookAdapter,
+      event: "beforeShellExecution",
+      payload: {
+        session_id: "cursor_native_fast",
+        cwd: "/tmp/station/web/task",
+        hook_event_name: "beforeShellExecution",
+        tool_name: "Shell",
+        tool_use_id: "tool_cursor_native_fast",
+      },
+    },
+  ] as const)("normalizes $provider native fast ingress through its provider adapter", async ({
+    provider,
+    adapter,
+    event,
+    payload,
+  }) => {
+    const clock = { now: () => new Date(now) };
+    const providers = new ProviderRegistry({
+      worktree: new FakeWorktreeProvider({ now }),
+      terminal: new FakeTerminalProvider({ now }),
+      harnesses: [new FakeHarnessProvider({ now })],
+      hookAdapters: [adapter],
+    });
+    const { sqlite, persistence, api } = createTestObserver({ config, providers, clock });
+
+    try {
+      const receipt = await api.ingestProviderHookEvent({
+        schemaVersion: STATION_SCHEMA_VERSION,
+        hookId: `hook_${provider}_native_fast`,
+        provider,
+        kind: "harness",
+        event,
+        receivedAt: now,
+        projectId: "web",
+        worktreeId: "wt_web_task",
+        worktreePath: "/tmp/station/web/task",
+        sessionId: "ses_web_task",
+        terminalProvider: "tmux",
+        terminalTargetId: "tmux:station:@1:%2",
+        payload,
+      });
+
+      expect(receipt).toMatchObject({ status: "accepted", provider, event });
+      await expect(
+        persistence.listProviderObservations({ entityKind: "harness_event" }),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          provider,
+          payload: expect.objectContaining({
+            provider,
+            eventType: event,
+            projectId: "web",
+            worktreeId: "wt_web_task",
+            sessionId: "ses_web_task",
+            terminalTargetId: "tmux:station:@1:%2",
+            status: expect.objectContaining({ value: "working" }),
+          }),
+        }),
+      ]);
+    } finally {
+      sqlite.close();
+    }
   });
 
   it("rejects a declared transport event that disagrees with provider normalization", async () => {

--- a/docs/harness-ingress.md
+++ b/docs/harness-ingress.md
@@ -47,17 +47,18 @@ bypasses that adapter. There is no secondary `HarnessProvider` raw-ingestion
 path: an accepted hook without a report-producing adapter is durable evidence
 to schedule reconcile, not a source of synthesized harness observations.
 
-Compiled Codex hook entries pass an explicit `--fast` marker and declared event
-to the generated script, except `PermissionRequest`, whose review semantics stay
-on canonical ingress. With Station session and worktree identity and an explicit
-Observer socket, the native launcher stamps one hook ID and sends the raw payload
-with an exact-build guard. The Observer rejects a build mismatch before mutation,
-enriches the provider payload from provider-neutral transport identity, and
-rejects disagreement between the declared event and the strictly parsed provider
-event. A byte-exact accepted receipt from that matching build completes in the
-native launcher and remains visible in the Observer report-processing log. Any
-other response or transport failure executes `stn __ingress` with the same hook
-ID for canonical validation, logging, spooling, startup, and error behavior.
+Generated Claude and Cursor hook entries pass an explicit `--fast` marker and
+declared event to their scripts. Codex does the same except for
+`PermissionRequest`, whose review semantics stay on canonical ingress. With
+Station session and worktree identity and an explicit Observer socket, the
+native launcher stamps one hook ID and sends the raw payload with an exact-build
+guard. The Observer rejects a build mismatch before mutation, enriches the
+provider payload from provider-neutral transport identity, and rejects
+disagreement between the declared event and the strictly parsed provider event.
+A byte-exact accepted receipt from that matching build completes in the native
+launcher and remains visible in the Observer report-processing log. Any other
+response or transport failure executes `stn __ingress` with the same hook ID for
+canonical validation, logging, spooling, startup, and error behavior.
 
 Station-generated Codex, Claude, and Cursor scripts, the OpenCode plugin, and
 Worktrunk lifecycle commands carry a strict artifact-owner marker. The canonical
@@ -97,10 +98,10 @@ Only an admitted, correlated event proceeds to shared event validation, Observer
 readiness and optional startup, delivery, compatibility handling, ordinary
 transport-failure spooling, and the existing final-receipt log.
 
-The explicit compiled Codex fast transport moves delivery ahead of canonical
-parsing only for event types selected by the Codex integration. Provider rules
-and the Observer-side adapter remain authoritative; no provider-specific payload
-logic is implemented in the native transport.
+The explicit compiled fast transport moves delivery ahead of canonical parsing
+only for event types selected by the Claude, Codex, or Cursor integration.
+Provider rules and the Observer-side adapter remain authoritative; no
+provider-specific payload logic is implemented in the native transport.
 
 ## Rollout
 

--- a/docs/harness-signals.md
+++ b/docs/harness-signals.md
@@ -72,9 +72,9 @@ Normalized events are `HarnessEventReport` / `HarnessEventObservation`
    use the raw `stn-ingress` path. `HarnessProvider` has no fallback raw-event
    ingestion operation; cwd-only and other unresolved report evidence is
    correlated against current graph truth only during Observer projection.
-   Compiled fast ingress may carry Station identity in provider-neutral envelope
-   fields; the Observer adapter translates those fields into the provider payload
-   before this one normalization pass.
+   Compiled fast ingress selected by Claude, Codex, or Cursor may carry Station
+   identity in provider-neutral envelope fields; the Observer adapter translates
+   those fields into the provider payload before this one normalization pass.
 2. **No provider vocabulary in core.** Observer core and the TUI must not
    match on provider prose (`reason` strings), provider event names, or
    provider keys in `providerData`. If core needs to branch on it, it becomes

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -93,14 +93,15 @@ hooks. A virtual compiled module path and filesystem root `/` are never accepted
 as ownership roots.
 
 The native ingress launcher does not own provider parsing or lifecycle policy.
-Only provider integrations opt configured events into `--fast`; the Observer
-performs strict normalization, and canonical ingress retains validation,
-auto-start, spooling, and error behavior for every non-accepted result. The
-native launcher recognizes only the exact validated accepted receipt emitted by
-the matching build; all other responses re-enter canonical ingress. Accepted
-fast delivery remains visible in the Observer's report-processing log. The
-initial socket request names the exact Observer build and is rejected before
-mutation on mismatch.
+Only provider integrations opt configured events into `--fast`; Claude and
+Cursor select every generated hook event, while Codex keeps
+`PermissionRequest` canonical. The Observer performs strict normalization, and
+canonical ingress retains validation, auto-start, spooling, and error behavior
+for every non-accepted result. The native launcher recognizes only the exact
+validated accepted receipt emitted by the matching build; all other responses
+re-enter canonical ingress. Accepted fast delivery remains visible in the
+Observer's report-processing log. The initial socket request names the exact
+Observer build and is rejected before mutation on mismatch.
 
 ## Runtime boundaries
 

--- a/integrations/harness/claude/src/hooks.ts
+++ b/integrations/harness/claude/src/hooks.ts
@@ -208,6 +208,7 @@ function expectedClaudeHookScript(input: ClaudeHookScriptOptions): string {
     options: input,
     ignoreFailure: true,
     redirectStderr: true,
+    forwardScriptArgs: true,
   });
 }
 

--- a/integrations/harness/claude/src/hooks/hookSettings.ts
+++ b/integrations/harness/claude/src/hooks/hookSettings.ts
@@ -1,4 +1,9 @@
-import { createJsonHookConfigEditor, isJsonObject } from "@station/harness-shared";
+import {
+  createJsonHookConfigEditor,
+  generatedHookScriptPath,
+  isJsonObject,
+} from "@station/harness-shared";
+import { commandLine } from "@station/runtime";
 import {
   CLAUDE_HOOK_EVENT_NAMES,
   type ClaudeForwardedEventType,
@@ -41,18 +46,18 @@ function matcherForEvent(eventName: ClaudeForwardedEventType): string | undefine
 
 function generatedHookEntry(
   eventName: ClaudeForwardedEventType,
-  hookScriptPath: string,
+  command: string,
 ): Record<string, unknown> {
-  const entry: Record<string, unknown> = { hooks: [generatedHookCommand(hookScriptPath)] };
+  const entry: Record<string, unknown> = { hooks: [generatedHookCommand(command)] };
   const matcher = matcherForEvent(eventName);
   if (matcher !== undefined) entry.matcher = matcher;
   return entry;
 }
 
-function generatedHookCommand(hookScriptPath: string): Record<string, unknown> {
+function generatedHookCommand(command: string): Record<string, unknown> {
   return {
     type: "command",
-    command: hookScriptPath,
+    command,
     timeout: 30,
     statusMessage: GENERATED_HOOK_STATUS_MESSAGE,
   };
@@ -62,7 +67,7 @@ function isGeneratedStationHookCommand(value: unknown): boolean {
   if (!isJsonObject(value) || value.type !== "command" || typeof value.command !== "string") {
     return false;
   }
-  if (value.command.endsWith(`/${GENERATED_HOOK_SCRIPT_NAME}`)) {
+  if (generatedHookScriptPath(value.command, GENERATED_HOOK_SCRIPT_NAME) !== undefined) {
     return true;
   }
   return (
@@ -75,8 +80,9 @@ export function expectedClaudeHookSettings(input: {
   hookScriptPath: string;
 }): ClaudeSettingsDocument {
   const hooks: Record<string, unknown> = {};
+  const commands = expectedClaudeHookCommands(input.hookScriptPath);
   for (const eventName of CLAUDE_HOOK_EVENT_NAMES) {
-    hooks[eventName] = [generatedHookEntry(eventName, input.hookScriptPath)];
+    hooks[eventName] = [generatedHookEntry(eventName, commands[eventName])];
   }
   return { hooks };
 }
@@ -112,10 +118,16 @@ export function missingClaudeHookEvents(
   document: ClaudeSettingsDocument,
   hookScriptPath: string,
 ): ClaudeForwardedEventType[] {
-  return hookConfigEditor.missingEvents(
-    document,
-    Object.fromEntries(
-      CLAUDE_HOOK_EVENT_NAMES.map((eventName) => [eventName, hookScriptPath]),
-    ) as Record<ClaudeForwardedEventType, string>,
-  );
+  return hookConfigEditor.missingEvents(document, expectedClaudeHookCommands(hookScriptPath));
+}
+
+function expectedClaudeHookCommands(
+  hookScriptPath: string,
+): Record<ClaudeForwardedEventType, string> {
+  return Object.fromEntries(
+    CLAUDE_HOOK_EVENT_NAMES.map((eventName) => [
+      eventName,
+      commandLine([hookScriptPath, "--fast", eventName]),
+    ]),
+  ) as Record<ClaudeForwardedEventType, string>;
 }

--- a/integrations/harness/claude/test/unit/hooks.test.ts
+++ b/integrations/harness/claude/test/unit/hooks.test.ts
@@ -57,11 +57,11 @@ describe("Claude hook setup", () => {
       hooks: Record<string, { matcher?: string; hooks: { command: string }[] }[]>;
     };
     expect(Object.keys(settings.hooks)).toEqual(expectedEvents);
-    for (const entries of Object.values(settings.hooks)) {
+    for (const [eventName, entries] of Object.entries(settings.hooks)) {
       expect(entries).toHaveLength(1);
       expect(entries[0]?.hooks[0]).toMatchObject({
         type: "command",
-        command: hookScriptPath,
+        command: `${hookScriptPath} --fast ${eventName}`,
         timeout: 30,
         statusMessage: "Notify station",
       });
@@ -103,7 +103,7 @@ describe("Claude hook setup", () => {
     // and leave scope decisions to the provider adapter.
     expect(script).not.toContain("STATION_SESSION_ID");
     expect(script).toContain("--config /tmp/station/config.toml");
-    expect(script).toContain("claude > /dev/null");
+    expect(script).toContain('claude "$@" > /dev/null');
     expect(script).not.toContain("payload_file=");
     expect(scriptMode).toBe(0o700);
     await expect(doctorClaudeHooks({ ...options, enabled: true })).resolves.toMatchObject({
@@ -111,6 +111,36 @@ describe("Claude hook setup", () => {
       installed: true,
       settingsPath,
     });
+  });
+
+  it("migrates legacy bare hook commands to event-declared fast commands", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-claude-hooks-legacy-"));
+    const settingsPath = join(root, "state", "hooks", "station-claude-settings.json");
+    const hookScriptPath = join(root, "state", "hooks", "station-claude-hook.sh");
+    await mkdir(join(root, "state", "hooks"), { recursive: true });
+    await writeFile(settingsPath, legacyClaudeSettings(hookScriptPath), "utf8");
+
+    const installed = await installClaudeHooks({
+      claudeSettingsPath: settingsPath,
+      claudeConfigDir: join(root, "claude-home"),
+      hookScriptPath,
+      env: {},
+    });
+    const settings = JSON.parse(await readFile(settingsPath, "utf8")) as {
+      hooks: Record<string, { hooks: { command: string }[] }[]>;
+    };
+
+    expect(installed.changed).toBe(true);
+    for (const eventName of expectedEvents) {
+      expect(settings.hooks[eventName]?.[0]?.hooks).toEqual([
+        {
+          type: "command",
+          command: `${hookScriptPath} --fast ${eventName}`,
+          timeout: 30,
+          statusMessage: "Notify station",
+        },
+      ]);
+    }
   });
 
   it("refuses install and uninstall from another Station runtime owner", async () => {
@@ -225,11 +255,14 @@ describe("Claude hook setup", () => {
     });
 
     const payload = JSON.stringify({ hook_event_name: "PreToolUse" });
-    const result = await runHookScript(hookScriptPath, payload, { TMPDIR: root });
+    const result = await runHookScript(hookScriptPath, payload, { TMPDIR: root }, [
+      "--fast",
+      "PreToolUse",
+    ]);
 
     expect(result).toEqual({ code: 0, stdout: "", stderr: "" });
     await expect(readFile(argsLog, "utf8")).resolves.toBe(
-      "--config /tmp/station/config.toml claude\n",
+      "--config /tmp/station/config.toml claude --fast PreToolUse\n",
     );
   });
 
@@ -262,15 +295,20 @@ describe("Claude hook setup", () => {
     });
 
     const payload = JSON.stringify({ hook_event_name: "PreToolUse" });
-    const result = await runHookScript(hookScriptPath, payload, {
-      TMPDIR: root,
-      STATION_SESSION_ID: "ses_web_task",
-      STATION_WORKTREE_ID: "wt_web_task",
-    });
+    const result = await runHookScript(
+      hookScriptPath,
+      payload,
+      {
+        TMPDIR: root,
+        STATION_SESSION_ID: "ses_web_task",
+        STATION_WORKTREE_ID: "wt_web_task",
+      },
+      ["--fast", "PreToolUse"],
+    );
 
     expect(result).toEqual({ code: 0, stdout: "", stderr: "" });
     await expect(readFile(argsLog, "utf8")).resolves.toBe(
-      "--config /tmp/station/config.toml claude\n",
+      "--config /tmp/station/config.toml claude --fast PreToolUse\n",
     );
     await expect(readFile(stdinLog, "utf8")).resolves.toBe(payload);
   });
@@ -396,10 +434,33 @@ function userSettingsWithGeneratedEntries(hookScriptPath: string): string {
   );
 }
 
+function legacyClaudeSettings(hookScriptPath: string): string {
+  return JSON.stringify({
+    hooks: Object.fromEntries(
+      expectedEvents.map((eventName) => [
+        eventName,
+        [
+          {
+            hooks: [
+              {
+                type: "command",
+                command: hookScriptPath,
+                timeout: 30,
+                statusMessage: "Notify station",
+              },
+            ],
+          },
+        ],
+      ]),
+    ),
+  });
+}
+
 async function runHookScript(
   scriptPath: string,
   stdin: string,
   env: NodeJS.ProcessEnv,
+  args: string[] = [],
 ): Promise<{ code: number | null; stdout: string; stderr: string }> {
   const childEnv: NodeJS.ProcessEnv = {};
   if (process.env.PATH !== undefined) {
@@ -411,7 +472,7 @@ async function runHookScript(
     }
   }
 
-  const child = spawn(scriptPath, [], {
+  const child = spawn(scriptPath, args, {
     env: childEnv,
     stdio: ["pipe", "pipe", "pipe"],
   });

--- a/integrations/harness/cursor/src/hooks.ts
+++ b/integrations/harness/cursor/src/hooks.ts
@@ -2,13 +2,14 @@
 // Upstream hook contract: https://cursor.com/docs/hooks
 // STATION ingress flow: docs/harness-ingress.md. Generated command + payload must match the ingress parser.
 import type { ProviderHookArtifactOwner, ProviderHookArtifactOwnership } from "@station/contracts";
+import { generatedHookScriptPath } from "@station/harness-shared";
 import {
   assertProviderHookArtifactOwnership,
   assignBackupPaths,
   classifyProviderHookArtifactOwnership,
+  commandLine,
   createHookSetupFileOps,
   expectedProviderHookScript,
-  hookCommandsForEvents,
   installConfigScriptHook,
   type ProviderHookScriptOptions,
   planConfigScriptHook,
@@ -25,7 +26,11 @@ import {
   removeGeneratedCursorHookCommands,
   stringifyJsonDocument,
 } from "./hooks/hookConfigEditor.js";
-import { CURSOR_HOOK_EVENT_NAMES, type CursorHookEventName } from "./hooks/hookConstants.js";
+import {
+  CURSOR_HOOK_EVENT_NAMES,
+  type CursorHookEventName,
+  GENERATED_HOOK_SCRIPT_NAME,
+} from "./hooks/hookConstants.js";
 import { CursorHookSetupError } from "./hooks/hookErrors.js";
 import { resolveCursorHookScriptPath, resolveCursorHooksPath } from "./hooks/hookPaths.js";
 
@@ -121,11 +126,20 @@ function missingDescription(plan: CursorHookPlan): string {
 function expectedCursorHookCommands(input: {
   hookScriptPath: string;
 }): Record<CursorHookEventName, string> {
-  return hookCommandsForEvents(CURSOR_HOOK_EVENT_NAMES, input.hookScriptPath);
+  return Object.fromEntries(
+    CURSOR_HOOK_EVENT_NAMES.map((eventName) => [
+      eventName,
+      commandLine([input.hookScriptPath, "--fast", eventName]),
+    ]),
+  ) as Record<CursorHookEventName, string>;
 }
 
 function expectedCursorHookScript(input: CursorHookScriptOptions): string {
-  return expectedProviderHookScript({ provider: "cursor", options: input });
+  return expectedProviderHookScript({
+    provider: "cursor",
+    options: input,
+    forwardScriptArgs: true,
+  });
 }
 
 async function sharedGeneratedHookPlan(
@@ -133,8 +147,17 @@ async function sharedGeneratedHookPlan(
   options: CursorHookPlanOptions,
 ): Promise<CursorHookDoctorResult | undefined> {
   const document = parseJsonDocument(source);
-  const hookScriptPath = sharedGeneratedHookScriptPath(generatedCursorHookCommands(document));
+  const configuredCommands = generatedCursorHookCommands(document);
+  const hookScriptPath = sharedGeneratedHookScriptPath(configuredCommands);
   if (hookScriptPath === undefined) {
+    return undefined;
+  }
+  const expectedCommands = expectedCursorHookCommands({ hookScriptPath });
+  if (
+    CURSOR_HOOK_EVENT_NAMES.some(
+      (eventName) => configuredCommands[eventName][0] !== expectedCommands[eventName],
+    )
+  ) {
     return undefined;
   }
 
@@ -144,7 +167,8 @@ async function sharedGeneratedHookPlan(
   );
   if (
     scriptBefore !== expectedScript &&
-    !providerHookScriptRoutesByStationEnv(scriptBefore, "cursor")
+    (!providerHookScriptRoutesByStationEnv(scriptBefore, "cursor") ||
+      !scriptBefore.includes('cursor "$@"'))
   ) {
     return undefined;
   }
@@ -166,7 +190,7 @@ async function sharedGeneratedHookPlan(
     status: ownershipConflict ? "warn" : "ok",
     installed: !ownershipConflict,
     missing: [],
-    commands: expectedCursorHookCommands({ hookScriptPath }),
+    commands: expectedCommands,
     message: ownershipConflict
       ? "Cursor hook artifact ownership conflicts with this Station runtime; run `stn hooks install cursor --yes --takeover` only to transfer it."
       : "Cursor hooks are installed.",
@@ -187,9 +211,13 @@ function sharedGeneratedHookScriptPath(
     if (command === undefined) {
       return undefined;
     }
+    const hookScriptPath = generatedHookScriptPath(command, GENERATED_HOOK_SCRIPT_NAME);
+    if (hookScriptPath === undefined) {
+      return undefined;
+    }
     if (shared === undefined) {
-      shared = command;
-    } else if (shared !== command) {
+      shared = hookScriptPath;
+    } else if (shared !== hookScriptPath) {
       return undefined;
     }
   }

--- a/integrations/harness/cursor/src/hooks/hookConfigEditor.ts
+++ b/integrations/harness/cursor/src/hooks/hookConfigEditor.ts
@@ -1,4 +1,8 @@
-import { createJsonHookConfigEditor, isJsonObject } from "@station/harness-shared";
+import {
+  createJsonHookConfigEditor,
+  generatedHookScriptPath,
+  isJsonObject,
+} from "@station/harness-shared";
 import { z } from "zod";
 import {
   CURSOR_HOOK_EVENT_NAMES,
@@ -52,9 +56,7 @@ export const documentContainsCommand: (document: CursorHooksDocument, command: s
   hookConfigEditor.documentContainsCommand;
 
 function commandLooksLikeGeneratedHookScript(command: string): boolean {
-  return (
-    command === GENERATED_HOOK_SCRIPT_NAME || command.endsWith(`/${GENERATED_HOOK_SCRIPT_NAME}`)
-  );
+  return generatedHookScriptPath(command, GENERATED_HOOK_SCRIPT_NAME) !== undefined;
 }
 
 export function parseJsonDocument(source: string): CursorHooksDocument {

--- a/integrations/harness/cursor/test/unit/hooks.test.ts
+++ b/integrations/harness/cursor/test/unit/hooks.test.ts
@@ -46,7 +46,9 @@ describe("Cursor hook setup", () => {
         "postToolUseFailure",
       ],
     });
-    expect(plan.commands.beforeShellExecution).toBe(hookScriptPath);
+    expect(plan.commands.beforeShellExecution).toBe(
+      `${hookScriptPath} --fast beforeShellExecution`,
+    );
     expect(plan.after).toContain('"beforeShellExecution"');
     await expect(readFile(hooksPath, "utf8")).rejects.toThrow();
     await expect(readFile(hookScriptPath, "utf8")).rejects.toThrow();
@@ -105,10 +107,12 @@ describe("Cursor hook setup", () => {
       timeout: 5,
     });
     expect(config.hooks.afterShellExecution).toContainEqual({
-      command: hookScriptPath,
+      command: `${hookScriptPath} --fast afterShellExecution`,
       timeout: 30,
     });
-    expect(config.hooks.beforeShellExecution).toEqual([{ command: hookScriptPath, timeout: 30 }]);
+    expect(config.hooks.beforeShellExecution).toEqual([
+      { command: `${hookScriptPath} --fast beforeShellExecution`, timeout: 30 },
+    ]);
     expect(script).toContain(
       `if [ -n "${shellParameter("STATION_OBSERVER_SOCKET_PATH:-")}" ]; then`,
     );
@@ -117,11 +121,11 @@ describe("Cursor hook setup", () => {
     expect(script).toContain('CONFIG_ARG=(--config "$STATION_CONFIG_PATH")');
     expect(script).toContain("CONFIG_ARG=(--config /tmp/station/config.toml)");
     expect(providerHookScriptRoutesByStationEnv(script, "cursor")).toBe(true);
-    expect(script).toContain("--no-auto-start cursor");
+    expect(script).toContain('--no-auto-start cursor "$@"');
     // External sessions carry no station env; the script must deliver anyway
     // and leave scope decisions to the provider adapter.
     expect(script).not.toContain("STATION_SESSION_ID");
-    expect(script).toContain("cursor > /dev/null");
+    expect(script).toContain('cursor "$@" > /dev/null');
     expect(scriptMode).toBe(0o700);
     await expect(
       doctorCursorHooks({
@@ -140,6 +144,25 @@ describe("Cursor hook setup", () => {
       hooksPath,
       hookScriptPath,
     });
+  });
+
+  it("migrates legacy bare hook commands to event-declared fast commands", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-cursor-hooks-legacy-"));
+    const hooksPath = join(root, "cursor", "hooks.json");
+    const hookScriptPath = join(root, "state", "hooks", "station-cursor-hook.sh");
+    await mkdir(join(root, "cursor"), { recursive: true });
+    await writeFile(hooksPath, legacyCursorHooks(hookScriptPath), "utf8");
+
+    const installed = await installCursorHooks({ cursorHooksPath: hooksPath, hookScriptPath });
+    const config = JSON.parse(await readFile(hooksPath, "utf8")) as {
+      hooks: Record<string, { command: string; timeout: number }[]>;
+    };
+
+    expect(installed.changed).toBe(true);
+    for (const [eventName, command] of Object.entries(installed.commands)) {
+      expect(config.hooks[eventName]).toEqual([{ command, timeout: 30 }]);
+      expect(command).toBe(`${hookScriptPath} --fast ${eventName}`);
+    }
   });
 
   it("doctor accepts a shared generated hook script that routes by Station env", async () => {
@@ -172,8 +195,8 @@ describe("Cursor hook setup", () => {
       installed: true,
       hookScriptPath: sharedHookScriptPath,
       commands: {
-        sessionStart: sharedHookScriptPath,
-        postToolUse: sharedHookScriptPath,
+        sessionStart: `${sharedHookScriptPath} --fast sessionStart`,
+        postToolUse: `${sharedHookScriptPath} --fast postToolUse`,
       },
     });
   });
@@ -270,11 +293,14 @@ describe("Cursor hook setup", () => {
     });
 
     const payload = JSON.stringify({ hook_event_name: "beforeShellExecution" });
-    const result = await runHookScript(hookScriptPath, payload, { TMPDIR: root });
+    const result = await runHookScript(hookScriptPath, payload, { TMPDIR: root }, [
+      "--fast",
+      "beforeShellExecution",
+    ]);
 
     expect(result).toEqual({ code: 0, stdout: "", stderr: "" });
     await expect(readFile(argsLog, "utf8")).resolves.toBe(
-      "--config /tmp/station/config.toml cursor\n",
+      "--config /tmp/station/config.toml cursor --fast beforeShellExecution\n",
     );
   });
 
@@ -305,15 +331,20 @@ describe("Cursor hook setup", () => {
     });
 
     const payload = JSON.stringify({ hook_event_name: "sessionStart" });
-    const result = await runHookScript(hookScriptPath, payload, {
-      TMPDIR: root,
-      STATION_SESSION_ID: "ses_web_task",
-      STATION_WORKTREE_ID: "wt_web_task",
-    });
+    const result = await runHookScript(
+      hookScriptPath,
+      payload,
+      {
+        TMPDIR: root,
+        STATION_SESSION_ID: "ses_web_task",
+        STATION_WORKTREE_ID: "wt_web_task",
+      },
+      ["--fast", "sessionStart"],
+    );
 
     expect(result).toEqual({ code: 0, stdout: "", stderr: "" });
     await expect(readFile(argsLog, "utf8")).resolves.toBe(
-      "--config /tmp/station/config.toml cursor\n",
+      "--config /tmp/station/config.toml cursor --fast sessionStart\n",
     );
     await expect(readFile(stdinLog, "utf8")).resolves.toBe(payload);
   });
@@ -345,17 +376,22 @@ describe("Cursor hook setup", () => {
       hookBin,
     });
 
-    const result = await runHookScript(hookScriptPath, '{"hook_event_name":"sessionStart"}', {
-      TMPDIR: root,
-      STATION_SESSION_ID: "ses_web_task",
-      STATION_WORKTREE_ID: "wt_web_task",
-      STATION_CONFIG_PATH: "/tmp/demo/config.toml",
-      STATION_OBSERVER_SOCKET_PATH: "/tmp/demo/observer.sock",
-    });
+    const result = await runHookScript(
+      hookScriptPath,
+      '{"hook_event_name":"sessionStart"}',
+      {
+        TMPDIR: root,
+        STATION_SESSION_ID: "ses_web_task",
+        STATION_WORKTREE_ID: "wt_web_task",
+        STATION_CONFIG_PATH: "/tmp/demo/config.toml",
+        STATION_OBSERVER_SOCKET_PATH: "/tmp/demo/observer.sock",
+      },
+      ["--fast", "sessionStart"],
+    );
 
     expect(result).toEqual({ code: 0, stdout: "", stderr: "" });
     await expect(readFile(argsLog, "utf8")).resolves.toBe(
-      "--socket /tmp/demo/observer.sock --config /tmp/demo/config.toml cursor\n",
+      "--socket /tmp/demo/observer.sock --config /tmp/demo/config.toml cursor --fast sessionStart\n",
     );
   });
 
@@ -428,6 +464,7 @@ async function runHookScript(
   scriptPath: string,
   stdin: string,
   env: NodeJS.ProcessEnv,
+  args: string[] = [],
 ): Promise<{ code: number | null; stdout: string; stderr: string }> {
   const childEnv: NodeJS.ProcessEnv = {};
   if (process.env.PATH !== undefined) {
@@ -439,7 +476,7 @@ async function runHookScript(
     }
   }
 
-  const child = spawn(scriptPath, [], {
+  const child = spawn(scriptPath, args, {
     env: childEnv,
     stdio: ["pipe", "pipe", "pipe"],
   });
@@ -498,4 +535,22 @@ function existingCursorHooks(): string {
     null,
     2,
   );
+}
+
+function legacyCursorHooks(hookScriptPath: string): string {
+  return JSON.stringify({
+    version: 1,
+    hooks: Object.fromEntries(
+      [
+        "sessionStart",
+        "stop",
+        "sessionEnd",
+        "beforeShellExecution",
+        "afterShellExecution",
+        "preToolUse",
+        "postToolUse",
+        "postToolUseFailure",
+      ].map((eventName) => [eventName, [{ command: hookScriptPath, timeout: 30 }]]),
+    ),
+  });
 }

--- a/packages/harness-shared/src/hooks/generatedCommand.ts
+++ b/packages/harness-shared/src/hooks/generatedCommand.ts
@@ -1,0 +1,18 @@
+/** Returns the generated hook script path when it is the command's first shell token. */
+export function generatedHookScriptPath(command: string, scriptName: string): string | undefined {
+  const executable = firstShellToken(command);
+  return executable === scriptName || executable.endsWith(`/${scriptName}`)
+    ? executable
+    : undefined;
+}
+
+function firstShellToken(command: string): string {
+  if (!command.startsWith("'")) {
+    const separator = command.indexOf(" ");
+    return command.slice(0, separator < 0 ? undefined : separator);
+  }
+
+  const closingQuote = /'(?: |$)/u.exec(command);
+  if (closingQuote?.index === undefined) return "";
+  return command.slice(1, closingQuote.index).replaceAll("'\\''", "'");
+}

--- a/packages/harness-shared/src/index.ts
+++ b/packages/harness-shared/src/index.ts
@@ -14,6 +14,7 @@ export {
   reportCorrelation,
 } from "./events.js";
 export { createHarnessHookAdapter } from "./hookAdapter.js";
+export { generatedHookScriptPath } from "./hooks/generatedCommand.js";
 export { createJsonHookConfigEditor, isJsonObject } from "./hooks/jsonConfig.js";
 export {
   type CommonLaunchEnvOptions,

--- a/packages/harness-shared/test/unit/generatedCommand.test.ts
+++ b/packages/harness-shared/test/unit/generatedCommand.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { generatedHookScriptPath } from "../../src/hooks/generatedCommand";
+
+describe("generatedHookScriptPath", () => {
+  it.each([
+    ["station-claude-hook.sh", "station-claude-hook.sh"],
+    ["/tmp/hooks/station-claude-hook.sh --fast Stop", "/tmp/hooks/station-claude-hook.sh"],
+    [
+      "'/tmp/hooks with spaces/station-claude-hook.sh' --fast 'PreToolUse'",
+      "/tmp/hooks with spaces/station-claude-hook.sh",
+    ],
+    [
+      "'/tmp/owner'\\''s hooks/station-claude-hook.sh' --fast Stop",
+      "/tmp/owner's hooks/station-claude-hook.sh",
+    ],
+  ])("extracts the supported generated script from %s", (command, expected) => {
+    expect(generatedHookScriptPath(command, "station-claude-hook.sh")).toBe(expected);
+  });
+
+  it.each([
+    "echo station-claude-hook.sh",
+    "'/tmp/hooks/station-claude-hook.sh --fast Stop",
+    "/tmp/hooks/not-station.sh --fast Stop",
+    "",
+  ])("rejects a command that does not execute the generated script: %s", (command) => {
+    expect(generatedHookScriptPath(command, "station-claude-hook.sh")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What this fixes

Station’s generated Claude and Cursor hooks always entered through the canonical Bun CLI, adding process startup before the Observer could receive an event. This delays agent-state changes reaching the TUI even when a matching Observer is already healthy.

## What changed

- Opt generated Claude and Cursor hook events into the existing compiled native ingress path with an explicit declared event.
- Forward generated-script arguments while preserving canonical ingress for missing ownership identity, transport failures, build mismatches, rejected events, and unrecognized responses.
- Migrate legacy bare generated commands and keep hook doctor/ownership checks strict for the new command shape.
- Cover provider-adapter normalization and update the ingress documentation.

## Testing

- `bun run test:all`
- `bun run build:binary -- --version 0.0.0-local`
- `bun run smoke:binary -- --expected-version 0.0.0-local`
- `STATION_REAL_CURSOR=1 bun run test:e2e:cursor:real`