### PR TITLE
fix(release): verify dedicated ingress artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -557,13 +557,15 @@ jobs:
           }
 
           test -x "$bin_dir/stn"
-          test "$(readlink "$bin_dir/stn-ingress")" = stn
+          test -x "$bin_dir/stn-ingress"
+          test ! -L "$bin_dir/stn-ingress"
           test "$(readlink "$bin_dir/stn-tmux-popup")" = stn
           test -f "$receipt_path"
           test ! -L "$receipt_path"
           test -f "$license_path"
           test ! -L "$license_path"
           test "$(mode "$bin_dir/stn")" = 755
+          test "$(mode "$bin_dir/stn-ingress")" = 755
           test "$(mode "$receipt_path")" = 600
           test "$(mode "$license_path")" = 644
           test "$(cat "$receipt_path")" = station-installer-binary-v1
@@ -638,11 +640,13 @@ jobs:
           test "$(cksum < "$bin_dir/stn")" = "$before_binary"
           test "$(cksum < "$license_path")" = "$before_license"
           test "$(ls -ldi "$bin_dir/stn" "$bin_dir/stn-ingress" "$bin_dir/stn-tmux-popup" "$receipt_path" "$license_path")" = "$before_entries"
-          test "$(readlink "$bin_dir/stn-ingress")" = stn
+          test -x "$bin_dir/stn-ingress"
+          test ! -L "$bin_dir/stn-ingress"
           test "$(readlink "$bin_dir/stn-tmux-popup")" = stn
 
           rm -rf "$lock_dir"
-          before_owned_entries="$(ls -ldi "$bin_dir/stn-ingress" "$bin_dir/stn-tmux-popup" "$receipt_path")"
+          before_ingress="$(cksum < "$bin_dir/stn-ingress")"
+          before_owned_entries="$(ls -ldi "$bin_dir/stn-tmux-popup" "$receipt_path")"
           (
             umask 0777
             HOME="$install_home" \
@@ -651,8 +655,10 @@ jobs:
           )
 
           test ! -e "$lock_dir"
-          test "$(ls -ldi "$bin_dir/stn-ingress" "$bin_dir/stn-tmux-popup" "$receipt_path")" = "$before_owned_entries"
-          test "$(readlink "$bin_dir/stn-ingress")" = stn
+          test "$(cksum < "$bin_dir/stn-ingress")" = "$before_ingress"
+          test "$(ls -ldi "$bin_dir/stn-tmux-popup" "$receipt_path")" = "$before_owned_entries"
+          test -x "$bin_dir/stn-ingress"
+          test ! -L "$bin_dir/stn-ingress"
           test "$(readlink "$bin_dir/stn-tmux-popup")" = stn
           test "$(cat "$receipt_path")" = station-installer-binary-v1
           actual="$(env -i \

--- a/tests/diagnostics/ci-workflow-policy.test.ts
+++ b/tests/diagnostics/ci-workflow-policy.test.ts
@@ -569,6 +569,27 @@ describe("hosted CI policy", () => {
     );
   });
 
+  it("verifies the installed ingress artifact as a dedicated executable", () => {
+    const installDraft = workflowJob(read(".github/workflows/release.yml"), "install-draft");
+    const verifyInstalled = namedWorkflowStep(installDraft, "Verify installed artifact");
+    const verifyRetry = namedWorkflowStep(
+      installDraft,
+      "Verify lock refusal and same-version retry",
+    );
+
+    for (const step of [verifyInstalled, verifyRetry]) {
+      expect(step).toContain('test -x "$bin_dir/stn-ingress"');
+      expect(step).toContain('test ! -L "$bin_dir/stn-ingress"');
+      expect(step).not.toContain('readlink "$bin_dir/stn-ingress"');
+    }
+    expect(verifyInstalled).toContain('test "$(mode "$bin_dir/stn-ingress")" = 755');
+    expect(verifyRetry).toContain('before_ingress="$(cksum < "$bin_dir/stn-ingress")"');
+    expect(verifyRetry).toContain('test "$(cksum < "$bin_dir/stn-ingress")" = "$before_ingress"');
+    expect(verifyRetry).not.toContain(
+      'ls -ldi "$bin_dir/stn-ingress" "$bin_dir/stn-tmux-popup" "$receipt_path"',
+    );
+  });
+
   it("keeps binary handoff stress manual, capped, and failure-artifact-only", () => {
     const stress = read(".github/workflows/binary-handoff-stress.yml");
     const packageJson = JSON.parse(read("package.json")) as {


### PR DESCRIPTION
## What this fixes

The release workflow still treated `stn-ingress` as a symlink after Station began shipping it as a dedicated native executable. Every `.14.6` draft-install lane therefore rejected an otherwise valid six-asset candidate before staged update acceptance.

## What changed

- Verify the installed ingress launcher as an executable regular file with mode `0755`.
- Keep the legacy ingress symlink fixture so the installer still proves upgrades from the older layout.
- During same-version retry, compare ingress content instead of inode identity because the installer atomically replaces the dedicated binary.
- Add a workflow-policy regression test for the dedicated ingress contract.

## Testing

- `bunx vitest run tests/diagnostics/ci-workflow-policy.test.ts` (14 passed)
- `bun run typecheck`
- `bun run lint`
- Isolated `.14.6` draft install: version, file type, mode, lock refusal, content preservation, and same-version retry passed.

## Safety and scope

This changes release acceptance assertions only. It does not change the installer, runtime, release assets, or the failed `.14.6` tag and draft.
