### PR TITLE
fix(update): bridge legacy ingress installations

### DIFF
--- a/apps/cli/src/update/installerInstallation.ts
+++ b/apps/cli/src/update/installerInstallation.ts
@@ -59,7 +59,7 @@ export async function inspectInstallerInstallation(
     const popupPath = join(installDir, "stn-tmux-popup");
     const receiptPath = join(installDir, receiptName);
     const [ingress, popup] = await Promise.all([
-      binaryIdentity(ingressPath),
+      ingressIdentity(ingressPath),
       launcherIdentity(popupPath),
     ]);
     if (ingress === undefined || popup === undefined) return undefined;
@@ -207,13 +207,13 @@ async function launcherIdentity(path: string) {
   }
 }
 
-async function binaryIdentity(path: string) {
+async function ingressIdentity(path: string) {
   try {
-    const binary = await lstat(path, { bigint: true });
-    if (!binary.isFile() || binary.isSymbolicLink() || (binary.mode & 0o111n) === 0n) {
-      return undefined;
+    const ingress = await lstat(path, { bigint: true });
+    if (ingress.isSymbolicLink()) {
+      return (await readlink(path)) === "stn" ? ingress : undefined;
     }
-    return binary;
+    return ingress.isFile() && (ingress.mode & 0o111n) !== 0n ? ingress : undefined;
   } catch {
     return undefined;
   }

--- a/apps/cli/test/unit/installer-binary-update.test.ts
+++ b/apps/cli/test/unit/installer-binary-update.test.ts
@@ -207,6 +207,21 @@ describe("installer-binary detection and planning", () => {
     expect(discoveries).toBe(0);
   });
 
+  it("detects the legacy exact ingress alias for one successor update", async () => {
+    const fixture = await installedFixture();
+    const ingressPath = join(fixture.installDir, "stn-ingress");
+    await unlink(ingressPath);
+    await symlink("stn", ingressPath);
+
+    await expect(createChannel(fixture).detect()).resolves.toMatchObject({
+      ingressIdentity: {
+        device: expect.any(String),
+        inode: expect.any(String),
+        sha256: createHash("sha256").update("current-binary").digest("hex"),
+      },
+    });
+  });
+
   it("returns undefined for source, unsupported, receipt-less, and non-owned layouts", async () => {
     const fixture = await installedFixture();
     await expect(

--- a/docs/install.md
+++ b/docs/install.md
@@ -138,6 +138,11 @@ Binaries older than the first release that supports `--reap` cannot execute
 this recovery path. Close affected sessions before installing that first
 supporting release, then run the update again.
 
+An update started by a legacy installer preserves its exact `stn-ingress`
+symlink while that older process verifies the new `stn` binary. The installed
+target accepts that transitional layout. Its next artifact update replaces the
+symlink with the native ingress binary under the current identity checks.
+
 After a normal exit, the TUI may report:
 
 ```text

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -191,6 +191,10 @@ The installer replaces the version-guarded ingress binary immediately before
 `stn`. Either mixed-version window falls back through canonical ingress because
 the native request cannot mutate an Observer with a different build. Update
 expectations use the v2 shape and bind both executable hashes and identities.
+When a legacy v1 update expectation owns an exact `stn-ingress` symlink, the
+installer preserves that symlink for the older process's post-installation
+check. The target updater accepts the transitional symlink as a v2 installation
+and replaces it with the native ingress binary on the next artifact update.
 
 Installer locking, interrupted-upgrade recovery, PATH guidance, and manual
 operator steps are documented in [Install Station](install.md). Those behaviors

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -828,7 +828,11 @@ validate_expected_installation() {
       fi
       ;;
     station-installer-expected-v2)
-      if [ ! -f "$ingress_path" ] || [ -L "$ingress_path" ] || [ ! -x "$ingress_path" ]; then
+      if [ -L "$ingress_path" ]; then
+        if ! readlink_target "$ingress_path" 2>/dev/null || [ "$link_target" != stn ]; then
+          fail "expected Station ingress launcher '$ingress_path' changed before installer commit."
+        fi
+      elif [ ! -f "$ingress_path" ] || [ ! -x "$ingress_path" ]; then
         fail "expected Station ingress binary '$ingress_path' changed before installer commit."
       fi
       ;;
@@ -1283,31 +1287,36 @@ if ! mv "$new_license" "$license_path"; then
   fail "could not install the Station license '$license_path'."
 fi
 
-# The ingress transport rejects a mismatched Observer build, so replacing it
-# immediately before the main binary keeps either mixed-version window safe.
+# A v1 updater requires its exact ingress symlink to survive post-installation
+# verification. The target updater records that layout as v2 and replaces it
+# with the native ingress binary during the next artifact update.
 revalidate_managed_paths
 validate_expected_installation
-if [ -e "$ingress_path" ] || [ -L "$ingress_path" ]; then
-  ingress_backup=$install_stage/stn-ingress.previous
+if [ "$expected_format" != station-installer-expected-v1 ]; then
+  # The ingress transport rejects a mismatched Observer build, so replacing it
+  # immediately before the main binary keeps either mixed-version window safe.
+  if [ -e "$ingress_path" ] || [ -L "$ingress_path" ]; then
+    ingress_backup=$install_stage/stn-ingress.previous
+    if ! alias_inode "$ingress_path"; then
+      fail "could not record the existing Station ingress launcher identity."
+    fi
+    previous_ingress_inode=$alias_inode_result
+    if ! ln -P "$ingress_path" "$ingress_backup"; then
+      fail "could not back up the existing Station ingress launcher '$ingress_path'."
+    fi
+    ingress_displaced=1
+  fi
+  if ! mv -f "$install_stage/stn-ingress.new" "$ingress_path"; then
+    fail "could not activate the verified Station ingress binary; restoring the previous installation."
+  fi
+  ingress_installed=1
   if ! alias_inode "$ingress_path"; then
-    fail "could not record the existing Station ingress launcher identity."
+    fail "could not record the activated Station ingress binary identity."
   fi
-  previous_ingress_inode=$alias_inode_result
-  if ! ln -P "$ingress_path" "$ingress_backup"; then
-    fail "could not back up the existing Station ingress launcher '$ingress_path'."
+  installed_ingress_inode=$alias_inode_result
+  if ! file_sha256 "$ingress_path" || [ "$hash_result" != "$installed_ingress_sha256" ]; then
+    fail "the activated Station ingress binary changed before runtime commit."
   fi
-  ingress_displaced=1
-fi
-if ! mv -f "$install_stage/stn-ingress.new" "$ingress_path"; then
-  fail "could not activate the verified Station ingress binary; restoring the previous installation."
-fi
-ingress_installed=1
-if ! alias_inode "$ingress_path"; then
-  fail "could not record the activated Station ingress binary identity."
-fi
-installed_ingress_inode=$alias_inode_result
-if ! file_sha256 "$ingress_path" || [ "$hash_result" != "$installed_ingress_sha256" ]; then
-  fail "the activated Station ingress binary changed before runtime commit."
 fi
 commit_started=1
 if mv -f "$install_stage/stn" "$binary_path"; then

--- a/scripts/test-runners/run-install-smoke.mjs
+++ b/scripts/test-runners/run-install-smoke.mjs
@@ -678,6 +678,55 @@ function scenarioReceiptAndExpectedInstallation() {
     target: "linux-x64",
   });
 
+  const legacyInstallDir = join(root, "legacy-expected-installation-bin");
+  const legacyDataHome = join(root, "legacy-expected-installation-data");
+  seedInstallation({
+    installDir: legacyInstallDir,
+    dataHome: legacyDataHome,
+    tag: rollbackTag,
+    withReceipt: true,
+  });
+  unlinkSync(join(legacyInstallDir, "stn-ingress"));
+  symlinkSync("stn", join(legacyInstallDir, "stn-ingress"));
+  const legacyIngress = lstatSync(join(legacyInstallDir, "stn-ingress"));
+  const legacyExpectedFile = join(root, "expected-installation.legacy");
+  writeExpectedInstallation(legacyExpectedFile, legacyInstallDir, "v1");
+  const legacyExpected = runInstaller({
+    installDir: legacyInstallDir,
+    platform: linuxX64(),
+    dataHome: legacyDataHome,
+    extraArguments: ["--expected-installation", legacyExpectedFile],
+  });
+  assertSuccess(legacyExpected, "legacy expected installation contract");
+  assertRuntimeVersion(legacyInstallDir, releaseTag, "legacy expected installation");
+  assertEqual(
+    readlinkSync(join(legacyInstallDir, "stn-ingress")),
+    "stn",
+    "legacy expected ingress target",
+  );
+  const preservedLegacyIngress = lstatSync(join(legacyInstallDir, "stn-ingress"));
+  assertEqual(
+    [preservedLegacyIngress.dev, preservedLegacyIngress.ino],
+    [legacyIngress.dev, legacyIngress.ino],
+    "legacy updater preserves ingress identity",
+  );
+
+  const successorExpectedFile = join(root, "expected-installation.successor");
+  writeExpectedInstallation(successorExpectedFile, legacyInstallDir);
+  const successorExpected = runInstaller({
+    installDir: legacyInstallDir,
+    platform: linuxX64(),
+    dataHome: legacyDataHome,
+    extraArguments: ["--expected-installation", successorExpectedFile],
+  });
+  assertSuccess(successorExpected, "successor expected installation contract");
+  assertInstalled({
+    installDir: legacyInstallDir,
+    dataHome: legacyDataHome,
+    tag: releaseTag,
+    target: "linux-x64",
+  });
+
   for (const changed of ["binary", "ingress", "receipt"]) {
     const installDir = join(root, `expected-${changed}-race-bin`);
     const dataHome = join(root, `expected-${changed}-race-data`);
@@ -3203,7 +3252,7 @@ if [ "\${1:-}" = --version ]; then printf '%s\\n' '${version}'; else printf '%s\
   writeText(join(licenseDir, "LICENSE"), `Station fixture license ${tag}\n`, 0o644);
 }
 
-function writeExpectedInstallation(path, installDir) {
+function writeExpectedInstallation(path, installDir, format = "v2") {
   const binary = join(installDir, "stn");
   const ingress = join(installDir, "stn-ingress");
   const popup = join(installDir, "stn-tmux-popup");
@@ -3216,13 +3265,15 @@ function writeExpectedInstallation(path, installDir) {
   writeText(
     path,
     [
-      "format=station-installer-expected-v2",
+      `format=station-installer-expected-${format}`,
       `binary_sha256=${binaryHash}`,
       `binary_device=${binaryStat.dev}`,
       `binary_inode=${binaryStat.ino}`,
       `ingress_device=${ingressStat.dev}`,
       `ingress_inode=${ingressStat.ino}`,
-      `ingress_sha256=${createHash("sha256").update(readFileSync(ingress)).digest("hex")}`,
+      ...(format === "v1"
+        ? []
+        : [`ingress_sha256=${createHash("sha256").update(readFileSync(ingress)).digest("hex")}`]),
       `popup_device=${popupStat.dev}`,
       `popup_inode=${popupStat.ino}`,
       `receipt_device=${receiptStat.dev}`,

--- a/scripts/test-runners/run-update-smoke.mjs
+++ b/scripts/test-runners/run-update-smoke.mjs
@@ -1503,10 +1503,24 @@ function releaseDownloadUrl(tag, name) {
 
 async function installIncumbent(source, installDir, dataHome) {
   const binary = join(installDir, "stn");
+  const ingressSource = join(dirname(source), "stn-ingress");
+  const ingress = join(installDir, "stn-ingress");
   await copyFile(source, binary);
   await chmod(binary, 0o755);
-  await copyFile(join(dirname(source), "stn-ingress"), join(installDir, "stn-ingress"));
-  await chmod(join(installDir, "stn-ingress"), 0o755);
+  const ingressSourceMetadata = await lstat(ingressSource);
+  if (ingressSourceMetadata.isSymbolicLink()) {
+    assertEqual(await readlink(ingressSource), "stn", "incumbent ingress source alias");
+    await symlink("stn", ingress);
+  } else {
+    assertEqual(ingressSourceMetadata.isFile(), true, "incumbent ingress source binary");
+    assertEqual(
+      (ingressSourceMetadata.mode & 0o111) !== 0,
+      true,
+      "incumbent ingress source executable mode",
+    );
+    await copyFile(ingressSource, ingress);
+    await chmod(ingress, 0o755);
+  }
   await symlink("stn", join(installDir, "stn-tmux-popup"));
   await writeFile(join(installDir, ".station-install-receipt"), receiptContent, {
     mode: 0o600,
@@ -1515,10 +1529,11 @@ async function installIncumbent(source, installDir, dataHome) {
   await mkdir(licenseDir, { recursive: true, mode: 0o700 });
   await copyFile(join(repoRoot, "LICENSE"), join(licenseDir, "LICENSE"));
   await chmod(join(licenseDir, "LICENSE"), 0o644);
+  const installedIngressMetadata = await lstat(ingress);
   assertEqual(
-    (await lstat(join(installDir, "stn-ingress"))).isFile(),
-    true,
-    "incumbent ingress binary",
+    installedIngressMetadata.isSymbolicLink(),
+    ingressSourceMetadata.isSymbolicLink(),
+    "incumbent ingress layout",
   );
   assertEqual(
     (await lstat(join(installDir, ".station-install-receipt"))).mode & 0o777,
@@ -1906,7 +1921,11 @@ function assertUpdateReport(report, reportJson, input, installedBinary, configPa
     assertPredecessorV4UpdateReport(report, input, installedBinary, configPath);
     return;
   }
-  assertEqual(report.schemaVersion, 6, `${input.name} update schema`);
+  assertEqual(
+    report.schemaVersion,
+    updateReportSchemaVersionForEmitter(reportEmitterVersion(input)),
+    `${input.name} update schema`,
+  );
   assertEqual(report.kind, "result", `${input.name} update result kind`);
   assertEqual(report.channel, "installer-binary", `${input.name} update channel`);
   const refusal = updateRequiresPreservation(input);
@@ -2198,7 +2217,11 @@ function assertDryUpdateReport(report, reportJson, input, evidence) {
   if (report.schemaVersion === 4) {
     return assertPredecessorV4DryUpdateReport(report, reportJson, input, evidence);
   }
-  assertEqual(report.schemaVersion, 6, `${input.name} dry-run schema`);
+  assertEqual(
+    report.schemaVersion,
+    updateReportSchemaVersionForEmitter(reportEmitterVersion(input)),
+    `${input.name} dry-run schema`,
+  );
   assertEqual(report.kind, "preview", `${input.name} dry-run kind`);
   assertEqual(report.channel, "installer-binary", `${input.name} dry-run channel`);
   assertCurrentReportEvidence(report, reportJson, input, evidence);


### PR DESCRIPTION
## What this fixes

The newest immutable predecessor uses the v1 installer expectation, which requires its exact stn-ingress symlink to survive post-installation verification. The native-ingress installer replaced that symlink before the predecessor could hand control to the target, so the no-Host release-boundary update installed the target but reported UPDATE_POSTCHECK_FAILED.

## What changed

- Preserve the exact ingress symlink only when a validated v1 update expectation owns it.
- Accept that exact transitional symlink in the target installer-binary channel and emit the v2 identity contract for the next artifact update.
- Preserve the supplied predecessor ingress layout in the composed update harness and assert schema 5 for the .14.5 emitter.
- Cover v1 identity preservation, v2 native-ingress replacement, and legacy-layout channel detection.

## Testing

- bun run build
- bun run typecheck
- bun run lint
- installer-binary-update.test.ts: 19 passed
- composed-update-report and CI workflow policy: 22 passed
- bun run smoke:install
- exact .14.5-to-source candidate release smoke: 8 scenarios passed
- compiled binary smoke passed; the local current-source update aggregate twice hit the existing macOS socket-ownership evidence race at different probes. Hosted standard-ci remains the merge gate.

## Safety and scope

The installer preserves a legacy ingress path only after the v1 expectation validates its symlink target, device, and inode. Direct installs and v2 update expectations continue to replace it with the verified native ingress binary. All runtime acceptance used isolated state, sockets, Hosts, and PTYs.