### PR TITLE
chore(release): prepare pre-alpha.14.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Station gives every agent an isolated Git worktree, keeps its terminal session a
 ## Install
 
 Station is experimental pre-alpha software. Install the current public version,
-`v0.0.0-pre-alpha.14.5`, with one command:
+`v0.0.0-pre-alpha.14.6`, with one command:
 
 ```sh
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.5/install.sh | sh
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.6/install.sh | sh
 ```
 
 Then complete and verify first-run setup:
@@ -125,11 +125,11 @@ Paste this prompt into a coding agent running on the machine where you want
 Station installed:
 
 ```text
-Install experimental Station v0.0.0-pre-alpha.14.5 and validate setup on this machine.
+Install experimental Station v0.0.0-pre-alpha.14.6 and validate setup on this machine.
 
 Safety and scope:
 - Do not clone the repository or build from source. Use only
-  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.5/install.sh`.
+  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.6/install.sh`.
 - Install to `~/.local/bin` unless I approve another location. Do not edit any
   shell startup file. If the installer reports a PATH mismatch, do not assume
   an export persists across agent tool calls or reaches my Terminal. Use the
@@ -208,7 +208,7 @@ or real-agent lanes.
 
 ## Release status
 
-Station `v0.0.0-pre-alpha.14.5` is an experimental pre-alpha. User-facing commands,
+Station `v0.0.0-pre-alpha.14.6` is an experimental pre-alpha. User-facing commands,
 configuration, state, and release packaging may change without compatibility.
 The old `v0.7.1-rc.*` releases were internal previews, not predecessors in the
 public version line. Report feedback and bugs through

--- a/apps/cli/test/integration/codex-hooks-command.test.ts
+++ b/apps/cli/test/integration/codex-hooks-command.test.ts
@@ -800,7 +800,7 @@ function artifactOwner(launcher: string, runtimeKind: "compiled" | "source", dig
     schemaVersion: 1 as const,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.5",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.6",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/integration/installer-binary-update.test.ts
+++ b/apps/cli/test/integration/installer-binary-update.test.ts
@@ -24,7 +24,7 @@ import type { NativeBinaryRelease } from "../../src/update/githubRelease.js";
 import { createInstallerBinaryUpdateChannel } from "../../src/update/installerBinaryUpdate.js";
 
 const CURRENT_TAG = "v0.7.1-rc.8";
-const TARGET_TAG = "v0.0.0-pre-alpha.14.5";
+const TARGET_TAG = "v0.0.0-pre-alpha.14.6";
 const RECEIPT = "station-installer-binary-v1\n";
 const tempRoots: string[] = [];
 

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -136,7 +136,7 @@ describe("CLI manual-smoke commands", () => {
       "--version",
     ]);
 
-    expect(direct).toEqual({ code: 0, output: "0.0.0-pre-alpha.14.5", outputFormat: "text" });
+    expect(direct).toEqual({ code: 0, output: "0.0.0-pre-alpha.14.6", outputFormat: "text" });
     expect(withMissingConfig).toEqual(direct);
   });
 

--- a/apps/cli/test/integration/popup-command.test.ts
+++ b/apps/cli/test/integration/popup-command.test.ts
@@ -15,7 +15,7 @@ import { createTempState, writeConfigToml } from "../../../../tests/support/temp
 const now = "2026-05-20T12:00:00.000Z";
 const buildIdentity = "a".repeat(64);
 const observerBuildVersion = `0.0.0-local+station.${buildIdentity}`;
-const higherObserverBuildVersion = `0.0.0-pre-alpha.14.5+station.${buildIdentity}`;
+const higherObserverBuildVersion = `0.0.0-pre-alpha.14.6+station.${buildIdentity}`;
 const tuiObserverBuildMismatchError = {
   tag: "TuiCommandError",
   code: "TUI_OBSERVER_BUILD_MISMATCH",

--- a/apps/cli/test/integration/provider-hook-ownership.test.ts
+++ b/apps/cli/test/integration/provider-hook-ownership.test.ts
@@ -241,7 +241,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.5",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.6",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -171,7 +171,7 @@ describe("CLI setup command", () => {
       schemaVersion: 1 as const,
       launcher: join(root, "source", "bin", "stn-ingress"),
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.14.5",
+      version: "0.0.0-pre-alpha.14.6",
       buildIdentity: "a".repeat(64),
     };
     const current = {

--- a/apps/cli/test/integration/tui-command.test.ts
+++ b/apps/cli/test/integration/tui-command.test.ts
@@ -19,7 +19,7 @@ import { resolveStationWorkspaceDir } from "../../src/stationWorkspace.js";
 const now = "2026-05-20T12:00:00.000Z";
 const buildIdentity = "a".repeat(64);
 const observerBuildVersion = `0.0.0-local+station.${buildIdentity}`;
-const higherObserverBuildVersion = `0.0.0-pre-alpha.14.5+station.${buildIdentity}`;
+const higherObserverBuildVersion = `0.0.0-pre-alpha.14.6+station.${buildIdentity}`;
 const nestedTuiDisabledError = {
   tag: "TuiCommandError",
   code: "NESTED_TUI_DISABLED",

--- a/apps/cli/test/integration/worktrunk-hooks-command.test.ts
+++ b/apps/cli/test/integration/worktrunk-hooks-command.test.ts
@@ -352,7 +352,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.5",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.6",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/unit/installer-binary-update.test.ts
+++ b/apps/cli/test/unit/installer-binary-update.test.ts
@@ -29,7 +29,7 @@ import {
 
 const CURRENT_TAG = "v0.7.1-rc.8";
 const CURRENT_VERSION = CURRENT_TAG.slice(1);
-const TARGET_TAG = "v0.0.0-pre-alpha.14.5";
+const TARGET_TAG = "v0.0.0-pre-alpha.14.6";
 const TARGET_VERSION = TARGET_TAG.slice(1);
 const TARGETS = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"] as const;
 const RECEIPT = "station-installer-binary-v1\n";

--- a/apps/cli/test/unit/observer-process/activation-surfacing.test.ts
+++ b/apps/cli/test/unit/observer-process/activation-surfacing.test.ts
@@ -17,7 +17,7 @@ import { createTempState } from "../../../../../tests/support/temp-projects";
 
 const now = "2026-05-20T12:00:00.000Z";
 const sourceBuildVersion = `0.0.0-pre-alpha.4+station.${"e".repeat(64)}`;
-const compiledBuildVersion = `0.0.0-pre-alpha.14.5+station.${"d".repeat(64)}`;
+const compiledBuildVersion = `0.0.0-pre-alpha.14.6+station.${"d".repeat(64)}`;
 
 const bootReason = "FATAL: socket owned by foreign build dbf7f368";
 

--- a/apps/cli/test/unit/observer-process/setup-observer-activation.test.ts
+++ b/apps/cli/test/unit/observer-process/setup-observer-activation.test.ts
@@ -15,7 +15,7 @@ vi.mock("../../../src/observerProcess.js", async (importActual) => {
 });
 
 const now = "2026-05-20T12:00:00.000Z";
-const compiledBuildVersion = `0.0.0-pre-alpha.14.5+station.${"d".repeat(64)}`;
+const compiledBuildVersion = `0.0.0-pre-alpha.14.6+station.${"d".repeat(64)}`;
 
 restartObserverSpy.mockImplementation(async () => ({
   status: "running",

--- a/apps/cli/test/unit/setup-json-presenter.test.ts
+++ b/apps/cli/test/unit/setup-json-presenter.test.ts
@@ -269,7 +269,7 @@ describe("setup plan projection", () => {
       schemaVersion: 1 as const,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.14.5",
+      version: "0.0.0-pre-alpha.14.6",
       buildIdentity: "a".repeat(64),
     };
     const current = {

--- a/apps/observer/test/unit/observerHandoff.test.ts
+++ b/apps/observer/test/unit/observerHandoff.test.ts
@@ -71,7 +71,7 @@ describe("classifyObserverBuildPrecedence", () => {
   });
 
   it("orders the public pre-alpha after the internal preview version line", () => {
-    const publicPreAlpha = observerBuildVersion("0.0.0-pre-alpha.14.5", higherBuildIdentity);
+    const publicPreAlpha = observerBuildVersion("0.0.0-pre-alpha.14.6", higherBuildIdentity);
     const internalPreview = observerBuildVersion("0.7.1-rc.8", lowerBuildIdentity);
 
     expect(precedenceFor(publicPreAlpha, internalPreview)).toEqual({
@@ -83,7 +83,7 @@ describe("classifyObserverBuildPrecedence", () => {
   });
 
   it("orders the next public pre-alpha epoch after the prior release", () => {
-    const nextEpoch = observerBuildVersion("0.0.0-pre-alpha.14.5", higherBuildIdentity);
+    const nextEpoch = observerBuildVersion("0.0.0-pre-alpha.14.6", higherBuildIdentity);
     const priorRelease = observerBuildVersion("0.0.0-pre-alpha.7", lowerBuildIdentity);
 
     expect(precedenceFor(nextEpoch, priorRelease)).toEqual({

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ can use it or help improve it.
 
 > [!IMPORTANT]
 > Station is experimental pre-alpha software. The current public version is
-> `v0.0.0-pre-alpha.14.5`. Native binaries support macOS 13+ and glibc 2.39+ Linux
+> `v0.0.0-pre-alpha.14.6`. Native binaries support macOS 13+ and glibc 2.39+ Linux
 > on arm64 and x64.
 
 ## Start Here
@@ -26,7 +26,7 @@ Choose the path that matches what you want to do:
 Install the current release:
 
 ```sh
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.5/install.sh | sh
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.6/install.sh | sh
 ```
 
 Then complete and verify setup:

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -10,7 +10,7 @@ only with explicit `stn update --drive-package-manager`; it does not install a
 tap, formula, or cask.
 
 The public installation path for experimental pre-alpha
-`v0.0.0-pre-alpha.14.5` is the exact-tag native installer documented in
+`v0.0.0-pre-alpha.14.6` is the exact-tag native installer documented in
 [Install Station](install.md). Do not use the historical tap for public
 onboarding, and do not update it as part of pre-alpha publication.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,7 +1,7 @@
 # Install Station
 
 Station is experimental pre-alpha software. The current public version is
-`v0.0.0-pre-alpha.14.5`.
+`v0.0.0-pre-alpha.14.6`.
 
 ## Binary Requirements
 
@@ -33,7 +33,7 @@ setup, update, and recovery reference.
 From any directory, run:
 
 ```bash
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.5/install.sh | sh
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.6/install.sh | sh
 ```
 
 The installer downloads only the stamped tag's matching native archive and
@@ -81,7 +81,7 @@ names in a new shell.
 Pass an absolute or home-relative path through the exact installer:
 
 ```bash
-curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.5/install.sh | \
+curl --disable -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.6/install.sh | \
   sh -s -- --install-dir "$HOME/bin"
 ```
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,6 +1,6 @@
 # Limitations and Workarounds
 
-Station `v0.0.0-pre-alpha.14.5` is experimental pre-alpha software. This page
+Station `v0.0.0-pre-alpha.14.6` is experimental pre-alpha software. This page
 lists user-visible constraints and the available operational workaround for
 each one.
 

--- a/integrations/harness/claude/test/unit/hooks.test.ts
+++ b/integrations/harness/claude/test/unit/hooks.test.ts
@@ -392,7 +392,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.5",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.6",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/cursor/test/unit/hooks.test.ts
+++ b/integrations/harness/cursor/test/unit/hooks.test.ts
@@ -455,7 +455,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.5",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.6",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/opencode/test/unit/pluginInstall.test.ts
+++ b/integrations/harness/opencode/test/unit/pluginInstall.test.ts
@@ -643,7 +643,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.5",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.6",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/opencode/test/unit/provider.test.ts
+++ b/integrations/harness/opencode/test/unit/provider.test.ts
@@ -301,7 +301,7 @@ describe("OpenCodeHarnessProvider", () => {
       schemaVersion: 1 as const,
       launcher: join(root, "requester", "bin", "stn-ingress"),
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.14.5",
+      version: "0.0.0-pre-alpha.14.6",
       buildIdentity: "a".repeat(64),
     };
 

--- a/integrations/worktree/worktrunk/test/unit/hooks.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/hooks.test.ts
@@ -266,7 +266,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.5",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.14.6",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "station",
-  "version": "0.0.0-pre-alpha.14.5",
+  "version": "0.0.0-pre-alpha.14.6",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -123,7 +123,7 @@ describe("contract schemas", () => {
       schemaVersion: 1,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source",
-      version: "0.0.0-pre-alpha.14.5",
+      version: "0.0.0-pre-alpha.14.6",
       buildIdentity: "a".repeat(64),
     } as const;
     const current = {

--- a/packages/contracts/test/schema/diagnostics-schema.test.ts
+++ b/packages/contracts/test/schema/diagnostics-schema.test.ts
@@ -238,7 +238,7 @@ describe("diagnostics schemas", () => {
         schemaVersion: 1,
         launcher: "/checkout/station/bin/stn-ingress",
         runtimeKind: "source",
-        version: "0.0.0-pre-alpha.14.5",
+        version: "0.0.0-pre-alpha.14.6",
         buildIdentity: "a".repeat(64),
       },
     };

--- a/packages/harness-shared/test/unit/provider.test.ts
+++ b/packages/harness-shared/test/unit/provider.test.ts
@@ -146,7 +146,7 @@ describe("createTerminalBoundHarnessProvider", () => {
       schemaVersion: 1 as const,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.14.5",
+      version: "0.0.0-pre-alpha.14.6",
       buildIdentity: "a".repeat(64),
     };
 

--- a/packages/runtime/src/buildInfo.ts
+++ b/packages/runtime/src/buildInfo.ts
@@ -99,7 +99,7 @@ export function isCompiledBinary(): boolean {
 
 function stationBuildVersion(): string {
   return typeof STATION_BUILD_VERSION === "undefined"
-    ? "0.0.0-pre-alpha.14.5"
+    ? "0.0.0-pre-alpha.14.6"
     : STATION_BUILD_VERSION;
 }
 

--- a/packages/runtime/test/unit/buildInfo.test.ts
+++ b/packages/runtime/test/unit/buildInfo.test.ts
@@ -40,7 +40,7 @@ describe("station build info", () => {
     const [first, second] = await Promise.all([stationBuildInfoAsync(), stationBuildInfoAsync()]);
 
     expect(first).toEqual({
-      version: "0.0.0-pre-alpha.14.5",
+      version: "0.0.0-pre-alpha.14.6",
       compiled: false,
       buildIdentity,
     });
@@ -78,14 +78,14 @@ describe("station build info", () => {
     expect(isCompiledBinary()).toBe(false);
     expect(verifyBuildIdentity).not.toHaveBeenCalled();
     expect(stationBuildInfo()).toEqual({
-      version: "0.0.0-pre-alpha.14.5",
+      version: "0.0.0-pre-alpha.14.6",
       compiled: false,
       buildIdentity,
     });
-    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.14.5+station.${buildIdentity}`);
-    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.14.5+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.14.6+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.14.6+station.${buildIdentity}`);
     expect(stationBuildInfo()).toEqual({
-      version: "0.0.0-pre-alpha.14.5",
+      version: "0.0.0-pre-alpha.14.6",
       compiled: false,
       buildIdentity,
     });

--- a/tests/diagnostics/composed-update-report.test.ts
+++ b/tests/diagnostics/composed-update-report.test.ts
@@ -81,7 +81,7 @@ function currentReport() {
 
 function predecessorV4Report() {
   const current = { version: "0.0.0-pre-alpha.14.3" };
-  const target = { version: "0.0.0-pre-alpha.14.5" };
+  const target = { version: "0.0.0-pre-alpha.14.6" };
   return {
     schemaVersion: 4,
     kind: "preview",

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -79,9 +79,9 @@ describe("release readiness docs", () => {
       "let your agent install and validate station",
     );
     expect(prompt).toContain(
-      "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.5/install.sh",
+      "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.6/install.sh",
     );
-    expect(prompt).toContain("v0.0.0-pre-alpha.14.5");
+    expect(prompt).toContain("v0.0.0-pre-alpha.14.6");
     expect(prompt).toContain("stn setup check --json");
     expect(prompt).toContain("stn doctor");
     expect(prompt).toContain("summary.requiredOk: true");
@@ -101,7 +101,7 @@ describe("release readiness docs", () => {
     expect(normalizedPrompt).toContain("verify all three launchers in a new shell");
     expect(normalizedPrompt).toContain("do not claim success");
     expect(install).toContain("../README.md#let-your-agent-install-and-validate-station");
-    expect(install).not.toContain("Install experimental Station v0.0.0-pre-alpha.14.5");
+    expect(install).not.toContain("Install experimental Station v0.0.0-pre-alpha.14.6");
   });
 
   it("keeps the Node.js 24.2+ development requirement consistent", async () => {
@@ -233,9 +233,9 @@ describe("release readiness docs", () => {
     );
     const packageJson = await readPackageManifest();
     const normalizedReleasing = releasing.replace(/\s+/g, " ");
-    const exactVersion = "v0.0.0-pre-alpha.14.5";
+    const exactVersion = "v0.0.0-pre-alpha.14.6";
     const exactInstallerUrl =
-      "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.5/install.sh";
+      "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.14.6/install.sh";
 
     for (const [path, document] of [
       ["README.md", readme],
@@ -389,7 +389,7 @@ describe("release readiness docs", () => {
       expect(promote).toContain(target);
     }
 
-    expect(packageJson.version).toBe("0.0.0-pre-alpha.14.5");
+    expect(packageJson.version).toBe("0.0.0-pre-alpha.14.6");
     expect(packageJson.scripts["smoke:install"]).toBe(
       "node scripts/test-runners/run-install-smoke.mjs",
     );


### PR DESCRIPTION
## What this fixes

Current `main` contains guarded update reaping and manual runtime repair, but the published `.14.5` release predates those capabilities. The next immutable release needs a distinct version identity.

## What changed

- Advance the package and source-build version to `0.0.0-pre-alpha.14.6`.
- Update exact-tag installer links and current-version documentation.
- Align build-identity, hook-ownership, update, and release-readiness fixtures with `.14.6`.
- Preserve `.14.5` as the frozen schema-v5 update-report emitter while current and local builds emit schema v6.

## Testing

- Focused composed-report, workflow-policy, and release-readiness diagnostics: 34 passed.
- `bun run build`, `bun run typecheck`, and `bun run lint`.
- `bun run test:ci:binary`: binary smoke and all eight ordered update scenarios passed.
- `TERM=xterm-256color bun run test:all`: 3,618 unit tests passed before one unchanged tmux fast-binding assertion exceeded its 5-second timeout; that file then passed 17/17 in isolation. Hosted `standard-ci` is required before merge.

## Safety and scope

This PR changes only release identity, documentation, and matching fixtures. The published `.14.5` tag and immutable release remain unchanged, and `v0.0.0-pre-alpha.14.6` does not yet exist.