### PR TITLE
fix(release): verify native ingress promotion

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -33,7 +33,7 @@ jobs:
       target_build_identity: ${{ steps.candidate.outputs.target_build_identity }}
       previous_tag: ${{ steps.candidate.outputs.previous_tag }}
     steps:
-      - name: Verify accepted candidate and publish its draft
+      - name: Verify accepted candidate and publish or re-verify its release
         id: candidate
         env:
           GH_TOKEN: ${{ github.token }}
@@ -129,7 +129,12 @@ jobs:
           remote_commit="$(gh api "repos/$GITHUB_REPOSITORY/commits/$TAG" --jq .sha)"
           test "$remote_commit" = "$commit"
           release_json="$(gh api "repos/$GITHUB_REPOSITORY/releases/$release_id")"
-          test "$(jq -r .draft <<<"$release_json")" = true
+          release_draft="$(jq -r .draft <<<"$release_json")"
+          release_immutable="$(jq -r .immutable <<<"$release_json")"
+          case "$release_draft:$release_immutable" in
+            true:false|false:true) ;;
+            *) echo "Release $release_id is neither a mutable draft nor an immutable publication." >&2; exit 1 ;;
+          esac
           test "$(jq -r .tag_name <<<"$release_json")" = "$TAG"
           expected_prerelease=false
           case "$version" in *-*) expected_prerelease=true ;; esac
@@ -165,7 +170,8 @@ jobs:
           final_ids="$(
             jq -r '.assets | sort_by(.name) | .[] | "\(.name)=\(.id)"' <<<"$final_release_json"
           )"
-          test "$(jq -r .draft <<<"$final_release_json")" = true
+          test "$(jq -r .draft <<<"$final_release_json")" = "$release_draft"
+          test "$(jq -r .immutable <<<"$final_release_json")" = "$release_immutable"
           test "$(jq -r .prerelease <<<"$final_release_json")" = "$expected_prerelease"
           test "$final_ids" = "$current_ids"
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$TAG" --jq .sha)" = "$commit"
@@ -206,13 +212,16 @@ jobs:
           )"
           test "$freshest_previous" = "$previous_tag"
 
-          gh api --method PATCH \
-            "repos/$GITHUB_REPOSITORY/releases/$release_id" \
-            -F tag_name="$TAG" \
-            -F prerelease="$expected_prerelease" \
-            -F draft=false >/dev/null
+          if [ "$release_draft" = true ]; then
+            gh api --method PATCH \
+              "repos/$GITHUB_REPOSITORY/releases/$release_id" \
+              -F tag_name="$TAG" \
+              -F prerelease="$expected_prerelease" \
+              -F draft=false >/dev/null
+          fi
           published_release_json="$(gh api "repos/$GITHUB_REPOSITORY/releases/$release_id")"
           test "$(jq -r .draft <<<"$published_release_json")" = false
+          test "$(jq -r .immutable <<<"$published_release_json")" = true
           test "$(jq -r .tag_name <<<"$published_release_json")" = "$TAG"
           test "$(jq -r .prerelease <<<"$published_release_json")" = "$expected_prerelease"
           test "$(
@@ -314,7 +323,8 @@ jobs:
           version="${EXPECTED_VERSION#v}"
           test "$(env -i HOME="$install_home" XDG_DATA_HOME="$data_home" \
             PATH="$bin_dir:$public_path" stn --version)" = "$version"
-          test "$(readlink "$bin_dir/stn-ingress")" = stn
+          test -x "$bin_dir/stn-ingress"
+          test ! -L "$bin_dir/stn-ingress"
           test "$(readlink "$bin_dir/stn-tmux-popup")" = stn
           receipt_path="$bin_dir/.station-install-receipt"
           test -f "$receipt_path"

--- a/tests/diagnostics/ci-workflow-policy.test.ts
+++ b/tests/diagnostics/ci-workflow-policy.test.ts
@@ -555,6 +555,9 @@ describe("hosted CI policy", () => {
     expect(promote).toContain('previous_tag="$(jq -er .previousTag candidate/manifest.json)"');
     expect(promote).toContain(".previousTag == $previousTag");
     expect(promote).toContain(".immutable");
+    expect(promote).toContain('case "$release_draft:$release_immutable" in');
+    expect(promote).toContain('if [ "$release_draft" = true ]; then');
+    expect(promote).toContain('test "$(jq -r .immutable <<<"$published_release_json")" = true');
     expect(promotion).toContain("group: station-release-publication");
     expect(promote).toContain('test "$freshest_previous" = "$previous_tag"');
     expect(promote.indexOf('test "$freshest_previous" = "$previous_tag"')).toBeLessThan(
@@ -571,13 +574,17 @@ describe("hosted CI policy", () => {
 
   it("verifies the installed ingress artifact as a dedicated executable", () => {
     const installDraft = workflowJob(read(".github/workflows/release.yml"), "install-draft");
+    const publicInstall = namedWorkflowStep(
+      workflowJob(read(".github/workflows/promote-release.yml"), "verify-public-install"),
+      "Install without GitHub credentials or gh",
+    );
     const verifyInstalled = namedWorkflowStep(installDraft, "Verify installed artifact");
     const verifyRetry = namedWorkflowStep(
       installDraft,
       "Verify lock refusal and same-version retry",
     );
 
-    for (const step of [verifyInstalled, verifyRetry]) {
+    for (const step of [verifyInstalled, verifyRetry, publicInstall]) {
       expect(step).toContain('test -x "$bin_dir/stn-ingress"');
       expect(step).toContain('test ! -L "$bin_dir/stn-ingress"');
       expect(step).not.toContain('readlink "$bin_dir/stn-ingress"');


### PR DESCRIPTION
## What this fixes

The `.14.8` promotion published the accepted immutable draft, then all four public-install jobs reached a stale assertion that still expected `stn-ingress` to be a symlink. Clean `.14.8` installs intentionally contain a dedicated native ingress executable, so the post-public check failed after successful installation. The workflow also needs a fail-closed way to re-verify the exact release now that GitHub has made it immutable.

## What changed

- Verify `stn-ingress` as an executable regular file while preserving the `stn-tmux-popup -> stn` alias check.
- Accept only a mutable draft or the same immutable publication bound by the accepted-candidate manifest, asset IDs, hashes, tag, and commit.
- Publish only the draft state; an immutable publication is re-verified without mutation.
- Extend CI policy coverage to keep both promotion behaviors and the native ingress layout current.

## Testing

- `bunx vitest run --config config/vitest/vitest.diagnostics.config.ts tests/diagnostics/ci-workflow-policy.test.ts` (14 tests)
- `bun run typecheck` (46 tasks)
- `bun run lint`
- pre-commit and pre-push hooks

## Safety and scope

This changes only promotion verification. It does not alter, replace, or delete the public `.14.8` tag or any of its six immutable assets.